### PR TITLE
Make baseline icons fit inside chips.

### DIFF
--- a/frontend/src/static/js/components/webstatus-overview-table.ts
+++ b/frontend/src/static/js/components/webstatus-overview-table.ts
@@ -102,7 +102,7 @@ export class WebstatusOverviewTable extends LitElement {
     const chipConfig = BASELINE_CHIP_CONFIGS[baselineStatus];
     return html`
       <span class="chip ${chipConfig.cssClass}">
-        <img height="24" src="/public/img/${chipConfig.icon}" />
+        <img height="16" src="/public/img/${chipConfig.icon}" />
         ${chipConfig.word}
       </span>
     `;


### PR DESCRIPTION
I had copied and pasted the `<img>` element from the initial version of this page without thinking about how the icons fit inside the baseline status chips.  Peter's mocks show a smaller icon that is about the same height as the text.  So, this makes it smaller.