### PR TITLE
Add query builder for feature search with Spanner support

### DIFF
--- a/lib/gcpspanner/feature_search_query.go
+++ b/lib/gcpspanner/feature_search_query.go
@@ -15,8 +15,137 @@
 package gcpspanner
 
 import (
+	"fmt"
+	"strings"
+
 	"cloud.google.com/go/spanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
 )
+
+type FeatureSearchFilterBuilder struct {
+	paramCounter int
+	params       map[string]interface{}
+}
+
+func NewFeatureSearchFilterBuilder() *FeatureSearchFilterBuilder {
+	return &FeatureSearchFilterBuilder{
+		paramCounter: 0,
+		params:       nil,
+	}
+}
+
+type FeatureSearchCompiledFilter struct {
+	params map[string]interface{}
+	clause string
+}
+
+func (f FeatureSearchCompiledFilter) Params() map[string]interface{} {
+	return f.params
+}
+
+func (f FeatureSearchCompiledFilter) Clause() string {
+	return f.clause
+}
+
+// addParamGetName adds a parameter to the map that will be used in the spanner params map.
+// Afterwards, get the name of the parameter. Then increment the counter.
+func (b *FeatureSearchFilterBuilder) addParamGetName(param interface{}) string {
+	name := fmt.Sprintf("param%d", b.paramCounter)
+	b.params[name] = param
+
+	// Increment for the next parameter.
+	b.paramCounter++
+
+	return name
+}
+
+func (b *FeatureSearchFilterBuilder) Build(node *searchtypes.SearchNode) *FeatureSearchCompiledFilter {
+	// Ensure it is not nil
+	if node == nil ||
+		// Check for our root node.
+		node.Operator != searchtypes.OperatorRoot ||
+		// Currently root should only have at most one child.
+		// lib/gcpspanner/searchtypes/features_search_visitor.go
+		len(node.Children) != 1 {
+		return nil
+	}
+
+	//  Initialize the map and (re)set counter to 0
+	b.params = make(map[string]interface{})
+	b.paramCounter = 0
+
+	generatedFilters := b.traverseAndGenerateFilters(node.Children[0])
+	filterClause := strings.Join(generatedFilters, " AND ")
+
+	return &FeatureSearchCompiledFilter{
+		params: b.params,
+		clause: filterClause,
+	}
+}
+
+func (b *FeatureSearchFilterBuilder) traverseAndGenerateFilters(node *searchtypes.SearchNode) []string {
+	var filters []string
+
+	switch {
+	case node.IsOperator(): // Handle AND/OR operators
+		var childFilters []string // Collect child filters first
+		for _, child := range node.Children {
+			childFilters = append(childFilters, b.traverseAndGenerateFilters(child)...)
+		}
+
+		// Join child filters using the current node's operator
+		if len(childFilters) > 0 {
+			joiner := " AND "
+			if node.Operator == searchtypes.OperatorOR {
+				joiner = " OR "
+			}
+			filterString := strings.Join(childFilters, joiner)
+
+			if strings.TrimSpace(filterString) != "" {
+				filters = append(filters, "("+filterString+")")
+			}
+
+		}
+
+	case node.Term != nil && (node.Operator == searchtypes.OperatorNone || node.Operator == searchtypes.OperatorNegation):
+		var filter string
+		switch node.Term.Identifier {
+		case searchtypes.IdentifierAvailableOn:
+			filter = b.availabilityFilter(node.Term.Value)
+		case searchtypes.IdentifierName:
+			filter = b.featureNameFilter(node.Term.Value)
+		case searchtypes.IdentifierBaselineStatus:
+			filter = b.baselineStatusFilter(node.Term.Value)
+		}
+		if filter != "" {
+			if node.Operator == searchtypes.OperatorNegation {
+				filter = "NOT (" + filter + ")"
+			}
+			filters = append(filters, "("+filter+")")
+		}
+	}
+
+	return filters
+}
+
+func (b *FeatureSearchFilterBuilder) availabilityFilter(browser string) string {
+	paramName := b.addParamGetName(browser)
+
+	return fmt.Sprintf(`wf.FeatureID IN (SELECT FeatureID FROM BrowserFeatureAvailabilities
+WHERE BrowserName = @%s)`, paramName)
+}
+
+func (b *FeatureSearchFilterBuilder) featureNameFilter(featureName string) string {
+	paramName := b.addParamGetName(featureName)
+
+	return fmt.Sprintf(`(wf.Name LIKE @%s OR wf.FeatureID LIKE @%s)`, paramName, paramName)
+}
+
+func (b *FeatureSearchFilterBuilder) baselineStatusFilter(baselineStatus string) string {
+	paramName := b.addParamGetName(baselineStatus)
+
+	return fmt.Sprintf(`fbs.Status = @%s`, paramName)
+}
 
 // Filterable modifies a query with a given filter.
 type Filterable interface {

--- a/lib/gcpspanner/feature_search_query_test.go
+++ b/lib/gcpspanner/feature_search_query_test.go
@@ -1,0 +1,272 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
+)
+
+type TestTree struct {
+	Query     string
+	InputTree *searchtypes.SearchNode
+}
+
+// nolint: gochecknoglobals // for testing only.
+var (
+	simpleAvailableOnQuery = TestTree{
+		Query: "available_on:chrome",
+		InputTree: &searchtypes.SearchNode{
+			Operator: searchtypes.OperatorRoot,
+			Term:     nil,
+			Children: []*searchtypes.SearchNode{
+				{
+					Term: &searchtypes.SearchTerm{
+						Identifier: searchtypes.IdentifierAvailableOn,
+						Value:      "chrome",
+					},
+					Children: nil,
+					Operator: searchtypes.OperatorNone,
+				},
+			},
+		},
+	}
+
+	simpleNameQuery = TestTree{
+		Query: `name:"CSS Grid"`,
+		InputTree: &searchtypes.SearchNode{
+			Operator: searchtypes.OperatorRoot,
+			Term:     nil,
+			Children: []*searchtypes.SearchNode{
+				{
+					Children: nil,
+					Term: &searchtypes.SearchTerm{
+						Identifier: searchtypes.IdentifierName,
+						Value:      "CSS Grid",
+					},
+					Operator: searchtypes.OperatorNone,
+				},
+			},
+		},
+	}
+
+	simpleNameByIDQuery = TestTree{
+		Query: `name:grid`,
+		InputTree: &searchtypes.SearchNode{
+			Operator: searchtypes.OperatorRoot,
+			Term:     nil,
+			Children: []*searchtypes.SearchNode{
+				{
+					Children: nil,
+					Term: &searchtypes.SearchTerm{
+						Identifier: searchtypes.IdentifierName,
+						Value:      "grid",
+					},
+					Operator: searchtypes.OperatorNone,
+				},
+			},
+		},
+	}
+
+	availableOnBaselineStatus = TestTree{
+		Query: "available_on:chrome AND baseline_status:high",
+		InputTree: &searchtypes.SearchNode{
+			Operator: searchtypes.OperatorRoot,
+			Term:     nil,
+			Children: []*searchtypes.SearchNode{
+				{
+					Operator: searchtypes.OperatorAND,
+					Term:     nil,
+					Children: []*searchtypes.SearchNode{
+						{
+							Children: nil,
+							Term: &searchtypes.SearchTerm{
+								Identifier: searchtypes.IdentifierAvailableOn,
+								Value:      "chrome",
+							},
+							Operator: searchtypes.OperatorNone,
+						},
+						{
+							Children: nil,
+							Term: &searchtypes.SearchTerm{
+								Identifier: searchtypes.IdentifierBaselineStatus,
+								Value:      "high",
+							},
+							Operator: searchtypes.OperatorNone,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	availableOnBaselineStatusWithNegation = TestTree{
+		Query: "-available_on:chrome AND baseline_status:high",
+		InputTree: &searchtypes.SearchNode{
+			Operator: searchtypes.OperatorRoot,
+			Term:     nil,
+			Children: []*searchtypes.SearchNode{
+				{
+					Operator: searchtypes.OperatorAND,
+					Term:     nil,
+					Children: []*searchtypes.SearchNode{
+						{
+							Children: nil,
+							Term: &searchtypes.SearchTerm{
+								Identifier: searchtypes.IdentifierAvailableOn,
+								Value:      "chrome",
+							},
+							Operator: searchtypes.OperatorNegation,
+						},
+						{
+							Children: nil,
+							Term: &searchtypes.SearchTerm{
+								Identifier: searchtypes.IdentifierBaselineStatus,
+								Value:      "high",
+							},
+							Operator: searchtypes.OperatorNone,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	complexQuery = TestTree{
+		Query: "available_on:chrome (baseline_status:high OR name:avif) OR name:grid",
+		InputTree: &searchtypes.SearchNode{
+			Operator: searchtypes.OperatorRoot,
+			Term:     nil,
+			Children: []*searchtypes.SearchNode{
+				{
+					Operator: searchtypes.OperatorOR,
+					Term:     nil,
+					Children: []*searchtypes.SearchNode{
+						{
+							Operator: searchtypes.OperatorAND,
+							Term:     nil,
+							Children: []*searchtypes.SearchNode{
+								{
+									Operator: searchtypes.OperatorNone,
+									Children: nil,
+									Term: &searchtypes.SearchTerm{
+										Identifier: searchtypes.IdentifierAvailableOn, Value: "chrome"},
+								},
+								{
+									Operator: searchtypes.OperatorOR,
+									Term:     nil,
+									Children: []*searchtypes.SearchNode{
+										{
+											Operator: searchtypes.OperatorNone,
+											Children: nil,
+											Term: &searchtypes.SearchTerm{
+												Identifier: searchtypes.IdentifierBaselineStatus, Value: "high"},
+										},
+										{
+											Operator: searchtypes.OperatorNone,
+											Children: nil,
+											Term: &searchtypes.SearchTerm{
+												Identifier: searchtypes.IdentifierName, Value: "avif"},
+										},
+									},
+								},
+							},
+						},
+						{
+							Operator: searchtypes.OperatorNone,
+							Children: nil,
+							Term:     &searchtypes.SearchTerm{Identifier: searchtypes.IdentifierName, Value: "grid"},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+// nolint:lll // Some queries will be long lines.
+func TestBuild(t *testing.T) {
+	testCases := []struct {
+		inputTestTree  TestTree
+		expectedClause string
+		expectedParams map[string]interface{}
+	}{
+		{
+			inputTestTree: simpleAvailableOnQuery,
+			expectedClause: `(wf.FeatureID IN (SELECT FeatureID FROM BrowserFeatureAvailabilities
+WHERE BrowserName = @param0))`,
+			expectedParams: map[string]interface{}{
+				"param0": "chrome",
+			},
+		},
+		{
+			inputTestTree:  simpleNameQuery,
+			expectedClause: `((wf.Name LIKE @param0 OR wf.FeatureID LIKE @param0))`,
+			expectedParams: map[string]interface{}{
+				"param0": "CSS Grid",
+			},
+		},
+		{
+			inputTestTree:  simpleNameByIDQuery,
+			expectedClause: `((wf.Name LIKE @param0 OR wf.FeatureID LIKE @param0))`,
+			expectedParams: map[string]interface{}{
+				"param0": "grid",
+			},
+		},
+		{
+			inputTestTree: availableOnBaselineStatus,
+			expectedClause: `((wf.FeatureID IN (SELECT FeatureID FROM BrowserFeatureAvailabilities
+WHERE BrowserName = @param0)) AND (fbs.Status = @param1))`,
+			expectedParams: map[string]interface{}{
+				"param0": "chrome",
+				"param1": "high",
+			},
+		},
+		{
+			inputTestTree: availableOnBaselineStatusWithNegation,
+			expectedClause: `((NOT (wf.FeatureID IN (SELECT FeatureID FROM BrowserFeatureAvailabilities
+WHERE BrowserName = @param0))) AND (fbs.Status = @param1))`,
+			expectedParams: map[string]interface{}{
+				"param0": "chrome",
+				"param1": "high",
+			},
+		},
+		{
+			inputTestTree: complexQuery,
+			expectedClause: `(((wf.FeatureID IN (SELECT FeatureID FROM BrowserFeatureAvailabilities
+WHERE BrowserName = @param0)) AND ((fbs.Status = @param1) OR ((wf.Name LIKE @param2 OR wf.FeatureID LIKE @param2)))) OR ((wf.Name LIKE @param3 OR wf.FeatureID LIKE @param3)))`,
+			expectedParams: map[string]interface{}{
+				"param0": "chrome",
+				"param1": "high",
+				"param2": "avif",
+				"param3": "grid",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.inputTestTree.Query, func(t *testing.T) {
+			b := NewFeatureSearchFilterBuilder()
+			filter := b.Build(tc.inputTestTree.InputTree)
+			if filter.Clause() != tc.expectedClause {
+				t.Errorf("\nexpected clause [%s]\n  actual clause [%s]", tc.expectedClause, filter.Clause())
+			}
+			if !reflect.DeepEqual(tc.expectedParams, filter.Params()) {
+				t.Errorf("expected params (%+v) actual params (%+v)", tc.expectedParams, filter.Params())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduce FeatureSearchFilterBuilder to dynamically generate Spanner queries. Includes parameter handling, filter creation, and correct parentheses for complex queries.

This uses the built SearchNode tree to create filters on the feature search query.

The SearchNode tree is built from the implemented ANTLR visitor from a previous PR.

This code will replace the current filtering system (which will be done in a future PR).

While this code introduces multiple filters, only the availabilityFilter is ready. Future PRs will make the others ready.

