### PR TITLE
Feature: Searching for features in spanner

### DIFF
--- a/lib/gcpspanner/client.go
+++ b/lib/gcpspanner/client.go
@@ -71,9 +71,20 @@ type WPTRunCursor struct {
 	LastRunID     int64     `json:"last_run_id"`
 }
 
+// FeatureResultCursor: Represents a point for resuming queries based on the last
+// feature ID. Useful for pagination.
+type FeatureResultCursor struct {
+	LastFeatureID string `json:"last_feature_id"`
+}
+
 // decodeWPTRunCursor provides a wrapper around the generic decodeCursor.
 func decodeWPTRunCursor(cursor string) (*WPTRunCursor, error) {
 	return decodeCursor[WPTRunCursor](cursor)
+}
+
+// decodeFeatureResultCursor provides a wrapper around the generic decodeCursor.
+func decodeFeatureResultCursor(cursor string) (*FeatureResultCursor, error) {
+	return decodeCursor[FeatureResultCursor](cursor)
 }
 
 // decodeCursor: Decodes a base64-encoded cursor string into a Cursor struct.
@@ -89,6 +100,11 @@ func decodeCursor[T any](cursor string) (*T, error) {
 	}
 
 	return &decoded, nil
+}
+
+// encodeFeatureResultCursor provides a wrapper around the generic encodeCursor.
+func encodeFeatureResultCursor(id string) string {
+	return encodeCursor[FeatureResultCursor](FeatureResultCursor{LastFeatureID: id})
 }
 
 // encodeWPTRunCursor provides a wrapper around the generic encodeCursor.

--- a/lib/gcpspanner/feature_search.go
+++ b/lib/gcpspanner/feature_search.go
@@ -1,0 +1,96 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/api/iterator"
+)
+
+// SpannerFeatureResult is a wrapper for the feature result that is actually
+// stored in spanner. This is useful because the spanner id is not useful to
+// return to the end user.
+type SpannerFeatureResult struct {
+	ID string `spanner:"ID"`
+	FeatureResult
+}
+
+// FeatureResultMetric contains metric information for a feature result query.
+// Very similar to WPTRunFeatureMetric.
+type FeatureResultMetric struct {
+	BrowserName string `json:"BrowserName"`
+	TotalTests  *int64 `json:"TotalTests"`
+	TestPass    *int64 `json:"TestPass"`
+}
+
+// FeatureResult contains information regarding a particular feature.
+type FeatureResult struct {
+	FeatureID           string                 `json:"FeatureID"`
+	Name                string                 `json:"Name"`
+	Status              string                 `json:"Status"`
+	StableMetrics       []*FeatureResultMetric `json:"StableMetrics"`
+	ExperimentalMetrics []*FeatureResultMetric `json:"ExperimentalMetrics"`
+}
+
+func (c *Client) FeaturesSearch(
+	ctx context.Context,
+	pageToken *string,
+	pageSize int,
+	filterables ...Filterable) ([]FeatureResult, *string, error) {
+	var cursor *FeatureResultCursor
+	var err error
+	if pageToken != nil {
+		cursor, err = decodeFeatureResultCursor(*pageToken)
+		if err != nil {
+			return nil, nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+	}
+	b := FeatureSearchQueryBuilder{
+		cursor:   cursor,
+		pageSize: pageSize,
+	}
+	stmt := b.Build(filterables...)
+	txn := c.Single()
+	defer txn.Close()
+	it := txn.Query(ctx, stmt)
+	defer it.Stop()
+
+	var results []FeatureResult
+	for {
+		row, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var result SpannerFeatureResult
+		if err := row.ToStruct(&result); err != nil {
+			return nil, nil, err
+		}
+		results = append(results, result.FeatureResult)
+	}
+
+	if len(results) == pageSize {
+		lastResult := results[len(results)-1]
+		newCursor := encodeFeatureResultCursor(lastResult.FeatureID)
+
+		return results, &newCursor, nil
+	}
+
+	return results, nil, nil
+}

--- a/lib/gcpspanner/feature_search_query.go
+++ b/lib/gcpspanner/feature_search_query.go
@@ -1,0 +1,165 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cloud.google.com/go/spanner"
+)
+
+// Filterable modifies a query with a given filter.
+type Filterable interface {
+	Params() map[string]interface{}
+	Clause() string
+}
+
+func NewAvailabileFilter(availableBrowsers []string) *AvailabileFilter {
+	return &AvailabileFilter{availableBrowsers: availableBrowsers}
+}
+
+// AvailabileFilter applies a filter to limit the features based on their availability in a list of browsers.
+type AvailabileFilter struct {
+	availableBrowsers []string
+}
+
+func (f AvailabileFilter) Clause() string {
+	return `wf.FeatureID IN (SELECT FeatureID FROM BrowserFeatureAvailabilities
+		WHERE BrowserName IN UNNEST(@availableBrowsers))`
+}
+
+func (f AvailabileFilter) Params() map[string]interface{} {
+	return map[string]interface{}{
+		"availableBrowsers": f.availableBrowsers,
+	}
+}
+
+func NewNotAvailabileFilter(notAvailableBrowsers []string) *NotAvailabileFilter {
+	return &NotAvailabileFilter{notAvailableBrowsers: notAvailableBrowsers}
+}
+
+// NotAvailabileFilter applies a filter to limit the features based on their unavailability in a list of browsers.
+type NotAvailabileFilter struct {
+	notAvailableBrowsers []string
+}
+
+func (f NotAvailabileFilter) Clause() string {
+	return `wf.FeatureID NOT IN (SELECT FeatureID FROM BrowserFeatureAvailabilities
+		WHERE BrowserName IN UNNEST(@notAvailableBrowsers))`
+}
+
+func (f NotAvailabileFilter) Params() map[string]interface{} {
+	return map[string]interface{}{
+		"notAvailableBrowsers": f.notAvailableBrowsers,
+	}
+}
+
+// FeatureSearchQueryBuilder builds a query to search for features.
+type FeatureSearchQueryBuilder struct {
+	cursor   *FeatureResultCursor
+	pageSize int
+}
+
+// Base provides the minimum query to get data for the features search.
+// This query retrieves the latest metrics for each unique BrowserName/FeatureID
+// combination associated with a given feature.
+//
+// It provides these metrics for both "stable" and "experimental" channels.
+// The results are designed to be used for the feature search and filtering.
+func (q FeatureSearchQueryBuilder) Base() string {
+	return `
+SELECT
+	wf.ID,
+	wf.FeatureID,
+	wf.Name,
+	COALESCE(fbs.Status, 'undefined') AS Status,
+
+	-- StableMetrics Calculation
+	(SELECT ARRAY_AGG(STRUCT(BrowserName, TotalTests, TestPass))
+		FROM (
+		SELECT browser_feature_list.BrowserName, TotalTests, TestPass
+		FROM (
+			-- Subquery to get distinct BrowserName, FeatureID combinations and their
+			-- associated maximum TimeStart for the specified FeatureID
+			SELECT DISTINCT BrowserName, FeatureID, MAX(wpr.TimeStart) AS MaxTimeStart
+			FROM WPTRunFeatureMetrics metrics
+			JOIN WPTRuns wpr ON metrics.ID = wpr.ID
+			WHERE metrics.FeatureID = wf.FeatureID
+			GROUP BY BrowserName, FeatureID
+		) browser_feature_list
+		-- Join to retrieve metrics, ensuring we get the latest run for each combination
+		JOIN WPTRunFeatureMetrics metrics ON browser_feature_list.FeatureID = metrics.FeatureID
+		JOIN WPTRuns wpr ON metrics.ID = wpr.ID AND browser_feature_list.BrowserName = wpr.BrowserName
+		WHERE wpr.Channel = 'stable'
+		AND wpr.TimeStart = browser_feature_list.MaxTimeStart
+	) latest_metric) AS StableMetrics,
+
+	-- ExperimentalMetrics Calculation
+	(SELECT ARRAY_AGG(STRUCT(BrowserName, TotalTests, TestPass))
+		FROM (
+		SELECT browser_feature_list.BrowserName, TotalTests, TestPass
+		FROM (
+			-- Subquery to get distinct BrowserName, FeatureID combinations and their
+			-- associated maximum TimeStart for the specified FeatureID
+			SELECT DISTINCT BrowserName, FeatureID, MAX(wpr.TimeStart) AS MaxTimeStart
+			FROM WPTRunFeatureMetrics metrics
+			JOIN WPTRuns wpr ON metrics.ID = wpr.ID
+			WHERE metrics.FeatureID = wf.FeatureID
+			GROUP BY BrowserName, FeatureID
+		) browser_feature_list
+		-- Join to retrieve metrics, ensuring we get the latest run for each combination
+		JOIN WPTRunFeatureMetrics metrics ON browser_feature_list.FeatureID = metrics.FeatureID
+		JOIN WPTRuns wpr ON metrics.ID = wpr.ID AND browser_feature_list.BrowserName = wpr.BrowserName
+		WHERE wpr.Channel = 'experimental'
+		AND wpr.TimeStart = browser_feature_list.MaxTimeStart
+	) latest_metric) AS ExperimentalMetrics,
+
+FROM WebFeatures wf
+LEFT OUTER JOIN FeatureBaselineStatus fbs ON wf.FeatureID = fbs.FeatureID
+`
+}
+
+func (q FeatureSearchQueryBuilder) Order() string {
+	// Stable sorting
+	return "ORDER BY wf.FeatureID"
+}
+
+func (q FeatureSearchQueryBuilder) Build(filters ...Filterable) spanner.Statement {
+	filterQuery := ""
+
+	filterParams := make(map[string]interface{})
+	if q.cursor != nil {
+		filterParams["cursorId"] = q.cursor.LastFeatureID
+		filterQuery += " wf.FeatureID > @cursorId"
+	}
+
+	filterParams["pageSize"] = q.pageSize
+
+	for _, filter := range filters {
+		if len(filterQuery) > 0 {
+			filterQuery += "AND "
+		}
+		filterQuery += filter.Clause() + " "
+		for key, value := range filter.Params() {
+			filterParams[key] = value
+		}
+	}
+	if len(filterQuery) > 0 {
+		filterQuery = "WHERE " + filterQuery
+	}
+	stmt := spanner.NewStatement(q.Base() + " " + filterQuery + " " + q.Order() + " LIMIT @pageSize")
+
+	stmt.Params = filterParams
+
+	return stmt
+}

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -1,0 +1,886 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+func setupRequiredTablesForFeaturesSearch(ctx context.Context,
+	client *Client, t *testing.T) {
+	//nolint: dupl // Okay to duplicate for tests
+	sampleFeatures := []WebFeature{
+		{
+			Name:      "Feature 1",
+			FeatureID: "feature1",
+		},
+		{
+			Name:      "Feature 2",
+			FeatureID: "feature2",
+		},
+		{
+			Name:      "Feature 3",
+			FeatureID: "feature3",
+		},
+		{
+			Name:      "Feature 4",
+			FeatureID: "feature4",
+		},
+	}
+	for _, feature := range sampleFeatures {
+		err := client.UpsertWebFeature(ctx, feature)
+		if err != nil {
+			t.Errorf("unexpected error during insert of features. %s", err.Error())
+		}
+	}
+
+	// nolint: dupl // Okay to duplicate for tests
+	sampleReleases := []BrowserRelease{
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "0.0.0",
+			ReleaseDate:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "0.0.0",
+			ReleaseDate:    time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "1.0.0",
+			ReleaseDate:    time.Date(2000, time.February, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "1.0.0",
+			ReleaseDate:    time.Date(2000, time.February, 2, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "2.0.0",
+			ReleaseDate:    time.Date(2000, time.March, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "2.0.0",
+			ReleaseDate:    time.Date(2000, time.March, 2, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, release := range sampleReleases {
+		err := client.InsertBrowserRelease(ctx, release)
+		if err != nil {
+			t.Errorf("unexpected error during insert of releases. %s", err.Error())
+		}
+	}
+
+	//nolint: dupl // Okay to duplicate for tests
+	sampleBrowserAvailabilities := []BrowserFeatureAvailability{
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "0.0.0",
+			FeatureID:      "feature1",
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "1.0.0",
+			FeatureID:      "feature1",
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "2.0.0",
+			FeatureID:      "feature2",
+		},
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "1.0.0",
+			FeatureID:      "feature3",
+		},
+	}
+	for _, availability := range sampleBrowserAvailabilities {
+		err := client.InsertBrowserFeatureAvailability(ctx, availability)
+		if err != nil {
+			t.Errorf("unexpected error during insert of availabilities. %s", err.Error())
+		}
+	}
+
+	//nolint: dupl // Okay to duplicate for tests
+	sampleBaselineStatuses := []FeatureBaselineStatus{
+		{
+			FeatureID: "feature1",
+			Status:    BaselineStatusUndefined,
+			LowDate:   nil,
+			HighDate:  nil,
+		},
+		{
+			FeatureID: "feature2",
+			Status:    BaselineStatusHigh,
+			LowDate:   valuePtr[time.Time](time.Date(2000, time.January, 15, 0, 0, 0, 0, time.UTC)),
+			HighDate:  valuePtr[time.Time](time.Date(2000, time.January, 31, 0, 0, 0, 0, time.UTC)),
+		},
+		{
+			FeatureID: "feature3",
+			Status:    BaselineStatusUndefined,
+			LowDate:   nil,
+			HighDate:  nil,
+		},
+		// feature4 will default to undefined.
+	}
+	for _, status := range sampleBaselineStatuses {
+		err := client.UpsertFeatureBaselineStatus(ctx, status)
+		if err != nil {
+			t.Errorf("unexpected error during insert of statuses. %s", err.Error())
+		}
+	}
+
+	// nolint: dupl // Okay to duplicate for tests
+	sampleRuns := []WPTRun{
+		{
+			RunID:            0,
+			TimeStart:        time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "fooBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.StableLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            1,
+			TimeStart:        time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "fooBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.ExperimentalLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            2,
+			TimeStart:        time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "barBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.StableLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            3,
+			TimeStart:        time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 1, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "barBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.ExperimentalLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            6,
+			TimeStart:        time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "fooBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.StableLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            7,
+			TimeStart:        time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "fooBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.ExperimentalLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            8,
+			TimeStart:        time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "barBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.StableLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+		{
+			RunID:            9,
+			TimeStart:        time.Date(2000, time.January, 2, 0, 0, 0, 0, time.UTC),
+			TimeEnd:          time.Date(2000, time.January, 2, 1, 0, 0, 0, time.UTC),
+			BrowserName:      "barBrowser",
+			BrowserVersion:   "0.0.0",
+			Channel:          shared.ExperimentalLabel,
+			OSName:           "os",
+			OSVersion:        "0.0.0",
+			FullRevisionHash: "abcdef0123456789",
+		},
+	}
+
+	for _, run := range sampleRuns {
+		err := client.InsertWPTRun(ctx, run)
+		if err != nil {
+			t.Errorf("unexpected error during insert of runs. %s", err.Error())
+		}
+	}
+
+	// nolint: dupl // Okay to duplicate for tests
+	sampleRunMetrics := []struct {
+		ExternalRunID int64
+		WPTRunFeatureMetric
+	}{
+		// Run 0 metrics - fooBrowser - stable
+		{
+			ExternalRunID: 0,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature1",
+				TotalTests: valuePtr[int64](20),
+				TestPass:   valuePtr[int64](10),
+			},
+		},
+		{
+			ExternalRunID: 0,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature2",
+				TotalTests: valuePtr[int64](5),
+				TestPass:   valuePtr[int64](0),
+			},
+		},
+		{
+			ExternalRunID: 0,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature3",
+				TotalTests: valuePtr[int64](50),
+				TestPass:   valuePtr[int64](5),
+			},
+		},
+		// Run 1 metrics - fooBrowser - experimental
+		{
+			ExternalRunID: 1,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature1",
+				TotalTests: valuePtr[int64](20),
+				TestPass:   valuePtr[int64](20),
+			},
+		},
+		// Run 2 metrics - barBrowser - stable
+		{
+			ExternalRunID: 2,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature1",
+				TotalTests: valuePtr[int64](20),
+				TestPass:   valuePtr[int64](10),
+			},
+		},
+		// Run 3 metrics - barBrowser - experimental
+		{
+			ExternalRunID: 3,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature1",
+				TotalTests: valuePtr[int64](20),
+				TestPass:   valuePtr[int64](10),
+			},
+		},
+		// Run 6 metrics - fooBrowser - stable
+		{
+			ExternalRunID: 6,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature1",
+				TotalTests: valuePtr[int64](20),
+				TestPass:   valuePtr[int64](20),
+			},
+		},
+		{
+			ExternalRunID: 6,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature2",
+				TotalTests: valuePtr[int64](10),
+				TestPass:   valuePtr[int64](0),
+			},
+		},
+		{
+			ExternalRunID: 6,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature3",
+				TotalTests: valuePtr[int64](50),
+				TestPass:   valuePtr[int64](35),
+			},
+		},
+		// Run 7 metrics - fooBrowser - experimental
+		{
+			ExternalRunID: 7,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature1",
+				TotalTests: valuePtr[int64](11),
+				TestPass:   valuePtr[int64](11),
+			},
+		},
+		{
+			ExternalRunID: 7,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature2",
+				TotalTests: valuePtr[int64](12),
+				TestPass:   valuePtr[int64](12),
+			},
+		},
+		// Run 8 metrics - barBrowser - stable
+		{
+			ExternalRunID: 8,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature1",
+				TotalTests: valuePtr[int64](33),
+				TestPass:   valuePtr[int64](33),
+			},
+		},
+		{
+			ExternalRunID: 8,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature2",
+				TotalTests: valuePtr[int64](10),
+				TestPass:   valuePtr[int64](10),
+			},
+		},
+		// Run 9 metrics - barBrowser - experimental
+		{
+			ExternalRunID: 9,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature1",
+				TotalTests: valuePtr[int64](220),
+				TestPass:   valuePtr[int64](220),
+			},
+		},
+		{
+			ExternalRunID: 9,
+			WPTRunFeatureMetric: WPTRunFeatureMetric{
+				FeatureID:  "feature2",
+				TotalTests: valuePtr[int64](120),
+				TestPass:   valuePtr[int64](120),
+			},
+		},
+	}
+	for _, metric := range sampleRunMetrics {
+		err := client.UpsertWPTRunFeatureMetric(ctx, metric.ExternalRunID, metric.WPTRunFeatureMetric)
+		if err != nil {
+			t.Errorf("unexpected error during insert of metrics. %s", err.Error())
+		}
+	}
+}
+
+func sortMetricsByBrowserName(metrics []*FeatureResultMetric) {
+	sort.Slice(metrics, func(i, j int) bool {
+		return metrics[i].BrowserName < metrics[j].BrowserName
+	})
+}
+func stabilizeFeatureResults(results []FeatureResult) {
+	for _, result := range results {
+		sortMetricsByBrowserName(result.StableMetrics)
+		sortMetricsByBrowserName(result.ExperimentalMetrics)
+	}
+}
+
+func testFeatureSearchAll(ctx context.Context, t *testing.T, client *Client) {
+	// Simple test to get all the features without filters.
+	expectedResults := []FeatureResult{
+		{
+			FeatureID: "feature1",
+			Name:      "Feature 1",
+			Status:    string(BaselineStatusUndefined),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](33),
+					TestPass:    valuePtr[int64](33),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](20),
+					TestPass:    valuePtr[int64](20),
+				},
+			},
+			ExperimentalMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](220),
+					TestPass:    valuePtr[int64](220),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](11),
+					TestPass:    valuePtr[int64](11),
+				},
+			},
+		},
+		{
+			FeatureID: "feature2",
+			Name:      "Feature 2",
+			Status:    string(BaselineStatusHigh),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](10),
+					TestPass:    valuePtr[int64](10),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](10),
+					TestPass:    valuePtr[int64](0),
+				},
+			},
+			ExperimentalMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](120),
+					TestPass:    valuePtr[int64](120),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](12),
+					TestPass:    valuePtr[int64](12),
+				},
+			},
+		},
+		{
+			FeatureID: "feature3",
+			Name:      "Feature 3",
+			Status:    string(BaselineStatusUndefined),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](50),
+					TestPass:    valuePtr[int64](35),
+				},
+			},
+			ExperimentalMetrics: nil,
+		},
+		{
+			FeatureID:           "feature4",
+			Name:                "Feature 4",
+			Status:              string(BaselineStatusUndefined),
+			StableMetrics:       nil,
+			ExperimentalMetrics: nil,
+		},
+	}
+	// Test: Get all the results.
+	results, _, err := client.FeaturesSearch(ctx, nil, 100)
+	if err != nil {
+		t.Errorf("unexpected error during search of features %s", err.Error())
+	}
+	stabilizeFeatureResults(results)
+	if !reflect.DeepEqual(expectedResults, results) {
+		t.Errorf("unequal results. expected (%+v) received (%+v) ", expectedResults, results)
+	}
+}
+
+func testFeatureSearchPagination(ctx context.Context, t *testing.T, client *Client) {
+	// Test: Get all the results with pagination.
+	// nolint: dupl
+	expectedResultsPageOne := []FeatureResult{
+		{
+			FeatureID: "feature1",
+			Name:      "Feature 1",
+			Status:    string(BaselineStatusUndefined),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](33),
+					TestPass:    valuePtr[int64](33),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](20),
+					TestPass:    valuePtr[int64](20),
+				},
+			},
+			ExperimentalMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](220),
+					TestPass:    valuePtr[int64](220),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](11),
+					TestPass:    valuePtr[int64](11),
+				},
+			},
+		},
+		{
+			FeatureID: "feature2",
+			Name:      "Feature 2",
+			Status:    string(BaselineStatusHigh),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](10),
+					TestPass:    valuePtr[int64](10),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](10),
+					TestPass:    valuePtr[int64](0),
+				},
+			},
+			ExperimentalMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](120),
+					TestPass:    valuePtr[int64](120),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](12),
+					TestPass:    valuePtr[int64](12),
+				},
+			},
+		},
+	}
+	results, token, err := client.FeaturesSearch(ctx, nil, 2)
+	if err != nil {
+		t.Errorf("unexpected error during search of features %s", err.Error())
+	}
+	stabilizeFeatureResults(results)
+	if !reflect.DeepEqual(expectedResultsPageOne, results) {
+		t.Errorf("unequal results. expected (%+v) received (%+v) ", expectedResultsPageOne, results)
+	}
+
+	expectedResultsPageTwo := []FeatureResult{
+		{
+			FeatureID: "feature3",
+			Name:      "Feature 3",
+			Status:    string(BaselineStatusUndefined),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](50),
+					TestPass:    valuePtr[int64](35),
+				},
+			},
+			ExperimentalMetrics: nil,
+		},
+		{
+			FeatureID:           "feature4",
+			Name:                "Feature 4",
+			Status:              string(BaselineStatusUndefined),
+			StableMetrics:       nil,
+			ExperimentalMetrics: nil,
+		},
+	}
+
+	results, token, err = client.FeaturesSearch(ctx, token, 2)
+	if err != nil {
+		t.Errorf("unexpected error during search of features %s", err.Error())
+	}
+	stabilizeFeatureResults(results)
+	if !reflect.DeepEqual(expectedResultsPageTwo, results) {
+		t.Errorf("unequal results. expected (%+v) received (%+v) ", expectedResultsPageTwo, results)
+	}
+
+	// Last page should have no results and should have no token.
+	results, token, err = client.FeaturesSearch(ctx, token, 2)
+	if err != nil {
+		t.Errorf("unexpected error during search of features %s", err.Error())
+	}
+	if token != nil {
+		t.Error("expected nil token")
+	}
+	var expectedResultsPageThree []FeatureResult
+	if !reflect.DeepEqual(expectedResultsPageThree, results) {
+		t.Errorf("unequal results. expected (%+v) received (%+v) ", expectedResultsPageThree, results)
+	}
+
+}
+
+func testFeatureSearchFilters(ctx context.Context, t *testing.T, client *Client) {
+	testFeatureAvailableSearchFilters(ctx, t, client)
+	testFeatureNotAvailableSearchFilters(ctx, t, client)
+	testFeatureCommonFilterCombos(ctx, t, client)
+}
+
+func testFeatureCommonFilterCombos(ctx context.Context, t *testing.T, client *Client) {
+	// Available and not available filters
+	expectedResults := []FeatureResult{
+		{
+			FeatureID: "feature2",
+			Name:      "Feature 2",
+			Status:    string(BaselineStatusHigh),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](10),
+					TestPass:    valuePtr[int64](10),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](10),
+					TestPass:    valuePtr[int64](0),
+				},
+			},
+			ExperimentalMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](120),
+					TestPass:    valuePtr[int64](120),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](12),
+					TestPass:    valuePtr[int64](12),
+				},
+			},
+		},
+	}
+	availableFilter := NewAvailabileFilter([]string{"barBrowser"})
+	notAvailableFilter := NewNotAvailabileFilter([]string{"fooBrowser"})
+	results, _, err := client.FeaturesSearch(ctx, nil, 100, availableFilter, notAvailableFilter)
+	if err != nil {
+		t.Errorf("unexpected error during search of features %s", err.Error())
+	}
+	stabilizeFeatureResults(results)
+	if !reflect.DeepEqual(expectedResults, results) {
+		t.Errorf("unequal results. expected (%+v) received (%+v) ", expectedResults, results)
+	}
+}
+
+func testFeatureNotAvailableSearchFilters(ctx context.Context, t *testing.T, client *Client) {
+	// Single browser
+	expectedResults := []FeatureResult{
+		{
+			FeatureID: "feature2",
+			Name:      "Feature 2",
+			Status:    string(BaselineStatusHigh),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](10),
+					TestPass:    valuePtr[int64](10),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](10),
+					TestPass:    valuePtr[int64](0),
+				},
+			},
+			ExperimentalMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](120),
+					TestPass:    valuePtr[int64](120),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](12),
+					TestPass:    valuePtr[int64](12),
+				},
+			},
+		},
+		{
+			FeatureID:           "feature4",
+			Name:                "Feature 4",
+			Status:              string(BaselineStatusUndefined),
+			StableMetrics:       nil,
+			ExperimentalMetrics: nil,
+		},
+	}
+	notAvailableFilter := NewNotAvailabileFilter([]string{"fooBrowser"})
+	results, _, err := client.FeaturesSearch(ctx, nil, 100, notAvailableFilter)
+	if err != nil {
+		t.Errorf("unexpected error during search of features %s", err.Error())
+	}
+	stabilizeFeatureResults(results)
+	if !reflect.DeepEqual(expectedResults, results) {
+		t.Errorf("unequal results. expected (%+v) received (%+v) ", expectedResults, results)
+	}
+}
+func testFeatureAvailableSearchFilters(ctx context.Context, t *testing.T, client *Client) {
+	// Single browser
+	// nolint: dupl
+	expectedResults := []FeatureResult{
+		{
+			FeatureID: "feature1",
+			Name:      "Feature 1",
+			Status:    string(BaselineStatusUndefined),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](33),
+					TestPass:    valuePtr[int64](33),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](20),
+					TestPass:    valuePtr[int64](20),
+				},
+			},
+			ExperimentalMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](220),
+					TestPass:    valuePtr[int64](220),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](11),
+					TestPass:    valuePtr[int64](11),
+				},
+			},
+		},
+		{
+			FeatureID: "feature2",
+			Name:      "Feature 2",
+			Status:    string(BaselineStatusHigh),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](10),
+					TestPass:    valuePtr[int64](10),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](10),
+					TestPass:    valuePtr[int64](0),
+				},
+			},
+			ExperimentalMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](120),
+					TestPass:    valuePtr[int64](120),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](12),
+					TestPass:    valuePtr[int64](12),
+				},
+			},
+		},
+	}
+	availableFilter := NewAvailabileFilter([]string{"barBrowser"})
+	results, _, err := client.FeaturesSearch(ctx, nil, 100, availableFilter)
+	if err != nil {
+		t.Errorf("unexpected error during search of features %s", err.Error())
+	}
+	stabilizeFeatureResults(results)
+	if !reflect.DeepEqual(expectedResults, results) {
+		t.Errorf("unequal results. expected (%+v) received (%+v) ", expectedResults, results)
+	}
+
+	// Multiple browsers.
+	expectedResults = []FeatureResult{
+		{
+			FeatureID: "feature1",
+			Name:      "Feature 1",
+			Status:    string(BaselineStatusUndefined),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](33),
+					TestPass:    valuePtr[int64](33),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](20),
+					TestPass:    valuePtr[int64](20),
+				},
+			},
+			ExperimentalMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](220),
+					TestPass:    valuePtr[int64](220),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](11),
+					TestPass:    valuePtr[int64](11),
+				},
+			},
+		},
+		{
+			FeatureID: "feature2",
+			Name:      "Feature 2",
+			Status:    string(BaselineStatusHigh),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](10),
+					TestPass:    valuePtr[int64](10),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](10),
+					TestPass:    valuePtr[int64](0),
+				},
+			},
+			ExperimentalMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "barBrowser",
+					TotalTests:  valuePtr[int64](120),
+					TestPass:    valuePtr[int64](120),
+				},
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](12),
+					TestPass:    valuePtr[int64](12),
+				},
+			},
+		},
+		{
+			FeatureID: "feature3",
+			Name:      "Feature 3",
+			Status:    string(BaselineStatusUndefined),
+			StableMetrics: []*FeatureResultMetric{
+				{
+					BrowserName: "fooBrowser",
+					TotalTests:  valuePtr[int64](50),
+					TestPass:    valuePtr[int64](35),
+				},
+			},
+			ExperimentalMetrics: nil,
+		},
+	}
+	availableFilter = NewAvailabileFilter([]string{"barBrowser", "fooBrowser"})
+	results, _, err = client.FeaturesSearch(ctx, nil, 100, availableFilter)
+	if err != nil {
+		t.Errorf("unexpected error during search of features %s", err.Error())
+	}
+	stabilizeFeatureResults(results)
+	if !reflect.DeepEqual(expectedResults, results) {
+		t.Errorf("unequal results. expected (%+v) received (%+v) ", expectedResults, results)
+	}
+}
+
+func TestFeaturesSearch(t *testing.T) {
+	client := getTestDatabase(t)
+	ctx := context.Background()
+	setupRequiredTablesForFeaturesSearch(ctx, client, t)
+
+	testFeatureSearchAll(ctx, t, client)
+	testFeatureSearchPagination(ctx, t, client)
+	testFeatureSearchFilters(ctx, t, client)
+}


### PR DESCRIPTION
This is splitting https://github.com/GoogleChrome/webstatus.dev/pull/54

This introduces the base query to search for pages of features.

This query will be useful for the overview page.

Introduce filterable interface (similar to the filterable for datastore).

Included filters that implement filterable:

- AvailableOn
- NotAvailableOn

If the user provides a list of browsers for either filter, it will do an OR with that list for that particular filter.

Example.
- URL: ?availableOn:browser1&availableOn=browser2 
- DatabaseQuery: availableOn=browser1 OR availableOn = browser2

This behavior may change for the availableOn filter to be an AND.

But the filter query can easily be changed.

Change-Id: I808316fc7b6156d901ffe80b2cd494215bcddd35