### PR TITLE
Fix the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,9 @@
       "version": "20.11.0"
     },
     "ghcr.io/devcontainers/features/terraform:1": {
-      "version": "1.7.3"
+      "version": "1.7.3",
+      "terragrunt": "0.55.7",
+      "tflint": "0.50.3"
     },
     "ghcr.io/lukewiwa/features/shellcheck:0": {
       "version": "v0.9.0"


### PR DESCRIPTION
Currently, it is failing during the installation of terragrunt.

Background:

By default the terraform [feature](https://github.com/devcontainers/features/tree/main/src/terraform) installs the latest version of terragrunt and tflint. (terraform itself is currently pinned). Terragrunt just updated an hour ago, which relates to when the build started to fail. That is why more recent builds fail.

This change  pins tflint and terragrunt just like terraform.

