### PR TITLE
Feature: switch to spanner for v1/features endpoint

### DIFF
--- a/backend/pkg/httpserver/get_features.go
+++ b/backend/pkg/httpserver/get_features.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// GetV1Features implements backend.StrictServerInterface.
+// nolint:ireturn // Expected ireturn for openapi generation.
+func (s *Server) GetV1Features(
+	ctx context.Context,
+	req backend.GetV1FeaturesRequestObject,
+) (backend.GetV1FeaturesResponseObject, error) {
+	featureData, nextPageToken, err := s.wptMetricsStorer.FeaturesSearch(
+		ctx,
+		req.Params.PageToken,
+		getPageSizeOrDefault(req.Params.PageSize),
+		getBrowserListOrDefault(req.Params.AvailableOn),
+		getBrowserListOrDefault(req.Params.NotAvailableOn),
+	)
+
+	if err != nil {
+		// TODO check error type
+		slog.Error("unable to get list of features", "error", err)
+
+		return backend.GetV1Features500JSONResponse{
+			Code:    500,
+			Message: "unable to get list of features",
+		}, nil
+	}
+
+	return backend.GetV1Features200JSONResponse{
+		Metadata: &backend.PageMetadata{
+			NextPageToken: nextPageToken,
+		},
+		Data: featureData,
+	}, nil
+}

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -1,0 +1,191 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestGetV1Features(t *testing.T) {
+	testCases := []struct {
+		name              string
+		mockConfig        MockFeaturesSearchConfig
+		expectedCallCount int // For the mock method
+		request           backend.GetV1FeaturesRequestObject
+		expectedResponse  backend.GetV1FeaturesResponseObject
+		expectedError     error
+	}{
+		{
+			name: "Success Case - no optional params - use defaults",
+			mockConfig: MockFeaturesSearchConfig{
+				expectedPageToken:            nil,
+				expectedPageSize:             100,
+				expectedAvailableBrowsers:    []string{},
+				expectedNotAvailableBrowsers: []string{},
+				data: []backend.Feature{
+					{
+						BaselineStatus: backend.High,
+						FeatureId:      "feature1",
+						Name:           "feature 1",
+						Spec:           nil,
+						Usage:          nil,
+						Wpt:            nil,
+					},
+				},
+				pageToken: nil,
+				err:       nil,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.GetV1Features200JSONResponse{
+				Data: []backend.Feature{
+					{
+						BaselineStatus: backend.High,
+						FeatureId:      "feature1",
+						Name:           "feature 1",
+						Spec:           nil,
+						Usage:          nil,
+						Wpt:            nil,
+					},
+				},
+				Metadata: &backend.PageMetadata{
+					NextPageToken: nil,
+				},
+			},
+			request: backend.GetV1FeaturesRequestObject{
+				Params: backend.GetV1FeaturesParams{
+					PageToken:      nil,
+					PageSize:       nil,
+					AvailableOn:    nil,
+					NotAvailableOn: nil,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success Case - include optional params",
+			mockConfig: MockFeaturesSearchConfig{
+				expectedPageToken:            inputPageToken,
+				expectedPageSize:             50,
+				expectedAvailableBrowsers:    []string{"browser1", "browser3"},
+				expectedNotAvailableBrowsers: []string{"browser2", "browser4"},
+				data: []backend.Feature{
+					{
+						BaselineStatus: backend.High,
+						FeatureId:      "feature1",
+						Name:           "feature 1",
+						Spec:           nil,
+						Usage:          nil,
+						Wpt:            nil,
+					},
+				},
+				pageToken: nextPageToken,
+				err:       nil,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.GetV1Features200JSONResponse{
+				Data: []backend.Feature{
+					{
+						BaselineStatus: backend.High,
+						FeatureId:      "feature1",
+						Name:           "feature 1",
+						Spec:           nil,
+						Usage:          nil,
+						Wpt:            nil,
+					},
+				},
+				Metadata: &backend.PageMetadata{
+					NextPageToken: nextPageToken,
+				},
+			},
+			request: backend.GetV1FeaturesRequestObject{
+				Params: backend.GetV1FeaturesParams{
+					PageToken:      inputPageToken,
+					PageSize:       valuePtr[int](50),
+					AvailableOn:    &[]string{"browser1", "browser3"},
+					NotAvailableOn: &[]string{"browser2", "browser4"},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "500 case",
+			mockConfig: MockFeaturesSearchConfig{
+				expectedPageToken:            nil,
+				expectedPageSize:             100,
+				expectedAvailableBrowsers:    []string{},
+				expectedNotAvailableBrowsers: []string{},
+				data: []backend.Feature{
+					{
+						BaselineStatus: backend.High,
+						FeatureId:      "feature1",
+						Name:           "feature 1",
+						Spec:           nil,
+						Usage:          nil,
+						Wpt:            nil,
+					},
+				},
+				pageToken: nil,
+				err:       errTest,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.GetV1Features500JSONResponse{
+				Code:    500,
+				Message: "unable to get list of features",
+			},
+			request: backend.GetV1FeaturesRequestObject{
+				Params: backend.GetV1FeaturesParams{
+					PageToken:      nil,
+					PageSize:       nil,
+					AvailableOn:    nil,
+					NotAvailableOn: nil,
+				},
+			},
+			expectedError: nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// nolint: exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				featuresSearchCfg: tc.mockConfig,
+				t:                 t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
+
+			// Call the function under test
+			resp, err := myServer.GetV1Features(context.Background(), tc.request)
+
+			// Assertions
+			if mockStorer.callCountFeaturesSearch != tc.expectedCallCount {
+				t.Errorf("Incorrect call count: expected %d, got %d",
+					tc.expectedCallCount,
+					mockStorer.callCountFeaturesSearch)
+			}
+
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tc.expectedResponse, resp) {
+				t.Errorf("Unexpected response: %v", resp)
+			}
+		})
+	}
+}

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -16,6 +16,7 @@ package spanneradapters
 
 import (
 	"context"
+	"math/big"
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
@@ -42,6 +43,11 @@ type BackendSpannerClient interface {
 		pageSize int,
 		pageToken *string,
 	) ([]gcpspanner.WPTRunAggregationMetricWithTime, *string, error)
+	FeaturesSearch(
+		ctx context.Context,
+		pageToken *string,
+		pageSize int,
+		filterables ...gcpspanner.Filterable) ([]gcpspanner.FeatureResult, *string, error)
 }
 
 // Backend converts queries to spaner to useable entities for the backend
@@ -125,4 +131,93 @@ func (s *Backend) ListMetricsForFeatureIDBrowserAndChannel(
 	}
 
 	return backendMetrics, nextPageToken, nil
+}
+
+func convertBaselineStatusBackendToSpanner(status backend.FeatureBaselineStatus) gcpspanner.BaselineStatus {
+	switch status {
+	case backend.High:
+		return gcpspanner.BaselineStatusHigh
+	case backend.Low:
+		return gcpspanner.BaselineStatusLow
+	case backend.None:
+		return gcpspanner.BaselineStatusNone
+	case backend.Undefined:
+		fallthrough
+	default:
+		return gcpspanner.BaselineStatusUndefined
+	}
+}
+
+func convertBaselineStatusSpannerToBackend(status gcpspanner.BaselineStatus) backend.FeatureBaselineStatus {
+	switch status {
+	case gcpspanner.BaselineStatusHigh:
+		return backend.High
+	case gcpspanner.BaselineStatusLow:
+		return backend.Low
+	case gcpspanner.BaselineStatusNone:
+		return backend.None
+	case gcpspanner.BaselineStatusUndefined:
+		fallthrough
+	default:
+		return backend.Undefined
+	}
+}
+
+func (s *Backend) FeaturesSearch(
+	ctx context.Context,
+	pageToken *string,
+	pageSize int,
+	availabileBrowsers []string,
+	notAvailabileBrowsers []string,
+) ([]backend.Feature, *string, error) {
+	var filters []gcpspanner.Filterable
+	if len(availabileBrowsers) > 0 {
+		filters = append(filters, gcpspanner.NewAvailabileFilter(availabileBrowsers))
+	}
+
+	if len(notAvailabileBrowsers) > 0 {
+		filters = append(filters, gcpspanner.NewNotAvailabileFilter(notAvailabileBrowsers))
+	}
+
+	featureResults, token, err := s.client.FeaturesSearch(ctx, pageToken, pageSize, filters...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	results := make([]backend.Feature, 0, len(featureResults))
+	for _, featureResult := range featureResults {
+		experimentalMetricsMap := make(map[string]backend.WPTFeatureData)
+		for _, metric := range featureResult.ExperimentalMetrics {
+			if metric.TestPass == nil || metric.TotalTests == nil || (metric.TotalTests != nil && *metric.TotalTests <= 0) {
+				continue
+			}
+			score, _ := big.NewRat(*metric.TestPass, *metric.TotalTests).Float64()
+			experimentalMetricsMap[metric.BrowserName] = backend.WPTFeatureData{
+				Score: &score,
+			}
+		}
+		stableMetricsMap := make(map[string]backend.WPTFeatureData)
+		for _, metric := range featureResult.StableMetrics {
+			if metric.TestPass == nil || metric.TotalTests == nil || (metric.TotalTests != nil && *metric.TotalTests <= 0) {
+				continue
+			}
+			score, _ := big.NewRat(*metric.TestPass, *metric.TotalTests).Float64()
+			stableMetricsMap[metric.BrowserName] = backend.WPTFeatureData{
+				Score: &score,
+			}
+		}
+		results = append(results, backend.Feature{
+			FeatureId:      featureResult.FeatureID,
+			Name:           featureResult.Name,
+			BaselineStatus: convertBaselineStatusSpannerToBackend(gcpspanner.BaselineStatus(featureResult.Status)),
+			Wpt: &backend.FeatureWPTSnapshots{
+				Experimental: &experimentalMetricsMap,
+				Stable:       &stableMetricsMap,
+			},
+			Spec:  nil,
+			Usage: nil,
+		})
+	}
+
+	return results, token, nil
 }

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -35,12 +35,22 @@ var (
 	testEnd              = time.Date(2000, time.January, 31, 0, 0, 0, 0, time.UTC)
 )
 
+type mockFeaturesSearchConfig struct {
+	expectedPageToken   *string
+	expectedPageSize    int
+	expectedFilterables []gcpspanner.Filterable
+	result              []gcpspanner.FeatureResult
+	returnedPageToken   *string
+	returnedError       error
+}
+
 type mockBackendSpannerClient struct {
-	t               *testing.T
-	aggregationData []gcpspanner.WPTRunAggregationMetricWithTime
-	featureData     []gcpspanner.WPTRunFeatureMetricWithTime
-	pageToken       *string
-	err             error
+	t                     *testing.T
+	aggregationData       []gcpspanner.WPTRunAggregationMetricWithTime
+	featureData           []gcpspanner.WPTRunFeatureMetricWithTime
+	mockFeaturesSearchCfg mockFeaturesSearchConfig
+	pageToken             *string
+	err                   error
 }
 
 func (c mockBackendSpannerClient) ListMetricsForFeatureIDBrowserAndChannel(
@@ -88,6 +98,22 @@ func (c mockBackendSpannerClient) ListMetricsOverTimeWithAggregatedTotals(
 	}
 
 	return c.aggregationData, c.pageToken, c.err
+}
+
+func (c mockBackendSpannerClient) FeaturesSearch(
+	_ context.Context,
+	pageToken *string,
+	pageSize int,
+	filterables ...gcpspanner.Filterable) ([]gcpspanner.FeatureResult, *string, error) {
+	if pageToken != c.mockFeaturesSearchCfg.expectedPageToken ||
+		pageSize != c.mockFeaturesSearchCfg.expectedPageSize ||
+		!reflect.DeepEqual(filterables, c.mockFeaturesSearchCfg.expectedFilterables) {
+		c.t.Error("unexpected input to mock")
+	}
+
+	return c.mockFeaturesSearchCfg.result,
+		c.mockFeaturesSearchCfg.returnedPageToken,
+		c.mockFeaturesSearchCfg.returnedError
 }
 
 func valuePtr[T any](in T) *T { return &in }
@@ -286,4 +312,273 @@ func TestListMetricsOverTimeWithAggregatedTotals(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConvertBaselineStatusBackendToSpanner(t *testing.T) {
+	var backendToSpannerTests = []struct {
+		name     string
+		input    backend.FeatureBaselineStatus
+		expected gcpspanner.BaselineStatus
+	}{
+		{"High to High", backend.High, gcpspanner.BaselineStatusHigh},
+		{"Low to Low", backend.Low, gcpspanner.BaselineStatusLow},
+		{"None to None", backend.None, gcpspanner.BaselineStatusNone},
+		{"Invalid to Undefined", backend.FeatureBaselineStatus("invalid"),
+			gcpspanner.BaselineStatusUndefined}, // Test default case
+	}
+	for _, tt := range backendToSpannerTests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertBaselineStatusBackendToSpanner(tt.input)
+			if result != tt.expected {
+				t.Errorf("convertBaselineStatusBackendToSpanner(%v): got %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConvertBaselineStatusSpannerToBackend(t *testing.T) {
+	var spannerToBackendTests = []struct {
+		name     string
+		input    gcpspanner.BaselineStatus
+		expected backend.FeatureBaselineStatus
+	}{
+		{"High to High", gcpspanner.BaselineStatusHigh, backend.High},
+		{"Low to Low", gcpspanner.BaselineStatusLow, backend.Low},
+		{"None to None", gcpspanner.BaselineStatusNone, backend.None},
+		{"Invalid to Undefined", gcpspanner.BaselineStatus("invalid"), backend.Undefined}, // Test default case
+	}
+	for _, tt := range spannerToBackendTests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertBaselineStatusSpannerToBackend(tt.input)
+			if result != tt.expected {
+				t.Errorf("convertBaselineStatusSpannerToBackend(%v): got %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFeaturesSearch(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		cfg                   mockFeaturesSearchConfig
+		inputPageToken        *string
+		inputPageSize         int
+		availabileBrowsers    []string
+		notAvailabileBrowsers []string
+		expectedFeatures      []backend.Feature
+	}{
+		{
+			name: "regular",
+			cfg: mockFeaturesSearchConfig{
+				expectedPageToken:   nonNilInputPageToken,
+				expectedPageSize:    100,
+				expectedFilterables: nil,
+				result: []gcpspanner.FeatureResult{
+					{
+						Name:      "feature 1",
+						FeatureID: "feature1",
+						Status:    "low",
+						StableMetrics: []*gcpspanner.FeatureResultMetric{
+							{
+								BrowserName: "browser3",
+								TestPass:    valuePtr[int64](10),
+								TotalTests:  valuePtr[int64](20),
+							},
+						},
+						ExperimentalMetrics: []*gcpspanner.FeatureResultMetric{
+							{
+								BrowserName: "browser3",
+								TestPass:    valuePtr[int64](10),
+								TotalTests:  valuePtr[int64](50),
+							},
+						},
+					},
+					{
+						Name:      "feature 2",
+						FeatureID: "feature2",
+						Status:    "high",
+						StableMetrics: []*gcpspanner.FeatureResultMetric{
+							{
+								BrowserName: "browser1",
+								TestPass:    valuePtr[int64](10),
+								TotalTests:  valuePtr[int64](20),
+							},
+							{
+								BrowserName: "browser2",
+								TestPass:    valuePtr[int64](5),
+								TotalTests:  valuePtr[int64](20),
+							},
+						},
+						ExperimentalMetrics: []*gcpspanner.FeatureResultMetric{
+							{
+								BrowserName: "browser1",
+								TestPass:    valuePtr[int64](10),
+								TotalTests:  valuePtr[int64](20),
+							},
+							{
+								BrowserName: "browser2",
+								TestPass:    valuePtr[int64](2),
+								TotalTests:  valuePtr[int64](20),
+							},
+						},
+					},
+				},
+				returnedPageToken: nonNilNextPageToken,
+				returnedError:     nil,
+			},
+			inputPageToken:        nonNilInputPageToken,
+			inputPageSize:         100,
+			availabileBrowsers:    nil,
+			notAvailabileBrowsers: nil,
+			expectedFeatures: []backend.Feature{
+				{
+					BaselineStatus: backend.Low,
+					FeatureId:      "feature1",
+					Name:           "feature 1",
+					Spec:           nil,
+					Usage:          nil,
+					Wpt: &backend.FeatureWPTSnapshots{
+						Experimental: &map[string]backend.WPTFeatureData{
+							"browser3": {
+								Score: valuePtr[float64](0.2),
+							},
+						},
+						Stable: &map[string]backend.WPTFeatureData{
+							"browser3": {
+								Score: valuePtr[float64](0.5),
+							},
+						},
+					},
+				},
+				{
+					BaselineStatus: backend.High,
+					FeatureId:      "feature2",
+					Name:           "feature 2",
+					Spec:           nil,
+					Usage:          nil,
+					Wpt: &backend.FeatureWPTSnapshots{
+						Experimental: &map[string]backend.WPTFeatureData{
+							"browser1": {
+								Score: valuePtr[float64](0.5),
+							},
+							"browser2": {
+								Score: valuePtr[float64](0.1),
+							},
+						},
+						Stable: &map[string]backend.WPTFeatureData{
+							"browser1": {
+								Score: valuePtr[float64](0.5),
+							},
+							"browser2": {
+								Score: valuePtr[float64](0.25),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint: exhaustruct
+			mock := mockBackendSpannerClient{
+				t:                     t,
+				mockFeaturesSearchCfg: tc.cfg,
+			}
+			bk := NewBackend(mock)
+			features, pageToken, err := bk.FeaturesSearch(
+				context.Background(),
+				tc.inputPageToken,
+				tc.inputPageSize,
+				tc.availabileBrowsers,
+				tc.notAvailabileBrowsers)
+			if !errors.Is(err, tc.cfg.returnedError) {
+				t.Error("unexpected error")
+			}
+
+			if pageToken != tc.cfg.returnedPageToken {
+				t.Error("unexpected page token")
+			}
+
+			if !slices.EqualFunc[[]backend.Feature](features, tc.expectedFeatures, CompareFeatures) {
+				t.Error("unexpected features")
+			}
+
+		})
+	}
+}
+
+// CompareFeatures checks if two backend.Feature structs are deeply equal.
+func CompareFeatures(f1, f2 backend.Feature) bool {
+	// 1. Basic Equality Checks
+	if f1.BaselineStatus != f2.BaselineStatus ||
+		f1.FeatureId != f2.FeatureId ||
+		f1.Name != f2.Name ||
+		f1.Usage != f2.Usage {
+		return false
+	}
+
+	// 2. Compare 'spec' (slice of strings)
+	if !reflect.DeepEqual(f1.Spec, f2.Spec) {
+		return false
+	}
+
+	// 3. Compare FeatureWPTSnapshots (nested structs)
+	if !compareWPTSnapshots(f1.Wpt, f2.Wpt) {
+		return false
+	}
+
+	// All fields match
+	return true
+}
+
+// compareWPTSnapshots helps compare FeatureWPTSnapshots structs.
+func compareWPTSnapshots(w1, w2 *backend.FeatureWPTSnapshots) bool {
+	// Handle nil cases
+	if (w1 == nil && w2 != nil) || (w1 != nil && w2 == nil) {
+		return false
+	}
+
+	if w1 == nil && w2 == nil { // Both nil
+		return true
+	}
+
+	// Compare 'Experimental' maps
+	if !compareFeatureDataMap(w1.Experimental, w2.Experimental) {
+		return false
+	}
+
+	// Compare 'Stable' maps
+	if !compareFeatureDataMap(w1.Stable, w2.Stable) {
+		return false
+	}
+
+	return true
+}
+
+// compareFeatureDataMap helps compare maps of WPTFeatureData.
+func compareFeatureDataMap(m1, m2 *map[string]backend.WPTFeatureData) bool {
+	// Handle nil cases
+	if (m1 == nil && m2 != nil) || (m1 != nil && m2 == nil) {
+		return false
+	}
+
+	if m1 == nil && m2 == nil { // Both nil
+		return true
+	}
+
+	// Check if lengths are equal
+	if len(*m1) != len(*m2) {
+		return false
+	}
+
+	// Compare each key-value pair
+	for k, v1 := range *m1 {
+		v2, ok := (*m2)[k]
+		if !ok || *v1.Score != *v2.Score {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
This is splitting https://github.com/GoogleChrome/webstatus.dev/pull/54 This is only for the v1/features endpoint not v1/features/{id}. That will come shortly after splitting up PR 54.

Added a new feature search interface to the backend (which spanner implements already). Switched the backend to using that.

Moved the features search handler to a separate file to help with organization.

Added: spanner adapters:
- This creates the translation layer between spanner to the openapi object backend object that is expected.

Now developers can run queries such as:
- http://127.0.0.1:8080/v1/features?availableOn=edge&availableOn=firefox

