### PR TITLE
Add infrastructure to deploy the WPT job

### DIFF
--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -1,36 +1,36 @@
 projects = {
-    host = "web-compass-staging"
-    internal = "webstatus-dev-internal-staging"
-    public = "webstatus-dev-public-staging"
+  host     = "web-compass-staging"
+  internal = "webstatus-dev-internal-staging"
+  public   = "webstatus-dev-public-staging"
 }
-project_name="web-compass-staging"
-spanner_processing_units=200
-deletion_protection=true
-secret_ids={
-    github_token = "jamestestGHtoken-readonly"
+project_name             = "web-compass-staging"
+spanner_processing_units = 400
+deletion_protection      = true
+secret_ids = {
+  github_token = "jamestestGHtoken-readonly"
 }
 datastore_region_id = "nam5"
-region_information= {
-    us-central1 = {
-        networks = {
-            internal = {
-                cidr = "10.1.0.0/16"
-            }
-            public = {
-                cidr = "10.2.0.0/16"
-            }
-        }
-    },
-    europe-west1 = {
-        networks = {
-            internal = {
-                cidr = "10.3.0.0/16"
-            }
-            public = {
-                cidr = "10.4.0.0/16"
-            }
-        }
-    },
+region_information = {
+  us-central1 = {
+    networks = {
+      internal = {
+        cidr = "10.1.0.0/16"
+      }
+      public = {
+        cidr = "10.2.0.0/16"
+      }
+    }
+  },
+  europe-west1 = {
+    networks = {
+      internal = {
+        cidr = "10.3.0.0/16"
+      }
+      public = {
+        cidr = "10.4.0.0/16"
+      }
+    }
+  },
 }
-backend_api_url="https://api-webstatus-dev.corp.goog"
-gsi_client_id="367048339992-5os99v0p6chosv28dpo9863h9sjeno36.apps.googleusercontent.com"
+backend_api_url = "https://api-webstatus-dev.corp.goog"
+gsi_client_id   = "367048339992-5os99v0p6chosv28dpo9863h9sjeno36.apps.googleusercontent.com"

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -103,11 +103,9 @@ resource "google_project_iam_member" "gcp_datastore_user" {
   member   = google_service_account.backend.member
 }
 
-resource "google_spanner_database_iam_member" "gcp_spanner_user" {
+resource "google_project_iam_member" "gcp_spanner_user" {
   role     = "roles/spanner.databaseReader"
   provider = google.internal_project
-  database = var.spanner_datails.database
-  instance = var.spanner_datails.instance
   project  = var.datastore_info.project_id
   member   = google_service_account.backend.member
 }

--- a/infra/ingestion/workflows.tf
+++ b/infra/ingestion/workflows.tf
@@ -27,3 +27,17 @@ module "web_features_repo_workflow" {
   repo_bucket                                  = var.buckets.repo_download_bucket
   docker_repository_details                    = var.docker_repository_details
 }
+
+module "wpt_workflow" {
+  source = "./workflows/wpt"
+  providers = {
+    google.internal_project = google.internal_project
+    google.public_project   = google.public_project
+  }
+
+  regions                   = var.regions
+  env_id                    = var.env_id
+  datastore_info            = var.datastore_info
+  spanner_datails           = var.spanner_datails
+  docker_repository_details = var.docker_repository_details
+}

--- a/infra/ingestion/workflows/wpt/main.tf
+++ b/infra/ingestion/workflows/wpt/main.tf
@@ -1,0 +1,36 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_service_account" "service_account" {
+  account_id   = "wpt-${var.env_id}"
+  provider     = google.internal_project
+  display_name = "WPT Workflow service account for ${var.env_id}"
+}
+
+resource "google_workflows_workflow" "workflow" {
+  count           = length(var.regions)
+  provider        = google.internal_project
+  name            = "${var.env_id}-wpt-${var.regions[count.index]}"
+  region          = var.regions[count.index]
+  description     = "WPT Workflow. Env id: ${var.env_id}"
+  service_account = google_service_account.service_account.id
+  source_contents = templatefile(
+    "${path.root}/../workflows/wpt/workflows.yaml.tftpl",
+    {
+      project_id   = google_cloud_run_v2_job.wpt[count.index].project
+      job_name     = google_cloud_run_v2_job.wpt[count.index].name
+      job_location = google_cloud_run_v2_job.wpt[count.index].location
+    }
+  )
+}

--- a/infra/ingestion/workflows/wpt/providers.tf
+++ b/infra/ingestion/workflows/wpt/providers.tf
@@ -1,0 +1,28 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+    google = {
+      source = "hashicorp/google"
+      configuration_aliases = [
+        google.internal_project,
+        google.public_project,
+      ]
+    }
+  }
+}

--- a/infra/ingestion/workflows/wpt/variables.tf
+++ b/infra/ingestion/workflows/wpt/variables.tf
@@ -1,0 +1,61 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Variables specific to this module.
+variable "data_window_duration" {
+  description = "How far back in time do we want to go. Units come from https://pkg.go.dev/time#ParseDuration"
+  type        = string
+  default     = "17520h" # 2 years
+}
+
+variable "timeout_seconds" {
+  description = "Timeout for the WPT job. Details here: https://cloud.google.com/run/docs/configuring/request-timeout#terraform"
+  type        = number
+  default     = "3600" # An hour
+}
+
+# Variables from parent modules.
+# Refer to the parent modules for more details
+variable "env_id" {
+  type = string
+}
+
+variable "regions" {
+  type = list(string)
+}
+
+
+variable "datastore_info" {
+  type = object({
+    database_name = string
+    project_id    = string
+  })
+}
+
+variable "spanner_datails" {
+  type = object({
+    instance   = string
+    database   = string
+    project_id = string
+  })
+}
+
+variable "docker_repository_details" {
+  type = object({
+    hostname = string
+    url      = string
+    location = string
+    name     = string
+  })
+}

--- a/infra/ingestion/workflows/wpt/wpt_job.tf
+++ b/infra/ingestion/workflows/wpt/wpt_job.tf
@@ -1,0 +1,114 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  service_dir = "workflows/steps/services/wpt_consumer"
+}
+resource "docker_image" "wpt_consumer_image" {
+  name = "${var.docker_repository_details.url}/wpt_consumer_image"
+  build {
+    context = "${path.cwd}/.."
+    build_args = {
+      service_dir : local.service_dir
+      MAIN_BINARY : "job"
+    }
+    dockerfile = "images/go_service.Dockerfile"
+  }
+  triggers = {
+    dir_sha1 = sha1(join("", [for f in fileset(path.cwd, "/../${local.service_dir}/**") : filesha1(f)], [for f in fileset(path.cwd, "/../lib/**") : filesha1(f)]))
+  }
+}
+resource "docker_registry_image" "wpt_consumer_remote_image" {
+  name          = docker_image.wpt_consumer_image.name
+  keep_remotely = true
+  triggers = {
+    dir_sha1 = sha1(join("", [for f in fileset(path.cwd, "/../${local.service_dir}/**") : filesha1(f)], [for f in fileset(path.cwd, "/../lib/**") : filesha1(f)]))
+  }
+}
+
+resource "google_service_account" "wpt_consumer_service_account" {
+  provider     = google.internal_project
+  account_id   = "wpt-consumer-${var.env_id}"
+  display_name = "WPT Consumer service account for ${var.env_id}"
+}
+
+resource "google_project_iam_member" "gcp_datastore_user" {
+  provider = google.internal_project
+  role     = "roles/datastore.user"
+  project  = var.datastore_info.project_id
+  member   = google_service_account.wpt_consumer_service_account.member
+}
+
+resource "google_project_iam_member" "gcp_spanner_user" {
+  provider = google.internal_project
+  role     = "roles/spanner.databaseUser"
+  project  = var.spanner_datails.project_id
+  member   = google_service_account.wpt_consumer_service_account.member
+}
+
+
+resource "google_cloud_run_v2_job" "wpt" {
+  provider = google.internal_project
+  count    = length(var.regions)
+  name     = "${var.env_id}-${var.regions[count.index]}-wpt-consumer"
+  location = var.regions[count.index]
+
+  template {
+    template {
+      timeout = format("%ds", var.timeout_seconds)
+      containers {
+        image = "${docker_image.wpt_consumer_image.name}@${docker_registry_image.wpt_consumer_remote_image.sha256_digest}"
+        env {
+          name  = "PROJECT_ID"
+          value = var.datastore_info.project_id
+        }
+        env {
+          name  = "DATASTORE_DATABASE"
+          value = var.datastore_info.database_name
+        }
+        env {
+          name  = "SPANNER_DATABASE"
+          value = var.spanner_datails.database
+        }
+        env {
+          name  = "SPANNER_INSTANCE"
+          value = var.spanner_datails.instance
+        }
+        env {
+          name  = "DATA_WINDOW_DURATION"
+          value = var.data_window_duration
+        }
+      }
+      service_account = google_service_account.wpt_consumer_service_account.email
+    }
+  }
+}
+
+resource "google_cloud_run_v2_job_iam_member" "wpt_step_invoker" {
+  count    = length(var.regions)
+  provider = google.internal_project
+  location = var.regions[count.index]
+  name     = google_cloud_run_v2_job.wpt[count.index].name
+  role     = "roles/run.invoker"
+  member   = google_service_account.service_account.member
+}
+
+resource "google_cloud_run_v2_job_iam_member" "wpt_step_status" {
+  count    = length(var.regions)
+  provider = google.internal_project
+  location = var.regions[count.index]
+  name     = google_cloud_run_v2_job.wpt[count.index].name
+  role     = "roles/run.viewer"
+  member   = google_service_account.service_account.member
+}

--- a/infra/services/internal_project_services.tf
+++ b/infra/services/internal_project_services.tf
@@ -59,3 +59,11 @@ resource "google_project_service" "internal_workflows" {
   disable_dependent_services = true
   disable_on_destroy         = false
 }
+
+resource "google_project_service" "internal_scheduler" {
+  provider = google.internal_project
+  service  = "cloudscheduler.googleapis.com"
+
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}

--- a/workflows/wpt/workflows.yaml.tftpl
+++ b/workflows/wpt/workflows.yaml.tftpl
@@ -1,0 +1,10 @@
+main:
+  steps:
+    - run_job:
+        call: googleapis.run.v1.namespaces.jobs.run
+        args:
+            name: namespaces/${project_id}/jobs/${job_name}
+            location: ${job_location}
+        result: job_execution
+    - finish:
+        return: $${job_execution}


### PR DESCRIPTION
This change adds the terraform to deploy the job.

It leverages some things from the existing cloud run services.

However, this is the first cloud run job. In the future, we can look at how to move some of these things to common terraform modules.

Also added the template for the workflow. It is a simple workflow that just calls the cloud run job.

Other changes:
- Reformat the terraform vars file for staging
- Turn on the cloud scheduler api for the future when we want to do cron triggers of the workflow

This is splitting up of #118

