### PR TITLE
Add code to upsert Baseline Statuses

### DIFF
--- a/lib/gcpspanner/baseline_status.go
+++ b/lib/gcpspanner/baseline_status.go
@@ -1,0 +1,122 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+const featureBaselineStatusTable = "FeatureBaselineStatus"
+
+// Options come from
+// https://github.com/web-platform-dx/web-features/blob/3d4d066c47c9f07514bf743b3955572a6073ff1e/packages/web-features/README.md
+// nolint: lll
+type BaselineStatus string
+
+const (
+	BaselineStatusUndefined BaselineStatus = "undefined"
+	BaselineStatusNone      BaselineStatus = "none"
+	BaselineStatusLow       BaselineStatus = "low"
+	BaselineStatusHigh      BaselineStatus = "high"
+)
+
+// SpannerFeatureBaselineStatus is a wrapper for the baseline status that is actually
+// stored in spanner. For now, it is the same. But we keep this structure to be
+// consistent to the other database models.
+type SpannerFeatureBaselineStatus struct {
+	FeatureBaselineStatus
+}
+
+// FeatureBaselineStatus contains information about the current baseline status
+// of a feature.
+type FeatureBaselineStatus struct {
+	FeatureID string         `spanner:"FeatureID"`
+	Status    BaselineStatus `spanner:"Status"`
+	LowDate   *time.Time     `spanner:"LowDate"`
+	HighDate  *time.Time     `spanner:"HighDate"`
+}
+
+// UpsertWebFeature will update the given baseline status.
+// If the status, does not exist, it will insert a new status.
+// If the status exists, it will allow updates to the status, low date and high date.
+func (c *Client) UpsertFeatureBaselineStatus(ctx context.Context, status FeatureBaselineStatus) error {
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.NewStatement(`
+		SELECT
+			FeatureID, Status, LowDate, HighDate
+		FROM FeatureBaselineStatus
+		WHERE FeatureID = @featureID
+		LIMIT 1`)
+		parameters := map[string]interface{}{
+			"featureID": status.FeatureID,
+		}
+		stmt.Params = parameters
+
+		// Attempt to query for the row.
+		it := txn.Query(ctx, stmt)
+		defer it.Stop()
+		var m *spanner.Mutation
+
+		row, err := it.Next()
+		// nolint: nestif // TODO: fix in the future.
+		if err != nil {
+			if errors.Is(err, iterator.Done) {
+				// No rows returned. Act as if this is an insertion.
+				var err error
+				m, err = spanner.InsertOrUpdateStruct(featureBaselineStatusTable, status)
+				if err != nil {
+					return errors.Join(ErrInternalQueryFailure, err)
+				}
+			} else {
+				// An unexpected error occurred.
+
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+		} else {
+			// Read the existing status and merge the values.
+			var existingStatus SpannerFeatureBaselineStatus
+			err = row.ToStruct(&existingStatus)
+			if err != nil {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+			// Only allow overriding of the status, low date and high date.
+			existingStatus.Status = cmp.Or[BaselineStatus](status.Status, existingStatus.Status)
+			existingStatus.LowDate = cmp.Or[*time.Time](status.LowDate, existingStatus.LowDate)
+			existingStatus.HighDate = cmp.Or[*time.Time](status.HighDate, existingStatus.HighDate)
+			m, err = spanner.InsertOrUpdateStruct(featureBaselineStatusTable, existingStatus)
+			if err != nil {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+		}
+		// Buffer the mutation to be committed.
+		err = txn.BufferWrite([]*spanner.Mutation{m})
+		if err != nil {
+			return errors.Join(ErrInternalQueryFailure, err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	return nil
+}

--- a/lib/gcpspanner/baseline_status_test.go
+++ b/lib/gcpspanner/baseline_status_test.go
@@ -1,0 +1,146 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func getSampleBaselineStatuses() []FeatureBaselineStatus {
+	return []FeatureBaselineStatus{
+		{
+			FeatureID: "feature1",
+			Status:    BaselineStatusUndefined,
+			LowDate:   nil,
+			HighDate:  nil,
+		},
+		{
+			FeatureID: "feature2",
+			Status:    BaselineStatusHigh,
+			LowDate:   valuePtr[time.Time](time.Date(2000, time.January, 15, 0, 0, 0, 0, time.UTC)),
+			HighDate:  valuePtr[time.Time](time.Date(2000, time.January, 31, 0, 0, 0, 0, time.UTC)),
+		},
+	}
+}
+
+func setupRequiredTablesForBaselineStatus(ctx context.Context,
+	client *Client, t *testing.T) {
+	sampleFeatures := getSampleFeatures()
+	for _, feature := range sampleFeatures {
+		err := client.UpsertWebFeature(ctx, feature)
+		if err != nil {
+			t.Errorf("unexpected error during insert of features. %s", err.Error())
+		}
+	}
+}
+
+// Helper method to get all the statuses in a stable order.
+func (c *Client) ReadAllBaselineStatuses(ctx context.Context, _ *testing.T) ([]FeatureBaselineStatus, error) {
+	stmt := spanner.NewStatement("SELECT * FROM FeatureBaselineStatus ORDER BY FeatureID ASC")
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []FeatureBaselineStatus
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var status SpannerFeatureBaselineStatus
+		if err := row.ToStruct(&status); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		ret = append(ret, status.FeatureBaselineStatus)
+	}
+
+	return ret, nil
+}
+func statusEquality(left, right FeatureBaselineStatus) bool {
+	return left.FeatureID == right.FeatureID &&
+		left.Status == right.Status &&
+		((left.LowDate != nil && right.LowDate != nil && left.LowDate.Equal(*right.LowDate)) ||
+			left.LowDate == right.LowDate) &&
+		((left.HighDate != nil && right.HighDate != nil && left.HighDate.Equal(*right.HighDate)) ||
+			left.LowDate == right.LowDate)
+}
+
+func TestUpsertFeatureBaselineStatus(t *testing.T) {
+	client := getTestDatabase(t)
+	ctx := context.Background()
+	setupRequiredTablesForBaselineStatus(ctx, client, t)
+	sampleStatuses := getSampleBaselineStatuses()
+
+	for _, status := range sampleStatuses {
+		err := client.UpsertFeatureBaselineStatus(ctx, status)
+		if err != nil {
+			t.Errorf("unexpected error during insert. %s", err.Error())
+		}
+	}
+
+	statuses, err := client.ReadAllBaselineStatuses(ctx, t)
+	if err != nil {
+		t.Errorf("unexpected error during read all. %s", err.Error())
+	}
+	if !slices.EqualFunc[[]FeatureBaselineStatus](
+		sampleStatuses,
+		statuses, statusEquality) {
+		t.Errorf("unequal status. expected %+v actual %+v", sampleStatuses, statuses)
+	}
+
+	err = client.UpsertFeatureBaselineStatus(ctx, FeatureBaselineStatus{
+		FeatureID: "feature1",
+		Status:    BaselineStatusHigh,
+		LowDate:   valuePtr[time.Time](time.Date(2000, time.February, 15, 0, 0, 0, 0, time.UTC)),
+		HighDate:  valuePtr[time.Time](time.Date(2000, time.February, 28, 0, 0, 0, 0, time.UTC)),
+	})
+	if err != nil {
+		t.Errorf("unexpected error during update. %s", err.Error())
+	}
+
+	expectedPageAfterUpdate := []FeatureBaselineStatus{
+		{
+			FeatureID: "feature1",
+			Status:    BaselineStatusHigh,
+			LowDate:   valuePtr[time.Time](time.Date(2000, time.February, 15, 0, 0, 0, 0, time.UTC)),
+			HighDate:  valuePtr[time.Time](time.Date(2000, time.February, 28, 0, 0, 0, 0, time.UTC)),
+		},
+		{
+			FeatureID: "feature2",
+			Status:    BaselineStatusHigh,
+			LowDate:   valuePtr[time.Time](time.Date(2000, time.January, 15, 0, 0, 0, 0, time.UTC)),
+			HighDate:  valuePtr[time.Time](time.Date(2000, time.January, 31, 0, 0, 0, 0, time.UTC)),
+		},
+	}
+
+	statuses, err = client.ReadAllBaselineStatuses(ctx, t)
+	if err != nil {
+		t.Errorf("unexpected error during read all after update. %s", err.Error())
+	}
+	if !slices.EqualFunc[[]FeatureBaselineStatus](
+		expectedPageAfterUpdate,
+		statuses, statusEquality) {
+		t.Errorf("unequal status. expected %+v actual %+v", expectedPageAfterUpdate, statuses)
+	}
+}


### PR DESCRIPTION
This is splitting https://github.com/GoogleChrome/webstatus.dev/pull/54

This introduces the code to upsert Baseline Statuses.

The schema for the table is introduced in https://github.com/GoogleChrome/webstatus.dev/pull/59

On updates, the status, low date and the high date can be changed.

The data for this comes from the web features repo.

