### PR TITLE
Display fetched feature data.

### DIFF
--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -30,11 +30,11 @@ export class FeaturePage extends LitElement {
   @state()
   feature?: components['schemas']['Feature'] | undefined
 
-  location!: {params: {featureId: string}}  // Set by router.
   featureId!: string
-
   @state()
   loading: boolean = true
+
+  location!: { params: { featureId: string } } // Set by router.
 
   async firstUpdated(): Promise<void> {
     // TODO(jrobbins): Use routerContext instead of this.location so that


### PR DESCRIPTION
This just gets the feature ID from the URL via the router and uses that to fetch feature info from the backend and display it.

For a UI URL like http://localhost:5555/features/grid is shows
![image](https://github.com/GoogleChrome/webstatus.dev/assets/17365/82d1ac39-6af4-4844-ae64-0cea418ca8e3)

I tried and failed to set up routerContext and use it, so for now I am relying on the documented router side-effect of setting this.location on whatever element it generates.