### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
     },
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
-      "dockerDashComposeVersion": "v2",
+      "dockerDashComposeVersion": "v2.24.6",
       // Debian will not work with moby.
       // Related to https://github.com/devcontainers/features/issues/831
       "moby": false


### PR DESCRIPTION
There's currently a release of docker compose going on.

Last working [run](https://github.com/GoogleChrome/webstatus.dev/actions/runs/8161809722/job/22311365478#step:3:813) used 2.24.6

Failing [run](https://github.com/GoogleChrome/webstatus.dev/actions/runs/8163611598/job/22317629429#step:3:782) is trying to use the new version 2.24.7

This pins the version to 2.24.6