### PR TITLE
Implementations for listAggregatedWPTMetrics & listFeatureWPTMetrics

### DIFF
--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics.go
@@ -1,0 +1,57 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// ListAggregatedWPTMetrics implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Name generated from openapi
+func (s *Server) ListAggregatedWPTMetrics(
+	ctx context.Context,
+	request backend.ListAggregatedWPTMetricsRequestObject,
+) (backend.ListAggregatedWPTMetricsResponseObject, error) {
+	slog.Info("parameters", "feature", getFeatureIDsOrDefault(request.Params.FeatureIds))
+
+	metrics, nextPageToken, err := s.wptMetricsStorer.ListMetricsOverTimeWithAggregatedTotals(
+		ctx,
+		getFeatureIDsOrDefault(request.Params.FeatureIds),
+		string(request.Browser),
+		string(request.Channel),
+		request.Params.StartAt.Time,
+		request.Params.EndAt.Time,
+		getPageSizeOrDefault(request.Params.PageSize),
+		request.Params.PageToken,
+	)
+	if err != nil {
+		slog.Error("unable to get aggregated metrics", "error", err)
+
+		return backend.ListAggregatedWPTMetrics500JSONResponse{
+			Code:    500,
+			Message: "unable to get aggregated metrics",
+		}, nil
+	}
+
+	return backend.ListAggregatedWPTMetrics200JSONResponse{
+		Data: metrics,
+		Metadata: &backend.PageMetadata{
+			NextPageToken: nextPageToken,
+		},
+	}, nil
+}

--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
@@ -1,0 +1,191 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+func TestListAggregatedWPTMetrics(t *testing.T) {
+	testCases := []struct {
+		name              string
+		mockConfig        MockListMetricsOverTimeWithAggregatedTotalsConfig
+		expectedCallCount int // For the mock method
+		request           backend.ListAggregatedWPTMetricsRequestObject
+		expectedResponse  backend.ListAggregatedWPTMetricsResponseObject
+		expectedError     error
+	}{
+		{
+			name: "Success Case - no optional params - use defaults",
+			mockConfig: MockListMetricsOverTimeWithAggregatedTotalsConfig{
+				expectedFeatureIDs: []string{},
+				expectedBrowser:    "chrome",
+				expectedChannel:    "experimental",
+				expectedStartAt:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:      time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:   100,
+				expectedPageToken:  nil,
+				pageToken:          nil,
+				err:                nil,
+				data: []backend.WPTRunMetric{
+					{
+						RunTimestamp:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						TestPassCount:   valuePtr[int64](2),
+						TotalTestsCount: valuePtr[int64](2),
+					},
+				},
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListAggregatedWPTMetrics200JSONResponse{
+				Data: []backend.WPTRunMetric{
+					{
+						RunTimestamp:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						TestPassCount:   valuePtr[int64](2),
+						TotalTestsCount: valuePtr[int64](2),
+					},
+				},
+				Metadata: &backend.PageMetadata{
+					NextPageToken: nil,
+				},
+			},
+			request: backend.ListAggregatedWPTMetricsRequestObject{
+				Params: backend.ListAggregatedWPTMetricsParams{
+					StartAt:    openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:      openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					PageToken:  nil,
+					PageSize:   nil,
+					FeatureIds: nil,
+				},
+				Browser: backend.Chrome,
+				Channel: backend.Experimental,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success Case - include optional params",
+			mockConfig: MockListMetricsOverTimeWithAggregatedTotalsConfig{
+				expectedFeatureIDs: []string{"feature1", "feature2"},
+				expectedBrowser:    "chrome",
+				expectedChannel:    "experimental",
+				expectedStartAt:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:      time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:   50,
+				expectedPageToken:  inputPageToken,
+				err:                nil,
+				data: []backend.WPTRunMetric{
+					{
+						RunTimestamp:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						TestPassCount:   valuePtr[int64](2),
+						TotalTestsCount: valuePtr[int64](2),
+					},
+				},
+				pageToken: nextPageToken,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListAggregatedWPTMetrics200JSONResponse{
+				Data: []backend.WPTRunMetric{
+					{
+						RunTimestamp:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						TestPassCount:   valuePtr[int64](2),
+						TotalTestsCount: valuePtr[int64](2),
+					},
+				},
+				Metadata: &backend.PageMetadata{
+					NextPageToken: nextPageToken,
+				},
+			},
+			request: backend.ListAggregatedWPTMetricsRequestObject{
+				Params: backend.ListAggregatedWPTMetricsParams{
+					StartAt:    openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:      openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					PageToken:  inputPageToken,
+					FeatureIds: valuePtr[[]string]([]string{"feature1", "feature2"}),
+					PageSize:   valuePtr[int](50),
+				},
+				Browser: backend.Chrome,
+				Channel: backend.Experimental,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "500 case",
+			mockConfig: MockListMetricsOverTimeWithAggregatedTotalsConfig{
+				expectedFeatureIDs: []string{},
+				expectedBrowser:    "chrome",
+				expectedChannel:    "experimental",
+				expectedStartAt:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:      time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:   100,
+				expectedPageToken:  nil,
+				data:               nil,
+				pageToken:          nil,
+				err:                errTest,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListAggregatedWPTMetrics500JSONResponse{
+				Code:    500,
+				Message: "unable to get aggregated metrics",
+			},
+			request: backend.ListAggregatedWPTMetricsRequestObject{
+				Params: backend.ListAggregatedWPTMetricsParams{
+					StartAt:    openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:      openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					FeatureIds: nil,
+					PageToken:  nil,
+					PageSize:   nil,
+				},
+				Browser: backend.Chrome,
+				Channel: backend.Experimental,
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// nolint: exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				aggregateCfg: tc.mockConfig,
+				t:            t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
+
+			// Call the function under test
+			resp, err := myServer.ListAggregatedWPTMetrics(context.Background(), tc.request)
+
+			// Assertions
+			if mockStorer.callCountListMetricsOverTimeWithAggregatedTotals != tc.expectedCallCount {
+				t.Errorf("Incorrect call count: expected %d, got %d",
+					tc.expectedCallCount,
+					mockStorer.callCountListMetricsOverTimeWithAggregatedTotals)
+			}
+
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tc.expectedResponse, resp) {
+				t.Errorf("Unexpected response: %v", resp)
+			}
+		})
+	}
+}

--- a/backend/pkg/httpserver/list_feature_wpt_metrics.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// ListFeatureWPTMetrics implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Name generated from openapi
+func (s *Server) ListFeatureWPTMetrics(
+	ctx context.Context,
+	request backend.ListFeatureWPTMetricsRequestObject,
+) (backend.ListFeatureWPTMetricsResponseObject, error) {
+	// TODO. Check if the feature exists and return a 404 if it does not.
+	metrics, nextPageToken, err := s.wptMetricsStorer.ListMetricsForFeatureIDBrowserAndChannel(
+		ctx,
+		request.FeatureId,
+		string(request.Browser),
+		string(request.Channel),
+		request.Params.StartAt.Time,
+		request.Params.EndAt.Time,
+		getPageSizeOrDefault(request.Params.PageSize),
+		request.Params.PageToken,
+	)
+	if err != nil {
+		slog.Error("unable to get feature metrics", "error", err)
+
+		return backend.ListFeatureWPTMetrics500JSONResponse{
+			Code:    500,
+			Message: "unable to get feature metrics",
+		}, nil
+	}
+
+	return backend.ListFeatureWPTMetrics200JSONResponse{
+		Data: metrics,
+		Metadata: &backend.PageMetadata{
+			NextPageToken: nextPageToken,
+		},
+	}, nil
+}

--- a/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
@@ -1,0 +1,193 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+func TestListFeatureWPTMetrics(t *testing.T) {
+	testCases := []struct {
+		name              string
+		mockConfig        MockListMetricsForFeatureIDBrowserAndChannelConfig
+		expectedCallCount int // For the mock method
+		request           backend.ListFeatureWPTMetricsRequestObject
+		expectedResponse  backend.ListFeatureWPTMetricsResponseObject
+		expectedError     error
+	}{
+		{
+			name: "Success Case - no optional params - use defaults",
+			mockConfig: MockListMetricsForFeatureIDBrowserAndChannelConfig{
+				expectedFeatureID: "fooFeature",
+				expectedBrowser:   "chrome",
+				expectedChannel:   "experimental",
+				expectedStartAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:     time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				pageToken:         nil,
+				err:               nil,
+
+				data: []backend.WPTRunMetric{
+					{
+						RunTimestamp:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						TestPassCount:   valuePtr[int64](2),
+						TotalTestsCount: valuePtr[int64](2),
+					},
+				},
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListFeatureWPTMetrics200JSONResponse{
+				Data: []backend.WPTRunMetric{
+					{
+						RunTimestamp:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						TestPassCount:   valuePtr[int64](2),
+						TotalTestsCount: valuePtr[int64](2),
+					},
+				},
+				Metadata: &backend.PageMetadata{
+					NextPageToken: nil,
+				},
+			},
+			request: backend.ListFeatureWPTMetricsRequestObject{
+				Params: backend.ListFeatureWPTMetricsParams{
+					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					PageToken: nil,
+					PageSize:  nil,
+				},
+				Browser:   backend.Chrome,
+				Channel:   backend.Experimental,
+				FeatureId: "fooFeature",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success Case - include optional params",
+			mockConfig: MockListMetricsForFeatureIDBrowserAndChannelConfig{
+				expectedFeatureID: "fooFeature",
+				expectedBrowser:   "chrome",
+				expectedChannel:   "experimental",
+				expectedStartAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:     time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:  50,
+				expectedPageToken: inputPageToken,
+				err:               nil,
+
+				data: []backend.WPTRunMetric{
+					{
+						RunTimestamp:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						TestPassCount:   valuePtr[int64](2),
+						TotalTestsCount: valuePtr[int64](2),
+					},
+				},
+				pageToken: nextPageToken,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListFeatureWPTMetrics200JSONResponse{
+				Data: []backend.WPTRunMetric{
+					{
+						RunTimestamp:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						TestPassCount:   valuePtr[int64](2),
+						TotalTestsCount: valuePtr[int64](2),
+					},
+				},
+				Metadata: &backend.PageMetadata{
+					NextPageToken: nextPageToken,
+				},
+			},
+			request: backend.ListFeatureWPTMetricsRequestObject{
+				Params: backend.ListFeatureWPTMetricsParams{
+					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					PageToken: inputPageToken,
+					PageSize:  valuePtr[int](50),
+				},
+				Browser:   backend.Chrome,
+				Channel:   backend.Experimental,
+				FeatureId: "fooFeature",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "500 case",
+			mockConfig: MockListMetricsForFeatureIDBrowserAndChannelConfig{
+				expectedFeatureID: "fooFeature",
+				expectedBrowser:   "chrome",
+				expectedChannel:   "experimental",
+				expectedPageToken: nil,
+				data:              nil,
+				pageToken:         nil,
+				expectedStartAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:     time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:  100,
+				err:               errTest,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListFeatureWPTMetrics500JSONResponse{
+				Code:    500,
+				Message: "unable to get feature metrics",
+			},
+			request: backend.ListFeatureWPTMetricsRequestObject{
+				Params: backend.ListFeatureWPTMetricsParams{
+					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					PageToken: nil,
+					PageSize:  nil,
+				},
+				Browser:   backend.Chrome,
+				Channel:   backend.Experimental,
+				FeatureId: "fooFeature",
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// nolint: exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				featureCfg: tc.mockConfig,
+				t:          t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
+
+			// Call the function under test
+			resp, err := myServer.ListFeatureWPTMetrics(context.Background(), tc.request)
+
+			// Assertions
+			if mockStorer.callCountListMetricsForFeatureIDBrowserAndChannel != tc.expectedCallCount {
+				t.Errorf("Incorrect call count: expected %d, got %d",
+					tc.expectedCallCount,
+					mockStorer.callCountListMetricsOverTimeWithAggregatedTotals)
+			}
+
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tc.expectedResponse, resp) {
+				t.Errorf("Unexpected response: %v", resp)
+			}
+		})
+	}
+}

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -1,0 +1,137 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func valuePtr[T any](in T) *T { return &in }
+
+type MockListMetricsForFeatureIDBrowserAndChannelConfig struct {
+	expectedFeatureID string
+	expectedBrowser   string
+	expectedChannel   string
+	expectedStartAt   time.Time
+	expectedEndAt     time.Time
+	expectedPageSize  int
+	expectedPageToken *string
+	data              []backend.WPTRunMetric
+	pageToken         *string
+	err               error
+}
+
+type MockListMetricsOverTimeWithAggregatedTotalsConfig struct {
+	expectedFeatureIDs []string
+	expectedBrowser    string
+	expectedChannel    string
+	expectedStartAt    time.Time
+	expectedEndAt      time.Time
+	expectedPageSize   int
+	expectedPageToken  *string
+	data               []backend.WPTRunMetric
+	pageToken          *string
+	err                error
+}
+
+type MockWPTMetricsStorer struct {
+	featureCfg                                        MockListMetricsForFeatureIDBrowserAndChannelConfig
+	aggregateCfg                                      MockListMetricsOverTimeWithAggregatedTotalsConfig
+	t                                                 *testing.T
+	callCountListMetricsForFeatureIDBrowserAndChannel int
+	callCountListMetricsOverTimeWithAggregatedTotals  int
+}
+
+func (m *MockWPTMetricsStorer) ListMetricsForFeatureIDBrowserAndChannel(_ context.Context,
+	featureID string, browser string, channel string,
+	startAt time.Time, endAt time.Time,
+	pageSize int, pageToken *string) ([]backend.WPTRunMetric, *string, error) {
+	m.callCountListMetricsForFeatureIDBrowserAndChannel++
+
+	if featureID != m.featureCfg.expectedFeatureID ||
+		browser != m.featureCfg.expectedBrowser ||
+		channel != m.featureCfg.expectedChannel ||
+		!startAt.Equal(m.featureCfg.expectedStartAt) ||
+		!endAt.Equal(m.featureCfg.expectedEndAt) ||
+		pageSize != m.featureCfg.expectedPageSize ||
+		pageToken != m.featureCfg.expectedPageToken {
+
+		m.t.Errorf("Incorrect arguments. Expected: %v, Got: { %s, %s, %s, %s, %s, %d %v }",
+			m.featureCfg, featureID, browser, channel, startAt, endAt, pageSize, pageToken)
+	}
+
+	return m.featureCfg.data, m.featureCfg.pageToken, m.featureCfg.err
+}
+
+func (m *MockWPTMetricsStorer) ListMetricsOverTimeWithAggregatedTotals(
+	_ context.Context,
+	featureIDs []string,
+	browser string,
+	channel string,
+	startAt, endAt time.Time,
+	pageSize int,
+	pageToken *string,
+) ([]backend.WPTRunMetric, *string, error) {
+	m.callCountListMetricsOverTimeWithAggregatedTotals++
+
+	if !slices.Equal(featureIDs, m.aggregateCfg.expectedFeatureIDs) ||
+		browser != m.aggregateCfg.expectedBrowser ||
+		channel != m.aggregateCfg.expectedChannel ||
+		!startAt.Equal(m.aggregateCfg.expectedStartAt) ||
+		!endAt.Equal(m.aggregateCfg.expectedEndAt) ||
+		pageSize != m.aggregateCfg.expectedPageSize ||
+		pageToken != m.aggregateCfg.expectedPageToken {
+
+		m.t.Errorf("Incorrect arguments. Expected: %v, Got: { %v, %s, %s, %s, %s, %d %v }",
+			m.aggregateCfg, featureIDs, browser, channel, startAt, endAt, pageSize, pageToken)
+	}
+
+	return m.aggregateCfg.data, m.aggregateCfg.pageToken, m.aggregateCfg.err
+}
+
+func TestGetPageSizeOrDefault(t *testing.T) {
+	testCases := []struct {
+		name          string
+		inputPageSize *int
+		expected      int
+	}{
+		{"Nil input", nil, 100},
+		{"Input below min", valuePtr[int](0), 100},
+		{"Valid input (below max)", valuePtr[int](25), 25},
+		{"Input above max", valuePtr[int](100), 100},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getPageSizeOrDefault(tc.inputPageSize)
+			if result != tc.expected {
+				t.Errorf("Expected %d, got %d", tc.expected, result)
+			}
+		})
+	}
+}
+
+// nolint: gochecknoglobals
+var (
+	inputPageToken = valuePtr[string]("input-token")
+	nextPageToken  = valuePtr[string]("next-page-token")
+	errTest        = errors.New("test error")
+)


### PR DESCRIPTION
This commit adds implementations for those two openapi operations.

For now, it's either a 200 for the success or 500 in the event of an error. Added TODOs for handling other status codes

Also, adjusted the backend binary to allow using the spanner client

Added two helper functions to help deal with optional parameters:
- getPageSizeOrDefault: uses the default 100 in the event the min and max in the openapi document are violated
- getFeatureIDsOrDefault: Handle the default case when no featureIDs (a null object) are passed.

