### PR TITLE
Implement the baseline status filter

### DIFF
--- a/antlr/FeatureSearch.g4
+++ b/antlr/FeatureSearch.g4
@@ -12,7 +12,7 @@ COLON: ':';
 WS: [ \t\r\n]+ -> skip;
 
 // Identifiers
-BASELINE_STATUS: 'none' | 'low' | 'high';
+BASELINE_STATUS: 'limited' | 'newly' | 'widely';
 BROWSER_NAME: 'chrome' | 'firefox' | 'edge' | 'safari';
 BROWSER_LIST: BROWSER_NAME (',' BROWSER_NAME)*;
 ANY_VALUE:

--- a/antlr/FeatureSearch.md
+++ b/antlr/FeatureSearch.md
@@ -16,7 +16,7 @@ This query language enables you to construct flexible searches to find features 
       - Grid
       - "CSS Grid"
   - baseline statuses (`BASELINE_STATUS`)
-    - Accepted Values: 'none' | 'low' | 'high'
+    - Accepted Values: 'limited' | 'newly' | 'widely'
     - Examples:
       - none
   - browser list (`BROWSER_LIST`)
@@ -56,7 +56,7 @@ This query language enables you to construct flexible searches to find features 
 
 ### Complex Queries
 
-- `available_on:chrome AND baseline_status:low` - Find features available on Chrome and having a low baseline status.
+- `available_on:chrome AND baseline_status:newly` - Find features available on Chrome and having a newly baseline status.
 - `-available_on:firefox OR name:"CSS Grid"` - Find features either not available on Firefox or named "CSS Grid".
 - `missing_in_one_of(chrome,firefox,safari)` - Find features missing from at least one of the listed browsers.
-- `"CSS Grid" baseline_status:none` - Find features named "CSS Grid" with a baseline status of none (implied AND).
+- `"CSS Grid" baseline_status:limited` - Find features named "CSS Grid" with a baseline status of none (implied AND).

--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -38,7 +38,7 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 			mockConfig: MockGetFeatureByIDConfig{
 				expectedFeatureID: "feature1",
 				data: &backend.Feature{
-					BaselineStatus: backend.High,
+					BaselineStatus: backend.Widely,
 					FeatureId:      "feature1",
 					Name:           "feature 1",
 					Spec:           nil,
@@ -49,7 +49,7 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 			},
 			expectedCallCount: 1,
 			expectedResponse: backend.GetV1FeaturesFeatureId200JSONResponse{
-				BaselineStatus: backend.High,
+				BaselineStatus: backend.Widely,
 				FeatureId:      "feature1",
 				Name:           "feature 1",
 				Spec:           nil,

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -43,7 +43,7 @@ func TestGetV1Features(t *testing.T) {
 				expectedSortBy:     nil,
 				data: []backend.Feature{
 					{
-						BaselineStatus: backend.High,
+						BaselineStatus: backend.Widely,
 						FeatureId:      "feature1",
 						Name:           "feature 1",
 						Spec:           nil,
@@ -58,7 +58,7 @@ func TestGetV1Features(t *testing.T) {
 			expectedResponse: backend.GetV1Features200JSONResponse{
 				Data: []backend.Feature{
 					{
-						BaselineStatus: backend.High,
+						BaselineStatus: backend.Widely,
 						FeatureId:      "feature1",
 						Name:           "feature 1",
 						Spec:           nil,
@@ -116,7 +116,7 @@ func TestGetV1Features(t *testing.T) {
 				expectedSortBy: valuePtr[backend.GetV1FeaturesParamsSort](backend.NameDesc),
 				data: []backend.Feature{
 					{
-						BaselineStatus: backend.High,
+						BaselineStatus: backend.Widely,
 						FeatureId:      "feature1",
 						Name:           "feature 1",
 						Spec:           nil,
@@ -131,7 +131,7 @@ func TestGetV1Features(t *testing.T) {
 			expectedResponse: backend.GetV1Features200JSONResponse{
 				Data: []backend.Feature{
 					{
-						BaselineStatus: backend.High,
+						BaselineStatus: backend.Widely,
 						FeatureId:      "feature1",
 						Name:           "feature 1",
 						Spec:           nil,
@@ -162,7 +162,7 @@ func TestGetV1Features(t *testing.T) {
 				expectedSortBy:     nil,
 				data: []backend.Feature{
 					{
-						BaselineStatus: backend.High,
+						BaselineStatus: backend.Widely,
 						FeatureId:      "feature1",
 						Name:           "feature 1",
 						Spec:           nil,
@@ -197,7 +197,7 @@ func TestGetV1Features(t *testing.T) {
 				expectedSortBy:     nil,
 				data: []backend.Feature{
 					{
-						BaselineStatus: backend.High,
+						BaselineStatus: backend.Widely,
 						FeatureId:      "feature1",
 						Name:           "feature 1",
 						Spec:           nil,
@@ -232,7 +232,7 @@ func TestGetV1Features(t *testing.T) {
 				expectedSortBy:     nil,
 				data: []backend.Feature{
 					{
-						BaselineStatus: backend.High,
+						BaselineStatus: backend.Widely,
 						FeatureId:      "feature1",
 						Name:           "feature 1",
 						Spec:           nil,

--- a/frontend/src/static/js/components/webstatus-overview-cells.ts
+++ b/frontend/src/static/js/components/webstatus-overview-cells.ts
@@ -87,17 +87,17 @@ export const BASELINE_CHIP_CONFIGS: Record<
     icon: 'cross.svg',
     word: 'Limited',
   },
-  none: {
+  limited: {
     cssClass: 'limited',
     icon: 'cross.svg',
     word: 'Limited',
   },
-  low: {
+  newly: {
     cssClass: 'newly',
     icon: 'cross.svg', // TODO(jrobbins): need dotted check
     word: 'New',
   },
-  high: {
+  widely: {
     cssClass: 'widely',
     icon: 'check.svg',
     word: 'Widely available',

--- a/frontend/src/static/js/utils/test/urls.test.ts
+++ b/frontend/src/static/js/utils/test/urls.test.ts
@@ -95,7 +95,7 @@ describe('formatFeaturePageUrl', () => {
   const feature: components['schemas']['Feature'] = {
     feature_id: 'grid',
     name: 'test feature',
-    baseline_status: 'none',
+    baseline_status: 'limited',
   };
   it('returns a plain URL when no location is passed', () => {
     const url = formatFeaturePageUrl(feature);

--- a/lib/gcpspanner/feature_search_query.go
+++ b/lib/gcpspanner/feature_search_query.go
@@ -153,7 +153,20 @@ func (b *FeatureSearchFilterBuilder) featureNameFilter(featureName string) strin
 }
 
 func (b *FeatureSearchFilterBuilder) baselineStatusFilter(baselineStatus string) string {
-	paramName := b.addParamGetName(baselineStatus)
+	var status BaselineStatus
+	// baseline status is limited to the values in antlr/FeatureSearch.g4.
+	switch baselineStatus {
+	case "limited":
+		status = BaselineStatusNone
+	case "newly":
+		status = BaselineStatusLow
+	case "widely":
+		status = BaselineStatusHigh
+	default:
+		// Catch-all returns an empty string which will be thrown away.
+		return ""
+	}
+	paramName := b.addParamGetName(string(status))
 
 	return fmt.Sprintf(`fbs.Status = @%s`, paramName)
 }

--- a/lib/gcpspanner/feature_search_query_test.go
+++ b/lib/gcpspanner/feature_search_query_test.go
@@ -83,7 +83,7 @@ var (
 	}
 
 	availableOnBaselineStatus = TestTree{
-		Query: "available_on:chrome AND baseline_status:high",
+		Query: "available_on:chrome AND baseline_status:widely",
 		InputTree: &searchtypes.SearchNode{
 			Operator: searchtypes.OperatorRoot,
 			Term:     nil,
@@ -104,7 +104,7 @@ var (
 							Children: nil,
 							Term: &searchtypes.SearchTerm{
 								Identifier: searchtypes.IdentifierBaselineStatus,
-								Value:      "high",
+								Value:      "widely",
 							},
 							Operator: searchtypes.OperatorNone,
 						},
@@ -115,7 +115,7 @@ var (
 	}
 
 	availableOnBaselineStatusWithNegation = TestTree{
-		Query: "-available_on:chrome AND baseline_status:high",
+		Query: "-available_on:chrome AND baseline_status:widely",
 		InputTree: &searchtypes.SearchNode{
 			Operator: searchtypes.OperatorRoot,
 			Term:     nil,
@@ -136,7 +136,7 @@ var (
 							Children: nil,
 							Term: &searchtypes.SearchTerm{
 								Identifier: searchtypes.IdentifierBaselineStatus,
-								Value:      "high",
+								Value:      "widely",
 							},
 							Operator: searchtypes.OperatorNone,
 						},
@@ -147,7 +147,7 @@ var (
 	}
 
 	complexQuery = TestTree{
-		Query: "available_on:chrome (baseline_status:high OR name:avif) OR name:grid",
+		Query: "available_on:chrome (baseline_status:widely OR name:avif) OR name:grid",
 		InputTree: &searchtypes.SearchNode{
 			Operator: searchtypes.OperatorRoot,
 			Term:     nil,
@@ -174,7 +174,7 @@ var (
 											Operator: searchtypes.OperatorNone,
 											Children: nil,
 											Term: &searchtypes.SearchTerm{
-												Identifier: searchtypes.IdentifierBaselineStatus, Value: "high"},
+												Identifier: searchtypes.IdentifierBaselineStatus, Value: "widely"},
 										},
 										{
 											Operator: searchtypes.OperatorNone,

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -45,7 +45,7 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
-			InputQuery: "available_on:chrome AND baseline_status:high",
+			InputQuery: "available_on:chrome AND baseline_status:widely",
 			ExpectedTree: &SearchNode{
 				Operator: OperatorRoot,
 				Term:     nil,
@@ -66,7 +66,7 @@ func TestParseQuery(t *testing.T) {
 								Children: nil,
 								Term: &SearchTerm{
 									Identifier: IdentifierBaselineStatus,
-									Value:      "high",
+									Value:      "widely",
 								},
 								Operator: OperatorNone,
 							},
@@ -76,7 +76,7 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
-			InputQuery: "available_on:chrome baseline_status:high",
+			InputQuery: "available_on:chrome baseline_status:widely",
 			ExpectedTree: &SearchNode{
 				Operator: OperatorRoot,
 				Term:     nil,
@@ -97,7 +97,7 @@ func TestParseQuery(t *testing.T) {
 								Children: nil,
 								Term: &SearchTerm{
 									Identifier: IdentifierBaselineStatus,
-									Value:      "high",
+									Value:      "widely",
 								},
 								Operator: OperatorNone,
 							},
@@ -107,7 +107,7 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
-			InputQuery: "available_on:chrome AND baseline_status:high OR name:grid",
+			InputQuery: "available_on:chrome AND baseline_status:widely OR name:grid",
 			ExpectedTree: &SearchNode{
 				Operator: OperatorRoot,
 				Term:     nil,
@@ -132,7 +132,7 @@ func TestParseQuery(t *testing.T) {
 										Children: nil,
 										Term: &SearchTerm{
 											Identifier: IdentifierBaselineStatus,
-											Value:      "high",
+											Value:      "widely",
 										},
 										Operator: OperatorNone,
 									},
@@ -151,7 +151,7 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
-			InputQuery: "(available_on:chrome AND baseline_status:high) OR name:grid",
+			InputQuery: "(available_on:chrome AND baseline_status:widely) OR name:grid",
 			ExpectedTree: &SearchNode{
 				Operator: OperatorRoot,
 				Term:     nil,
@@ -173,7 +173,7 @@ func TestParseQuery(t *testing.T) {
 									{
 										Term: &SearchTerm{
 											Identifier: IdentifierBaselineStatus,
-											Value:      "high",
+											Value:      "widely",
 										},
 										Operator: OperatorNone,
 									},
@@ -192,7 +192,7 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
-			InputQuery: "(available_on:chrome AND baseline_status:high OR name:avif) OR name:grid",
+			InputQuery: "(available_on:chrome AND baseline_status:widely OR name:avif) OR name:grid",
 			ExpectedTree: &SearchNode{
 				Operator: OperatorRoot,
 				Term:     nil,
@@ -217,7 +217,7 @@ func TestParseQuery(t *testing.T) {
 											{
 												Operator: OperatorNone,
 												Children: nil,
-												Term:     &SearchTerm{Identifier: IdentifierBaselineStatus, Value: "high"},
+												Term:     &SearchTerm{Identifier: IdentifierBaselineStatus, Value: "widely"},
 											},
 										},
 									},
@@ -239,7 +239,7 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
-			InputQuery: "available_on:chrome (baseline_status:high OR name:avif) OR name:grid",
+			InputQuery: "available_on:chrome (baseline_status:widely OR name:avif) OR name:grid",
 			ExpectedTree: &SearchNode{
 				Operator: OperatorRoot,
 				Term:     nil,
@@ -264,7 +264,7 @@ func TestParseQuery(t *testing.T) {
 											{
 												Operator: OperatorNone,
 												Children: nil,
-												Term:     &SearchTerm{Identifier: IdentifierBaselineStatus, Value: "high"},
+												Term:     &SearchTerm{Identifier: IdentifierBaselineStatus, Value: "widely"},
 											},
 											{
 												Operator: OperatorNone,
@@ -355,7 +355,7 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
-			InputQuery: "-available_on:chrome OR baseline_status:high",
+			InputQuery: "-available_on:chrome OR baseline_status:widely",
 			ExpectedTree: &SearchNode{
 				Operator: OperatorRoot,
 				Term:     nil,
@@ -376,7 +376,7 @@ func TestParseQuery(t *testing.T) {
 								Operator: OperatorNone,
 								Term: &SearchTerm{
 									Identifier: IdentifierBaselineStatus,
-									Value:      "high",
+									Value:      "widely",
 								},
 								Children: nil,
 							},
@@ -446,6 +446,16 @@ func TestParseQueryBadInput(t *testing.T) {
 		// unbalanced parenthesis.
 		{
 			input: "(name:grid ()",
+		},
+		// Old baseline_status phrases will parse with error now.
+		{
+			input: "baseline_status:high",
+		},
+		{
+			input: "baseline_status:low",
+		},
+		{
+			input: "baseline_status:none",
 		},
 	}
 	for _, tc := range testCases {

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -146,11 +146,11 @@ func (s *Backend) ListMetricsForFeatureIDBrowserAndChannel(
 
 func convertBaselineStatusBackendToSpanner(status backend.FeatureBaselineStatus) gcpspanner.BaselineStatus {
 	switch status {
-	case backend.High:
+	case backend.Widely:
 		return gcpspanner.BaselineStatusHigh
-	case backend.Low:
+	case backend.Newly:
 		return gcpspanner.BaselineStatusLow
-	case backend.None:
+	case backend.Limited:
 		return gcpspanner.BaselineStatusNone
 	case backend.Undefined:
 		fallthrough
@@ -162,11 +162,11 @@ func convertBaselineStatusBackendToSpanner(status backend.FeatureBaselineStatus)
 func convertBaselineStatusSpannerToBackend(status gcpspanner.BaselineStatus) backend.FeatureBaselineStatus {
 	switch status {
 	case gcpspanner.BaselineStatusHigh:
-		return backend.High
+		return backend.Widely
 	case gcpspanner.BaselineStatusLow:
-		return backend.Low
+		return backend.Newly
 	case gcpspanner.BaselineStatusNone:
-		return backend.None
+		return backend.Limited
 	case gcpspanner.BaselineStatusUndefined:
 		fallthrough
 	default:

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -357,9 +357,9 @@ func TestConvertBaselineStatusBackendToSpanner(t *testing.T) {
 		input    backend.FeatureBaselineStatus
 		expected gcpspanner.BaselineStatus
 	}{
-		{"High to High", backend.High, gcpspanner.BaselineStatusHigh},
-		{"Low to Low", backend.Low, gcpspanner.BaselineStatusLow},
-		{"None to None", backend.None, gcpspanner.BaselineStatusNone},
+		{"Widely to High", backend.Widely, gcpspanner.BaselineStatusHigh},
+		{"Newly to Low", backend.Newly, gcpspanner.BaselineStatusLow},
+		{"Limited to None", backend.Limited, gcpspanner.BaselineStatusNone},
 		{"Invalid to Undefined", backend.FeatureBaselineStatus("invalid"),
 			gcpspanner.BaselineStatusUndefined}, // Test default case
 	}
@@ -379,9 +379,9 @@ func TestConvertBaselineStatusSpannerToBackend(t *testing.T) {
 		input    gcpspanner.BaselineStatus
 		expected backend.FeatureBaselineStatus
 	}{
-		{"High to High", gcpspanner.BaselineStatusHigh, backend.High},
-		{"Low to Low", gcpspanner.BaselineStatusLow, backend.Low},
-		{"None to None", gcpspanner.BaselineStatusNone, backend.None},
+		{"High to Widely", gcpspanner.BaselineStatusHigh, backend.Widely},
+		{"Low to Newly", gcpspanner.BaselineStatusLow, backend.Newly},
+		{"None to Limited", gcpspanner.BaselineStatusNone, backend.Limited},
 		{"Invalid to Undefined", gcpspanner.BaselineStatus("invalid"), backend.Undefined}, // Test default case
 	}
 	for _, tt := range spannerToBackendTests {
@@ -472,7 +472,7 @@ func TestFeaturesSearch(t *testing.T) {
 			sortOrder: nil,
 			expectedFeatures: []backend.Feature{
 				{
-					BaselineStatus: backend.Low,
+					BaselineStatus: backend.Newly,
 					FeatureId:      "feature1",
 					Name:           "feature 1",
 					Spec:           nil,
@@ -491,7 +491,7 @@ func TestFeaturesSearch(t *testing.T) {
 					},
 				},
 				{
-					BaselineStatus: backend.High,
+					BaselineStatus: backend.Widely,
 					FeatureId:      "feature2",
 					Name:           "feature 2",
 					Spec:           nil,
@@ -655,7 +655,7 @@ func TestGetFeature(t *testing.T) {
 				returnedError: nil,
 			},
 			expectedFeature: &backend.Feature{
-				BaselineStatus: backend.Low,
+				BaselineStatus: backend.Newly,
 				FeatureId:      "feature1",
 				Name:           "feature 1",
 				Spec:           nil,

--- a/lib/gds/web_feature.go
+++ b/lib/gds/web_feature.go
@@ -90,7 +90,7 @@ func (c *Client) ListWebFeatureData(ctx context.Context, pageToken *string) ([]b
 			FeatureId:      *val.WebFeatureID,
 			Name:           *val.Name,
 			Spec:           nil,
-			BaselineStatus: backend.None,
+			BaselineStatus: backend.Limited,
 		}
 	}
 

--- a/lib/gds/web_feature_test.go
+++ b/lib/gds/web_feature_test.go
@@ -42,7 +42,7 @@ func TestFeatureDataOperations(t *testing.T) {
 	}
 
 	expectedFeatures := []backend.Feature{
-		{FeatureId: "id-1", Spec: nil, Name: "version-1-name", BaselineStatus: backend.None},
+		{FeatureId: "id-1", Spec: nil, Name: "version-1-name", BaselineStatus: backend.Limited},
 	}
 	if !slices.Equal[[]backend.Feature](features, expectedFeatures) {
 		t.Errorf("slices not equal actual [%v] expected [%v]", features, expectedFeatures)
@@ -62,7 +62,7 @@ func TestFeatureDataOperations(t *testing.T) {
 	}
 
 	expectedFeatures = []backend.Feature{
-		{FeatureId: "id-1", Spec: nil, Name: "version-2-name", BaselineStatus: backend.None},
+		{FeatureId: "id-1", Spec: nil, Name: "version-2-name", BaselineStatus: backend.Limited},
 	}
 	if !slices.Equal[[]backend.Feature](features, expectedFeatures) {
 		t.Errorf("slices not equal actual [%v] expected [%v]", features, expectedFeatures)

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -385,9 +385,9 @@ components:
           type: string
           enum:
             - undefined
-            - none
-            - low
-            - high
+            - limited
+            - newly
+            - widely
         usage:
           type: number
           format: float


### PR DESCRIPTION
This change adjusts the openapi to match the language that we use on the frontend: widely, newly, limited

Adjust all the code in the backend and frontend to fix compile errors after changing the openapi enum.

This change adds a translation layer to feature_search_query.go to convert the input from the user to enum used in the database to match this document: https://github.com/web-platform-dx/web-features/tree/main/packages/web-features

Example urls:
- http://localhost:8080/v1/features?q=baseline_status:widely
- http://localhost:8080/v1/features?q=baseline_status:newly%20AND%20available_on:firefox

