### PR TITLE
Adjust the openapi spec for the /v1/features endpoint

### DIFF
--- a/frontend/src/static/js/components/webstatus-overview-cells.ts
+++ b/frontend/src/static/js/components/webstatus-overview-cells.ts
@@ -57,6 +57,11 @@ const BASELINE_CHIP_CONFIGS: Record<
   components['schemas']['Feature']['baseline_status'],
   BaselineChipConfig
 > = {
+  undefined: {
+    cssClass: 'limited',
+    icon: 'cross.svg',
+    word: 'Limited',
+  },
   none: {
     cssClass: 'limited',
     icon: 'cross.svg',

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -26,19 +26,25 @@ paths:
         - $ref: '#/components/parameters/paginationTokenParam'
         - $ref: '#/components/parameters/paginationSizeParam'
         - in: query
-          name: baseline_start_year
+          name: availableOn
+          description: >
+            A comma-separated list of browsers.
+            The returned features are available on these browsers.
+          required: false
           schema:
-            type: integer
-            minimum: 2023
-            maximum: 2023
-          description: Start range (inclusive) for when features became part of baseline
+            type: array
+            items:
+              type: string
         - in: query
-          name: baseline_end_year
+          name: notAvailableOn
+          description: >
+            A comma-separated list of browsers.
+            The returned features are not available on these browsers.
+          required: false
           schema:
-            type: integer
-            minimum: 2023
-            maximum: 2023
-          description: End range (inclusive) for when features became part of baseline
+            type: array
+            items:
+              type: string
       responses:
         '200':
           description: OK
@@ -226,6 +232,7 @@ components:
           - chrome
           - firefox
           - safari
+          - edge
     channelPathParam:
       in: path
       name: channel
@@ -304,7 +311,7 @@ components:
       properties:
         score:
           type: number
-          format: float
+          format: double
     PageMetadata:
       type: object
       properties:
@@ -321,6 +328,25 @@ components:
             $ref: '#/components/schemas/Feature'
       required:
         - data
+    FeatureWPTSnapshots:
+      type: object
+      properties:
+        stable:
+          type: object
+          description: >
+            Contains snapshot of the stable WPT data. The keys for the
+            object comes from the different cases in
+            https://github.com/web-platform-tests/wpt.fyi/blob/fb5bae7c6d04563864ef1c28a263a0a8d6637c4e/shared/product_spec.go#L71-L104
+          additionalProperties:
+            $ref: '#/components/schemas/WPTFeatureData'
+        experimental:
+          type: object
+          description: >
+            Contains snapshot of the experimental WPT data. The keys for the
+            object comes from the different cases in
+            https://github.com/web-platform-tests/wpt.fyi/blob/fb5bae7c6d04563864ef1c28a263a0a8d6637c4e/shared/product_spec.go#L71-L104
+          additionalProperties:
+            $ref: '#/components/schemas/WPTFeatureData'
     Feature:
       type: object
       properties:
@@ -339,6 +365,7 @@ components:
         baseline_status:
           type: string
           enum:
+            - undefined
             - none
             - low
             - high
@@ -350,24 +377,7 @@ components:
           minimum: 0.0
           maximum: 100.0
         wpt:
-          type: object
-          properties:
-            stable:
-              type: object
-              description: >
-                Contains snapshot of the stable WPT data. The keys for the
-                object comes from the different cases in
-                https://github.com/web-platform-tests/wpt.fyi/blob/fb5bae7c6d04563864ef1c28a263a0a8d6637c4e/shared/product_spec.go#L71-L104
-              additionalProperties:
-                $ref: '#/components/schemas/WPTFeatureData'
-            experimental:
-              type: object
-              description: >
-                Contains snapshot of the experimental WPT data. The keys for the
-                object comes from the different cases in
-                https://github.com/web-platform-tests/wpt.fyi/blob/fb5bae7c6d04563864ef1c28a263a0a8d6637c4e/shared/product_spec.go#L71-L104
-              additionalProperties:
-                $ref: '#/components/schemas/WPTFeatureData'
+          $ref: '#/components/schemas/FeatureWPTSnapshots'
       required:
         - feature_id
         - name


### PR DESCRIPTION
# OpenAPI Adjustments
## v1/features
### Query Params:

Removed:
- baseline_start_year
- baseline_end_year

These filters were examples of how to do queries. We will eventually bring them back.

Added:
- availableOn
- notAvailableOn

**note** These are to support the filters in the button format. Not advanced AND and OR queries that would be manually typed.

### Components:

Added:
- edge to the browsers

Changed:
- score to be a double to match the future value from the database.
- Moved wpt score section to dedicated component called: FeatureWPTSnapshots.
- Added undefined to baseline_status because it can be undefined: https://github.com/web-platform-dx/web-features/blob/1cec26a8adc26203d42ecbef65d4d8a613dab265/schemas/defs.schema.json#L149-L152

# Frontend:

Added:
- case for the undefined status to match none.

