### PR TITLE
Add Spanner to web feature ingestion. Fix prefilter

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -151,8 +151,7 @@ cd infra
 gcloud auth login
 gcloud auth application-default login --project=web-compass-staging --no-browser
 ENV_ID="staging"
-# SAVE THAT ENV_ID
-terraform select new $ENV_ID
+terraform workspace select $ENV_ID
 terraform init --var-file=.envs/staging.tfvars --backend-config=.envs/backend-staging.tfvars
 terraform plan \
     -var-file=".envs/staging.tfvars" \

--- a/infra/ingestion/variables.tf
+++ b/infra/ingestion/variables.tf
@@ -55,3 +55,11 @@ variable "projects" {
     public   = string
   })
 }
+
+variable "spanner_datails" {
+  type = object({
+    project_id = string
+    instance   = string
+    database   = string
+  })
+}

--- a/infra/ingestion/workflows.tf
+++ b/infra/ingestion/workflows.tf
@@ -23,6 +23,7 @@ module "web_features_repo_workflow" {
   env_id                                       = var.env_id
   repo_downloader_step_region_to_step_info_map = module.repo_downloader_step.region_to_step_info_map
   datastore_info                               = var.datastore_info
+  spanner_datails                              = var.spanner_datails
   repo_bucket                                  = var.buckets.repo_download_bucket
   docker_repository_details                    = var.docker_repository_details
 }

--- a/infra/ingestion/workflows/web_features_repo/variables.tf
+++ b/infra/ingestion/workflows/web_features_repo/variables.tf
@@ -38,6 +38,14 @@ variable "datastore_info" {
   })
 }
 
+variable "spanner_datails" {
+  type = object({
+    instance   = string
+    database   = string
+    project_id = string
+  })
+}
+
 variable "docker_repository_details" {
   type = object({
     hostname = string

--- a/infra/ingestion/workflows/web_features_repo/web_feature_service.tf
+++ b/infra/ingestion/workflows/web_features_repo/web_feature_service.tf
@@ -54,7 +54,15 @@ resource "google_project_iam_member" "gcp_datastore_user" {
   role     = "roles/datastore.user"
   project  = var.datastore_info.project_id
   member   = google_service_account.web_feature_consumer_service_account.member
+}
 
+resource "google_spanner_database_iam_member" "gcp_spanner_user" {
+  role     = "roles/spanner.databaseUser"
+  provider = google.internal_project
+  database = var.spanner_datails.database
+  instance = var.spanner_datails.instance
+  project  = var.spanner_datails.project_id
+  member   = google_service_account.web_feature_consumer_service_account.member
 }
 
 resource "google_cloud_run_v2_service" "web_feature_service" {
@@ -77,6 +85,14 @@ resource "google_cloud_run_v2_service" "web_feature_service" {
       env {
         name  = "DATASTORE_DATABASE"
         value = var.datastore_info.database_name
+      }
+      env {
+        name  = "SPANNER_DATABASE"
+        value = var.spanner_datails.database
+      }
+      env {
+        name  = "SPANNER_INSTANCE"
+        value = var.spanner_datails.instance
       }
     }
     service_account = google_service_account.web_feature_consumer_service_account.email

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -65,6 +65,7 @@ module "ingestion" {
   buckets                   = module.storage.buckets
   secret_ids                = var.secret_ids
   datastore_info            = module.storage.datastore_info
+  spanner_datails           = module.storage.spanner_info
   projects                  = var.projects
   depends_on                = [module.services]
 }

--- a/infra/storage/outputs.tf
+++ b/infra/storage/outputs.tf
@@ -14,8 +14,9 @@
 
 output "spanner_info" {
   value = {
-    instance = google_spanner_instance.main.name
-    database = google_spanner_database.database.name
+    instance   = google_spanner_instance.main.name
+    database   = google_spanner_database.database.name
+    project_id = google_spanner_instance.main.project
   }
 }
 

--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -93,11 +93,15 @@ func (f GCPFeatureSearchBaseQuery) buildChannelMetricsFilter(
 		)
 		filters = append(filters, filter)
 	}
-	filterStr := strings.Join(filters, " OR ")
+	var filterStr string
+	var retParams map[string]interface{}
+	if len(filters) > 0 {
+		filterStr = strings.Join(filters, " OR ")
+		filterStr = " AND (" + filterStr + ")"
+		retParams = params
+	}
 
-	filterStr = " AND (" + filterStr + ")"
-
-	return filterStr, params
+	return filterStr, retParams
 }
 
 // LatestRunResult contains the information for when a given BrowserName & Channel combination last ran.

--- a/lib/gcpspanner/feature_base_query_test.go
+++ b/lib/gcpspanner/feature_base_query_test.go
@@ -1,0 +1,92 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"maps"
+	"testing"
+	"time"
+)
+
+func TestGCPBuildChannelMetricsFilter(t *testing.T) {
+	testCases := []struct {
+		name           string
+		inputChannel   string
+		inputResults   []LatestRunResult
+		expectedFilter string
+		expectedParams map[string]interface{}
+	}{
+		{
+			name:           "no results",
+			inputChannel:   "stable",
+			inputResults:   []LatestRunResult{},
+			expectedFilter: "",
+			expectedParams: nil,
+		},
+		{
+			name:         "one result",
+			inputChannel: "stable",
+			inputResults: []LatestRunResult{
+				{
+					Channel:     "stable",
+					BrowserName: "fooBrowser",
+					TimeStart:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			expectedFilter: " AND ((metrics.BrowserName = @stablebrowser0 AND metrics.TimeStart = @stabletime0))",
+			expectedParams: map[string]interface{}{
+				"stablebrowser0": "fooBrowser",
+				"stabletime0":    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name:         "multiple results",
+			inputChannel: "stable",
+			inputResults: []LatestRunResult{
+				{
+					Channel:     "stable",
+					BrowserName: "fooBrowser",
+					TimeStart:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+				{
+					Channel:     "stable",
+					BrowserName: "barBrowser",
+					TimeStart:   time.Date(2023, time.December, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			// nolint: lll // WONTFIX. Expected string will be long.
+			expectedFilter: " AND ((metrics.BrowserName = @stablebrowser0 AND metrics.TimeStart = @stabletime0) OR (metrics.BrowserName = @stablebrowser1 AND metrics.TimeStart = @stabletime1))",
+			expectedParams: map[string]interface{}{
+				"stablebrowser0": "fooBrowser",
+				"stabletime0":    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				"stablebrowser1": "barBrowser",
+				"stabletime1":    time.Date(2023, time.December, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := GCPFeatureSearchBaseQuery{}
+			filterStr, params := q.buildChannelMetricsFilter(tc.inputChannel, tc.inputResults)
+			if filterStr != tc.expectedFilter {
+				t.Errorf("unexpected filter.\nexpected |%s|\nactual |%s|", tc.expectedFilter, filterStr)
+			}
+			if !maps.Equal(tc.expectedParams, params) {
+				t.Errorf("unexpected params.\nexpected |%s|\nactual |%s|", tc.expectedParams, params)
+			}
+		})
+	}
+}

--- a/workflows/steps/services/web_feature_consumer/manifests/pod.yaml
+++ b/workflows/steps/services/web_feature_consumer/manifests/pod.yaml
@@ -36,6 +36,12 @@ spec:
           value: ''
         - name: DATASTORE_EMULATOR_HOST
           value: 'datastore:8085'
+        - name: SPANNER_DATABASE
+          value: 'local'
+        - name: SPANNER_INSTANCE
+          value: 'local'
+        - name: SPANNER_EMULATOR_HOST
+          value: 'spanner:9010'
       resources:
         limits:
           cpu: 250m


### PR DESCRIPTION
Previously, the web features ingestion pipeline only connected to datastore.

This change adds the details so that the ingestion pipeline can connect to spanner, locally and in GCP.

This will prepare us for loading the web features data.

Additionally, the prefilter logic for GCP spanner has a bug where it prints out a string if the database is empty. That should not happen. Fixed that. And added a test to catch that in the future.

Other touch ups:
- Fix command in DEVELOPMENT.md. And remove comment since you don't need to save the ENV_ID since it is "staging"

This splits up #112 