### PR TITLE
Add local In-Memory Cache helper

### DIFF
--- a/lib/cachetypes/errors.go
+++ b/lib/cachetypes/errors.go
@@ -1,0 +1,19 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cachetypes
+
+import "errors"
+
+var ErrCachedDataNotFound = errors.New("cached data not found for key")

--- a/lib/localcache/cache.go
+++ b/lib/localcache/cache.go
@@ -1,0 +1,75 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localcache
+
+import (
+	"context"
+	"sync"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
+)
+
+// LocalDataCache is an in-memory thread safe cache.
+// It uses generics so that users of it can uses any type of data they want.
+// The key K must be of type comparable. More infomration here: https://go.dev/blog/comparable
+// The value V can be any type.
+type LocalDataCache[K comparable, V any] struct {
+	mu   *sync.RWMutex
+	data map[K]V
+}
+
+// NewLocalDataCache creates a new LocalDataCache instance.
+func NewLocalDataCache[K comparable, V any]() *LocalDataCache[K, V] {
+	data := make(map[K]V)
+
+	return &LocalDataCache[K, V]{
+		data: data,
+		mu:   &sync.RWMutex{},
+	}
+}
+
+// Cache stores a value in the cache.
+func (c *LocalDataCache[K, V]) Cache(
+	_ context.Context,
+	key K,
+	in V,
+) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data[key] = in
+
+	return nil
+}
+
+// Get retrieves a value from the cache.
+// It returns a copy of the value if it exists in the cache.
+//   - It returns a copy instead of a pointer so that users cannot modify it and impact the value stored in the cache.
+//
+// It returns cachetypes.ErrCachedDataNotFound if it does not exist.
+// nolint: ireturn // V is not a interface always. Can ignore this.
+func (c *LocalDataCache[K, V]) Get(
+	_ context.Context,
+	key K,
+) (V, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if data, found := c.data[key]; found {
+		return data, nil
+	}
+
+	// Return a zero valued version of V and the not found error.
+	return *new(V), cachetypes.ErrCachedDataNotFound
+}

--- a/lib/localcache/cache_test.go
+++ b/lib/localcache/cache_test.go
@@ -1,0 +1,110 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localcache
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
+)
+
+type getCacheDataTest struct {
+	name          string
+	cacheData     map[string]string // Initial state of the cache
+	key           string
+	expectedValue string
+	expectedErr   error
+}
+
+type cacheDataTest struct {
+	name          string
+	cacheData     map[string]string // Initial state of the cache
+	key           string
+	value         string
+	expectedError error
+}
+
+func TestLocalDataCache(t *testing.T) {
+	// Test for Get Method
+	getCacheDataTests := []getCacheDataTest{
+		{
+			name:          "Cache Hit",
+			cacheData:     map[string]string{"hello": "world"},
+			key:           "hello",
+			expectedValue: "world",
+			expectedErr:   nil,
+		},
+		{
+			name:          "Cache Miss",
+			cacheData:     map[string]string{}, // Empty cache
+			key:           "missing-key",
+			expectedValue: "",
+			expectedErr:   cachetypes.ErrCachedDataNotFound,
+		},
+	}
+	for _, tt := range getCacheDataTests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := NewLocalDataCache[string, string]()
+			cache.data = tt.cacheData
+			val, err := cache.Get(context.Background(), tt.key)
+
+			if !errors.Is(err, tt.expectedErr) {
+				t.Errorf("Expected error: %v, Got: %v", tt.expectedErr, err)
+			}
+			if !reflect.DeepEqual(val, tt.expectedValue) {
+				t.Errorf("Expected value: %v, Got: %v", tt.expectedValue, val)
+			}
+		})
+	}
+
+	// Test for Cache Method
+	cacheDataTests := []cacheDataTest{
+		{
+			name:          "Add New Entry",
+			cacheData:     map[string]string{},
+			key:           "new-key",
+			value:         "new-value",
+			expectedError: nil,
+		},
+		{
+			name:          "Overwrite Existing",
+			cacheData:     map[string]string{"existing": "old"},
+			key:           "existing",
+			value:         "updated",
+			expectedError: nil,
+		},
+	}
+	for idx, tt := range cacheDataTests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := NewLocalDataCache[string, string]()
+			cache.data = tt.cacheData
+			err := cache.Cache(context.Background(), tt.key, cacheDataTests[idx].value)
+
+			if !errors.Is(err, tt.expectedError) {
+				t.Errorf("Expected error: %v, Got: %v", tt.expectedError, err)
+			}
+			cachedValue, err := cache.Get(context.Background(), tt.key)
+			if err != nil {
+				t.Errorf("Error retrieving cached value: %v", err)
+			}
+			if !reflect.DeepEqual(cachedValue, cacheDataTests[idx].value) {
+				t.Errorf("Cached value mismatch. Expected: %v, Got: %v", tt.value, cachedValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This implements the future Cache interface that will be used by the WPT Workflow (which could be switched to use redis in the future too).


The WPT workflow will need to cache a version of the data.json from the web features Github releases to prevent each local worker from downloading and potentially getting throttled.

It uses generics so that it can used for any data types in the future.

The local in memory cache is thread safe.

There is also a new cachetype error so that future Cache types (like redis) can return the same wrapped errors as other implementations of the cache interface.

This is part of splitting up #118

