### PR TITLE
Enable search by feature name

### DIFF
--- a/infra/storage/spanner/migrations/000001.sql
+++ b/infra/storage/spanner/migrations/000001.sql
@@ -17,10 +17,17 @@ CREATE TABLE IF NOT EXISTS WebFeatures (
     ID STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
     FeatureID STRING(64) NOT NULL, -- From web features repo.
     Name STRING(64) NOT NULL,
+    -- Additional lowercase columns for case-insensitive search
+    FeatureID_Lowercase STRING(64) AS (LOWER(FeatureID)) STORED,
+    Name_Lowercase STRING(64) AS (LOWER(Name)) STORED,
 ) PRIMARY KEY (ID);
 
 -- Used to enforce that only one FeatureID from web features can exist.
 CREATE UNIQUE NULL_FILTERED INDEX WebFeaturesByFeatureID ON WebFeatures (FeatureID);
+
+-- Index on FeatureID and Name for case-insensitive search
+CREATE INDEX IDX_FEATUREID_LOWER ON WebFeatures(FeatureID_Lowercase);
+CREATE INDEX IDX_NAME_LOWER ON WebFeatures(Name_Lowercase);
 
 -- WPTRuns contains metadata from wpt.fyi runs.
 -- More information: https://github.com/web-platform-tests/wpt.fyi/blob/main/api/README.md#apiruns

--- a/lib/gcpspanner/feature_search_query.go
+++ b/lib/gcpspanner/feature_search_query.go
@@ -136,9 +136,19 @@ WHERE BrowserName = @%s)`, paramName)
 }
 
 func (b *FeatureSearchFilterBuilder) featureNameFilter(featureName string) string {
+	// Normalize the string to lower case to use the computed column.
+	featureName = strings.ToLower(featureName)
+	// Safely add the database % wildcards if they do not already exist.
+	if !strings.HasPrefix(featureName, "%") {
+		featureName = "%" + featureName
+	}
+	if !strings.HasSuffix(featureName, "%") {
+		featureName = featureName + "%"
+	}
+
 	paramName := b.addParamGetName(featureName)
 
-	return fmt.Sprintf(`(wf.Name LIKE @%s OR wf.FeatureID LIKE @%s)`, paramName, paramName)
+	return fmt.Sprintf(`(wf.Name_Lowercase LIKE @%s OR wf.FeatureID_Lowercase LIKE @%s)`, paramName, paramName)
 }
 
 func (b *FeatureSearchFilterBuilder) baselineStatusFilter(baselineStatus string) string {

--- a/lib/gcpspanner/feature_search_query_test.go
+++ b/lib/gcpspanner/feature_search_query_test.go
@@ -215,16 +215,16 @@ WHERE BrowserName = @param0))`,
 		},
 		{
 			inputTestTree:  simpleNameQuery,
-			expectedClause: `((wf.Name LIKE @param0 OR wf.FeatureID LIKE @param0))`,
+			expectedClause: `((wf.Name_Lowercase LIKE @param0 OR wf.FeatureID_Lowercase LIKE @param0))`,
 			expectedParams: map[string]interface{}{
-				"param0": "CSS Grid",
+				"param0": "%" + "css grid" + "%",
 			},
 		},
 		{
 			inputTestTree:  simpleNameByIDQuery,
-			expectedClause: `((wf.Name LIKE @param0 OR wf.FeatureID LIKE @param0))`,
+			expectedClause: `((wf.Name_Lowercase LIKE @param0 OR wf.FeatureID_Lowercase LIKE @param0))`,
 			expectedParams: map[string]interface{}{
-				"param0": "grid",
+				"param0": "%" + "grid" + "%",
 			},
 		},
 		{
@@ -248,12 +248,12 @@ WHERE BrowserName = @param0))) AND (fbs.Status = @param1))`,
 		{
 			inputTestTree: complexQuery,
 			expectedClause: `(((wf.FeatureID IN (SELECT FeatureID FROM BrowserFeatureAvailabilities
-WHERE BrowserName = @param0)) AND ((fbs.Status = @param1) OR ((wf.Name LIKE @param2 OR wf.FeatureID LIKE @param2)))) OR ((wf.Name LIKE @param3 OR wf.FeatureID LIKE @param3)))`,
+WHERE BrowserName = @param0)) AND ((fbs.Status = @param1) OR ((wf.Name_Lowercase LIKE @param2 OR wf.FeatureID_Lowercase LIKE @param2)))) OR ((wf.Name_Lowercase LIKE @param3 OR wf.FeatureID_Lowercase LIKE @param3)))`,
 			expectedParams: map[string]interface{}{
 				"param0": "chrome",
 				"param1": "high",
-				"param2": "avif",
-				"param3": "grid",
+				"param2": "%" + "avif" + "%",
+				"param3": "%" + "grid" + "%",
 			},
 		},
 	}


### PR DESCRIPTION
Improve search performance with precomputed lowercase columns: FeatureID_Lowercase, Name_Lowercase.

The name query will allow us to do search by feature Id and name with partial strings.

Previously, the provided string had to be the full string to match.

