### PR TITLE
Add job binary for WPT workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,8 +285,10 @@ clean-node:
 ################################
 dev_workflows: web_feature_local_workflow
 web_feature_local_workflow: FLAGS := -web_consumer_host=http://localhost:8092
-web_feature_local_workflow:
+web_feature_local_workflow: port-forward-manual
 	go run ./util/cmd/local_web_feature_workflow/main.go $(FLAGS)
+	./util/run_job.sh wpt-consumer images/go_service.Dockerfile workflows/steps/services/wpt_consumer \
+		workflows/steps/services/wpt_consumer/manifests/job.yaml wpt-consumer
 dev_fake_data: is_local_migration_ready
 	fuser -k 9010/tcp || true
 	kubectl port-forward --address 127.0.0.1 pod/spanner 9010:9010 2>&1 >/dev/null &

--- a/workflows/steps/services/wpt_consumer/cmd/job/main.go
+++ b/workflows/steps/services/wpt_consumer/cmd/job/main.go
@@ -1,0 +1,133 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"cmp"
+	"context"
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters"
+	"github.com/GoogleChrome/webstatus.dev/lib/gds"
+	"github.com/GoogleChrome/webstatus.dev/lib/localcache"
+	"github.com/GoogleChrome/webstatus.dev/lib/workerpool"
+	"github.com/GoogleChrome/webstatus.dev/lib/wptfyi"
+	"github.com/GoogleChrome/webstatus.dev/workflows/steps/services/wpt_consumer/pkg/workflow"
+	"github.com/google/go-github/v47/github"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Configuration and Client Setup
+
+	// wpt.fyi setup
+	wptFyiHostname := cmp.Or[string](os.Getenv("WPT_FYI_HOSTNAME"), "wpt.fyi")
+
+	wptPageLimitStr := os.Getenv("WPT_FYI_PAGE_LIMIT")
+	wptPageLimit := shared.MaxCountMaxValue
+	if wptPageLimitStr != "" {
+		var parseErr error
+		wptPageLimit, parseErr = strconv.Atoi(wptPageLimitStr)
+		if parseErr != nil {
+			slog.Error("unable to parse custom page limit", "input", wptPageLimitStr)
+			os.Exit(1)
+		}
+	}
+
+	// Datastore setup
+	var datastoreDB *string
+	if value, found := os.LookupEnv("DATASTORE_DATABASE"); found {
+		datastoreDB = &value
+	}
+	projectID := os.Getenv("PROJECT_ID")
+	dsClient, err := gds.NewDatastoreClient(projectID, datastoreDB)
+	if err != nil {
+		slog.Error("failed to create datastore client", "error", err.Error())
+		os.Exit(1)
+	}
+	_ = dsClient
+
+	// Spanner setup
+	spannerDB := os.Getenv("SPANNER_DATABASE")
+	spannerInstance := os.Getenv("SPANNER_INSTANCE")
+	spannerClient, err := gcpspanner.NewSpannerClient(projectID, spannerInstance, spannerDB)
+	if err != nil {
+		slog.Error("failed to create spanner client", "error", err.Error())
+		os.Exit(1)
+	}
+
+	ghClient := github.NewClient(nil)
+	// Currently, keep it at 8. 4 browsers, 2 channels each.
+	numWorkers := 8
+
+	dataWindowDuration := os.Getenv("DATA_WINDOW_DURATION")
+	duration, err := time.ParseDuration(dataWindowDuration)
+	if err != nil {
+		slog.Error("unable to parse DATA_WINDOW_DURATION duration", "input value", dataWindowDuration)
+		os.Exit(1)
+	}
+
+	// Worker Pool Setup
+	pool := workerpool.Pool[workflow.JobArguments]{}
+
+	worker := workflow.NewWptRunsWorker(
+		wptfyi.NewHTTPClient(wptFyiHostname),
+		workflow.NewWPTRunsProcessor(
+			workflow.NewWPTRunProcessor(
+				workflow.NewHTTPResultsGetter(),
+				workflow.NewCacheableWebFeaturesDataGetter(
+					shared.NewGitHubWebFeaturesClient(ghClient),
+					localcache.NewLocalDataCache[string, shared.WebFeaturesData](),
+				),
+				spanneradapters.NewWPTWorkflowConsumer(spannerClient),
+			),
+		),
+	)
+
+	// Job Generation
+	jobChan := make(chan workflow.JobArguments)
+	go func() {
+		startAt := time.Now().UTC().Add(-duration)
+		browsers := shared.GetDefaultBrowserNames()
+		channels := []string{shared.StableLabel, shared.ExperimentalLabel}
+		for _, browser := range browsers {
+			for _, channel := range channels {
+				args := workflow.NewJobArguments(
+					startAt,
+					browser,
+					channel,
+					wptPageLimit,
+				)
+				slog.Info("sending args to worker pool", "args", args)
+				jobChan <- args
+			}
+		}
+		// Close the job channel now that we are done.
+		close(jobChan)
+	}()
+
+	// Job Execution and Error Handling
+	errs := pool.Start(ctx, jobChan, numWorkers, worker)
+	if len(errs) > 0 {
+		slog.Error("workflow returned errors", "error", errs)
+		os.Exit(1)
+	}
+}

--- a/workflows/steps/services/wpt_consumer/manifests/job.yaml
+++ b/workflows/steps/services/wpt_consumer/manifests/job.yaml
@@ -1,0 +1,49 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wpt-consumer
+  labels:
+    app.kubernetes.io/name: wpt-consumer
+spec:
+  template:
+    spec:
+      containers:
+        - name: wpt-consumer
+          image: wpt-consumer
+          imagePullPolicy: Never # Need this for pushing directly into minikube
+          env:
+            - name: PROJECT_ID
+              value: local
+            - name: DATASTORE_DATABASE
+              value: ''
+            - name: DATASTORE_EMULATOR_HOST
+              value: 'datastore:8085'
+            - name: SPANNER_DATABASE
+              value: 'local'
+            - name: SPANNER_INSTANCE
+              value: 'local'
+            - name: SPANNER_EMULATOR_HOST
+              value: 'spanner:9010'
+            - name: DATA_WINDOW_DURATION
+              value: '48h'
+            - name: WPT_FYI_PAGE_LIMIT
+              value: '2'
+          resources:
+            limits:
+              cpu: 250m
+              memory: 512Mi
+      restartPolicy: Never

--- a/workflows/steps/services/wpt_consumer/pkg/workflow/wpt_run_processor.go
+++ b/workflows/steps/services/wpt_consumer/pkg/workflow/wpt_run_processor.go
@@ -57,7 +57,7 @@ type ResultsDownloader interface {
 // WebFeaturesDataGetter describes an interface that will get the web features data.
 type WebFeaturesDataGetter interface {
 	// Get the web features metadata for the particular commit sha.
-	GetWebFeaturesData(context.Context, string) (*shared.WebFeaturesData, error)
+	GetWebFeaturesData(context.Context, string) (shared.WebFeaturesData, error)
 }
 
 // WebFeatureWPTScoreStorer describes the interface to store run data and metrics data.
@@ -84,7 +84,7 @@ func (w WPTRunProcessor) ProcessRun(
 		return err
 	}
 
-	metricsPerFeature := resultsSummaryFile.Score(ctx, webFeaturesData)
+	metricsPerFeature := resultsSummaryFile.Score(ctx, &webFeaturesData)
 
 	// Insert the data.
 

--- a/workflows/steps/services/wpt_consumer/pkg/workflow/wpt_run_processor_test.go
+++ b/workflows/steps/services/wpt_consumer/pkg/workflow/wpt_run_processor_test.go
@@ -45,14 +45,14 @@ func (m *MockResultsDownloader) DownloadResults(_ context.Context, _ string) (Re
 
 type MockWebFeaturesDataGetter struct {
 	shouldFail      bool
-	webFeaturesData *shared.WebFeaturesData
+	webFeaturesData shared.WebFeaturesData
 }
 
 var errGetWebFeaturesData = errors.New("web features test error")
 
 func (m *MockWebFeaturesDataGetter) GetWebFeaturesData(
 	_ context.Context,
-	_ string) (*shared.WebFeaturesData, error) {
+	_ string) (shared.WebFeaturesData, error) {
 	if m.shouldFail {
 		return nil, errGetWebFeaturesData
 	}
@@ -180,8 +180,12 @@ func TestProcessRun(t *testing.T) {
 				shouldFail: false,
 			},
 			mockWebFeaturesDataGetter: &MockWebFeaturesDataGetter{
-				webFeaturesData: &shared.WebFeaturesData{},
-				shouldFail:      false,
+				webFeaturesData: shared.WebFeaturesData{
+					"test1.html": {
+						"feature1": nil,
+					},
+				},
+				shouldFail: false,
 			},
 			expectedErr: nil,
 		},
@@ -210,7 +214,7 @@ func TestProcessRun(t *testing.T) {
 				shouldFail:     true,
 			},
 			mockWebFeaturesDataGetter: &MockWebFeaturesDataGetter{
-				webFeaturesData: nil,
+				webFeaturesData: shared.WebFeaturesData{},
 				shouldFail:      false,
 			},
 			expectedErr: errDownloadResults,
@@ -244,7 +248,7 @@ func TestProcessRun(t *testing.T) {
 				shouldFail: false,
 			},
 			mockWebFeaturesDataGetter: &MockWebFeaturesDataGetter{
-				webFeaturesData: nil,
+				webFeaturesData: shared.WebFeaturesData{},
 				shouldFail:      true,
 			},
 			expectedErr: errGetWebFeaturesData,
@@ -296,7 +300,7 @@ func TestProcessRun(t *testing.T) {
 				shouldFail: false,
 			},
 			mockWebFeaturesDataGetter: &MockWebFeaturesDataGetter{
-				webFeaturesData: &shared.WebFeaturesData{},
+				webFeaturesData: shared.WebFeaturesData{},
 				shouldFail:      false,
 			},
 			expectedErr: errInsertWPTRun,
@@ -355,7 +359,7 @@ func TestProcessRun(t *testing.T) {
 				shouldFail: false,
 			},
 			mockWebFeaturesDataGetter: &MockWebFeaturesDataGetter{
-				webFeaturesData: &shared.WebFeaturesData{},
+				webFeaturesData: shared.WebFeaturesData{},
 				shouldFail:      false,
 			},
 			expectedErr: errUpsertWPTMetric,


### PR DESCRIPTION
This is the entrypoint to the WPT workflow that builds on all the work of the others PRs split out from PR #118

It parses all the needed configurations, creates the worker pool, sends the jobs and reports back any errors.

Additionally, the Makefile has been changed so that the dev_workflow also calls this new job.

The job.yaml file describes the kubernetes job.

Other changes: changes to the GetWebFeaturesData method to match the return type of the datacacher type.

This is splitting up of #118


