### PR TITLE
Adds WPTRunFeatureMetrics Spanner Table

### DIFF
--- a/infra/storage/spanner.sql
+++ b/infra/storage/spanner.sql
@@ -29,3 +29,16 @@ CREATE TABLE IF NOT EXISTS WPTRuns (
 
 -- Used to enforce that only one ExternalRunID from wpt.fyi can exist.
 CREATE UNIQUE NULL_FILTERED INDEX RunsByExternalRunID ON WPTRuns (ExternalRunID);
+
+-- WPTRunFeatureMetrics contains metrics for individual features for a given run.
+CREATE TABLE IF NOT EXISTS WPTRunFeatureMetrics (
+    ID STRING(36) NOT NULL,
+    ExternalRunID INT64 NOT NULL, -- ID from WPT
+    FeatureID STRING(64) NOT NULL,
+    TotalTests INT64,
+    TestPass INT64,
+) PRIMARY KEY (ID, FeatureID)
+,    INTERLEAVE IN PARENT WPTRuns ON DELETE CASCADE;
+
+-- Used to enforce that only one combination of ExternalRunID and FeatureID can exist.
+CREATE UNIQUE NULL_FILTERED INDEX MetricsByExternalRunIDAndFeature ON WPTRunFeatureMetrics (ExternalRunID, FeatureID);

--- a/lib/gcpspanner/wpt_run_feature_metric.go
+++ b/lib/gcpspanner/wpt_run_feature_metric.go
@@ -1,0 +1,440 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+const wptRunFeatureMetricTable = "WPTRunFeatureMetrics"
+
+// SpannerWPTRunFeatureMetric is a wrapper for the metric data that is actually
+// stored in spanner. This is useful because the spanner id is not useful to
+// return to the end user since it is used to decouple the primary keys between
+// this system and wpt.fyi.
+type SpannerWPTRunFeatureMetric struct {
+	ID string `spanner:"ID"`
+	WPTRunFeatureMetric
+}
+
+// WPTRunFeatureMetric represents the metrics for a particular feature in a run.
+type WPTRunFeatureMetric struct {
+	RunID      int64  `spanner:"ExternalRunID"`
+	FeatureID  string `spanner:"FeatureID"`
+	TotalTests *int64 `spanner:"TotalTests"`
+	TestPass   *int64 `spanner:"TestPass"`
+}
+
+// UpsertWPTRunFeatureMetric will upsert the given WPT Run metric.
+// The RunID must exists in a row in the WPTRuns table.
+// If the metric does not exist, it will insert a new metric.
+// If the metric exists, it will only update the TotalTests and TestPass columns.
+func (c *Client) UpsertWPTRunFeatureMetric(ctx context.Context, in WPTRunFeatureMetric) error {
+	id, err := c.GetIDOfWPTRunByRunID(ctx, in.RunID)
+	if err != nil {
+		return err
+	}
+
+	// Create a metric with the retrieved ID
+	metric := SpannerWPTRunFeatureMetric{
+		ID:                  *id,
+		WPTRunFeatureMetric: in,
+	}
+	_, err = c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.NewStatement(`
+			SELECT
+				ID, ExternalRunID, FeatureID, TotalTests, TestPass
+			FROM WPTRunFeatureMetrics
+			WHERE ExternalRunID = @externalRunID
+			LIMIT 1`)
+		parameters := map[string]interface{}{
+			"externalRunID": metric.RunID,
+		}
+		stmt.Params = parameters
+
+		// Attempt to query for the row.
+		it := txn.Query(ctx, stmt)
+		defer it.Stop()
+		var m *spanner.Mutation
+		row, err := it.Next()
+
+		// nolint: nestif // TODO: fix in the future.
+		if err != nil {
+			if errors.Is(err, iterator.Done) {
+				// No rows returned. Act as if this is an insertion.
+				var err error
+				m, err = spanner.InsertOrUpdateStruct(wptRunFeatureMetricTable, metric)
+				if err != nil {
+					return errors.Join(ErrInternalQueryFailure, err)
+				}
+			} else {
+				// An unexpected error occurred.
+
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+		} else {
+			// Read the existing metric and merge the values.
+			var existingMetric SpannerWPTRunFeatureMetric
+			err = row.ToStruct(&existingMetric)
+			if err != nil {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+			// Only allow overriding of the test numbers.
+			existingMetric.TestPass = cmp.Or[*int64](metric.TestPass, existingMetric.TestPass, nil)
+			existingMetric.TotalTests = cmp.Or[*int64](metric.TotalTests, existingMetric.TotalTests, nil)
+			m, err = spanner.InsertOrUpdateStruct(wptRunFeatureMetricTable, metric)
+			if err != nil {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+		}
+
+		// Buffer the mutation to be committed.
+		err = txn.BufferWrite([]*spanner.Mutation{m})
+		if err != nil {
+			return errors.Join(ErrInternalQueryFailure, err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	return nil
+}
+
+// GetMetricByRunIDAndFeatureID attempts to get a metric for the given id from
+// wpt.fyi and web feature id.
+func (c *Client) GetMetricByRunIDAndFeatureID(
+	ctx context.Context,
+	runID int64,
+	featureID string,
+) (*WPTRunFeatureMetric, error) {
+	txn := c.ReadOnlyTransaction()
+	defer txn.Close()
+	stmt := spanner.NewStatement(`
+		SELECT
+			ExternalRunID, FeatureID, TotalTests, TestPass
+		FROM WPTRunFeatureMetrics
+		WHERE ExternalRunID = @externalRunID AND FeatureID = @featureID
+		LIMIT 1`)
+	parameters := map[string]interface{}{
+		"externalRunID": runID,
+		"featureID":     featureID,
+	}
+	stmt.Params = parameters
+	it := txn.Query(ctx, stmt)
+	defer it.Stop()
+
+	row, err := it.Next()
+	if err != nil {
+		if errors.Is(err, iterator.Done) {
+			return nil, errors.Join(ErrQueryReturnedNoResults, err)
+		}
+
+		return nil, errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	var metric WPTRunFeatureMetric
+	if err := row.ToStruct(&metric); err != nil {
+		return nil, errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	return &metric, nil
+}
+
+// WPTRunFeatureMetricWithTime contains metrics for a feature at a given time.
+type WPTRunFeatureMetricWithTime struct {
+	TimeStart  time.Time `spanner:"TimeStart"`
+	RunID      int64     `spanner:"ExternalRunID"`
+	TotalTests *int64    `spanner:"TotalTests"`
+	TestPass   *int64    `spanner:"TestPass"`
+}
+
+// ListMetricsForFeatureIDBrowserAndChannel attempts to return a page of
+// metrics based on a web feature id, browser name and channel. A time window
+// must be specified to analyze the runs according to the TimeStart of the run.
+// If the page size matches the pageSize, a page token is returned. Else,
+// no page token is returned.
+func (c *Client) ListMetricsForFeatureIDBrowserAndChannel(
+	ctx context.Context,
+	featureID string,
+	browser string,
+	channel string,
+	startAt time.Time,
+	endAt time.Time,
+	pageSize int,
+	pageToken *string,
+) ([]WPTRunFeatureMetricWithTime, *string, error) {
+	var stmt spanner.Statement
+	params := map[string]interface{}{
+		"featureID":   featureID,
+		"browserName": browser,
+		"channel":     channel,
+		"startAt":     startAt,
+		"endAt":       endAt,
+		"pageSize":    pageSize,
+	}
+
+	if pageToken == nil {
+		stmt = spanner.NewStatement(
+			`SELECT wpfm.ExternalRunID, r.TimeStart, wpfm.TotalTests, wpfm.TestPass
+				FROM WPTRuns r
+				JOIN WPTRunFeatureMetrics wpfm ON r.ExternalRunID = wpfm.ExternalRunID
+				WHERE wpfm.FeatureID = @featureID
+					AND r.BrowserName = @browserName
+					AND r.Channel = @channel
+		  			AND r.TimeStart >= @startAt AND r.TimeStart < @endAt
+				ORDER BY r.TimeStart DESC, r.ExternalRunID DESC LIMIT @pageSize`)
+	} else {
+		cursor, err := decodeWPTRunCursor(*pageToken)
+		if err != nil {
+			return nil, nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		stmt = spanner.NewStatement(
+			`SELECT wpfm.ExternalRunID, r.TimeStart, wpfm.TotalTests, wpfm.TestPass
+                FROM WPTRuns r
+                JOIN WPTRunFeatureMetrics wpfm ON r.ExternalRunID = wpfm.ExternalRunID
+                WHERE wpfm.FeatureID = @featureID
+					AND r.BrowserName = @browserName
+					AND r.Channel = @channel
+                   	AND r.TimeStart >= @startAt AND r.TimeStart < @endAt
+                   	AND (r.TimeStart < @lastTimestamp OR
+                    	r.TimeStart = @lastTimestamp AND r.ExternalRunID < @lastRunID)
+                ORDER BY r.TimeStart DESC, r.ExternalRunID DESC LIMIT @pageSize`)
+		params["lastTimestamp"] = cursor.LastTimeStart
+		params["lastRunID"] = cursor.LastRunID
+	}
+	stmt.Params = params
+
+	txn := c.Single()
+	defer txn.Close()
+	it := txn.Query(ctx, stmt)
+	defer it.Stop()
+
+	var featureMetrics []WPTRunFeatureMetricWithTime
+	for {
+		row, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var featureMetric WPTRunFeatureMetricWithTime
+		if err := row.ToStruct(&featureMetric); err != nil {
+			return nil, nil, err
+		}
+		featureMetrics = append(featureMetrics, featureMetric)
+	}
+
+	if len(featureMetrics) == pageSize {
+		lastFeatureMetric := featureMetrics[len(featureMetrics)-1]
+		newCursor := encodeWPTRunCursor(lastFeatureMetric.TimeStart, lastFeatureMetric.RunID)
+
+		return featureMetrics, &newCursor, nil
+	}
+
+	return featureMetrics, nil, nil
+}
+
+// WPTRunAggregationMetricWithTime contains metrics for a particular aggregation
+// at a given time. For now, it is the same metrics as
+// WPTRunFeatureMetricWithTime.
+type WPTRunAggregationMetricWithTime struct {
+	WPTRunFeatureMetricWithTime
+}
+
+// ListMetricsOverTimeWithAggregatedTotals attempts to return a page of
+// metrics based on browser name and channel. Users can provide a list of web
+// feature ids. If the list is provided, the aggregation will be scoped to those
+// feature ids. If an empty or nil list is provided, the aggregation is applied
+// to all features.
+// A time window must be specified to analyze the runs according to the
+// TimeStart of the run.
+// If the page size matches the pageSize, a page token is returned. Else,
+// no page token is returned.
+func (c *Client) ListMetricsOverTimeWithAggregatedTotals(
+	ctx context.Context,
+	featureIDs []string,
+	browser string,
+	channel string,
+	startAt, endAt time.Time,
+	pageSize int,
+	pageToken *string,
+) ([]WPTRunAggregationMetricWithTime, *string, error) {
+	params := map[string]interface{}{
+		"browserName": browser,
+		"channel":     channel,
+		"startAt":     startAt,
+		"endAt":       endAt,
+		"pageSize":    pageSize,
+	}
+
+	var stmt spanner.Statement
+	// nolint: nestif // TODO: fix in the future.
+	if pageToken == nil {
+		if len(featureIDs) == 0 {
+			stmt = noPageTokenAllFeatures(params)
+		} else {
+			stmt = noPageTokenFeatureSubset(params, featureIDs)
+		}
+	} else {
+		cursor, err := decodeWPTRunCursor(*pageToken)
+		if err != nil {
+			return nil, nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		if len(featureIDs) == 0 {
+			stmt = withPageTokenAllFeatures(params, *cursor)
+		} else {
+			stmt = withPageTokenFeatureSubset(params, featureIDs, *cursor)
+		}
+	}
+
+	txn := c.Single()
+	defer txn.Close()
+	it := txn.Query(ctx, stmt)
+	defer it.Stop()
+
+	var aggregationMetrics []WPTRunAggregationMetricWithTime
+	for {
+		row, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var aggregationMetric WPTRunAggregationMetricWithTime
+		if err := row.ToStruct(&aggregationMetric); err != nil {
+			return nil, nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		aggregationMetrics = append(aggregationMetrics, aggregationMetric)
+	}
+
+	if len(aggregationMetrics) == pageSize {
+		lastFeatureMetric := aggregationMetrics[len(aggregationMetrics)-1]
+		newCursor := encodeWPTRunCursor(lastFeatureMetric.TimeStart, lastFeatureMetric.RunID)
+
+		return aggregationMetrics, &newCursor, nil
+	}
+
+	return aggregationMetrics, nil, nil
+}
+
+// noPageTokenAllFeatures builds a spanner statement when a page token
+// is not provided and the aggregation applies to all features.
+func noPageTokenAllFeatures(params map[string]interface{}) spanner.Statement {
+	stmt := spanner.NewStatement(`
+		SELECT
+			r.ExternalRunID,
+			r.TimeStart,
+			SUM(wpfm.TotalTests) AS TotalTests,
+			SUM(wpfm.TestPass) AS TestPass
+		FROM WPTRuns r
+		JOIN WPTRunFeatureMetrics wpfm ON r.ExternalRunID = wpfm.ExternalRunID
+		WHERE r.BrowserName = @browserName
+		AND r.Channel = @channel
+		AND r.TimeStart >= @startAt AND r.TimeStart < @endAt
+		GROUP BY r.ExternalRunID, r.TimeStart
+		ORDER BY r.TimeStart DESC, r.ExternalRunID DESC LIMIT @pageSize`)
+	stmt.Params = params
+
+	return stmt
+}
+
+// noPageTokenFeatureSubset builds a spanner statement when a page token is
+// not provided and the aggregation applies to a particular list of features.
+func noPageTokenFeatureSubset(params map[string]interface{}, featureIDs []string) spanner.Statement {
+	stmt := spanner.NewStatement(`
+	SELECT
+		r.ExternalRunID,
+		r.TimeStart,
+		SUM(wpfm.TotalTests) AS TotalTests,
+		SUM(wpfm.TestPass) AS TestPass
+	FROM WPTRuns r
+	JOIN WPTRunFeatureMetrics wpfm ON r.ExternalRunID = wpfm.ExternalRunID
+	WHERE wpfm.FeatureID IN UNNEST(@featureIDs)
+	AND r.BrowserName = @browserName
+	AND r.Channel = @channel
+	AND r.TimeStart >= @startAt AND r.TimeStart < @endAt
+	GROUP BY r.ExternalRunID, r.TimeStart
+	ORDER BY r.TimeStart DESC, r.ExternalRunID DESC LIMIT @pageSize`)
+	params["featureIDs"] = featureIDs
+	stmt.Params = params
+
+	return stmt
+}
+
+// withPageTokenAllFeatures builds a spanner statement when a page token is
+// provided and the aggregation applies to all features.
+func withPageTokenAllFeatures(params map[string]interface{}, cursor WPTRunCursor) spanner.Statement {
+	stmt := spanner.NewStatement(`
+		SELECT
+			r.ExternalRunID,
+			r.TimeStart,
+			SUM(wpfm.TotalTests) AS TotalTests,
+			SUM(wpfm.TestPass) AS TestPass
+		FROM WPTRuns r
+		JOIN WPTRunFeatureMetrics wpfm ON r.ExternalRunID = wpfm.ExternalRunID
+		WHERE r.BrowserName = @browserName
+		AND r.Channel = @channel
+		AND r.TimeStart >= @startAt AND r.TimeStart < @endAt
+		AND (r.TimeStart < @lastTimestamp OR
+			 r.TimeStart = @lastTimestamp AND r.ExternalRunID < @lastRunID)
+		GROUP BY r.ExternalRunID, r.TimeStart
+		ORDER BY r.TimeStart DESC, r.ExternalRunID DESC LIMIT @pageSize`)
+	params["lastTimestamp"] = cursor.LastTimeStart
+	params["lastRunID"] = cursor.LastRunID
+	stmt.Params = params
+
+	return stmt
+}
+
+// withPageTokenFeatureSubset builds a spanner statement when a page token is
+// provided and the aggregation applies to a particular list of features.
+func withPageTokenFeatureSubset(
+	params map[string]interface{},
+	featureIDs []string,
+	cursor WPTRunCursor) spanner.Statement {
+	stmt := spanner.NewStatement(`
+		SELECT
+			r.ExternalRunID,
+			r.TimeStart,
+			SUM(wpfm.TotalTests) AS TotalTests,
+			SUM(wpfm.TestPass) AS TestPass
+		FROM WPTRuns r
+		JOIN WPTRunFeatureMetrics wpfm ON r.ExternalRunID = wpfm.ExternalRunID
+		WHERE wpfm.FeatureID IN UNNEST(@featureIDs)
+		AND r.BrowserName = @browserName
+		AND r.Channel = @channel
+		AND r.TimeStart >= @startAt AND r.TimeStart < @endAt
+		AND (r.TimeStart < @lastTimestamp OR
+			 r.TimeStart = @lastTimestamp AND r.ExternalRunID < @lastRunID)
+		GROUP BY r.ExternalRunID, r.TimeStart
+		ORDER BY r.TimeStart DESC, r.ExternalRunID DESC LIMIT @pageSize`)
+	params["featureIDs"] = featureIDs
+	params["lastTimestamp"] = cursor.LastTimeStart
+	params["lastRunID"] = cursor.LastRunID
+	stmt.Params = params
+
+	return stmt
+}

--- a/lib/gcpspanner/wpt_run_feature_metric_test.go
+++ b/lib/gcpspanner/wpt_run_feature_metric_test.go
@@ -1,0 +1,651 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"google.golang.org/grpc/codes"
+)
+
+func valuePtr[T any](in T) *T {
+	return &in
+}
+
+func getSampleRunMetrics() []WPTRunFeatureMetric {
+	return []WPTRunFeatureMetric{
+		// Run 0 metrics
+		{
+			RunID:      0,
+			FeatureID:  "fooFeature",
+			TotalTests: valuePtr[int64](20),
+			TestPass:   valuePtr[int64](10),
+		},
+		{
+			RunID:      0,
+			FeatureID:  "barFeature",
+			TotalTests: valuePtr[int64](5),
+			TestPass:   valuePtr[int64](0),
+		},
+		{
+			RunID:      0,
+			FeatureID:  "bazFeature",
+			TotalTests: valuePtr[int64](50),
+			TestPass:   valuePtr[int64](5),
+		},
+		// Run 1 metrics
+		{
+			RunID:      1,
+			FeatureID:  "fooFeature",
+			TotalTests: valuePtr[int64](20),
+			TestPass:   valuePtr[int64](20),
+		},
+		// Run 2 metrics
+		{
+			RunID:      2,
+			FeatureID:  "fooFeature",
+			TotalTests: valuePtr[int64](20),
+			TestPass:   valuePtr[int64](10),
+		},
+		// Run 3 metrics
+		{
+			RunID:      3,
+			FeatureID:  "fooFeature",
+			TotalTests: valuePtr[int64](20),
+			TestPass:   valuePtr[int64](10),
+		},
+		// Run 6 metrics
+		{
+			RunID:      6,
+			FeatureID:  "fooFeature",
+			TotalTests: valuePtr[int64](20),
+			TestPass:   valuePtr[int64](20),
+		},
+		{
+			RunID:      6,
+			FeatureID:  "barFeature",
+			TotalTests: valuePtr[int64](10),
+			TestPass:   valuePtr[int64](0),
+		},
+		{
+			RunID:      6,
+			FeatureID:  "bazFeature",
+			TotalTests: valuePtr[int64](50),
+			TestPass:   valuePtr[int64](35),
+		},
+		// Run 7 metrics
+		{
+			RunID:      7,
+			FeatureID:  "fooFeature",
+			TotalTests: valuePtr[int64](20),
+			TestPass:   valuePtr[int64](20),
+		},
+		{
+			RunID:      7,
+			FeatureID:  "barFeature",
+			TotalTests: valuePtr[int64](10),
+			TestPass:   valuePtr[int64](10),
+		},
+		// Run 8 metrics
+		{
+			RunID:      8,
+			FeatureID:  "fooFeature",
+			TotalTests: valuePtr[int64](20),
+			TestPass:   valuePtr[int64](20),
+		},
+		{
+			RunID:      8,
+			FeatureID:  "barFeature",
+			TotalTests: valuePtr[int64](10),
+			TestPass:   valuePtr[int64](10),
+		},
+		// Run 9 metrics
+		{
+			RunID:      9,
+			FeatureID:  "fooFeature",
+			TotalTests: valuePtr[int64](20),
+			TestPass:   valuePtr[int64](20),
+		},
+		{
+			RunID:      9,
+			FeatureID:  "barFeature",
+			TotalTests: valuePtr[int64](10),
+			TestPass:   valuePtr[int64](10),
+		},
+	}
+}
+
+func TestUpsertWPTRunFeatureMetric(t *testing.T) {
+	client, migrationHandler := getTestDatabase(t)
+	migrationHandler.ApplyAll(t)
+	ctx := context.Background()
+
+	sampleRunMetrics := getSampleRunMetrics()
+
+	// Should fail without the runs being uploaded first
+	for _, metric := range sampleRunMetrics {
+		err := client.UpsertWPTRunFeatureMetric(ctx, metric)
+		if spanner.ErrCode(err) != codes.NotFound {
+			t.Errorf("expected not found error upon insert. received %s", err.Error())
+		}
+	}
+
+	// Now, let's insert the runs.
+	for _, run := range getSampleRuns() {
+		err := client.InsertWPTRun(ctx, run)
+		if !errors.Is(err, nil) {
+			t.Errorf("expected no error upon insert. received %s", err.Error())
+		}
+	}
+
+	// Now, let's insert the metrics
+	for _, metric := range sampleRunMetrics {
+		err := client.UpsertWPTRunFeatureMetric(ctx, metric)
+		if !errors.Is(err, nil) {
+			t.Errorf("expected no error upon insert. received %s", err.Error())
+		}
+	}
+
+	metric, err := client.GetMetricByRunIDAndFeatureID(ctx, 0, "fooFeature")
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error when reading the metric. received %s", err.Error())
+	}
+
+	if metric == nil {
+		t.Fatal("expected non null metric")
+	}
+
+	if !reflect.DeepEqual(sampleRunMetrics[0], *metric) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", sampleRunMetrics[0], *metric)
+	}
+
+	// Test 1. Upsert a metric where the run only has one metric.
+	// Upsert the metric
+	updatedMetric1 := WPTRunFeatureMetric{
+		RunID:      0,
+		FeatureID:  "fooFeature",
+		TotalTests: valuePtr[int64](300), // Change this value
+		TestPass:   valuePtr[int64](100), // Change this value
+	}
+
+	err = client.UpsertWPTRunFeatureMetric(ctx, updatedMetric1)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error upon insert. received %s", err.Error())
+	}
+
+	// Try to get the metric again and compare with the updated metric.
+	metric, err = client.GetMetricByRunIDAndFeatureID(ctx, 0, "fooFeature")
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error when reading the metric. received %s", err.Error())
+	}
+
+	if metric == nil {
+		t.Fatal("expected non null metric")
+	}
+
+	if !reflect.DeepEqual(updatedMetric1, *metric) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", updatedMetric1, *metric)
+	}
+
+	// Test 2. Upsert a metric where the run has multiple metrics.
+	updatedMetric2 := WPTRunFeatureMetric{
+		RunID:      9,
+		FeatureID:  "barFeature",
+		TotalTests: valuePtr[int64](300), // Change this value
+		TestPass:   valuePtr[int64](100), // Change this value
+	}
+	// Upsert the metric
+	err = client.UpsertWPTRunFeatureMetric(ctx, updatedMetric2)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error upon insert. received %s", err.Error())
+	}
+
+	// Try to get the metric again and compare with the updated metric.
+	metric, err = client.GetMetricByRunIDAndFeatureID(ctx, 9, "barFeature")
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error when reading the metric. received %s", err.Error())
+	}
+
+	if metric == nil {
+		t.Fatal("expected non null metric")
+	}
+
+	if !reflect.DeepEqual(updatedMetric2, *metric) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", updatedMetric2, *metric)
+	}
+
+	// Get the other metric for that run which should be unaffected
+	metric, err = client.GetMetricByRunIDAndFeatureID(ctx, 9, "fooFeature")
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error when reading the metric. received %s", err.Error())
+	}
+
+	if metric == nil {
+		t.Fatal("expected non null metric")
+	}
+
+	otherMetric := WPTRunFeatureMetric{
+		RunID:      9,
+		FeatureID:  "fooFeature",
+		TotalTests: valuePtr[int64](20),
+		TestPass:   valuePtr[int64](20),
+	}
+	if !reflect.DeepEqual(otherMetric, *metric) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", otherMetric, *metric)
+	}
+}
+
+func TestListMetricsForFeatureIDBrowserAndChannel(t *testing.T) {
+	client, migrationHandler := getTestDatabase(t)
+	migrationHandler.ApplyAll(t)
+	ctx := context.Background()
+	// Load up runs and metrics
+	// Now, let's insert the runs.
+	for _, run := range getSampleRuns() {
+		err := client.InsertWPTRun(ctx, run)
+		if !errors.Is(err, nil) {
+			t.Errorf("expected no error upon insert. received %s", err.Error())
+		}
+	}
+
+	// Now, let's insert the metrics
+	for _, metric := range getSampleRunMetrics() {
+		err := client.UpsertWPTRunFeatureMetric(ctx, metric)
+		if !errors.Is(err, nil) {
+			t.Errorf("expected no error upon insert. received %s", err.Error())
+		}
+	}
+
+	// Test 1. Get all the metrics. Should only be 2 for the browser, channel,
+	// feature combination.
+	metrics, token, err := client.ListMetricsForFeatureIDBrowserAndChannel(
+		ctx,
+		"fooFeature",
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		10,
+		nil,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error during listing of metrics. received %s", err.Error())
+	}
+	if token != nil {
+		t.Error("expected null token")
+	}
+	expectedMetrics := []WPTRunFeatureMetricWithTime{
+		{
+			TimeStart:  time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			RunID:      6,
+			TotalTests: valuePtr[int64](20),
+			TestPass:   valuePtr[int64](20),
+		},
+		{
+			TimeStart:  time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			RunID:      0,
+			TotalTests: valuePtr[int64](20),
+			TestPass:   valuePtr[int64](10),
+		},
+	}
+	if !reflect.DeepEqual(expectedMetrics, metrics) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetrics, metrics)
+	}
+
+	// Test 2. Try pagination. Only return 1 per page.
+	// Get page 1
+	metrics, token, err = client.ListMetricsForFeatureIDBrowserAndChannel(
+		ctx,
+		"fooFeature",
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		1,
+		nil,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error during listing of metrics. received %s", err.Error())
+	}
+	if token == nil {
+		t.Error("expected token")
+	}
+	expectedMetricsPageOne := []WPTRunFeatureMetricWithTime{
+		expectedMetrics[0],
+	}
+	if !reflect.DeepEqual(expectedMetricsPageOne, metrics) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetricsPageOne, metrics)
+	}
+	// Get page 2.
+	metrics, token, err = client.ListMetricsForFeatureIDBrowserAndChannel(
+		ctx,
+		"fooFeature",
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		1,
+		token,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error during listing of metrics. received %s", err.Error())
+	}
+	if token == nil {
+		t.Error("expected token")
+	}
+	expectedMetricsPageTwo := []WPTRunFeatureMetricWithTime{
+		expectedMetrics[1],
+	}
+	if !reflect.DeepEqual(expectedMetricsPageTwo, metrics) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetricsPageTwo, metrics)
+	}
+	// Get page 3
+	metrics, token, err = client.ListMetricsForFeatureIDBrowserAndChannel(
+		ctx,
+		"fooFeature",
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		1,
+		token,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error during listing of metrics. received %s", err.Error())
+	}
+	if token != nil {
+		t.Error("expected no token")
+	}
+	var expectedMetricsPageThree []WPTRunFeatureMetricWithTime
+	if !reflect.DeepEqual(expectedMetricsPageThree, metrics) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetricsPageThree, metrics)
+	}
+}
+
+func TestListMetricsOverTimeWithAggregatedTotals(t *testing.T) {
+	client, migrationHandler := getTestDatabase(t)
+	migrationHandler.ApplyAll(t)
+	ctx := context.Background()
+	// Load up runs and metrics
+	// Now, let's insert the runs.
+	for _, run := range getSampleRuns() {
+		err := client.InsertWPTRun(ctx, run)
+		if !errors.Is(err, nil) {
+			t.Errorf("expected no error upon insert. received %s", err.Error())
+		}
+	}
+
+	// Now, let's insert the metrics
+	for _, metric := range getSampleRunMetrics() {
+		err := client.UpsertWPTRunFeatureMetric(ctx, metric)
+		if !errors.Is(err, nil) {
+			t.Errorf("expected no error upon insert. received %s", err.Error())
+		}
+	}
+
+	// Test 1. Get aggregation metrics for all features.
+	metrics, token, err := client.ListMetricsOverTimeWithAggregatedTotals(
+		ctx,
+		nil,
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		10,
+		nil,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error during listing of metrics. received %s", err.Error())
+	}
+	if token != nil {
+		t.Error("expected null token")
+	}
+	expectedMetrics := []WPTRunAggregationMetricWithTime{
+		{
+			WPTRunFeatureMetricWithTime: WPTRunFeatureMetricWithTime{
+				TimeStart:  time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+				RunID:      6,
+				TotalTests: valuePtr[int64](80),
+				TestPass:   valuePtr[int64](55),
+			},
+		},
+		{
+			WPTRunFeatureMetricWithTime: WPTRunFeatureMetricWithTime{
+				TimeStart:  time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				RunID:      0,
+				TotalTests: valuePtr[int64](75),
+				TestPass:   valuePtr[int64](15),
+			},
+		},
+	}
+	if !reflect.DeepEqual(expectedMetrics, metrics) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetrics, metrics)
+	}
+
+	// Test 2. Get aggregation metrics for all features with pagination.
+	// Get page 1.
+	metrics, token, err = client.ListMetricsOverTimeWithAggregatedTotals(
+		ctx,
+		nil,
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		1,
+		nil,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error during listing of metrics. received %s", err.Error())
+	}
+	if token == nil {
+		t.Error("expected token")
+	}
+	expectedMetricsPageOne := []WPTRunAggregationMetricWithTime{
+		{
+			WPTRunFeatureMetricWithTime: WPTRunFeatureMetricWithTime{
+				TimeStart:  time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+				RunID:      6,
+				TotalTests: valuePtr[int64](80),
+				TestPass:   valuePtr[int64](55),
+			},
+		},
+	}
+	if !reflect.DeepEqual(expectedMetricsPageOne, metrics) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetricsPageOne, metrics)
+	}
+
+	// Get page 2.
+	metrics, token, err = client.ListMetricsOverTimeWithAggregatedTotals(
+		ctx,
+		nil,
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		1,
+		token,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error during listing of metrics. received %s", err.Error())
+	}
+	if token == nil {
+		t.Error("expected token")
+	}
+	expectedMetricsPageTwo := []WPTRunAggregationMetricWithTime{
+		{
+			WPTRunFeatureMetricWithTime: WPTRunFeatureMetricWithTime{
+				TimeStart:  time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				RunID:      0,
+				TotalTests: valuePtr[int64](75),
+				TestPass:   valuePtr[int64](15),
+			},
+		},
+	}
+	if !reflect.DeepEqual(expectedMetricsPageTwo, metrics) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetricsPageTwo, metrics)
+	}
+
+	// Get page 3.
+	metrics, token, err = client.ListMetricsOverTimeWithAggregatedTotals(
+		ctx,
+		nil,
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		1,
+		token,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error during listing of metrics. received %s", err.Error())
+	}
+	if token != nil {
+		t.Error("expected no token")
+	}
+	var expectedMetricsPageThree []WPTRunAggregationMetricWithTime
+	if !reflect.DeepEqual(expectedMetricsPageThree, metrics) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetricsPageThree, metrics)
+	}
+
+	// Test 3. Get aggregation metrics for subset of features.
+	metrics, token, err = client.ListMetricsOverTimeWithAggregatedTotals(
+		ctx,
+		[]string{"barFeature", "bazFeature"},
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		10,
+		nil,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error during listing of metrics. received %s", err.Error())
+	}
+	if token != nil {
+		t.Error("expected null token")
+	}
+	expectedMetrics = []WPTRunAggregationMetricWithTime{
+		{
+			WPTRunFeatureMetricWithTime: WPTRunFeatureMetricWithTime{
+				TimeStart:  time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+				RunID:      6,
+				TotalTests: valuePtr[int64](60),
+				TestPass:   valuePtr[int64](35),
+			},
+		},
+		{
+			WPTRunFeatureMetricWithTime: WPTRunFeatureMetricWithTime{
+				TimeStart:  time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				RunID:      0,
+				TotalTests: valuePtr[int64](55),
+				TestPass:   valuePtr[int64](5),
+			},
+		},
+	}
+	if !reflect.DeepEqual(expectedMetrics, metrics) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetrics, metrics)
+	}
+
+	// Test 4. Get aggregation metrics for subset of features with pagination.
+	// Get page 1.
+	metrics, token, err = client.ListMetricsOverTimeWithAggregatedTotals(
+		ctx,
+		[]string{"barFeature", "bazFeature"},
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		1,
+		nil,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error during listing of metrics. received %s", err.Error())
+	}
+	if token == nil {
+		t.Error("expected token")
+	}
+	expectedMetricsPageOne = []WPTRunAggregationMetricWithTime{
+		{
+			WPTRunFeatureMetricWithTime: WPTRunFeatureMetricWithTime{
+				TimeStart:  time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+				RunID:      6,
+				TotalTests: valuePtr[int64](60),
+				TestPass:   valuePtr[int64](35),
+			},
+		},
+	}
+	if !reflect.DeepEqual(expectedMetricsPageOne, metrics) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetricsPageOne, metrics)
+	}
+
+	// Get page 2.
+	metrics, token, err = client.ListMetricsOverTimeWithAggregatedTotals(
+		ctx,
+		[]string{"barFeature", "bazFeature"},
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		1,
+		token,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error during listing of metrics. received %s", err.Error())
+	}
+	if token == nil {
+		t.Error("expected token")
+	}
+	expectedMetricsPageTwo = []WPTRunAggregationMetricWithTime{
+		{
+			WPTRunFeatureMetricWithTime: WPTRunFeatureMetricWithTime{
+				TimeStart:  time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				RunID:      0,
+				TotalTests: valuePtr[int64](55),
+				TestPass:   valuePtr[int64](5),
+			},
+		},
+	}
+	if !reflect.DeepEqual(expectedMetricsPageTwo, metrics) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetricsPageTwo, metrics)
+	}
+
+	// Get page 3.
+	metrics, token, err = client.ListMetricsOverTimeWithAggregatedTotals(
+		ctx,
+		[]string{"barFeature", "bazFeature"},
+		"fooBrowser",
+		shared.StableLabel,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		1,
+		token,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error during listing of metrics. received %s", err.Error())
+	}
+	if token != nil {
+		t.Error("expected no token")
+	}
+
+	if !reflect.DeepEqual(expectedMetricsPageThree, metrics) {
+		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetricsPageThree, metrics)
+	}
+}


### PR DESCRIPTION
This is splitting #40 to only include the WPTRuns table.

Why this change?
- This table in combination with the WPTRuns table will allow for analysis for metrics over time.

Methods to help with the various page designs:

ListMetricsForFeatureIDBrowserAndChannel
- Useful for getting metrics over time for a feature. Page: `Feature Detail`

ListMetricsOverTimeWithAggregatedTotals
- Useful for getting metrics over time for a subset of features or all features. Page: `Stats Page`
- If a subset of features is not provided, it will do the default mode of the "Global feature support" graph on the stats page.

The tests for those methods show how those will work too.

Other methods:

UpsertWPTRunFeatureMetric
- insert or updates an existing metric based on the run id and feature id. On updates, it only changes the test counts.

