### PR TITLE
Use Spanner for v1/features/<id>

### DIFF
--- a/backend/pkg/httpserver/get_feature.go
+++ b/backend/pkg/httpserver/get_feature.go
@@ -1,0 +1,52 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// GetV1FeaturesFeatureId implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Name generated from openapi
+func (s *Server) GetV1FeaturesFeatureId(
+	ctx context.Context,
+	request backend.GetV1FeaturesFeatureIdRequestObject,
+) (backend.GetV1FeaturesFeatureIdResponseObject, error) {
+	feature, err := s.wptMetricsStorer.GetFeature(ctx, request.FeatureId)
+	if err != nil {
+		if errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {
+			return backend.GetV1FeaturesFeatureId404JSONResponse{
+				Code:    http.StatusNotFound,
+				Message: fmt.Sprintf("feature id %s is not found", request.FeatureId),
+			}, nil
+		}
+		// Catch all for all other errors.
+		slog.Error("unable to get feature", "error", err)
+
+		return backend.GetV1FeaturesFeatureId500JSONResponse{
+			Code:    500,
+			Message: "unable to get feature",
+		}, nil
+	}
+
+	return backend.GetV1FeaturesFeatureId200JSONResponse(*feature), nil
+}

--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -1,0 +1,127 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestGetV1FeaturesFeatureId(t *testing.T) {
+	testCases := []struct {
+		name              string
+		mockConfig        MockGetFeatureByIDConfig
+		expectedCallCount int // For the mock method
+		request           backend.GetV1FeaturesFeatureIdRequestObject
+		expectedResponse  backend.GetV1FeaturesFeatureIdResponseObject
+		expectedError     error
+	}{
+		{
+			name: "Success Case - no optional params - use defaults",
+			mockConfig: MockGetFeatureByIDConfig{
+				expectedFeatureID: "feature1",
+				data: &backend.Feature{
+					BaselineStatus: backend.High,
+					FeatureId:      "feature1",
+					Name:           "feature 1",
+					Spec:           nil,
+					Usage:          nil,
+					Wpt:            nil,
+				},
+				err: nil,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.GetV1FeaturesFeatureId200JSONResponse{
+				BaselineStatus: backend.High,
+				FeatureId:      "feature1",
+				Name:           "feature 1",
+				Spec:           nil,
+				Usage:          nil,
+				Wpt:            nil,
+			},
+			request: backend.GetV1FeaturesFeatureIdRequestObject{
+				FeatureId: "feature1",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "404",
+			mockConfig: MockGetFeatureByIDConfig{
+				expectedFeatureID: "feature1",
+				data:              nil,
+				err:               gcpspanner.ErrQueryReturnedNoResults,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.GetV1FeaturesFeatureId404JSONResponse{
+				Code:    404,
+				Message: "feature id feature1 is not found",
+			},
+			request: backend.GetV1FeaturesFeatureIdRequestObject{
+				FeatureId: "feature1",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "500",
+			mockConfig: MockGetFeatureByIDConfig{
+				expectedFeatureID: "feature1",
+				data:              nil,
+				err:               errTest,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.GetV1FeaturesFeatureId500JSONResponse{
+				Code:    500,
+				Message: "unable to get feature",
+			},
+			request: backend.GetV1FeaturesFeatureIdRequestObject{
+				FeatureId: "feature1",
+			},
+			expectedError: nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// nolint: exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				getFeatureByIDConfig: tc.mockConfig,
+				t:                    t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
+
+			// Call the function under test
+			resp, err := myServer.GetV1FeaturesFeatureId(context.Background(), tc.request)
+
+			// Assertions
+			if mockStorer.callCountGetFeature != tc.expectedCallCount {
+				t.Errorf("Incorrect call count: expected %d, got %d",
+					tc.expectedCallCount,
+					mockStorer.callCountGetFeature)
+			}
+
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tc.expectedResponse, resp) {
+				t.Errorf("Unexpected response: %v", resp)
+			}
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -18,7 +18,6 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/http"
 	"time"
@@ -59,6 +58,10 @@ type WPTMetricsStorer interface {
 		availabileBrowsers []string,
 		notAvailabileBrowsers []string,
 	) ([]backend.Feature, *string, error)
+	GetFeature(
+		ctx context.Context,
+		featureID string,
+	) (*backend.Feature, error)
 }
 
 type Server struct {
@@ -88,26 +91,6 @@ func getBrowserListOrDefault(browserList *[]string) []string {
 	var defaultBrowserList []string
 
 	return *(cmp.Or[*[]string](browserList, &defaultBrowserList))
-}
-
-// GetV1FeaturesFeatureId implements backend.StrictServerInterface.
-// nolint: revive, ireturn // Name generated from openapi
-func (s *Server) GetV1FeaturesFeatureId(
-	ctx context.Context,
-	request backend.GetV1FeaturesFeatureIdRequestObject,
-) (backend.GetV1FeaturesFeatureIdResponseObject, error) {
-	feature, err := s.metadataStorer.GetWebFeatureData(ctx, request.FeatureId)
-	if err != nil {
-		// TODO. Check if the feature exists and return a 404 if it does not.
-		slog.Error("unable to get feature", "error", err)
-
-		return backend.GetV1FeaturesFeatureId500JSONResponse{
-			Code:    500,
-			Message: "unable to get feature",
-		}, nil
-	}
-
-	return backend.GetV1FeaturesFeatureId200JSONResponse(*feature), nil
 }
 
 func NewHTTPServer(

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -62,14 +62,22 @@ type MockFeaturesSearchConfig struct {
 	err                          error
 }
 
+type MockGetFeatureByIDConfig struct {
+	expectedFeatureID string
+	data              *backend.Feature
+	err               error
+}
+
 type MockWPTMetricsStorer struct {
 	featureCfg                                        MockListMetricsForFeatureIDBrowserAndChannelConfig
 	aggregateCfg                                      MockListMetricsOverTimeWithAggregatedTotalsConfig
 	featuresSearchCfg                                 MockFeaturesSearchConfig
+	getFeatureByIDConfig                              MockGetFeatureByIDConfig
 	t                                                 *testing.T
 	callCountFeaturesSearch                           int
 	callCountListMetricsForFeatureIDBrowserAndChannel int
 	callCountListMetricsOverTimeWithAggregatedTotals  int
+	callCountGetFeature                               int
 }
 
 func (m *MockWPTMetricsStorer) ListMetricsForFeatureIDBrowserAndChannel(_ context.Context,
@@ -137,6 +145,20 @@ func (m *MockWPTMetricsStorer) FeaturesSearch(
 	}
 
 	return m.featuresSearchCfg.data, m.featuresSearchCfg.pageToken, m.featuresSearchCfg.err
+}
+
+func (m *MockWPTMetricsStorer) GetFeature(
+	_ context.Context,
+	featureID string,
+) (*backend.Feature, error) {
+	m.callCountGetFeature++
+
+	if featureID != m.getFeatureByIDConfig.expectedFeatureID {
+		m.t.Errorf("Incorrect arguments. Expected: %v, Got: { %s }",
+			m.getFeatureByIDConfig, featureID)
+	}
+
+	return m.getFeatureByIDConfig.data, m.getFeatureByIDConfig.err
 }
 
 func TestGetPageSizeOrDefault(t *testing.T) {

--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -1,0 +1,81 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+// FeatureBaseQuery contains the base query for all feature
+// related queries.
+type FeatureBaseQuery struct{}
+
+// Query providess the basic information for a feature.
+// It provides:
+//  1. The Internal ID of the feature
+//  2. The external ID from web features repo
+//  3. The human readable name.
+//  4. The baseline status.
+//  5. The latest metrics from WPT.
+//     It provides these metrics for both "stable" and "experimental" channels.
+//     The metrics retrieved are for each unique BrowserName/Channel/FeatureID.
+func (f FeatureBaseQuery) Query() string {
+	return `
+SELECT
+	wf.ID,
+	wf.FeatureID,
+	wf.Name,
+	COALESCE(fbs.Status, 'undefined') AS Status,
+
+	-- StableMetrics Calculation
+	(SELECT ARRAY_AGG(STRUCT(BrowserName, TotalTests, TestPass))
+		FROM (
+		SELECT browser_feature_list.BrowserName, TotalTests, TestPass
+		FROM (
+			-- Subquery to get distinct BrowserName, FeatureID combinations and their
+			-- associated maximum TimeStart for the specified FeatureID
+			SELECT DISTINCT BrowserName, FeatureID, MAX(wpr.TimeStart) AS MaxTimeStart
+			FROM WPTRunFeatureMetrics metrics
+			JOIN WPTRuns wpr ON metrics.ID = wpr.ID
+			WHERE metrics.FeatureID = wf.FeatureID
+			GROUP BY BrowserName, FeatureID
+		) browser_feature_list
+		-- Join to retrieve metrics, ensuring we get the latest run for each combination
+		JOIN WPTRunFeatureMetrics metrics ON browser_feature_list.FeatureID = metrics.FeatureID
+		JOIN WPTRuns wpr ON metrics.ID = wpr.ID AND browser_feature_list.BrowserName = wpr.BrowserName
+		WHERE wpr.Channel = 'stable'
+		AND wpr.TimeStart = browser_feature_list.MaxTimeStart
+	) latest_metric) AS StableMetrics,
+
+	-- ExperimentalMetrics Calculation
+	(SELECT ARRAY_AGG(STRUCT(BrowserName, TotalTests, TestPass))
+		FROM (
+		SELECT browser_feature_list.BrowserName, TotalTests, TestPass
+		FROM (
+			-- Subquery to get distinct BrowserName, FeatureID combinations and their
+			-- associated maximum TimeStart for the specified FeatureID
+			SELECT DISTINCT BrowserName, FeatureID, MAX(wpr.TimeStart) AS MaxTimeStart
+			FROM WPTRunFeatureMetrics metrics
+			JOIN WPTRuns wpr ON metrics.ID = wpr.ID
+			WHERE metrics.FeatureID = wf.FeatureID
+			GROUP BY BrowserName, FeatureID
+		) browser_feature_list
+		-- Join to retrieve metrics, ensuring we get the latest run for each combination
+		JOIN WPTRunFeatureMetrics metrics ON browser_feature_list.FeatureID = metrics.FeatureID
+		JOIN WPTRuns wpr ON metrics.ID = wpr.ID AND browser_feature_list.BrowserName = wpr.BrowserName
+		WHERE wpr.Channel = 'experimental'
+		AND wpr.TimeStart = browser_feature_list.MaxTimeStart
+	) latest_metric) AS ExperimentalMetrics,
+
+FROM WebFeatures wf
+LEFT OUTER JOIN FeatureBaselineStatus fbs ON wf.FeatureID = fbs.FeatureID
+`
+}

--- a/lib/gcpspanner/feature_search.go
+++ b/lib/gcpspanner/feature_search.go
@@ -60,8 +60,9 @@ func (c *Client) FeaturesSearch(
 		}
 	}
 	b := FeatureSearchQueryBuilder{
-		cursor:   cursor,
-		pageSize: pageSize,
+		baseQuery: FeatureBaseQuery{},
+		cursor:    cursor,
+		pageSize:  pageSize,
 	}
 	stmt := b.Build(filterables...)
 	txn := c.Single()
@@ -80,7 +81,7 @@ func (c *Client) FeaturesSearch(
 		}
 		var result SpannerFeatureResult
 		if err := row.ToStruct(&result); err != nil {
-			return nil, nil, err
+			return nil, nil, errors.Join(ErrInternalQueryFailure, err)
 		}
 		results = append(results, result.FeatureResult)
 	}

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -399,9 +399,14 @@ func sortMetricsByBrowserName(metrics []*FeatureResultMetric) {
 }
 func stabilizeFeatureResults(results []FeatureResult) {
 	for _, result := range results {
-		sortMetricsByBrowserName(result.StableMetrics)
-		sortMetricsByBrowserName(result.ExperimentalMetrics)
+		stabilizeFeatureResult(result)
 	}
+}
+
+func stabilizeFeatureResult(result FeatureResult) {
+	sortMetricsByBrowserName(result.StableMetrics)
+	sortMetricsByBrowserName(result.ExperimentalMetrics)
+
 }
 
 func testFeatureSearchAll(ctx context.Context, t *testing.T, client *Client) {

--- a/lib/gcpspanner/get_feature.go
+++ b/lib/gcpspanner/get_feature.go
@@ -1,0 +1,90 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func (c *Client) GetFeature(
+	ctx context.Context,
+	filter Filterable,
+) (*FeatureResult, error) {
+	b := GetFeatureQueryBuilder{
+		baseQuery: FeatureBaseQuery{},
+	}
+	stmt := b.Build(filter)
+	txn := c.Single()
+	defer txn.Close()
+	it := txn.Query(ctx, stmt)
+	defer it.Stop()
+
+	row, err := it.Next()
+	if err != nil {
+		// No row found
+		if errors.Is(err, iterator.Done) {
+			return nil, errors.Join(ErrQueryReturnedNoResults, err)
+		}
+
+		// Catch-all for other errors.
+		return nil, errors.Join(ErrInternalQueryFailure, err)
+	}
+	var result SpannerFeatureResult
+	if err := row.ToStruct(&result); err != nil {
+		return nil, errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	return &result.FeatureResult, nil
+}
+
+func (c *Client) GetIDFromFeatureID(ctx context.Context, filter *FeatureIDFilter) (*string, error) {
+	query := `
+	SELECT
+		ID
+	FROM WebFeatures wf ` +
+		"WHERE " + filter.Clause() + `
+	LIMIT 1
+	`
+	stmt := spanner.NewStatement(query)
+
+	stmt.Params = filter.Params()
+
+	// Attempt to query for the row.
+	txn := c.Single()
+	defer txn.Close()
+	it := txn.Query(ctx, stmt)
+	defer it.Stop()
+	row, err := it.Next()
+	if err != nil {
+		// No row found
+		if errors.Is(err, iterator.Done) {
+			return nil, errors.Join(ErrQueryReturnedNoResults, err)
+		}
+
+		// Catch-all for other errors.
+		return nil, errors.Join(ErrInternalQueryFailure, err)
+	}
+	var id string
+	err = row.Column(0, &id)
+	if err != nil {
+		return nil, errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	return &id, nil
+}

--- a/lib/gcpspanner/get_feature_query.go
+++ b/lib/gcpspanner/get_feature_query.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cloud.google.com/go/spanner"
+)
+
+func NewFeatureIDFilter(featureID string) *FeatureIDFilter {
+	return &FeatureIDFilter{featureID: featureID}
+}
+
+// FeatureIDFilter will limit the search to a particular feature ID.
+type FeatureIDFilter struct {
+	featureID string
+}
+
+func (f FeatureIDFilter) Clause() string {
+	return `
+wf.FeatureID = @featureID
+`
+}
+
+func (f FeatureIDFilter) Params() map[string]interface{} {
+	return map[string]interface{}{
+		"featureID": f.featureID,
+	}
+}
+
+// GetFeatureQueryBuilder builds a query to search for one feature.
+type GetFeatureQueryBuilder struct {
+	baseQuery FeatureBaseQuery
+}
+
+func (q GetFeatureQueryBuilder) Base() string {
+	return q.baseQuery.Query()
+}
+
+func (q GetFeatureQueryBuilder) Build(filter Filterable) spanner.Statement {
+	stmt := spanner.NewStatement(q.Base() + " WHERE " + filter.Clause() + " LIMIT 1")
+	stmt.Params = filter.Params()
+
+	return stmt
+}

--- a/lib/gcpspanner/get_feature_test.go
+++ b/lib/gcpspanner/get_feature_test.go
@@ -1,0 +1,101 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestGetFeature(t *testing.T) {
+	client := getTestDatabase(t)
+	ctx := context.Background()
+
+	setupRequiredTablesForFeaturesSearch(ctx, client, t)
+
+	// Test for present feature
+	result, err := client.GetFeature(ctx, NewFeatureIDFilter("feature2"))
+	if err != nil {
+		t.Errorf("unexpected error. %s", err.Error())
+	}
+
+	expectedResult := &FeatureResult{
+		FeatureID: "feature2",
+		Name:      "Feature 2",
+		Status:    string(BaselineStatusHigh),
+		StableMetrics: []*FeatureResultMetric{
+			{
+				BrowserName: "barBrowser",
+				TotalTests:  valuePtr[int64](10),
+				TestPass:    valuePtr[int64](10),
+			},
+			{
+				BrowserName: "fooBrowser",
+				TotalTests:  valuePtr[int64](10),
+				TestPass:    valuePtr[int64](0),
+			},
+		},
+		ExperimentalMetrics: []*FeatureResultMetric{
+			{
+				BrowserName: "barBrowser",
+				TotalTests:  valuePtr[int64](120),
+				TestPass:    valuePtr[int64](120),
+			},
+			{
+				BrowserName: "fooBrowser",
+				TotalTests:  valuePtr[int64](12),
+				TestPass:    valuePtr[int64](12),
+			},
+		},
+	}
+
+	stabilizeFeatureResult(*result)
+
+	if !reflect.DeepEqual(*expectedResult, *result) {
+		t.Errorf("unequal results. expected (%+v) received (%+v) ", *expectedResult, *result)
+	}
+
+	// Also check the id of the feature.
+	id, err := client.GetIDFromFeatureID(ctx, NewFeatureIDFilter("feature2"))
+	if err != nil {
+		t.Errorf("unexpected error. %s", err.Error())
+	}
+	if id == nil {
+		t.Error("expected an id")
+	} else if len(*id) != 36 {
+		// TODO. Assert it is indeed a uuid. For now, check the length.
+		t.Errorf("expected auto-generated uuid. id is only length %d", len(*id))
+	}
+
+	// Test for non existent feature
+	result, err = client.GetFeature(ctx, NewFeatureIDFilter("nopefeature2"))
+	if !errors.Is(err, ErrQueryReturnedNoResults) {
+		t.Errorf("unexpected error. %s", err)
+	}
+	if result != nil {
+		t.Error("expected null result")
+	}
+
+	// Also check the id of the feature does not exist
+	id, err = client.GetIDFromFeatureID(ctx, NewFeatureIDFilter("nopefeature2"))
+	if !errors.Is(err, ErrQueryReturnedNoResults) {
+		t.Errorf("unexpected error. %s", err)
+	}
+	if id != nil {
+		t.Error("expected null id")
+	}
+}


### PR DESCRIPTION
This commit uses the same base query for features search and builds on it to only focus on one feature ID.

Adds the spanner adapter too to translate between spanner and openapi models.

Beforehand, the code used datastore to get feature data. But now we use spanner for all of the data that is relational.

