### PR TITLE
Add code to insert Browser Releases

### DIFF
--- a/lib/gcpspanner/browser_releases.go
+++ b/lib/gcpspanner/browser_releases.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/grpc/codes"
+)
+
+const browserReleasesTable = "BrowserReleases"
+
+// SpannerBrowserRelease is a wrapper for the browser release that is actually
+// stored in spanner. For now, it is the same. But we keep this structure to be
+// consistent to the other database models.
+type SpannerBrowserRelease struct {
+	BrowserRelease
+}
+
+// BrowserRelease contains information regarding a certain browser release.
+type BrowserRelease struct {
+	BrowserName    string    `spanner:"BrowserName"`
+	BrowserVersion string    `spanner:"BrowserVersion"`
+	ReleaseDate    time.Time `spanner:"ReleaseDate"`
+}
+
+// InsertBrowserRelease will insert the given browser release.
+// If the release, does not exist, it will insert a new release.
+// If the release exists, it currently does nothing and keeps the existing as-is.
+// nolint: dupl // TODO. Will refactor for common patterns.
+func (c *Client) InsertBrowserRelease(ctx context.Context, release BrowserRelease) error {
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		_, err := txn.ReadRow(
+			ctx,
+			browserReleasesTable,
+			spanner.Key{release.BrowserName, release.BrowserVersion},
+			[]string{
+				"ReleaseDate",
+			})
+		if err != nil {
+			// Received an error other than not found. Return now.
+			if spanner.ErrCode(err) != codes.NotFound {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+			m, err := spanner.InsertOrUpdateStruct(browserReleasesTable, release)
+			if err != nil {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+			err = txn.BufferWrite([]*spanner.Mutation{m})
+			if err != nil {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+		}
+		// For now, do not overwrite anything for releases.
+		return nil
+
+	})
+	if err != nil {
+		return errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	return nil
+}

--- a/lib/gcpspanner/browser_releases_test.go
+++ b/lib/gcpspanner/browser_releases_test.go
@@ -1,0 +1,108 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func getSampleBrowserReleases() []BrowserRelease {
+	// nolint: dupl // Okay to duplicate for tests
+	return []BrowserRelease{
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "0.0.0",
+			ReleaseDate:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "0.0.0",
+			ReleaseDate:    time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "1.0.0",
+			ReleaseDate:    time.Date(2000, time.February, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "1.0.0",
+			ReleaseDate:    time.Date(2000, time.February, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "2.0.0",
+			ReleaseDate:    time.Date(2000, time.March, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "2.0.0",
+			ReleaseDate:    time.Date(2000, time.March, 2, 0, 0, 0, 0, time.UTC),
+		},
+	}
+}
+
+// Helper method to get all the browser releases in a stable order.
+// nolint: lll
+func (c *Client) ReadAllBrowserReleases(ctx context.Context, _ *testing.T) ([]BrowserRelease, error) {
+	stmt := spanner.NewStatement("SELECT BrowserName, BrowserVersion, ReleaseDate FROM BrowserReleases ORDER BY ReleaseDate ASC")
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []BrowserRelease
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var release SpannerBrowserRelease
+		if err := row.ToStruct(&release); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		ret = append(ret, release.BrowserRelease)
+	}
+
+	return ret, nil
+}
+
+func TestInsertBrowserRelease(t *testing.T) {
+	client := getTestDatabase(t)
+	ctx := context.Background()
+	sampleBrowserReleases := getSampleBrowserReleases()
+	for _, release := range sampleBrowserReleases {
+		err := client.InsertBrowserRelease(ctx, release)
+		if err != nil {
+			t.Errorf("unexpected error during insert. %s", err.Error())
+		}
+	}
+
+	releases, err := client.ReadAllBrowserReleases(ctx, t)
+	if err != nil {
+		t.Errorf("unexpected error during read all. %s", err.Error())
+	}
+	if !slices.Equal[[]BrowserRelease](sampleBrowserReleases, releases) {
+		t.Errorf("unequal releases. expected %+v actual %+v", sampleBrowserReleases, releases)
+	}
+}


### PR DESCRIPTION
This is splitting https://github.com/GoogleChrome/webstatus.dev/pull/54

This introduces the code to insert browser releases.

The schema for the table is introduced in https://github.com/GoogleChrome/webstatus.dev/pull/59

This data will come from https://github.com/mdn/browser-compat-data/tree/main/browsers Specifically, the github release's data.json.

It will do nothing on update. In the future, we could allow for corrections of specific fields.
