### PR TITLE
Add baseline status card to feature detail page.

### DIFF
--- a/frontend/scripts/postinstall.js
+++ b/frontend/scripts/postinstall.js
@@ -34,13 +34,11 @@ await cpy(
   {rename: 'safari-preview_24x24.png'}
 );
 
-await cpy(`${BROWSER_LOGO_DIR}/chrome-canary/*_32x32.png`, IMG_DEST);
-await cpy(`${BROWSER_LOGO_DIR}/edge-dev/*_32x32.png`, IMG_DEST);
-await cpy(`${BROWSER_LOGO_DIR}/firefox-nightly/*_32x32.png`, IMG_DEST);
-await cpy(
-  `${BROWSER_LOGO_DIR}/safari-technology-preview/*_32x32.png`,
-  IMG_DEST,
-  {rename: 'safari-preview_32x32.png'}
-);
+await cpy(`${BROWSER_LOGO_DIR}/chrome/*_32x32.png`, IMG_DEST);
+await cpy(`${BROWSER_LOGO_DIR}/edge/*_32x32.png`, IMG_DEST);
+await cpy(`${BROWSER_LOGO_DIR}/firefox/*_32x32.png`, IMG_DEST);
+await cpy(`${BROWSER_LOGO_DIR}/safari/*_32x32.png`, IMG_DEST, {
+  rename: 'safari_32x32.png',
+});
 
 console.log(`copied logos to ${IMG_DEST}`);

--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -31,7 +31,10 @@ import {type components} from 'webstatus.dev-backend';
 import {type APIClient} from '../api/client.js';
 import {formatFeaturePageUrl, formatOverviewPageUrl} from '../utils/urls.js';
 import {apiClientContext} from '../contexts/api-client-context.js';
-import {renderWPTScore} from './webstatus-overview-cells.js';
+import {
+  BASELINE_CHIP_CONFIGS,
+  renderWPTScore,
+} from './webstatus-overview-cells.js';
 
 @customElement('webstatus-feature-page')
 export class FeaturePage extends LitElement {
@@ -180,6 +183,21 @@ export class FeaturePage extends LitElement {
     `;
   }
 
+  renderBaselineCard(): TemplateResult {
+    if (!this.feature) return html``;
+
+    const chipConfig = BASELINE_CHIP_CONFIGS[this.feature.baseline_status];
+
+    return html`
+      <sl-card class="halign-stretch wptScore">
+        <img height="28" src="/public/img/${chipConfig.icon}" class="icon" />
+        <div>Baseline</div>
+        <div class="score">${chipConfig.word}</div>
+        <div class="avail">Baseline since ...</div>
+      </sl-card>
+    `;
+  }
+
   renderWPTScores(): TemplateResult {
     return html`
       <section id="wpt-scores">
@@ -189,6 +207,7 @@ export class FeaturePage extends LitElement {
           ${this.renderOneWPTCard('edge', 'edge_32x32.png')}
           ${this.renderOneWPTCard('firefox', 'firefox_32x32.png')}
           ${this.renderOneWPTCard('safari', 'safari_32x32.png')}
+          ${this.renderBaselineCard()}
         </div>
       </section>
     `;

--- a/frontend/src/static/js/components/webstatus-overview-cells.ts
+++ b/frontend/src/static/js/components/webstatus-overview-cells.ts
@@ -78,7 +78,7 @@ interface BaselineChipConfig {
   word: string;
 }
 
-const BASELINE_CHIP_CONFIGS: Record<
+export const BASELINE_CHIP_CONFIGS: Record<
   components['schemas']['Feature']['baseline_status'],
   BaselineChipConfig
 > = {


### PR DESCRIPTION
This PR implements a part of the feature detail page that was previously missed.

In this PR:
* Add a card for baseline status and the appropriate icon.
* Also, fix the copying of the stable browser icons in post install.js.

We may want to move this info to be separate from the WPT test results, but for now it is at least showing up on the page so that we can discuss it.