### PR TITLE
Add code to upsert WebFeatures

### DIFF
--- a/lib/gcpspanner/web_features.go
+++ b/lib/gcpspanner/web_features.go
@@ -1,0 +1,107 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cmp"
+	"context"
+	"errors"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+const webFeaturesTable = "WebFeatures"
+
+// SpannerWebFeature is a wrapper for the feature that is actually
+// stored in spanner. This is useful because the spanner id is not useful to
+// return to the end user since it is only used to decouple the primary keys
+// between this system and web features repo.
+type SpannerWebFeature struct {
+	ID string `spanner:"ID"`
+	WebFeature
+}
+
+// WebFeature contains common metadata for a Web Feature.
+// Columns come from the ../../infra/storage/spanner/migrations/*.sql files.
+type WebFeature struct {
+	FeatureID string `spanner:"FeatureID"`
+	Name      string `spanner:"Name"`
+}
+
+// UpsertWebFeature will upsert the given web feature.
+// If the feature, does not exist, it will insert a new feature.
+// If the run exists, it will only update the name.
+func (c *Client) UpsertWebFeature(ctx context.Context, feature WebFeature) error {
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.NewStatement(`
+		SELECT
+			ID, FeatureID, Name
+		FROM WebFeatures
+		WHERE FeatureID = @featureID
+		LIMIT 1`)
+		parameters := map[string]interface{}{
+			"featureID": feature.FeatureID,
+		}
+		stmt.Params = parameters
+
+		// Attempt to query for the row.
+		it := txn.Query(ctx, stmt)
+		defer it.Stop()
+		var m *spanner.Mutation
+
+		row, err := it.Next()
+		// nolint: nestif // TODO: fix in the future.
+		if err != nil {
+			if errors.Is(err, iterator.Done) {
+				// No rows returned. Act as if this is an insertion.
+				var err error
+				m, err = spanner.InsertOrUpdateStruct(webFeaturesTable, feature)
+				if err != nil {
+					return errors.Join(ErrInternalQueryFailure, err)
+				}
+			} else {
+				// An unexpected error occurred.
+
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+		} else {
+			// Read the existing feature and merge the values.
+			var existingFeature SpannerWebFeature
+			err = row.ToStruct(&existingFeature)
+			if err != nil {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+			// Only allow overriding of the feature name.
+			existingFeature.Name = cmp.Or[string](feature.Name, existingFeature.Name)
+			m, err = spanner.InsertOrUpdateStruct(webFeaturesTable, existingFeature)
+			if err != nil {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+		}
+		// Buffer the mutation to be committed.
+		err = txn.BufferWrite([]*spanner.Mutation{m})
+		if err != nil {
+			return errors.Join(ErrInternalQueryFailure, err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	return nil
+}

--- a/lib/gcpspanner/web_features_test.go
+++ b/lib/gcpspanner/web_features_test.go
@@ -1,0 +1,128 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func getSampleFeatures() []WebFeature {
+	return []WebFeature{
+		{
+			Name:      "Feature 1",
+			FeatureID: "feature1",
+		},
+		{
+			Name:      "Feature 2",
+			FeatureID: "feature2",
+		},
+		{
+			Name:      "Feature 3",
+			FeatureID: "feature3",
+		},
+		{
+			Name:      "Feature 4",
+			FeatureID: "feature4",
+		},
+	}
+}
+
+// Helper method to get all the features in a stable order.
+func (c *Client) ReadAllWebFeatures(ctx context.Context, t *testing.T) ([]WebFeature, error) {
+	stmt := spanner.NewStatement("SELECT ID, FeatureID, Name FROM WebFeatures ORDER BY FeatureID ASC")
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []WebFeature
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var feature SpannerWebFeature
+		if err := row.ToStruct(&feature); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		if feature.ID == "" {
+			t.Error("retrieved feature ID is empty")
+		}
+		ret = append(ret, feature.WebFeature)
+	}
+
+	return ret, nil
+}
+
+func TestUpsertWebFeature(t *testing.T) {
+	client := getTestDatabase(t)
+	ctx := context.Background()
+	sampleFeatures := getSampleFeatures()
+	for _, feature := range sampleFeatures {
+		err := client.UpsertWebFeature(ctx, feature)
+		if err != nil {
+			t.Errorf("unexpected error during insert. %s", err.Error())
+		}
+	}
+	features, err := client.ReadAllWebFeatures(ctx, t)
+	if err != nil {
+		t.Errorf("unexpected error during read all. %s", err.Error())
+	}
+	if !slices.Equal[[]WebFeature](sampleFeatures, features) {
+		t.Errorf("unequal features. expected %+v actual %+v", sampleFeatures, features)
+	}
+
+	err = client.UpsertWebFeature(ctx, WebFeature{
+		Name:      "Feature 1!!",
+		FeatureID: "feature1",
+	})
+	if err != nil {
+		t.Errorf("unexpected error during update. %s", err.Error())
+	}
+
+	features, err = client.ReadAllWebFeatures(ctx, t)
+	if err != nil {
+		t.Errorf("unexpected error during read all. %s", err.Error())
+	}
+
+	expectedPageAfterUpdate := []WebFeature{
+		{
+			Name:      "Feature 1!!", // Updated field
+			FeatureID: "feature1",
+		},
+		{
+			Name:      "Feature 2",
+			FeatureID: "feature2",
+		},
+		{
+			Name:      "Feature 3",
+			FeatureID: "feature3",
+		},
+		{
+			Name:      "Feature 4",
+			FeatureID: "feature4",
+		},
+	}
+	if !slices.Equal[[]WebFeature](expectedPageAfterUpdate, features) {
+		t.Errorf("unequal features after update. expected %+v actual %+v", sampleFeatures, features)
+	}
+}


### PR DESCRIPTION
This is splitting https://github.com/GoogleChrome/webstatus.dev/pull/54

This introduces the code to upsert WebFeatures.

The schema for the table is introduced in https://github.com/GoogleChrome/webstatus.dev/pull/59

On updates, only the name can be changed.

