### PR TITLE
Enable concurrent builds with skaffold

### DIFF
--- a/.dev/datastore/Dockerfile
+++ b/.dev/datastore/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/cloud-sdk:442.0.0-emulators
+FROM google/cloud-sdk:464.0.0-emulators
 
 # https://cloud.google.com/datastore/docs/tools/datastore-emulator
 ENTRYPOINT [ "gcloud", "beta", "emulators", "datastore", "start", "--host-port=0.0.0.0:8085", "--project=local", "--log-http", "--verbosity=debug", "--use-firestore-in-datastore-mode" ]

--- a/.dev/spanner/Dockerfile
+++ b/.dev/spanner/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/cloud-sdk:442.0.0-emulators
+FROM google/cloud-sdk:464.0.0-emulators
 
 
 ENTRYPOINT [ "gcloud", "emulators", "spanner", "start", "--host-port=0.0.0.0:9010", "--rest-port=9020", "--project=local", "--log-http", "--verbosity=debug", "--user-output-enabled" ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM mcr.microsoft.com/devcontainers/base:bullseye
 
-ENV CLOUD_SDK_VERSION=459.0.0
+ENV CLOUD_SDK_VERSION=464.0.0
 # Install gcloud similarly to how it is done in cloud-sdk-docker
 # https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/debian_component_based/Dockerfile
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;

--- a/lib/gds/web_feature_test.go
+++ b/lib/gds/web_feature_test.go
@@ -41,7 +41,9 @@ func TestFeatureDataOperations(t *testing.T) {
 		t.Errorf("failed to list %s", err.Error())
 	}
 
-	expectedFeatures := []backend.Feature{{FeatureId: "id-1", Spec: nil, Name: "version-1-name"}}
+	expectedFeatures := []backend.Feature{
+		{FeatureId: "id-1", Spec: nil, Name: "version-1-name", BaselineStatus: backend.None},
+	}
 	if !slices.Equal[[]backend.Feature](features, expectedFeatures) {
 		t.Errorf("slices not equal actual [%v] expected [%v]", features, expectedFeatures)
 	}
@@ -59,7 +61,9 @@ func TestFeatureDataOperations(t *testing.T) {
 		t.Errorf("failed to list %s", err.Error())
 	}
 
-	expectedFeatures = []backend.Feature{{FeatureId: "id-1", Spec: nil, Name: "version-2-name"}}
+	expectedFeatures = []backend.Feature{
+		{FeatureId: "id-1", Spec: nil, Name: "version-2-name", BaselineStatus: backend.None},
+	}
 	if !slices.Equal[[]backend.Feature](features, expectedFeatures) {
 		t.Errorf("slices not equal actual [%v] expected [%v]", features, expectedFeatures)
 	}


### PR DESCRIPTION
This will enable faster builds on local machines that have many cores. Previously, the concurrency factor was 1. This now uses the number of processing units (from nproc)

Also re-arrange the go_service.Dockerfile layers to make the common library layer cachable between all the go services.

Other skaffold behavior changes:
- Disabled caching of images and enabled image pruning because it will actually use up a lot of disk space if not manually pruned from time-to-time. (I ran into this myself where I needed to run `docker system prune -a` a few times because my host machine ran out of space) [Docs](https://github.com/GoogleChrome/webstatus.dev/pull/new/jcscottiii/speed-up-and-updates)

Other notes:
- Update the versions of the emulators
- Fix the go-test make target that allowed failing tests to have a zero exit code
- Fix the go test that was broken

