### PR TITLE
Generate filter query, set location

### DIFF
--- a/frontend/src/static/js/components/webstatus-overview-filters.ts
+++ b/frontend/src/static/js/components/webstatus-overview-filters.ts
@@ -156,8 +156,7 @@ export class WebstatusOverviewFilters extends LitElement {
         let orClauseString = orClauseArray
           .map((value: string) => `${key}:${value}`)
           .join(' OR ');
-        if (orClauseArray.length > 1)
-          orClauseString = `(${orClauseString})`;
+        if (orClauseArray.length > 1) orClauseString = `(${orClauseString})`;
         andClauseArray.push(orClauseString);
       }
     }


### PR DESCRIPTION
This PR does some refactoring to distinguish the filter input (the form field and buttons) from the query string (on the URL).

It also generates the query string and sets  the URL when the user clicks the glowing filter button.  When loading the page with a query string, the query string is parsed and the filter UI is repopulated with the corresponding settings.

The filter query itself doesn't seem to be working, however.  For http://localhost:5555/?q=(baseline_status%3Alimited) , the result is not (yet) filtering by Baseline.

![image](https://github.com/GoogleChrome/webstatus.dev/assets/570125/348636db-07ae-46fc-9a91-1c2086f2fe26)
