### PR TITLE
Use font-family suggested by Peter.

### DIFF
--- a/frontend/src/static/index.html
+++ b/frontend/src/static/index.html
@@ -19,10 +19,6 @@
   <head>
     <meta charset="UTF-8" />
     <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Inter"
-    />
-    <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet"
     />

--- a/frontend/src/static/js/css/shared-css.ts
+++ b/frontend/src/static/js/css/shared-css.ts
@@ -22,7 +22,8 @@ export const SHARED_STYLES = [
   RESET,
   css`
     :host {
-      font-family: 'Inter';
+      font-family: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+        'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
     }
   `
 ]


### PR DESCRIPTION
This is the font-family value suggested by Peter.  It is shown at the top of the "Design system" page in figma.  Basically, it follows the idea laid out on modernfontstacks.com to use symbolic font-family options instead of web fonts.  This makes for one less thing to load when the page loads, and it means that the browser makes a choice of which actual font to use on each platform, which usually are high quality fonts.   The actual visual difference to the user is not much.