### PR TITLE
Add scoring logic for the feature specific metrics

### DIFF
--- a/workflows/steps/services/wpt_consumer/pkg/workflow/score_webfeature.go
+++ b/workflows/steps/services/wpt_consumer/pkg/workflow/score_webfeature.go
@@ -1,0 +1,92 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"cmp"
+	"context"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/wptconsumertypes"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// WPTStatusAbbreviation is an enumeration of the abbreivations from
+// https://github.com/web-platform-tests/wpt.fyi/tree/main/api#results-summaries
+type WPTStatusAbbreviation string
+
+const (
+	WPTStatusOK                 WPTStatusAbbreviation = "O"
+	WPTStatusPass               WPTStatusAbbreviation = "P"
+	WPTStatusFail               WPTStatusAbbreviation = "F"
+	WPTStatusSkip               WPTStatusAbbreviation = "S"
+	WPTStatusError              WPTStatusAbbreviation = "E"
+	WPTStatusNotRun             WPTStatusAbbreviation = "N"
+	WPTStatusCrash              WPTStatusAbbreviation = "C"
+	WPTStatusTimeout            WPTStatusAbbreviation = "T"
+	WPTStatusPreconditionFailed WPTStatusAbbreviation = "PF"
+)
+
+// Score calculates web feature metrics from a V2 results summary file.
+// It ensures the file is in the expected format and uses web features
+// data for the scoring logic.
+func (s ResultsSummaryFileV2) Score(
+	ctx context.Context,
+	testToWebFeatures *shared.WebFeaturesData) map[string]wptconsumertypes.WPTFeatureMetric {
+	scoreMap := make(map[string]wptconsumertypes.WPTFeatureMetric)
+	for test, testSummary := range s {
+		if len(testSummary.Counts) < 2 {
+			// Need at least the number of subtests passes and the number of subtests
+			continue
+		}
+		s.scoreTest(ctx, test, scoreMap, testToWebFeatures, testSummary.Counts[0], testSummary.Counts[1])
+	}
+
+	return scoreMap
+}
+
+// scoreTest updates web feature metrics for a single test
+// based on provided subtest results and web features data.
+func (s ResultsSummaryFileV2) scoreTest(
+	_ context.Context,
+	test string,
+	webFeatureScoreMap map[string]wptconsumertypes.WPTFeatureMetric,
+	testToWebFeatures *shared.WebFeaturesData,
+	numberOfSubtestPassing int,
+	numberofSubtests int,
+) {
+	var webFeatures map[string]interface{}
+	var found bool
+	if webFeatures, found = (*testToWebFeatures)[test]; !found {
+		// There are no web features associated with this test. Skip
+		return
+	}
+	// Calculate the value early so we can re-use for multiple web features.
+	countsAsPassing := numberOfSubtestPassing == numberofSubtests
+	for webFeature := range webFeatures {
+		initialTotal := new(int64)
+		initialPass := new(int64)
+		*initialTotal = 0
+		*initialPass = 0
+		webFeatureScore := cmp.Or(
+			webFeatureScoreMap[webFeature],
+			wptconsumertypes.WPTFeatureMetric{TotalTests: initialTotal, TestPass: initialPass})
+		*webFeatureScore.TotalTests++
+		// If all of the sub tests passed, only count it.
+		if countsAsPassing {
+			*webFeatureScore.TestPass++
+		}
+		webFeatureScoreMap[webFeature] = webFeatureScore
+	}
+}

--- a/workflows/steps/services/wpt_consumer/pkg/workflow/score_webfeature_test.go
+++ b/workflows/steps/services/wpt_consumer/pkg/workflow/score_webfeature_test.go
@@ -1,0 +1,154 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/wptconsumertypes"
+	"github.com/web-platform-tests/wpt.fyi/api/query"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+func getSimpleWebFeaturesData() shared.WebFeaturesData {
+	return shared.WebFeaturesData{
+		"test1.html": {
+			"feature1": nil,
+		},
+	}
+}
+
+func getSimpleSummary() ResultsSummaryFileV2 {
+	return ResultsSummaryFileV2{
+		"test1.html": query.SummaryResult{
+			Status: string(WPTStatusPass),
+			Counts: []int{1, 1},
+		},
+	}
+}
+
+func getComplexWebFeaturesData() shared.WebFeaturesData {
+	return shared.WebFeaturesData{
+		"test1.html": {
+			"feature1": nil,
+			"feature2": nil,
+		},
+		"test2-not-passing.html": {
+			"feature2": nil,
+			"feature3": nil,
+			"feature4": nil,
+		},
+		"test3.html": {
+			"feature1": nil,
+			"feature2": nil,
+			"feature3": nil,
+			"feature5": nil,
+		},
+		"malformed-counts-test.html": {
+			"feature5": nil,
+		},
+	}
+}
+
+func getComplexSummary() ResultsSummaryFileV2 {
+	return ResultsSummaryFileV2{
+		"test1.html": query.SummaryResult{
+			Status: string(WPTStatusPass),
+			Counts: []int{1, 1},
+		},
+		"test2-not-passing.html": query.SummaryResult{
+			Status: string(WPTStatusFail),
+			Counts: []int{1, 11},
+		},
+		"test3.html": query.SummaryResult{
+			Status: string(WPTStatusPass),
+			Counts: []int{100, 100},
+		},
+		"no-webfeatures-mapping-test.html": query.SummaryResult{
+			Status: string(WPTStatusPass),
+			Counts: []int{1000, 1000},
+		},
+		// Mapped in side web features, it should no contribute the count if the summary data is bad.
+		"malformed-counts-test.html": query.SummaryResult{
+			Status: string(WPTStatusPass),
+			Counts: []int{1000},
+		},
+		"passing-but-test-not-mapped-in-webfeatures-test.html": query.SummaryResult{
+			Status: string(WPTStatusPass),
+			Counts: []int{10, 10},
+		},
+	}
+}
+
+func TestScore(t *testing.T) {
+	testCases := []struct {
+		name              string
+		summary           ResultsSummaryFileV2
+		testToWebFeatures shared.WebFeaturesData
+		expectedOutput    map[string]wptconsumertypes.WPTFeatureMetric
+	}{
+		{
+			name:              "simple",
+			testToWebFeatures: getSimpleWebFeaturesData(),
+			summary:           getSimpleSummary(),
+			expectedOutput: map[string]wptconsumertypes.WPTFeatureMetric{
+				"feature1": {
+					TotalTests: valuePtr[int64](1),
+					TestPass:   valuePtr[int64](1),
+				},
+			},
+		},
+		{
+			name:              "complex",
+			testToWebFeatures: getComplexWebFeaturesData(),
+			summary:           getComplexSummary(),
+			expectedOutput: map[string]wptconsumertypes.WPTFeatureMetric{
+				"feature1": {
+					TotalTests: valuePtr[int64](2),
+					TestPass:   valuePtr[int64](2),
+				},
+				"feature2": {
+					TotalTests: valuePtr[int64](3),
+					TestPass:   valuePtr[int64](2),
+				},
+				"feature3": {
+					TotalTests: valuePtr[int64](2),
+					TestPass:   valuePtr[int64](1),
+				},
+				"feature4": {
+					TotalTests: valuePtr[int64](1),
+					TestPass:   valuePtr[int64](0),
+				},
+				"feature5": {
+					TotalTests: valuePtr[int64](1),
+					TestPass:   valuePtr[int64](1),
+				},
+			},
+		},
+	}
+	for idx, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output := tc.summary.Score(
+				context.Background(),
+				&testCases[idx].testToWebFeatures,
+			)
+			if !reflect.DeepEqual(tc.expectedOutput, output) {
+				t.Errorf("unexpected score\nexpected %v\nreceived %v", tc.expectedOutput, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change applies the WPT v2 summary files (since we only read those files)

This is part of splitting up #118
- The only difference is that the score logic has been moved to the file itself since the v2 file knows the format. And future file formats can have their own scoring logic.
- In PR 118, it was not easily able to accomodate future file formats

