### PR TITLE
Use Apply for the multiple WPTRunMetrics

### DIFF
--- a/.dev/spanner/manifests/pod.yaml
+++ b/.dev/spanner/manifests/pod.yaml
@@ -30,4 +30,4 @@ spec:
       resources:
         limits:
           cpu: '4'
-          memory: 1024Mi
+          memory: '1.5Gi'


### PR DESCRIPTION
Previously, WPTRunMetrics were added one-by-one.

Now we use client.Apply which allows multiple mutations to be submitted.

Turns out BatchWrite is not implemented in the emulator.

It take a little over a minute to run the script now. Which is an improvement because it took multiple minutes runsPerBrowserPerChannel was only set to 10.

Now runsPerBrowserPerChannel is set to 100.

```
$ make dev_fake_data
kubectl wait --for=condition=ready pod/spanner
pod/spanner condition met
fuser -k 9010/tcp || true
kubectl port-forward --address 127.0.0.1 pod/spanner 9010:9010 2>&1 >/dev/null &
SPANNER_EMULATOR_HOST=localhost:9010 go run ./util/cmd/load_fake_data/main.go -spanner_project=local -spanner_instance=local -spanner_database=local || true
2024/03/20 00:52:13 INFO establishing spanner client project=local instance=local database=local
2024/03/20 00:52:14 INFO releases generated "amount of releases created"=200
2024/03/20 00:52:15 INFO features generated "amount of features created"=150
2024/03/20 00:53:25 INFO runs and metrics generated "amount of runs created"=800 "amount of metrics created"=120000
2024/03/20 00:53:26 INFO statuses generated "amount of statuses created"=150
2024/03/20 00:53:26 INFO availabilities generated "amount of availabilities created"=278
2024/03/20 00:53:26 INFO loading fake data successful
```

Other changes:
- Append a number to the end of the feature id name. Currently we use Lorem Ipsum words. But there are only about 180 of them. If we ever try to add more, it would not work. This change fixes that.
- Increase the memory of the spanner instance to 1.5Gb. Because setting runsPerBrowserPerChannel to 100 requires a little more than 1024MB and will crash otherwise.
