### PR TITLE
Fix the filtering logic for the metrics.

### DIFF
--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -50,7 +50,7 @@ SELECT
 			SELECT DISTINCT BrowserName, FeatureID, MAX(wpr.TimeStart) AS MaxTimeStart
 			FROM WPTRunFeatureMetrics metrics
 			JOIN WPTRuns wpr ON metrics.ID = wpr.ID
-			WHERE metrics.FeatureID = wf.FeatureID
+			WHERE metrics.FeatureID = wf.FeatureID AND wpr.Channel = 'stable'
 			GROUP BY BrowserName, FeatureID
 		) browser_feature_list
 		-- Join to retrieve metrics, ensuring we get the latest run for each combination
@@ -70,7 +70,7 @@ SELECT
 			SELECT DISTINCT BrowserName, FeatureID, MAX(wpr.TimeStart) AS MaxTimeStart
 			FROM WPTRunFeatureMetrics metrics
 			JOIN WPTRuns wpr ON metrics.ID = wpr.ID
-			WHERE metrics.FeatureID = wf.FeatureID
+			WHERE metrics.FeatureID = wf.FeatureID AND wpr.Channel = 'experimental'
 			GROUP BY BrowserName, FeatureID
 		) browser_feature_list
 		-- Join to retrieve metrics, ensuring we get the latest run for each combination


### PR DESCRIPTION
Upon loading the dashboard with fake data, only one browser shows metrics data.

The data exists but this changed to ensure it pulled the data from the same channel as the outer query.

![image](https://github.com/GoogleChrome/webstatus.dev/assets/7788930/90c91cd3-04d0-4a69-ba94-5075fd83cc70)


