### PR TITLE
Add framework to get WebFeaturesData.

### DIFF
--- a/workflows/steps/services/wpt_consumer/pkg/workflow/get_web_feature_map.go
+++ b/workflows/steps/services/wpt_consumer/pkg/workflow/get_web_feature_map.go
@@ -1,0 +1,85 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+type DataCacher[K comparable, V any] interface {
+	// Cache stores a value associated with a key in the cache.
+	Cache(context.Context, K, V) error
+	// Get retrieves a value from the cache by its key.
+	Get(context.Context, K) (V, error)
+}
+
+// NewCacheableWebFeaturesDataGetter returns a new CacheableWebFeaturesDataGetter,
+// which implements caching behavior on top of an underlying WebFeatureDataGetter.
+func NewCacheableWebFeaturesDataGetter(
+	client WebFeatureDataGetter,
+	cache DataCacher[string, shared.WebFeaturesData]) *CacheableWebFeaturesDataGetter {
+	return &CacheableWebFeaturesDataGetter{
+		client: client,
+		cache:  cache,
+	}
+}
+
+type CacheableWebFeaturesDataGetter struct {
+	client WebFeatureDataGetter
+	cache  DataCacher[string, shared.WebFeaturesData]
+}
+
+const (
+	cacheKeyLatest = "latest-web-features"
+)
+
+// WebFeatureDataGetter defines an interface for retrieving web features data
+// from some underlying source.
+type WebFeatureDataGetter interface {
+	Get(context.Context) (shared.WebFeaturesData, error)
+}
+
+func (g *CacheableWebFeaturesDataGetter) GetWebFeaturesData(
+	ctx context.Context, _ string) (shared.WebFeaturesData, error) {
+	// 1. Attempts to retrieve data from the cache.
+	// 2. If not found or an unexpected cache error occurs, falls back to fetching data directly.
+	// 3. Caches freshly fetched data for future requests.
+
+	// Step 1.
+	cachedData, err := g.cache.Get(ctx, cacheKeyLatest)
+	if err == nil {
+		return cachedData, nil
+	} else if !errors.Is(err, cachetypes.ErrCachedDataNotFound) {
+		slog.Warn("unexpected error when trying to get cache data", "err", err)
+	}
+
+	// Step 2.
+	data, err := g.client.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 3.
+	if err := g.cache.Cache(ctx, cacheKeyLatest, data); err != nil {
+		slog.Warn("unable to cache web features data", "err", err)
+	}
+
+	return data, nil
+}

--- a/workflows/steps/services/wpt_consumer/pkg/workflow/get_web_feature_map_test.go
+++ b/workflows/steps/services/wpt_consumer/pkg/workflow/get_web_feature_map_test.go
@@ -1,0 +1,148 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+type MockWebFeatureDataGetter struct {
+	data shared.WebFeaturesData
+	err  error
+}
+
+func (g *MockWebFeatureDataGetter) Get(_ context.Context) (shared.WebFeaturesData, error) {
+	return g.data, g.err
+}
+
+type mockCacheGetConfig struct {
+	expectedKey string
+	data        shared.WebFeaturesData
+	err         error
+}
+
+type mockCacheCacheConfig struct {
+	expectedKey  string
+	expectedData shared.WebFeaturesData
+	err          error
+}
+type MockDataCacher struct {
+	mockCacheGetConfig   *mockCacheGetConfig
+	mockCacheCacheConfig *mockCacheCacheConfig
+	t                    *testing.T
+}
+
+func (m *MockDataCacher) Cache(_ context.Context, key string, value shared.WebFeaturesData) error {
+	if key != m.mockCacheCacheConfig.expectedKey ||
+		!reflect.DeepEqual(value, m.mockCacheCacheConfig.expectedData) {
+		m.t.Error("unexpected input to Cache")
+	}
+
+	return m.mockCacheCacheConfig.err
+}
+
+func (m *MockDataCacher) Get(_ context.Context, key string) (shared.WebFeaturesData, error) {
+	if key != m.mockCacheGetConfig.expectedKey {
+		m.t.Error("unexpected input to Get")
+	}
+
+	return m.mockCacheGetConfig.data, m.mockCacheGetConfig.err
+}
+
+type getWebFeaturesDataTest struct {
+	name                     string
+	mockWebFeatureDataGetter *MockWebFeatureDataGetter
+	mockCacheCacheConfig     *mockCacheCacheConfig
+	mockCacheGetConfig       *mockCacheGetConfig
+	expectedData             shared.WebFeaturesData
+	expectedErr              error
+}
+
+// nolint: gochecknoglobals
+var (
+	liveData = shared.WebFeaturesData{
+		"test1.html": {
+			"feature1": nil,
+		},
+	}
+	cachedData = shared.WebFeaturesData{"from-cache": nil}
+)
+
+func TestGetWebFeaturesData(t *testing.T) {
+	testCases := []getWebFeaturesDataTest{
+		{
+			name: "Cache Hit",
+			mockWebFeatureDataGetter: &MockWebFeatureDataGetter{
+				data: nil,
+				err:  nil,
+			},
+			mockCacheGetConfig: &mockCacheGetConfig{
+				expectedKey: cacheKeyLatest,
+				data:        cachedData,
+				err:         nil,
+			},
+			mockCacheCacheConfig: nil,
+			expectedErr:          nil,
+			expectedData:         cachedData,
+		},
+		{
+			name: "Cache Miss",
+			mockWebFeatureDataGetter: &MockWebFeatureDataGetter{
+				data: liveData,
+				err:  nil,
+			},
+			mockCacheGetConfig: &mockCacheGetConfig{
+				expectedKey: cacheKeyLatest,
+				data:        nil,
+				err:         cachetypes.ErrCachedDataNotFound,
+			},
+			mockCacheCacheConfig: &mockCacheCacheConfig{
+				expectedKey:  cacheKeyLatest,
+				expectedData: liveData,
+				err:          nil,
+			},
+			expectedData: liveData,
+			expectedErr:  nil,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			dataCacher := MockDataCacher{
+				t:                    t,
+				mockCacheGetConfig:   tt.mockCacheGetConfig,
+				mockCacheCacheConfig: tt.mockCacheCacheConfig,
+			}
+			getter := NewCacheableWebFeaturesDataGetter(
+				tt.mockWebFeatureDataGetter,
+				&dataCacher)
+
+			data, err := getter.GetWebFeaturesData(context.Background(), "test-revision")
+
+			if !errors.Is(err, tt.expectedErr) {
+				t.Errorf("Expected error: %v, Got: %v", tt.expectedErr, err)
+			}
+
+			if !reflect.DeepEqual(data, tt.expectedData) {
+				t.Error("unexpected data")
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Adds WebFeatureDataGetter interface, aligning with external signature [1]
* Implements generic DataCacher interface for rate-limit mitigation with Github.
* Prepares structure for future integration with [1]

[1] https://github.com/web-platform-tests/wpt.fyi/blob/2795551903615821f720b354fb61e75c8332deab/shared/web_features_manifest_github_download.go#L192

