### PR TITLE
Add missing required field to the payload

### DIFF
--- a/lib/gds/web_feature.go
+++ b/lib/gds/web_feature.go
@@ -87,9 +87,10 @@ func (c *Client) ListWebFeatureData(ctx context.Context, pageToken *string) ([]b
 	for idx, val := range featureData {
 		// nolint: exhaustruct // TODO revisit once we adjust the ingestion data to incorporate the new fields.
 		ret[idx] = backend.Feature{
-			FeatureId: *val.WebFeatureID,
-			Name:      *val.Name,
-			Spec:      nil,
+			FeatureId:      *val.WebFeatureID,
+			Name:           *val.Name,
+			Spec:           nil,
+			BaselineStatus: backend.None,
 		}
 	}
 


### PR DESCRIPTION
In the openapi.yaml for the backend, baseline_status is a required field. But the backend currently doesn't provide that. This fixes that by putting the none value as the default for now.

https://github.com/GoogleChrome/webstatus.dev/pull/35 Needs this.

