### PR TITLE
Remove redundant information from Metrics table.

### DIFF
--- a/.dev/spanner/manifests/pod.yaml
+++ b/.dev/spanner/manifests/pod.yaml
@@ -29,5 +29,5 @@ spec:
           name: rest-port
       resources:
         limits:
-          cpu: 250m
+          cpu: '2'
           memory: 1024Mi

--- a/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
@@ -37,7 +37,7 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 		{
 			name: "Success Case - no optional params - use defaults",
 			mockConfig: MockListMetricsForFeatureIDBrowserAndChannelConfig{
-				expectedFeatureID: "fooFeature",
+				expectedFeatureID: "feature1",
 				expectedBrowser:   "chrome",
 				expectedChannel:   "experimental",
 				expectedStartAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
@@ -77,14 +77,14 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 				},
 				Browser:   backend.Chrome,
 				Channel:   backend.Experimental,
-				FeatureId: "fooFeature",
+				FeatureId: "feature1",
 			},
 			expectedError: nil,
 		},
 		{
 			name: "Success Case - include optional params",
 			mockConfig: MockListMetricsForFeatureIDBrowserAndChannelConfig{
-				expectedFeatureID: "fooFeature",
+				expectedFeatureID: "feature1",
 				expectedBrowser:   "chrome",
 				expectedChannel:   "experimental",
 				expectedStartAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
@@ -124,14 +124,14 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 				},
 				Browser:   backend.Chrome,
 				Channel:   backend.Experimental,
-				FeatureId: "fooFeature",
+				FeatureId: "feature1",
 			},
 			expectedError: nil,
 		},
 		{
 			name: "500 case",
 			mockConfig: MockListMetricsForFeatureIDBrowserAndChannelConfig{
-				expectedFeatureID: "fooFeature",
+				expectedFeatureID: "feature1",
 				expectedBrowser:   "chrome",
 				expectedChannel:   "experimental",
 				expectedPageToken: nil,
@@ -156,7 +156,7 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 				},
 				Browser:   backend.Chrome,
 				Channel:   backend.Experimental,
-				FeatureId: "fooFeature",
+				FeatureId: "feature1",
 			},
 			expectedError: nil,
 		},

--- a/infra/storage/spanner/migrations/000001.sql
+++ b/infra/storage/spanner/migrations/000001.sql
@@ -48,13 +48,11 @@ CREATE INDEX RunsForFeatureSearchWithChannel ON WPTRuns(ExternalRunID, Channel, 
 -- WPTRunFeatureMetrics contains metrics for individual features for a given run.
 CREATE TABLE IF NOT EXISTS WPTRunFeatureMetrics (
     ID STRING(36) NOT NULL,
-    ExternalRunID INT64 NOT NULL, -- ID from WPT. TODO. Deprecated. Will remove in future PR.
     FeatureID STRING(64) NOT NULL,
     TotalTests INT64,
     TestPass INT64,
-    -- TODO. After removing ExternalRunID, enable the following.
-    -- FOREIGN KEY (FeatureID) REFERENCES WebFeatures(FeatureID),
-    -- FOREIGN KEY (ID) REFERENCES WPTRuns(ID)
+    FOREIGN KEY (FeatureID) REFERENCES WebFeatures(FeatureID),
+    FOREIGN KEY (ID) REFERENCES WPTRuns(ID)
 ) PRIMARY KEY (ID, FeatureID)
 ,    INTERLEAVE IN PARENT WPTRuns ON DELETE CASCADE;
 

--- a/lib/gcpspanner/wpt_run.go
+++ b/lib/gcpspanner/wpt_run.go
@@ -36,7 +36,7 @@ type SpannerWPTRun struct {
 }
 
 // WPTRun contains common metadata for a run.
-// Columns come from the ../../infra/storage/spanner.sql file.
+// Columns come from the ../../infra/storage/spanner/migrations/*.sql files.
 type WPTRun struct {
 	RunID            int64     `spanner:"ExternalRunID"`
 	TimeStart        time.Time `spanner:"TimeStart"`

--- a/lib/gcpspanner/wpt_run_test.go
+++ b/lib/gcpspanner/wpt_run_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func getSampleRuns() []WPTRun {
+	// nolint: dupl // Okay to duplicate for tests
 	return []WPTRun{
 		{
 			RunID:            0,


### PR DESCRIPTION
This is splitting https://github.com/GoogleChrome/webstatus.dev/pull/54

Given that the ID from wpt is stored in the runs table, we do not need to duplicate it in the metrics table. We can leverage the ID that we store instead.

This is a clean up PR that was from the larger PR but we needed to get other tables merged in first.

**Note**
Heads up for reviewers: We will probably need to treat FeatureID as a changeable ID.

That will change the schema after I finish splitting PR 54

https: //github.com/web-platform-dx/web-features/blob/baf32f21b28a33ef8fff8cefc0c43636e5b8ceb6/schemas/defs.schema.json#L10-L23
