### PR TITLE
Enable sourcemaps for local frontend builds

### DIFF
--- a/frontend/rollup.config.mjs
+++ b/frontend/rollup.config.mjs
@@ -19,6 +19,8 @@ import terser from '@rollup/plugin-terser';
 import copy from 'rollup-plugin-copy';
 import css from 'rollup-plugin-css-only';
 
+const isLocalEnv = process.env.BUILD_ENV === 'local';
+
 export default [
   {
     input: 'build/static/js/index.js',
@@ -55,6 +57,7 @@ export default [
     ],
     output: {
       dir: 'dist/static/public',
+      sourcemap: isLocalEnv,
       entryFileNames: 'js/[name].js',
     },
     onwarn: warning => {

--- a/frontend/skaffold.yaml
+++ b/frontend/skaffold.yaml
@@ -29,6 +29,7 @@ profiles:
             dockerfile: images/nodejs_service.Dockerfile
             buildArgs:
               service_dir: frontend
+              build_env: local
       local: {}
     manifests:
       rawYaml:

--- a/images/nodejs_service.Dockerfile
+++ b/images/nodejs_service.Dockerfile
@@ -18,6 +18,8 @@ FROM base as builder
 
 WORKDIR /work
 ARG service_dir
+ARG build_env
+ENV BUILD_ENV ${build_env}
 COPY package.json package.json
 COPY package-lock.json package-lock.json
 COPY ${service_dir}/package.json ${service_dir}/package.json


### PR DESCRIPTION
Problem: Developers cannot debug locally

![image](https://github.com/GoogleChrome/webstatus.dev/assets/7788930/5030a8fc-41b4-4043-a726-afe1b80f385d)

You will see in the screenshot that it includes no files

This change enables [sourcemaps](https://rollupjs.org/configuration-options/#output-sourcemap) on the output

Now you will see that it includes the intermediate build folder with the javascript

![image](https://github.com/GoogleChrome/webstatus.dev/assets/7788930/0ab0792d-0493-4b7e-ac0f-8b39aefd6c3c)

And if you put a breakpoint, it will pause execution

![image](https://github.com/GoogleChrome/webstatus.dev/assets/7788930/ee09035f-5c55-4bf6-9443-77b49c37cb09)

