### PR TITLE
Modify the features querying to use ?q query param

### DIFF
--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
@@ -55,8 +56,7 @@ type WPTMetricsStorer interface {
 		ctx context.Context,
 		pageToken *string,
 		pageSize int,
-		availabileBrowsers []string,
-		notAvailabileBrowsers []string,
+		searchNode *searchtypes.SearchNode,
 	) ([]backend.Feature, *string, error)
 	GetFeature(
 		ctx context.Context,
@@ -85,12 +85,6 @@ func getFeatureIDsOrDefault(featureIDs *[]string) []string {
 	var defaultFeatureIDs []string
 
 	return *(cmp.Or[*[]string](featureIDs, &defaultFeatureIDs))
-}
-
-func getBrowserListOrDefault(browserList *[]string) []string {
-	var defaultBrowserList []string
-
-	return *(cmp.Or[*[]string](browserList, &defaultBrowserList))
 }
 
 func NewHTTPServer(

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
@@ -47,7 +48,7 @@ type BackendSpannerClient interface {
 		ctx context.Context,
 		pageToken *string,
 		pageSize int,
-		filterables ...gcpspanner.Filterable) ([]gcpspanner.FeatureResult, *string, error)
+		searchNode *searchtypes.SearchNode) ([]gcpspanner.FeatureResult, *string, error)
 	GetFeature(
 		ctx context.Context,
 		filter gcpspanner.Filterable,
@@ -210,19 +211,9 @@ func (s *Backend) FeaturesSearch(
 	ctx context.Context,
 	pageToken *string,
 	pageSize int,
-	availabileBrowsers []string,
-	notAvailabileBrowsers []string,
+	searchNode *searchtypes.SearchNode,
 ) ([]backend.Feature, *string, error) {
-	var filters []gcpspanner.Filterable
-	if len(availabileBrowsers) > 0 {
-		filters = append(filters, gcpspanner.NewAvailabileFilter(availabileBrowsers))
-	}
-
-	if len(notAvailabileBrowsers) > 0 {
-		filters = append(filters, gcpspanner.NewNotAvailabileFilter(notAvailabileBrowsers))
-	}
-
-	featureResults, token, err := s.client.FeaturesSearch(ctx, pageToken, pageSize, filters...)
+	featureResults, token, err := s.client.FeaturesSearch(ctx, pageToken, pageSize, searchNode)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -26,25 +26,15 @@ paths:
         - $ref: '#/components/parameters/paginationTokenParam'
         - $ref: '#/components/parameters/paginationSizeParam'
         - in: query
-          name: availableOn
+          name: q
           description: >
-            A comma-separated list of browsers.
-            The returned features are available on these browsers.
+            A query string to represent the filters to apply the datastore while searching.
+            The query must follow the ANTLR grammar. Please read the query readme at antlr/FeatureSearch.md.
+            The query must be url safe.
           required: false
           schema:
-            type: array
-            items:
-              type: string
-        - in: query
-          name: notAvailableOn
-          description: >
-            A comma-separated list of browsers.
-            The returned features are not available on these browsers.
-          required: false
-          schema:
-            type: array
-            items:
-              type: string
+            type: string
+            minLength: 1
       responses:
         '200':
           description: OK


### PR DESCRIPTION
Previously, the filters had separate query params. It was not scalable and did not allow complex queries.

The openapi yaml has been modified to remove the old query params in favor of a new `q` query parameter.

Sample queries:
- http://localhost:8080/v1/features?q=available_on:chrome
- http://localhost:8080/v1/features?q=available_on:chrome%20OR%20available_on:firefox

