### PR TITLE
Make necessary changes to push to GCP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ dev_fake_data:
 	kubectl wait --for=condition=ready pod/spanner
 	fuser -k 9010/tcp || true
 	kubectl port-forward --address 127.0.0.1 pod/spanner 9010:9010 2>&1 >/dev/null &
-	go run ./util/cmd/load_fake_data/main.go || true
+	SPANNER_EMULATOR_HOST=localhost:9010 go run ./util/cmd/load_fake_data/main.go -spanner_project=local -spanner_instance=local -spanner_database=local || true
 	fuser -k 9010/tcp || true
 
 ################################

--- a/frontend/src/static/js/api/client.ts
+++ b/frontend/src/static/js/api/client.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import createClient, {type FetchOptions} from 'openapi-fetch';
+import createClient, {HeadersOptions, type FetchOptions} from 'openapi-fetch';
 import {type components, type paths} from 'webstatus.dev-backend';
 
 // TODO. Remove once not behind UbP
@@ -22,10 +22,19 @@ const temporaryFetchOptions: FetchOptions<unknown> = {
   credentials: 'include',
 };
 
+// TODO. Remove once not behind UbP
+// https://github.com/drwpow/openapi-typescript/issues/1431
+const temporaryHeaders: HeadersOptions = {
+  'Content-Type': null,
+};
+
 export class APIClient {
   private readonly client: ReturnType<typeof createClient<paths>>;
   constructor(baseUrl: string) {
-    this.client = createClient<paths>({baseUrl});
+    this.client = createClient<paths>({
+      baseUrl,
+      headers: temporaryHeaders,
+    });
   }
 
   public async getFeature(

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -103,6 +103,15 @@ resource "google_project_iam_member" "gcp_datastore_user" {
   member   = google_service_account.backend.member
 }
 
+resource "google_spanner_database_iam_member" "gcp_spanner_user" {
+  role     = "roles/spanner.databaseReader"
+  provider = google.internal_project
+  database = var.spanner_datails.database
+  instance = var.spanner_datails.instance
+  project  = var.datastore_info.project_id
+  member   = google_service_account.backend.member
+}
+
 resource "google_cloud_run_service_iam_member" "public" {
   provider = google.public_project
   for_each = google_cloud_run_v2_service.service

--- a/infra/services/public_project_services.tf
+++ b/infra/services/public_project_services.tf
@@ -27,3 +27,13 @@ resource "google_project_service" "public_certificate_manager" {
   disable_dependent_services = true
   disable_on_destroy         = false
 }
+
+# https://stackoverflow.com/questions/68154414/google-cloud-spanner-requests-enabling-on-a-different-project
+# Public project does not deploy actual instances but it is needed.
+resource "google_project_service" "public_spanner" {
+  provider = google.public_project
+  service  = "spanner.googleapis.com"
+
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}

--- a/infra/storage/docker_repository.tf
+++ b/infra/storage/docker_repository.tf
@@ -26,7 +26,7 @@ resource "null_resource" "docker_auth_setup" {
   triggers = {
     docker_region = var.docker_repository_region
     # Debug to always force the auth.
-    # always_run    = "${timestamp()}"
+    always_run = "${timestamp()}"
   }
   provisioner "local-exec" {
     command = "gcloud auth configure-docker -q ${self.triggers.docker_region}-docker.pkg.dev"

--- a/infra/storage/spanner/migrations/000001.sql
+++ b/infra/storage/spanner/migrations/000001.sql
@@ -29,9 +29,9 @@ CREATE TABLE IF NOT EXISTS WPTRuns (
     ExternalRunID INT64 NOT NULL, -- ID from WPT
     TimeStart TIMESTAMP NOT NULL,
     TimeEnd TIMESTAMP NOT NULL,
-    BrowserName STRING(64),
-    BrowserVersion STRING(32), -- From wpt.fyi. Contains major.minor.patch and more.
-    Channel STRING(32),
+    BrowserName STRING(64) NOT NULL,
+    BrowserVersion STRING(32) NOT NULL, -- From wpt.fyi. Contains major.minor.patch and more.
+    Channel STRING(32) NOT NULL,
     OSName STRING(64),
     OSVersion STRING(32),
     FullRevisionHash STRING(40),
@@ -74,7 +74,7 @@ CREATE TABLE IF NOT EXISTS BrowserReleases (
 -- BrowserFeatureAvailabilities contains information when a browser is available for a feature.
 -- Information from https://github.com/mdn/browser-compat-data/tree/main/browsers
 CREATE TABLE IF NOT EXISTS BrowserFeatureAvailabilities (
-    BrowserName STRING(64), -- From BCD not wpt.fyi.
+    BrowserName STRING(64) NOT NULL, -- From BCD not wpt.fyi.
     BrowserVersion STRING(8) NOT NULL, -- From BCD not wpt.fyi. Only contains major number.
     FeatureID STRING(64) NOT NULL, -- From web features repo.
     FOREIGN KEY (FeatureID) REFERENCES WebFeatures(FeatureID),

--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -27,6 +27,11 @@ type FeatureBaseQuery struct{}
 //  5. The latest metrics from WPT.
 //     It provides these metrics for both "stable" and "experimental" channels.
 //     The metrics retrieved are for each unique BrowserName/Channel/FeatureID.
+//
+// Note about the metrics calculations:
+// The metrics columns need to be wrapped in TO_JSON. As a result, the metrics
+// need to be parsed. More details about it in the TODO below.
+// TODO: Fix https://github.com/GoogleChrome/webstatus.dev/issues/77
 func (f FeatureBaseQuery) Query() string {
 	return `
 SELECT
@@ -36,7 +41,7 @@ SELECT
 	COALESCE(fbs.Status, 'undefined') AS Status,
 
 	-- StableMetrics Calculation
-	(SELECT ARRAY_AGG(STRUCT(BrowserName, TotalTests, TestPass))
+	(SELECT TO_JSON(ARRAY_AGG(STRUCT(BrowserName, TotalTests, TestPass)))
 		FROM (
 		SELECT browser_feature_list.BrowserName, TotalTests, TestPass
 		FROM (
@@ -56,7 +61,7 @@ SELECT
 	) latest_metric) AS StableMetrics,
 
 	-- ExperimentalMetrics Calculation
-	(SELECT ARRAY_AGG(STRUCT(BrowserName, TotalTests, TestPass))
+	(SELECT TO_JSON(ARRAY_AGG(STRUCT(BrowserName, TotalTests, TestPass)))
 		FROM (
 		SELECT browser_feature_list.BrowserName, TotalTests, TestPass
 		FROM (

--- a/util/cmd/load_fake_data/main.go
+++ b/util/cmd/load_fake_data/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log/slog"
 	"math/rand"
@@ -30,10 +31,6 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
-
-const testSpannerProject = "local"
-const testSpannerInstance = "local"
-const testSpannerDBName = "local"
 
 const releasesPerBrowser = 50
 const runsPerBrowserPerChannel = 1
@@ -276,8 +273,20 @@ func generateRunsAndMetrics(
 
 func main() {
 	// Use the grpc port from spanner in .dev/spanner/skaffold.yaml
-	os.Setenv("SPANNER_EMULATOR_HOST", "localhost:9010")
-	client, err := gcpspanner.NewSpannerClient(testSpannerProject, testSpannerInstance, testSpannerDBName)
+	// Describe the command line flags and parse the flags
+	var (
+		spannerProject  = flag.String("spanner_project", "", "Spanner Project")
+		spannerInstance = flag.String("spanner_instance", "", "Spanner Instance")
+		spannerDatabase = flag.String("spanner_database", "", "Spanner Database")
+	)
+	flag.Parse()
+
+	slog.Info("establishing spanner client",
+		"project", *spannerProject,
+		"instance", *spannerInstance,
+		"database", *spannerDatabase)
+
+	client, err := gcpspanner.NewSpannerClient(*spannerProject, *spannerInstance, *spannerDatabase)
 	if err != nil {
 		slog.Error("unable to create spanner client", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
It has been awhile since the last push to GCP. Now that we use spanner, I found out some differences between spanner emulator and real spanner. Additionally, I fixed issue regarding the website talking to the api behind UberProxy.

More below details below:

The fontend client was fixed to prevent headers from being automatically set by the openapi generated client. This is needed for UberProxy.

Modified DEVELOPMENT.md with more steps on how to deploy to staging.

Modified the fake data script to be configurable. This allows us to load data fake data into staging.

Modified terraform to give backend access to spanner with IAM membership.

Modified table to add more NOT NULL constraints. (Was an attempt to fix issue 77 but might as well keep it.)

Modified features search base query to wrap the metrics in TO_JSON. That is an issue that only occurred on real spanner not in the emulator. Issue #77 was created to handle it.

