### PR TITLE
Adds WPTRuns Spanner table

### DIFF
--- a/infra/storage/spanner.sql
+++ b/infra/storage/spanner.sql
@@ -12,8 +12,20 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
--- This a placeholder statement for the migration handler to execute.
--- This will be replaced.
-CREATE TABLE Placeholder (
-    ID INT64 NOT NULL
+-- WPTRuns contains metadata from wpt.fyi runs.
+-- More information: https://github.com/web-platform-tests/wpt.fyi/blob/main/api/README.md#apiruns
+CREATE TABLE IF NOT EXISTS WPTRuns (
+    ID STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
+    ExternalRunID INT64 NOT NULL, -- ID from WPT
+    TimeStart TIMESTAMP NOT NULL,
+    TimeEnd TIMESTAMP NOT NULL,
+    BrowserName STRING(64),
+    BrowserVersion STRING(32),
+    Channel STRING(32),
+    OSName STRING(64),
+    OSVersion STRING(32),
+    FullRevisionHash STRING(40),
 ) PRIMARY KEY (ID);
+
+-- Used to enforce that only one ExternalRunID from wpt.fyi can exist.
+CREATE UNIQUE NULL_FILTERED INDEX RunsByExternalRunID ON WPTRuns (ExternalRunID);

--- a/lib/gcpspanner/wpt_run.go
+++ b/lib/gcpspanner/wpt_run.go
@@ -1,0 +1,120 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/grpc/codes"
+)
+
+const wptRunsTable = "WPTRuns"
+const indexRunsByExternalRunID = "RunsByExternalRunID"
+
+// SpannerWPTRun is a wrapper for the run data that is actually
+// stored in spanner. This is useful because the spanner id is not useful to
+// return to the end user since it is only used to decouple the primary keys
+// between this system and wpt.fyi.
+type SpannerWPTRun struct {
+	ID string `spanner:"ID"`
+	WPTRun
+}
+
+// WPTRun contains common metadata for a run.
+// Columns come from the ../../infra/storage/spanner.sql file.
+type WPTRun struct {
+	RunID            int64     `spanner:"ExternalRunID"`
+	TimeStart        time.Time `spanner:"TimeStart"`
+	TimeEnd          time.Time `spanner:"TimeEnd"`
+	BrowserName      string    `spanner:"BrowserName"`
+	BrowserVersion   string    `spanner:"BrowserVersion"`
+	Channel          string    `spanner:"Channel"`
+	OSName           string    `spanner:"OSName"`
+	OSVersion        string    `spanner:"OSVersion"`
+	FullRevisionHash string    `spanner:"FullRevisionHash"`
+}
+
+// InsertWPTRun will insert the given WPT Run.
+// If the run, does not exist, it will insert a new run.
+// If the run exists, it currently does nothing and keeps the existing as-is.
+// The update case should be revisited later on.
+// It uses the RunsByExternalRunID index to quickly look up the row.
+func (c *Client) InsertWPTRun(ctx context.Context, run WPTRun) error {
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		_, err := txn.ReadRowUsingIndex(
+			ctx,
+			wptRunsTable,
+			indexRunsByExternalRunID,
+			spanner.Key{run.RunID},
+			[]string{
+				"ID",
+			})
+		if err != nil {
+			// Received an error other than not found. Return now.
+			if spanner.ErrCode(err) != codes.NotFound {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+			m, err := spanner.InsertOrUpdateStruct(wptRunsTable, run)
+			if err != nil {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+			err = txn.BufferWrite([]*spanner.Mutation{m})
+			if err != nil {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+		}
+		// For now, do not overwrite anything for wpt runs.
+		return nil
+
+	})
+	if err != nil {
+		return errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	return nil
+}
+
+// GetIDOfWPTRunByRunID is a helper function to help get the spanner ID of the
+// run. This ID then can be used to create WPT Run Metrics. By linking with this
+// ID, we do not have to be coupled with the ID from wpt.fyi.
+// It uses the RunsByExternalRunID index to quickly look up the row.
+func (c *Client) GetIDOfWPTRunByRunID(ctx context.Context, runID int64) (*string, error) {
+	txn := c.Single()
+	defer txn.Close()
+	row, err := txn.ReadRowUsingIndex(
+		ctx,
+		wptRunsTable,
+		indexRunsByExternalRunID,
+		spanner.Key{runID},
+		[]string{
+			"ID",
+		})
+	if err != nil {
+		// For now, do not check for the "does not exist" error. Treat it as ErrInternalQueryFailure for now.
+		// Can revisit whether or not separate that error from the rest of the errors in the future, if needed.
+
+		return nil, errors.Join(ErrInternalQueryFailure, err)
+	}
+	var id string
+	err = row.Column(0, &id)
+	if err != nil {
+		return nil, errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	return &id, nil
+}

--- a/lib/gcpspanner/wpt_run_test.go
+++ b/lib/gcpspanner/wpt_run_test.go
@@ -1,0 +1,143 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+func getSampleRuns() []WPTRun {
+	return []WPTRun{
+		{
+			RunID:            0,
+			TimeStart:        time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "fooBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.StableLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            1,
+			TimeStart:        time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "fooBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.ExperimentalLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            2,
+			TimeStart:        time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "barBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.StableLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            3,
+			TimeStart:        time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "barBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.ExperimentalLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            6,
+			TimeStart:        time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "fooBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.StableLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            7,
+			TimeStart:        time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "fooBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.ExperimentalLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            8,
+			TimeStart:        time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "barBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.StableLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            9,
+			TimeStart:        time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "barBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.ExperimentalLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+	}
+}
+
+func TestInsertWPTRun(t *testing.T) {
+	client, migrationHandler := getTestDatabase(t)
+	migrationHandler.ApplyAll(t)
+	ctx := context.Background()
+	for _, run := range getSampleRuns() {
+		err := client.InsertWPTRun(ctx, run)
+		if !errors.Is(err, nil) {
+			t.Errorf("expected no error upon insert. received %s", err.Error())
+		}
+		// TODO: test update if we decide to allow updates in the future.
+		id, err := client.GetIDOfWPTRunByRunID(ctx, run.RunID)
+		if !errors.Is(err, nil) {
+			t.Errorf("expected no error upon insert. received %s", err.Error())
+		}
+		if id == nil {
+			t.Error("expected an id")
+
+			continue
+		}
+		if len(*id) != 36 {
+			// TODO. Assert it is indeed a uuid. For now, check the length.
+			t.Errorf("expected auto-generated uuid. id is only length %d", len(*id))
+		}
+	}
+}


### PR DESCRIPTION
This is splitting #40 to only include the WPTRuns table.

Implements WPTRuns table to store run metadata from wpt.fyi. Currently supports inserting new runs only; upsert functionality can be added later if needed.

Table decisions:
- Due to wpt.fyi having a different database system, it would be best to have our own IDs so that we are not coupled to their IDs. I did however create an unique index named "RunsByExternalRunID" so that we can 1) ensure that there is only at most one row with the ID from wpt.fyi and 2) quickly look up our ID from the wpt.fyi ID.

Table design considerations:

* **Unique ID:** Custom IDs generated for decoupling from wpt.fyi's database different structure.
* **RunsByExternalRunID Index:** Unique index on wpt.fyi's RunID for efficient lookups and to enforce a one-to-one mapping between systems.
* **GetIDOfWPTRunByRunID:** Helper function for retrieving internal ID from wpt.fyi's ID.

