### PR TITLE
Send search query from frontend to backend.

### DIFF
--- a/frontend/src/static/js/api/client.ts
+++ b/frontend/src/static/js/api/client.ts
@@ -21,6 +21,10 @@ export type FeatureSortOrderType = NonNullable<
   paths['/v1/features']['get']['parameters']['query']
 >['sort'];
 
+export type FeatureSearchType = NonNullable<
+  paths['/v1/features']['get']['parameters']['query']
+>['q'];
+
 // TODO. Remove once not behind UbP
 const temporaryFetchOptions: FetchOptions<unknown> = {
   credentials: 'include',
@@ -55,11 +59,15 @@ export class APIClient {
   }
 
   public async getFeatures(
+    q: FeatureSearchType,
     sort: FeatureSortOrderType
   ): Promise<components['schemas']['FeaturePage']['data']> {
+    const qsParams: {q?: FeatureSearchType; sort?: FeatureSortOrderType} = {};
+    if (q) qsParams.q = q;
+    if (sort) qsParams.sort = sort;
     const {data, error} = await this.client.GET('/v1/features', {
       params: {
-        query: {sort},
+        query: qsParams,
       },
       ...temporaryFetchOptions,
     });

--- a/frontend/src/static/js/components/webstatus-overview-filters.ts
+++ b/frontend/src/static/js/components/webstatus-overview-filters.ts
@@ -16,7 +16,7 @@
 
 import {LitElement, type TemplateResult, CSSResultGroup, css, html} from 'lit';
 import {customElement} from 'lit/decorators.js';
-import {getSearchQuery} from '../utils/urls.js';
+import {formatOverviewPageUrl, getSearchQuery} from '../utils/urls.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {SlInput, SlMenu, SlMenuItem} from '@shoelace-style/shoelace';
 
@@ -164,19 +164,12 @@ export class WebstatusOverviewFilters extends LitElement {
     return filterInputString;
   }
 
-  // Generates the query string from the filter input.
-  generateFilterQueryString(filterInputMap: Map<string, string[]>): string {
-    const filterInputString = this.generateFilterInputString(filterInputMap);
-    const filterInputStringEncoded = encodeURIComponent(filterInputString);
-    const filterQueryString = `?q=${filterInputStringEncoded}`;
-    return filterQueryString;
-  }
-
   gotoFilterQueryString(): void {
-    const filterQueryString = this.generateFilterQueryString(
-      this.filterInputMap
-    );
-    window.location.href = filterQueryString;
+    const newUrl = formatOverviewPageUrl(this.location, {
+      q: this.filterInput.value,
+      start: 0,
+    });
+    window.location.href = newUrl;
   }
 
   // Returns a handler for changes to a filter menu.
@@ -214,6 +207,12 @@ export class WebstatusOverviewFilters extends LitElement {
     this.initializeFilterInput();
   }
 
+  handleSearchKey(event: KeyboardEvent) {
+    if (event.code === 'Enter') {
+      this.gotoFilterQueryString();
+    }
+  }
+
   render(): TemplateResult {
     const input = getSearchQuery(this.location);
     return html`
@@ -224,6 +223,7 @@ export class WebstatusOverviewFilters extends LitElement {
             class="halign-stretch"
             placeholder="Filter by ..."
             value="${input}"
+            @keyup=${this.handleSearchKey}
           >
             <sl-button
               id="filter-submit-button"

--- a/frontend/src/static/js/components/webstatus-overview-page.ts
+++ b/frontend/src/static/js/components/webstatus-overview-page.ts
@@ -20,8 +20,12 @@ import {LitElement, type TemplateResult, html} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
 import {type components} from 'webstatus.dev-backend';
 
-import {getSortSpec} from '../utils/urls.js';
-import {type APIClient, FeatureSortOrderType} from '../api/client.js';
+import {getSearchQuery, getSortSpec} from '../utils/urls.js';
+import {
+  type APIClient,
+  type FeatureSortOrderType,
+  type FeatureSearchType,
+} from '../api/client.js';
 import {apiClientContext} from '../contexts/api-client-context.js';
 import './webstatus-overview-content.js';
 
@@ -56,7 +60,8 @@ export class OverviewPage extends LitElement {
   ) {
     if (typeof apiClient !== 'object') return;
     const sortSpec = getSortSpec(routerLocation) as FeatureSortOrderType;
-    this.features = await apiClient.getFeatures(sortSpec);
+    const searchQuery = getSearchQuery(routerLocation) as FeatureSearchType;
+    this.features = await apiClient.getFeatures(searchQuery, sortSpec);
   }
 
   render(): TemplateResult {

--- a/frontend/src/static/js/utils/urls.ts
+++ b/frontend/src/static/js/utils/urls.ts
@@ -38,6 +38,7 @@ export function getPaginationStart(location: {search: string}): number {
 }
 
 type QueryStringOverrides = {
+  q?: string;
   start?: number;
   sort?: string;
 };
@@ -54,7 +55,7 @@ function getContextualQueryStringParams(
     return '';
   }
   const searchParams = new URLSearchParams();
-  const searchQuery = getSearchQuery(location);
+  const searchQuery = 'q' in overrides ? overrides.q : getSearchQuery(location);
   if (searchQuery) {
     searchParams.set('q', searchQuery);
   }


### PR DESCRIPTION
This PR sends the user query to the backend, allowing the page to be roughly usable for that use case for the first time.  When the user types some letters like "ae" into the search box, and then presses enter or clicks the magnifying glass icon, the search text is added to the URL and that triggers a re-request for the matching features.

In this PR:
* Add the `q` parameter to the API call in client.ts.  It is only added if non-empty due to a constraint in the API definition.
* Change the filters element to submit the query by calling `formatOverviewPageUrl()`.  This changes the `q` parameter and sets `start` back to zero, but it would maintain any query string parameters for sorting or column customization.  Rather than regenerating the query string from the widget values, it assumes that the search input box has already been updated with any widget values.
* Also, add support for pressing Enter in the search box.
* In the overview page, include the search query in the API call when loading the list of features.