### PR TITLE
Add PageMetadataWithTotal component in openapi [pt 3/3]

### DIFF
--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -42,7 +42,7 @@ func TestGetV1Features(t *testing.T) {
 				expectedSearchNode: nil,
 				expectedSortBy:     nil,
 				page: &backend.FeaturePage{
-					Metadata: &backend.PageMetadataWithTotal{
+					Metadata: backend.PageMetadataWithTotal{
 						NextPageToken: nil,
 						Total:         100,
 					},
@@ -71,7 +71,7 @@ func TestGetV1Features(t *testing.T) {
 						Wpt:            nil,
 					},
 				},
-				Metadata: &backend.PageMetadataWithTotal{
+				Metadata: backend.PageMetadataWithTotal{
 					NextPageToken: nil,
 					Total:         100,
 				},
@@ -121,7 +121,7 @@ func TestGetV1Features(t *testing.T) {
 				},
 				expectedSortBy: valuePtr[backend.GetV1FeaturesParamsSort](backend.NameDesc),
 				page: &backend.FeaturePage{
-					Metadata: &backend.PageMetadataWithTotal{
+					Metadata: backend.PageMetadataWithTotal{
 						NextPageToken: nextPageToken,
 						Total:         100,
 					},
@@ -150,7 +150,7 @@ func TestGetV1Features(t *testing.T) {
 						Wpt:            nil,
 					},
 				},
-				Metadata: &backend.PageMetadataWithTotal{
+				Metadata: backend.PageMetadataWithTotal{
 					NextPageToken: nextPageToken,
 					Total:         100,
 				},

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -229,7 +229,7 @@ func (s *Backend) FeaturesSearch(
 	}
 
 	ret := &backend.FeaturePage{
-		Metadata: &backend.PageMetadataWithTotal{
+		Metadata: backend.PageMetadataWithTotal{
 			NextPageToken: page.NextPageToken,
 			Total:         page.Total,
 		},

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -472,7 +472,7 @@ func TestFeaturesSearch(t *testing.T) {
 			},
 			sortOrder: nil,
 			expectedPage: &backend.FeaturePage{
-				Metadata: &backend.PageMetadataWithTotal{
+				Metadata: backend.PageMetadataWithTotal{
 					NextPageToken: nonNilNextPageToken,
 					Total:         100,
 				},

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -357,6 +357,7 @@ components:
             $ref: '#/components/schemas/Feature'
       required:
         - data
+        - metadata
     FeatureWPTSnapshots:
       type: object
       properties:


### PR DESCRIPTION
The previous PageMetadata only had the next page token.

Instead of adjusting the current page metadata to have an optional total, it would mean we would need to document which endpoints will return total versus not.

That would be tedious to maintain as we add more endpoints.

Instead, this change adds a new component that has both the next page token and total which lets the client know that this client is always returning the total.

After adding the new PageMetadataWithTotal to the FeaturePage component, update the existing models to use it and update the tests.

