### PR TITLE
Add sort query parameter for /v1/features api

### DIFF
--- a/backend/pkg/httpserver/get_features.go
+++ b/backend/pkg/httpserver/get_features.go
@@ -59,6 +59,7 @@ func (s *Server) GetV1Features(
 		req.Params.PageToken,
 		getPageSizeOrDefault(req.Params.PageSize),
 		node,
+		req.Params.Sort,
 	)
 
 	if err != nil {

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -40,6 +40,7 @@ func TestGetV1Features(t *testing.T) {
 				expectedPageToken:  nil,
 				expectedPageSize:   100,
 				expectedSearchNode: nil,
+				expectedSortBy:     nil,
 				data: []backend.Feature{
 					{
 						BaselineStatus: backend.High,
@@ -74,6 +75,7 @@ func TestGetV1Features(t *testing.T) {
 					PageToken: nil,
 					PageSize:  nil,
 					Q:         nil,
+					Sort:      nil,
 				},
 			},
 			expectedError: nil,
@@ -111,6 +113,7 @@ func TestGetV1Features(t *testing.T) {
 						},
 					},
 				},
+				expectedSortBy: valuePtr[backend.GetV1FeaturesParamsSort](backend.NameDesc),
 				data: []backend.Feature{
 					{
 						BaselineStatus: backend.High,
@@ -145,6 +148,7 @@ func TestGetV1Features(t *testing.T) {
 					PageToken: inputPageToken,
 					PageSize:  valuePtr[int](50),
 					Q:         valuePtr(url.QueryEscape("available_on:chrome AND name:grid")),
+					Sort:      valuePtr[backend.GetV1FeaturesParamsSort](backend.NameDesc),
 				},
 			},
 			expectedError: nil,
@@ -155,6 +159,7 @@ func TestGetV1Features(t *testing.T) {
 				expectedPageToken:  nil,
 				expectedPageSize:   100,
 				expectedSearchNode: nil,
+				expectedSortBy:     nil,
 				data: []backend.Feature{
 					{
 						BaselineStatus: backend.High,
@@ -178,6 +183,7 @@ func TestGetV1Features(t *testing.T) {
 					PageToken: nil,
 					PageSize:  nil,
 					Q:         nil,
+					Sort:      nil,
 				},
 			},
 			expectedError: nil,
@@ -188,6 +194,7 @@ func TestGetV1Features(t *testing.T) {
 				expectedPageToken:  nil,
 				expectedPageSize:   100,
 				expectedSearchNode: nil,
+				expectedSortBy:     nil,
 				data: []backend.Feature{
 					{
 						BaselineStatus: backend.High,
@@ -210,6 +217,7 @@ func TestGetV1Features(t *testing.T) {
 				Params: backend.GetV1FeaturesParams{
 					PageToken: nil,
 					PageSize:  nil,
+					Sort:      nil,
 					Q:         valuePtr[string]("badterm:foo"),
 				},
 			},
@@ -221,6 +229,7 @@ func TestGetV1Features(t *testing.T) {
 				expectedPageToken:  nil,
 				expectedPageSize:   100,
 				expectedSearchNode: nil,
+				expectedSortBy:     nil,
 				data: []backend.Feature{
 					{
 						BaselineStatus: backend.High,
@@ -244,6 +253,7 @@ func TestGetV1Features(t *testing.T) {
 					PageToken: nil,
 					PageSize:  nil,
 					Q:         valuePtr[string]("%"),
+					Sort:      nil,
 				},
 			},
 			expectedError: nil,

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -57,6 +57,7 @@ type WPTMetricsStorer interface {
 		pageToken *string,
 		pageSize int,
 		searchNode *searchtypes.SearchNode,
+		sortOrder *backend.GetV1FeaturesParamsSort,
 	) ([]backend.Feature, *string, error)
 	GetFeature(
 		ctx context.Context,

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -58,6 +58,7 @@ type MockFeaturesSearchConfig struct {
 	expectedPageToken  *string
 	expectedPageSize   int
 	expectedSearchNode *searchtypes.SearchNode
+	expectedSortBy     *backend.GetV1FeaturesParamsSort
 	data               []backend.Feature
 	pageToken          *string
 	err                error
@@ -133,14 +134,16 @@ func (m *MockWPTMetricsStorer) FeaturesSearch(
 	pageToken *string,
 	pageSize int,
 	node *searchtypes.SearchNode,
+	sortBy *backend.GetV1FeaturesParamsSort,
 ) ([]backend.Feature, *string, error) {
 	m.callCountFeaturesSearch++
 
 	if pageToken != m.featuresSearchCfg.expectedPageToken ||
 		pageSize != m.featuresSearchCfg.expectedPageSize ||
-		!reflect.DeepEqual(node, m.featuresSearchCfg.expectedSearchNode) {
-		m.t.Errorf("Incorrect arguments. Expected: %v, Got: { %v %d %v }",
-			m.featuresSearchCfg, pageSize, pageToken, node)
+		!reflect.DeepEqual(node, m.featuresSearchCfg.expectedSearchNode) ||
+		!reflect.DeepEqual(sortBy, m.featuresSearchCfg.expectedSortBy) {
+		m.t.Errorf("Incorrect arguments. Expected: %v, Got: { %v %d %v %v }",
+			m.featuresSearchCfg, pageSize, pageToken, node, sortBy)
 	}
 
 	return m.featuresSearchCfg.data, m.featuresSearchCfg.pageToken, m.featuresSearchCfg.err

--- a/lib/gcpspanner/feature_search.go
+++ b/lib/gcpspanner/feature_search.go
@@ -57,7 +57,9 @@ func (c *Client) FeaturesSearch(
 	ctx context.Context,
 	pageToken *string,
 	pageSize int,
-	searchNode *searchtypes.SearchNode) ([]FeatureResult, *string, error) {
+	searchNode *searchtypes.SearchNode,
+	sortOrder Sortable,
+) ([]FeatureResult, *string, error) {
 	// Build filterable
 	filterBuilder := NewFeatureSearchFilterBuilder()
 	filter := filterBuilder.Build(searchNode)
@@ -75,7 +77,7 @@ func (c *Client) FeaturesSearch(
 		cursor:    cursor,
 		pageSize:  pageSize,
 	}
-	stmt := queryBuilder.Build(filter)
+	stmt := queryBuilder.Build(filter, sortOrder)
 	txn := c.Single()
 	defer txn.Close()
 	it := txn.Query(ctx, stmt)

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -35,6 +35,35 @@ paths:
           schema:
             type: string
             minLength: 1
+        - in: query
+          name: sort
+          description: >
+            Field to sort by, with 'asc' for ascending and 'desc' for descending order.
+            Defaults to sorting by 'name' in ascending order (e.g., 'name_asc').
+          required: false
+          schema:
+            type: string
+            enum:
+              - name_asc
+              - name_desc
+              - baseline_status_asc
+              - baseline_status_desc
+              - wpt_stable_chrome_asc
+              - wpt_stable_chrome_desc
+              - wpt_stable_safari_asc
+              - wpt_stable_safari_desc
+              - wpt_stable_edge_asc
+              - wpt_stable_edge_desc
+              - wpt_stable_firefox_asc
+              - wpt_stable_firefox_desc
+              - wpt_experimental_chrome_asc
+              - wpt_experimental_chrome_desc
+              - wpt_experimental_safari_asc
+              - wpt_experimental_safari_desc
+              - wpt_experimental_edge_asc
+              - wpt_experimental_edge_desc
+              - wpt_experimental_firefox_asc
+              - wpt_experimental_firefox_desc
       responses:
         '200':
           description: OK


### PR DESCRIPTION
This adds an enumerated list of values that can be used to sort the data returned by the endpoint

Previously, I thought of using regex patterns to describe the possible values but then I would need to create and maintain those values in both the frontend and backend. But now by explicitly listing each possible value, the code generation creates the enums for us.

While multiple values have been created, only the name_asc, and name_desc actually works. They have been provided so that the frontend can go ahead and wire them up now.

In the event no sort value is provided, name_asc is used.

In the event non supported sort value is provided, name_asc is used. (this will go away once I support the others)

Sample queries:
- http://localhost:8080/v1/features?sort=name_desc
- http://localhost:8080/v1/features?sort=name_asc