### PR TITLE
Introduce the high-level WPT Run Datastore Entity.

### DIFF
--- a/lib/gds/web_feature_test.go
+++ b/lib/gds/web_feature_test.go
@@ -26,7 +26,7 @@ import (
 // nolint: exhaustruct // No need to use every option of 3rd party struct.
 func TestFeatureDataOperations(t *testing.T) {
 	ctx := context.Background()
-	client, cleanup := getTestDatabase(ctx, t)
+	client, _, cleanup := getTestDatabase(ctx, t)
 	defer cleanup()
 
 	// Part 1. Try to insert the first version

--- a/lib/gds/wpt_run_common_test.go
+++ b/lib/gds/wpt_run_common_test.go
@@ -1,0 +1,278 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gds
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// nolint: gochecknoglobals
+// Set of initial runs that each test suite starts off with.
+var sampleWPTRuns = []WPTRun{
+	{
+		WPTRunMetadata: &WPTRunMetadata{
+			RunID:          0,
+			TimeStart:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			TimeEnd:        time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "0.0.0",
+			Channel:        shared.StableLabel,
+			OSName:         "os",
+			OSVersion:      "0.0.0",
+		},
+		TestMetric: &WPTRunMetric{
+			TotalTests: intPtr(2),
+			TestPass:   intPtr(2),
+		},
+		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
+			{
+				FeatureID: "fooFeature",
+				WPTRunMetric: WPTRunMetric{
+					TotalTests: intPtr(1),
+					TestPass:   intPtr(0),
+				},
+			},
+		},
+	},
+	{
+		WPTRunMetadata: &WPTRunMetadata{
+			RunID:          1,
+			TimeStart:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			TimeEnd:        time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "0.0.0",
+			Channel:        shared.ExperimentalLabel,
+			OSName:         "os",
+			OSVersion:      "0.0.0",
+		},
+		TestMetric: &WPTRunMetric{
+			TotalTests: intPtr(3),
+			TestPass:   intPtr(3),
+		},
+		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
+			{
+				FeatureID: "fooFeature",
+				WPTRunMetric: WPTRunMetric{
+					TotalTests: intPtr(1),
+					TestPass:   intPtr(1),
+				},
+			},
+		},
+	},
+	{
+		WPTRunMetadata: &WPTRunMetadata{
+			RunID:          2,
+			TimeStart:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			TimeEnd:        time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+			BrowserName:    "barBrowser",
+			BrowserVersion: "0.0.0",
+			Channel:        shared.StableLabel,
+			OSName:         "os",
+			OSVersion:      "0.0.0",
+		},
+		TestMetric: &WPTRunMetric{
+			TotalTests: intPtr(2),
+			TestPass:   intPtr(2),
+		},
+		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
+			{
+				FeatureID: "fooFeature",
+				WPTRunMetric: WPTRunMetric{
+					TotalTests: intPtr(1),
+					TestPass:   intPtr(1),
+				},
+			},
+		},
+	},
+	{
+		WPTRunMetadata: &WPTRunMetadata{
+			RunID:          3,
+			TimeStart:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			TimeEnd:        time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+			BrowserName:    "barBrowser",
+			BrowserVersion: "0.0.0",
+			Channel:        shared.ExperimentalLabel,
+			OSName:         "os",
+			OSVersion:      "0.0.0",
+		},
+		TestMetric: &WPTRunMetric{
+			TotalTests: intPtr(3),
+			TestPass:   intPtr(3),
+		},
+		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
+			{
+				FeatureID: "fooFeature",
+				WPTRunMetric: WPTRunMetric{
+					TotalTests: intPtr(1),
+					TestPass:   intPtr(1),
+				},
+			},
+		},
+	},
+	{
+		WPTRunMetadata: &WPTRunMetadata{
+			RunID:          6,
+			TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "0.0.0",
+			Channel:        shared.StableLabel,
+			OSName:         "os",
+			OSVersion:      "0.0.0",
+		},
+		TestMetric: &WPTRunMetric{
+			TotalTests: intPtr(2),
+			TestPass:   intPtr(2),
+		},
+		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
+			{
+				FeatureID: "fooFeature",
+				WPTRunMetric: WPTRunMetric{
+					TotalTests: intPtr(1),
+					TestPass:   intPtr(1),
+				},
+			},
+			{
+				FeatureID: "barFeature",
+				WPTRunMetric: WPTRunMetric{
+					TotalTests: intPtr(1),
+					TestPass:   intPtr(1),
+				},
+			},
+		},
+	},
+	{
+		WPTRunMetadata: &WPTRunMetadata{
+			RunID:          7,
+			TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "0.0.0",
+			Channel:        shared.ExperimentalLabel,
+			OSName:         "os",
+			OSVersion:      "0.0.0",
+		},
+		TestMetric: &WPTRunMetric{
+			TotalTests: intPtr(3),
+			TestPass:   intPtr(3),
+		},
+		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
+			{
+				FeatureID: "fooFeature",
+				WPTRunMetric: WPTRunMetric{
+					TotalTests: intPtr(2),
+					TestPass:   intPtr(2),
+				},
+			},
+			{
+				FeatureID: "barFeature",
+				WPTRunMetric: WPTRunMetric{
+					TotalTests: intPtr(1),
+					TestPass:   intPtr(1),
+				},
+			},
+		},
+	},
+	{
+		WPTRunMetadata: &WPTRunMetadata{
+			RunID:          8,
+			TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+			BrowserName:    "barBrowser",
+			BrowserVersion: "0.0.0",
+			Channel:        shared.StableLabel,
+			OSName:         "os",
+			OSVersion:      "0.0.0",
+		},
+		TestMetric: &WPTRunMetric{
+			TotalTests: intPtr(2),
+			TestPass:   intPtr(2),
+		},
+		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
+			{
+				FeatureID: "barFeature",
+				WPTRunMetric: WPTRunMetric{
+					TotalTests: intPtr(1),
+					TestPass:   intPtr(1),
+				},
+			},
+			{
+				FeatureID: "fooFeature",
+				WPTRunMetric: WPTRunMetric{
+					TotalTests: intPtr(1),
+					TestPass:   intPtr(1),
+				},
+			},
+		},
+	},
+	{
+		WPTRunMetadata: &WPTRunMetadata{
+			RunID:          9,
+			TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+			BrowserName:    "barBrowser",
+			BrowserVersion: "0.0.0",
+			Channel:        shared.ExperimentalLabel,
+			OSName:         "os",
+			OSVersion:      "0.0.0",
+		},
+		TestMetric: &WPTRunMetric{
+			TotalTests: intPtr(3),
+			TestPass:   intPtr(3),
+		},
+		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
+			{
+				FeatureID: "fooFeature",
+				WPTRunMetric: WPTRunMetric{
+					TotalTests: intPtr(1),
+					TestPass:   intPtr(1),
+				},
+			},
+			{
+				FeatureID: "barFeature",
+				WPTRunMetric: WPTRunMetric{
+					TotalTests: intPtr(2),
+					TestPass:   intPtr(2),
+				},
+			},
+		},
+	},
+}
+
+func setupEntities(ctx context.Context, t *testing.T, client *Client) {
+	for _, run := range sampleWPTRuns {
+		err := client.StoreWPTRunMetadata(ctx, run.WPTRunMetadata)
+		if err != nil {
+			t.Errorf("unable to store wpt run %s", err.Error())
+		}
+		err = client.StoreWPTRunMetrics(ctx, run.RunID,
+			run.TestMetric)
+		if err != nil {
+			t.Errorf("unable to store wpt run metric %s", err.Error())
+		}
+		featureMap := make(map[string]WPTRunMetric)
+		for _, featureMetric := range run.FeatureTestMetrics {
+			featureMap[featureMetric.FeatureID] = featureMetric.WPTRunMetric
+		}
+		err = client.StoreWPTRunMetricsForFeatures(ctx, run.RunID, featureMap)
+		if err != nil {
+			t.Errorf("unable to store wpt run metrics per feature %s", err.Error())
+		}
+	}
+}

--- a/lib/gds/wpt_run_metrics.go
+++ b/lib/gds/wpt_run_metrics.go
@@ -104,7 +104,7 @@ func (c *Client) ListWPTMetricsByBrowser(
 	ret := make([]WPTRunToMetrics, 0, len(runs))
 	for _, run := range runs {
 		ret = append(ret, WPTRunToMetrics{
-			WPTRunMetadata: run.WPTRunMetadata,
+			WPTRunMetadata: *run.WPTRunMetadata,
 			WPTRunMetric:   run.TestMetric,
 		})
 	}

--- a/lib/gds/wpt_run_metrics_group_by_feature_test.go
+++ b/lib/gds/wpt_run_metrics_group_by_feature_test.go
@@ -1,0 +1,79 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gds
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+func testWPTMetricsByBrowserByFeature(ctx context.Context, client *Client, t *testing.T) {
+	// Step 1b. Pick a range that gets both entries of feature specific metrics.
+	featureMetrics, _, err := client.ListWPTMetricsByBrowserByFeature(
+		ctx,
+		"fooBrowser",
+		shared.ExperimentalLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		"fooFeature",
+		nil,
+	)
+	if err != nil {
+		t.Errorf("unable to get metrics for browser by feature. %s", err.Error())
+	}
+	expectedPageFeatureMetrics := []*WPTRunToMetricsByFeature{
+		{
+			WPTRunMetadata: WPTRunMetadata{
+				RunID:          7,
+				TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+				TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+				BrowserName:    "fooBrowser",
+				BrowserVersion: "0.0.0",
+				Channel:        shared.ExperimentalLabel,
+				OSName:         "os",
+				OSVersion:      "0.0.0",
+			},
+			WPTRunMetric: &WPTRunMetric{
+				TotalTests: intPtr(2),
+				TestPass:   intPtr(2),
+			},
+			FeatureID: "fooFeature",
+		},
+		{
+			WPTRunMetadata: WPTRunMetadata{
+				RunID:          1,
+				TimeStart:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				TimeEnd:        time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+				BrowserName:    "fooBrowser",
+				BrowserVersion: "0.0.0",
+				Channel:        shared.ExperimentalLabel,
+				OSName:         "os",
+				OSVersion:      "0.0.0",
+			},
+			WPTRunMetric: &WPTRunMetric{
+				TotalTests: intPtr(1),
+				TestPass:   intPtr(1),
+			},
+			FeatureID: "fooFeature",
+		},
+	}
+	if !reflect.DeepEqual(expectedPageFeatureMetrics, featureMetrics) {
+		t.Errorf("unequal slices")
+	}
+}

--- a/lib/gds/wpt_run_metrics_test.go
+++ b/lib/gds/wpt_run_metrics_test.go
@@ -1,0 +1,111 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gds
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+func testWPTMetricsByBrowser(ctx context.Context, client *Client, t *testing.T) {
+	// Get the foo browser
+	// Step 1. Pick a range that gets both entries of run wide metrics.
+	metrics, _, err := client.ListWPTMetricsByBrowser(
+		ctx,
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		nil,
+	)
+	if err != nil {
+		t.Errorf("unable to get metrics for browser. %s", err.Error())
+	}
+	expectedPageBoth := []WPTRunToMetrics{
+		{
+			WPTRunMetadata: WPTRunMetadata{
+				RunID:          6,
+				TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+				TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+				BrowserName:    "fooBrowser",
+				BrowserVersion: "0.0.0",
+				Channel:        shared.StableLabel,
+				OSName:         "os",
+				OSVersion:      "0.0.0",
+			},
+			WPTRunMetric: &WPTRunMetric{
+				TotalTests: intPtr(2),
+				TestPass:   intPtr(2),
+			},
+		},
+		{
+			WPTRunMetadata: WPTRunMetadata{
+				RunID:          0,
+				TimeStart:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				TimeEnd:        time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+				BrowserName:    "fooBrowser",
+				BrowserVersion: "0.0.0",
+				Channel:        shared.StableLabel,
+				OSName:         "os",
+				OSVersion:      "0.0.0",
+			},
+			WPTRunMetric: &WPTRunMetric{
+				TotalTests: intPtr(2),
+				TestPass:   intPtr(2),
+			},
+		},
+	}
+	if !reflect.DeepEqual(expectedPageBoth, metrics) {
+		t.Error("unequal slices")
+	}
+
+	// Step 2. Pick a range that only gets run-wide metric.
+	metrics, _, err = client.ListWPTMetricsByBrowser(
+		ctx,
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		nil,
+	)
+	if err != nil {
+		t.Errorf("unable to get metrics for browser. %s", err.Error())
+	}
+	expectedPageLast := []WPTRunToMetrics{
+		{
+			WPTRunMetadata: WPTRunMetadata{
+				RunID:          6,
+				TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+				TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+				BrowserName:    "fooBrowser",
+				BrowserVersion: "0.0.0",
+				Channel:        shared.StableLabel,
+				OSName:         "os",
+				OSVersion:      "0.0.0",
+			},
+			WPTRunMetric: &WPTRunMetric{
+				TotalTests: intPtr(2),
+				TestPass:   intPtr(2),
+			},
+		},
+	}
+	if !reflect.DeepEqual(expectedPageLast, metrics) {
+		t.Error("unequal slices")
+	}
+}

--- a/lib/gds/wpt_run_test.go
+++ b/lib/gds/wpt_run_test.go
@@ -16,6 +16,7 @@ package gds
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -23,174 +24,43 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-// nolint: gochecknoglobals
-var sampleWPTRuns = []WPTRun{
-	{
-		WPTRunMetadata: WPTRunMetadata{
-			RunID:          0,
-			TimeStart:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-			TimeEnd:        time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
-			BrowserName:    "fooBrowser",
-			BrowserVersion: "0.0.0",
-			Channel:        shared.StableLabel,
-			OSName:         "os",
-			OSVersion:      "0.0.0",
-		},
-		TestMetric: &WPTRunMetric{
-			TotalTests: intPtr(2),
-			TestPass:   intPtr(2),
-		},
-		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
-			{
-				FeatureID: "fooFeature",
-				WPTRunMetric: WPTRunMetric{
-					TotalTests: intPtr(1),
-					TestPass:   intPtr(0),
-				},
-			},
-		},
-	},
-	{
-		WPTRunMetadata: WPTRunMetadata{
-			RunID:          1,
-			TimeStart:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-			TimeEnd:        time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
-			BrowserName:    "fooBrowser",
-			BrowserVersion: "0.0.0",
-			Channel:        shared.ExperimentalLabel,
-			OSName:         "os",
-			OSVersion:      "0.0.0",
-		},
-		TestMetric: &WPTRunMetric{
-			TotalTests: intPtr(3),
-			TestPass:   intPtr(3),
-		},
-		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
-			{
-				FeatureID: "fooFeature",
-				WPTRunMetric: WPTRunMetric{
-					TotalTests: intPtr(1),
-					TestPass:   intPtr(1),
-				},
-			},
-		},
-	},
-	{
-		WPTRunMetadata: WPTRunMetadata{
-			RunID:          2,
-			TimeStart:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-			TimeEnd:        time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
-			BrowserName:    "barBrowser",
-			BrowserVersion: "0.0.0",
-			Channel:        shared.StableLabel,
-			OSName:         "os",
-			OSVersion:      "0.0.0",
-		},
-		TestMetric: &WPTRunMetric{
-			TotalTests: intPtr(2),
-			TestPass:   intPtr(2),
-		},
-		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
-			{
-				FeatureID: "fooFeature",
-				WPTRunMetric: WPTRunMetric{
-					TotalTests: intPtr(1),
-					TestPass:   intPtr(1),
-				},
-			},
-		},
-	},
-	{
-		WPTRunMetadata: WPTRunMetadata{
-			RunID:          3,
-			TimeStart:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-			TimeEnd:        time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
-			BrowserName:    "barBrowser",
-			BrowserVersion: "0.0.0",
-			Channel:        shared.ExperimentalLabel,
-			OSName:         "os",
-			OSVersion:      "0.0.0",
-		},
-		TestMetric: &WPTRunMetric{
-			TotalTests: intPtr(3),
-			TestPass:   intPtr(3),
-		},
-		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
-			{
-				FeatureID: "fooFeature",
-				WPTRunMetric: WPTRunMetric{
-					TotalTests: intPtr(1),
-					TestPass:   intPtr(1),
-				},
-			},
-		},
-	},
-	{
-		WPTRunMetadata: WPTRunMetadata{
-			RunID:          6,
-			TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
-			TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
-			BrowserName:    "fooBrowser",
-			BrowserVersion: "0.0.0",
-			Channel:        shared.StableLabel,
-			OSName:         "os",
-			OSVersion:      "0.0.0",
-		},
-		TestMetric: &WPTRunMetric{
-			TotalTests: intPtr(2),
-			TestPass:   intPtr(2),
-		},
-		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
-			{
-				FeatureID: "fooFeature",
-				WPTRunMetric: WPTRunMetric{
-					TotalTests: intPtr(1),
-					TestPass:   intPtr(1),
-				},
-			},
-			{
-				FeatureID: "barFeature",
-				WPTRunMetric: WPTRunMetric{
-					TotalTests: intPtr(1),
-					TestPass:   intPtr(1),
-				},
-			},
-		},
-	},
-	{
-		WPTRunMetadata: WPTRunMetadata{
-			RunID:          7,
-			TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
-			TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
-			BrowserName:    "fooBrowser",
-			BrowserVersion: "0.0.0",
-			Channel:        shared.ExperimentalLabel,
-			OSName:         "os",
-			OSVersion:      "0.0.0",
-		},
-		TestMetric: &WPTRunMetric{
-			TotalTests: intPtr(3),
-			TestPass:   intPtr(3),
-		},
-		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
-			{
-				FeatureID: "fooFeature",
-				WPTRunMetric: WPTRunMetric{
-					TotalTests: intPtr(2),
-					TestPass:   intPtr(2),
-				},
-			},
-			{
-				FeatureID: "barFeature",
-				WPTRunMetric: WPTRunMetric{
-					TotalTests: intPtr(1),
-					TestPass:   intPtr(1),
-				},
-			},
-		},
-	},
-	{
-		WPTRunMetadata: WPTRunMetadata{
+func TestWPTRunOperations(t *testing.T) {
+	ctx := context.Background()
+
+	// Getting the test database is expensive that is why the methods below aren't their own tests.
+	// For now, get it once and use it in the sub tests below.
+	client, resetDB, cleanup := getTestDatabase(ctx, t)
+	defer cleanup()
+
+	// Test methods at the WPT Runs and WPT Metadata level
+	setupEntities(ctx, t, client)
+	testWPTRuns(ctx, client, t)
+	resetDB()
+
+	// Test methods at the WPT Metrics level
+	setupEntities(ctx, t, client)
+	testWPTMetricsByBrowser(ctx, client, t)
+	resetDB()
+
+	// Test methods at the Feature WPT metrics level
+	setupEntities(ctx, t, client)
+	testWPTMetricsByBrowserByFeature(ctx, client, t)
+	resetDB()
+}
+
+func testWPTRuns(ctx context.Context, client *Client, t *testing.T) {
+	// Try to get a non existant run.
+	_, err := client.GetWPTRun(ctx, 1000)
+	if !errors.Is(err, ErrEntityNotFound) {
+		t.Error("expected ErrEntityNotFound")
+	}
+	// Get a known run
+	run, err := client.GetWPTRun(ctx, 8)
+	if !errors.Is(err, nil) {
+		t.Error("expected no error")
+	}
+	expectedRunID8 := &WPTRun{
+		WPTRunMetadata: &WPTRunMetadata{
 			RunID:          8,
 			TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
 			TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
@@ -206,37 +76,12 @@ var sampleWPTRuns = []WPTRun{
 		},
 		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
 			{
-				FeatureID: "fooFeature",
-				WPTRunMetric: WPTRunMetric{
-					TotalTests: intPtr(1),
-					TestPass:   intPtr(1),
-				},
-			},
-			{
 				FeatureID: "barFeature",
 				WPTRunMetric: WPTRunMetric{
 					TotalTests: intPtr(1),
 					TestPass:   intPtr(1),
 				},
 			},
-		},
-	},
-	{
-		WPTRunMetadata: WPTRunMetadata{
-			RunID:          9,
-			TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
-			TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
-			BrowserName:    "barBrowser",
-			BrowserVersion: "0.0.0",
-			Channel:        shared.ExperimentalLabel,
-			OSName:         "os",
-			OSVersion:      "0.0.0",
-		},
-		TestMetric: &WPTRunMetric{
-			TotalTests: intPtr(3),
-			TestPass:   intPtr(3),
-		},
-		FeatureTestMetrics: []WPTRunMetricsGroupByFeature{
 			{
 				FeatureID: "fooFeature",
 				WPTRunMetric: WPTRunMetric{
@@ -244,190 +89,9 @@ var sampleWPTRuns = []WPTRun{
 					TestPass:   intPtr(1),
 				},
 			},
-			{
-				FeatureID: "barFeature",
-				WPTRunMetric: WPTRunMetric{
-					TotalTests: intPtr(2),
-					TestPass:   intPtr(2),
-				},
-			},
-		},
-	},
-}
-
-func setupEntities(ctx context.Context, t *testing.T, client *Client) {
-	for _, run := range sampleWPTRuns {
-		err := client.StoreWPTRunMetadata(ctx, run.WPTRunMetadata)
-		if err != nil {
-			t.Errorf("unable to store wpt run %s", err.Error())
-		}
-		err = client.StoreWPTRunMetrics(ctx, run.RunID,
-			run.TestMetric)
-		if err != nil {
-			t.Errorf("unable to store wpt run metric %s", err.Error())
-		}
-		featureMap := make(map[string]WPTRunMetric)
-		for _, featureMetric := range run.FeatureTestMetrics {
-			featureMap[featureMetric.FeatureID] = featureMetric.WPTRunMetric
-		}
-		err = client.StoreWPTRunMetricsForFeatures(ctx, run.RunID, featureMap)
-		if err != nil {
-			t.Errorf("unable to store wpt run metrics per feature %s", err.Error())
-		}
-	}
-}
-
-func testWPTMetricsByBrowser(ctx context.Context, client *Client, t *testing.T) {
-	// Get the foo browser
-	// Step 1. Pick a range that gets both entries of run wide metrics.
-	metrics, _, err := client.ListWPTMetricsByBrowser(
-		ctx,
-		"fooBrowser",
-		shared.StableLabel,
-		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
-		nil,
-	)
-	if err != nil {
-		t.Errorf("unable to get metrics for browser. %s", err.Error())
-	}
-	expectedPageBoth := []WPTRunToMetrics{
-		{
-			WPTRunMetadata: WPTRunMetadata{
-				RunID:          6,
-				TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
-				TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
-				BrowserName:    "fooBrowser",
-				BrowserVersion: "0.0.0",
-				Channel:        shared.StableLabel,
-				OSName:         "os",
-				OSVersion:      "0.0.0",
-			},
-			WPTRunMetric: &WPTRunMetric{
-				TotalTests: intPtr(2),
-				TestPass:   intPtr(2),
-			},
-		},
-		{
-			WPTRunMetadata: WPTRunMetadata{
-				RunID:          0,
-				TimeStart:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-				TimeEnd:        time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
-				BrowserName:    "fooBrowser",
-				BrowserVersion: "0.0.0",
-				Channel:        shared.StableLabel,
-				OSName:         "os",
-				OSVersion:      "0.0.0",
-			},
-			WPTRunMetric: &WPTRunMetric{
-				TotalTests: intPtr(2),
-				TestPass:   intPtr(2),
-			},
 		},
 	}
-	if !reflect.DeepEqual(expectedPageBoth, metrics) {
-		t.Error("unequal slices")
+	if !reflect.DeepEqual(expectedRunID8, run) {
+		t.Errorf("expected run id 8 does not equal actual run. expected (%+v) actual (%+v)", expectedRunID8, run)
 	}
-
-	// Step 2. Pick a range that only gets run-wide metric.
-	metrics, _, err = client.ListWPTMetricsByBrowser(
-		ctx,
-		"fooBrowser",
-		shared.StableLabel,
-		time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
-		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
-		nil,
-	)
-	if err != nil {
-		t.Errorf("unable to get metrics for browser. %s", err.Error())
-	}
-	expectedPageLast := []WPTRunToMetrics{
-		{
-			WPTRunMetadata: WPTRunMetadata{
-				RunID:          6,
-				TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
-				TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
-				BrowserName:    "fooBrowser",
-				BrowserVersion: "0.0.0",
-				Channel:        shared.StableLabel,
-				OSName:         "os",
-				OSVersion:      "0.0.0",
-			},
-			WPTRunMetric: &WPTRunMetric{
-				TotalTests: intPtr(2),
-				TestPass:   intPtr(2),
-			},
-		},
-	}
-	if !reflect.DeepEqual(expectedPageLast, metrics) {
-		t.Error("unequal slices")
-	}
-}
-
-func testWPTMetricsByBrowserByFeature(ctx context.Context, client *Client, t *testing.T) {
-	// Step 1b. Pick a range that gets both entries of feature specific metrics.
-	featureMetrics, _, err := client.ListWPTMetricsByBrowserByFeature(
-		ctx,
-		"fooBrowser",
-		shared.ExperimentalLabel,
-		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
-		"fooFeature",
-		nil,
-	)
-	if err != nil {
-		t.Errorf("unable to get metrics for browser by feature. %s", err.Error())
-	}
-	expectedPageFeatureMetrics := []*WPTRunToMetricsByFeature{
-		{
-			WPTRunMetadata: WPTRunMetadata{
-				RunID:          7,
-				TimeStart:      time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
-				TimeEnd:        time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
-				BrowserName:    "fooBrowser",
-				BrowserVersion: "0.0.0",
-				Channel:        shared.ExperimentalLabel,
-				OSName:         "os",
-				OSVersion:      "0.0.0",
-			},
-			WPTRunMetric: &WPTRunMetric{
-				TotalTests: intPtr(2),
-				TestPass:   intPtr(2),
-			},
-			FeatureID: "fooFeature",
-		},
-		{
-			WPTRunMetadata: WPTRunMetadata{
-				RunID:          1,
-				TimeStart:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-				TimeEnd:        time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
-				BrowserName:    "fooBrowser",
-				BrowserVersion: "0.0.0",
-				Channel:        shared.ExperimentalLabel,
-				OSName:         "os",
-				OSVersion:      "0.0.0",
-			},
-			WPTRunMetric: &WPTRunMetric{
-				TotalTests: intPtr(1),
-				TestPass:   intPtr(1),
-			},
-			FeatureID: "fooFeature",
-		},
-	}
-	if !reflect.DeepEqual(expectedPageFeatureMetrics, featureMetrics) {
-		t.Errorf("unequal slices")
-	}
-}
-
-func TestWPTRunMetricsOperations(t *testing.T) {
-	ctx := context.Background()
-
-	// Getting the test database is expensive that is why the methods below aren't their own tests.
-	// For now, get it once and use it in the sub tests below.
-	client, cleanup := getTestDatabase(ctx, t)
-	defer cleanup()
-	setupEntities(ctx, t, client)
-
-	testWPTMetricsByBrowser(ctx, client, t)
-	testWPTMetricsByBrowserByFeature(ctx, client, t)
 }


### PR DESCRIPTION
The WPT Run entity contains relevant information about an individual run retrieved from wpt.fyi's runs API.

Each WPT Run contains two optional types of metrics:
- A metric for the whole run
- A list of metrics. One for each feature.

Exposed methods that allow users to upsert:
- The metadata
- The metric for the whole run
- The metric for individual features in the run

Certain fields are only write-once. And the rest are append-only. In the future, we can include an overwrite if needed.

There are list methods that allow users to get data about:
- The individual run
- The high-level metrics for each run. (useful for the stats page)
- The metric for an individual feature (useful for the overview and the feature detail page)

