### PR TITLE
Fix count display and loadingTask usage.

### DIFF
--- a/frontend/src/static/js/components/webstatus-overview-content.ts
+++ b/frontend/src/static/js/components/webstatus-overview-content.ts
@@ -15,7 +15,7 @@
  */
 
 import {LitElement, type TemplateResult, CSSResultGroup, css, html} from 'lit';
-import {Task, TaskStatus} from '@lit/task';
+import {type Task} from '@lit/task';
 import {customElement, state} from 'lit/decorators.js';
 import {type components} from 'webstatus.dev-backend';
 
@@ -28,6 +28,9 @@ import {SHARED_STYLES} from '../css/shared-css.js';
 export class WebstatusOverviewContent extends LitElement {
   @state()
   features: Array<components['schemas']['Feature']> = [];
+
+  @state()
+  totalCount: number | undefined = undefined;
 
   loadingTask!: Task; // Set by parent.
 
@@ -49,18 +52,10 @@ export class WebstatusOverviewContent extends LitElement {
   }
 
   renderCount(): TemplateResult {
-    if (this.loadingTask.status === TaskStatus.INITIAL) {
-      return html`About to load features`;
-    }
-    if (this.loadingTask.status === TaskStatus.ERROR) {
-      // TODO(jrobbins): this is never reached.
-      return html`Could not load features`;
-    }
-    if (this.loadingTask.status === TaskStatus.PENDING) {
+    if (this.totalCount === undefined) {
       return html`Loading features...`;
     }
 
-    const numFeatures = this.features.length;
     const date = new Date().toLocaleDateString('en-US', {
       year: 'numeric',
       month: 'long',
@@ -70,7 +65,7 @@ export class WebstatusOverviewContent extends LitElement {
     return html`
       <span class="stats-summary">
         <sl-icon library="phosphor" name="clock-clockwise"></sl-icon>
-        ${numFeatures} features
+        ${this.totalCount} features
       </span>
       <span class="stats-summary">
         <sl-icon library="phosphor" name="clock-clockwise"></sl-icon>
@@ -110,7 +105,7 @@ export class WebstatusOverviewContent extends LitElement {
         </webstatus-overview-table>
         <webstatus-pagination
           .location=${this.location}
-          .features=${this.features}
+          .totalCount=${this.totalCount}
         ></webstatus-pagination>
       </div>
     `;

--- a/frontend/src/static/js/components/webstatus-overview-page.ts
+++ b/frontend/src/static/js/components/webstatus-overview-page.ts
@@ -40,6 +40,9 @@ export class OverviewPage extends LitElement {
   features: Array<components['schemas']['Feature']> = [];
 
   @state()
+  totalCount: number | undefined = undefined;
+
+  @state()
   location!: {search: string}; // Set by router.
 
   constructor() {
@@ -61,7 +64,9 @@ export class OverviewPage extends LitElement {
     if (typeof apiClient !== 'object') return;
     const sortSpec = getSortSpec(routerLocation) as FeatureSortOrderType;
     const searchQuery = getSearchQuery(routerLocation) as FeatureSearchType;
+    this.totalCount = undefined;
     this.features = await apiClient.getFeatures(searchQuery, sortSpec);
+    this.totalCount = this.features.length;
   }
 
   render(): TemplateResult {
@@ -69,6 +74,7 @@ export class OverviewPage extends LitElement {
       <webstatus-overview-content
         .location=${this.location}
         .features=${this.features}
+        .totalCount=${this.totalCount}
         .loadingTask=${this.loadingTask}
       >
       </webstatus-overview-content>


### PR DESCRIPTION
This fixes the top text that was stuck always saying "Loading features...". 

Now it shows that text only while loading and then shows the count of features after loading is complete.

The mistake was failing to understand how lit's async tasks work.  I had thought that whenever the task changes state, the render() method of component that reference it would be updated.  However, the docs say that the host will be notified, not every component that references it.  It had worked for the table because the task had a side-effect of updating the this.features property.

In this PR, I go with what works: the task has the side-effect of setting properties, and then those property changes trigger rendering.  In the case of `totalCount`, that would need to be a separate property anyway as soon as the backend supports pagination.