### PR TITLE
Fix port forwarding.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,18 @@ delete-local:
 port-forward-manual: port-forward-terminate
 	kubectl wait --for=condition=ready pod/frontend
 	kubectl wait --for=condition=ready pod/backend
+	kubectl wait --for=condition=ready pod/web-feature-consumer
 	kubectl port-forward --address 127.0.0.1 pod/frontend 5555:5555 2>&1 >/dev/null &
 	kubectl port-forward --address 127.0.0.1 pod/backend 8080:8080 2>&1 >/dev/null &
+	kubectl port-forward --address 127.0.0.1 pod/web-feature-consumer 8092:8080 2>&1 >/dev/null &
+	curl -s -o /dev/null -m 5 http://localhost:8080 || true
+	curl -s -o /dev/null -m 5 http://localhost:5555 || true
+	curl -s -o /dev/null -m 5 http://localhost:8092 || true
 
 port-forward-terminate:
-	pkill kubectl -9 || true
+	fuser -k 5555/tcp || true
+	fuser -k 8080/tcp || true
+	fuser -k 8092/tcp || true
 
 # Prerequisite target to start minikube if necessary
 minikube-running:


### PR DESCRIPTION
Now that we manually do it with port-forward-manual, it is forwarded inside of the devcontainer (which is why the playwright tests continue to work). But if you try to access it outside  of the  devcontainer on your host machine, it does not auto forward all the way to the host sometimes.

For some reason, running curl while inside the devcontainer helps with that.

Also, the port-forward-terminate has been changed to kill the actual port instead of the kubectl binary. Killing the kubectl binary would stop following logs and stop rebuilds in skaffold.

