### PR TITLE
Add code to insert browser availabilities

### DIFF
--- a/lib/gcpspanner/browser_availabilities.go
+++ b/lib/gcpspanner/browser_availabilities.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/grpc/codes"
+)
+
+const browserFeatureAvailabilitiesTable = "BrowserFeatureAvailabilities"
+
+// SpannerBrowserFeatureAvailability is a wrapper for the browser availability
+// information for a feature stored in spanner. For now, it is the same. But we
+// keep this structure to be consistent to the other database models.
+type SpannerBrowserFeatureAvailability struct {
+	BrowserFeatureAvailability
+}
+
+// BrowserFeatureAvailability contains availability information for a particular
+// feature in a browser.
+type BrowserFeatureAvailability struct {
+	BrowserName    string
+	BrowserVersion string
+	FeatureID      string
+}
+
+// InsertBrowserFeatureAvailability will insert the given browser feature availability.
+// If the feature availability, does not exist, it will insert a new feature availability.
+// If the feature availability exists, it currently does nothing and keeps the existing as-is.
+// nolint: dupl // TODO. Will refactor for common patterns.
+func (c *Client) InsertBrowserFeatureAvailability(
+	ctx context.Context,
+	featureAvailability BrowserFeatureAvailability) error {
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		_, err := txn.ReadRow(
+			ctx,
+			browserFeatureAvailabilitiesTable,
+			spanner.Key{featureAvailability.FeatureID, featureAvailability.BrowserName},
+			[]string{
+				"BrowserVersion",
+			})
+		if err != nil {
+			// Received an error other than not found. Return now.
+			if spanner.ErrCode(err) != codes.NotFound {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+			m, err := spanner.InsertOrUpdateStruct(browserFeatureAvailabilitiesTable, featureAvailability)
+			if err != nil {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+			err = txn.BufferWrite([]*spanner.Mutation{m})
+			if err != nil {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+		}
+		// For now, do not overwrite anything for releases.
+		return nil
+
+	})
+	if err != nil {
+		return errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	return nil
+}

--- a/lib/gcpspanner/browser_availabilities_test.go
+++ b/lib/gcpspanner/browser_availabilities_test.go
@@ -1,0 +1,145 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func getSampleBrowserAvailabilities() []BrowserFeatureAvailability {
+	return []BrowserFeatureAvailability{
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "0.0.0",
+			FeatureID:      "feature1",
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "1.0.0",
+			FeatureID:      "feature1",
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "2.0.0",
+			FeatureID:      "feature2",
+		},
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "1.0.0",
+			FeatureID:      "feature2",
+		},
+		// Should not actually insert this one due to UniqueFeatureBrowser index
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "2.0.0",
+			FeatureID:      "feature1",
+		},
+	}
+}
+
+func setupRequiredTablesForBrowserFeatureAvailability(
+	ctx context.Context,
+	client *Client, t *testing.T) {
+	sampleBrowserReleases := getSampleBrowserReleases()
+	for _, release := range sampleBrowserReleases {
+		err := client.InsertBrowserRelease(ctx, release)
+		if err != nil {
+			t.Errorf("unexpected error during insert of releases. %s", err.Error())
+		}
+	}
+	sampleFeatures := getSampleFeatures()
+	for _, feature := range sampleFeatures {
+		err := client.UpsertWebFeature(ctx, feature)
+		if err != nil {
+			t.Errorf("unexpected error during insert of features. %s", err.Error())
+		}
+	}
+}
+
+// Helper method to get all the Availabilities in a stable order.
+// nolint: lll
+func (c *Client) ReadAllAvailabilities(ctx context.Context, _ *testing.T) ([]BrowserFeatureAvailability, error) {
+	stmt := spanner.NewStatement("SELECT * FROM BrowserFeatureAvailabilities ORDER BY BrowserVersion ASC, BrowserName ASC, FeatureID ASC")
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []BrowserFeatureAvailability
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var availability SpannerBrowserFeatureAvailability
+		if err := row.ToStruct(&availability); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		ret = append(ret, availability.BrowserFeatureAvailability)
+	}
+
+	return ret, nil
+}
+
+func TestInsertBrowserFeatureAvailability(t *testing.T) {
+	client := getTestDatabase(t)
+	ctx := context.Background()
+	setupRequiredTablesForBrowserFeatureAvailability(ctx, client, t)
+	sampleAvailabilities := getSampleBrowserAvailabilities()
+	for _, availability := range sampleAvailabilities {
+		err := client.InsertBrowserFeatureAvailability(ctx, availability)
+		if err != nil {
+			t.Errorf("unexpected error during insert. %s", err.Error())
+		}
+	}
+
+	expectedPage := []BrowserFeatureAvailability{
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "0.0.0",
+			FeatureID:      "feature1",
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "1.0.0",
+			FeatureID:      "feature1",
+		},
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "1.0.0",
+			FeatureID:      "feature2",
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "2.0.0",
+			FeatureID:      "feature2",
+		},
+	}
+
+	availabilities, err := client.ReadAllAvailabilities(ctx, t)
+	if err != nil {
+		t.Errorf("unexpected error during read all. %s", err.Error())
+	}
+	if !slices.Equal[[]BrowserFeatureAvailability](expectedPage, availabilities) {
+		t.Errorf("unequal availabilities. expected %+v actual %+v", expectedPage, availabilities)
+	}
+}


### PR DESCRIPTION
This is splitting https://github.com/GoogleChrome/webstatus.dev/pull/54

This introduces the code to insert browser availability for a feature.

The schema for the table is introduced in https://github.com/GoogleChrome/webstatus.dev/pull/59

This data will come from the web features repo. Using the versions there, it will match up with the versions in the browser releases table to give users when the feature was release.

It will do nothing on update. In the future, we could allow for corrections of specific fields.

