### PR TITLE
Implement the BCD Data Filter interface

### DIFF
--- a/lib/gcpspanner/spanneradapters/bcdconsumertypes/types.go
+++ b/lib/gcpspanner/spanneradapters/bcdconsumertypes/types.go
@@ -19,7 +19,19 @@ import "time"
 // BrowserRelease is the representation of the metric that comes from the BCD Consumer
 // This is located in the shared lib package so that it can be used in the adapter and the workflow.
 type BrowserRelease struct {
-	BrowserName    string
+	BrowserName    BrowserName
 	BrowserVersion string
 	ReleaseDate    time.Time
 }
+
+// BrowserName is an enumeration of the high-level keys found in the data.json
+// for the browsers. The json schema itself does not list these names explicitly
+// so we maintain our own subset here.
+type BrowserName string
+
+const (
+	Chrome  BrowserName = "chrome"
+	Edge    BrowserName = "edge"
+	Firefox BrowserName = "firefox"
+	Safari  BrowserName = "safari"
+)

--- a/workflows/steps/services/bcd_consumer/go.mod
+++ b/workflows/steps/services/bcd_consumer/go.mod
@@ -6,4 +6,7 @@ replace github.com/GoogleChrome/webstatus.dev/lib => ../../../../lib
 
 replace github.com/GoogleChrome/webstatus.dev/lib/gen => ../../../../lib/gen
 
-require github.com/GoogleChrome/webstatus.dev/lib/gen v0.0.0-00010101000000-000000000000
+require (
+	github.com/GoogleChrome/webstatus.dev/lib v0.0.0-00010101000000-000000000000
+	github.com/GoogleChrome/webstatus.dev/lib/gen v0.0.0-00010101000000-000000000000
+)

--- a/workflows/steps/services/bcd_consumer/pkg/workflow/bcd_filter_data.go
+++ b/workflows/steps/services/bcd_consumer/pkg/workflow/bcd_filter_data.go
@@ -1,0 +1,104 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/bcdconsumertypes"
+	"github.com/GoogleChrome/webstatus.dev/workflows/steps/services/bcd_consumer/pkg/data"
+)
+
+// ErrMissingBrowser indicates the filtered browser was not found in the bcd data.
+var ErrMissingBrowser = errors.New("browser not found in bcd data")
+
+// ErrMalformedReleaseDate indicates that the release date could not be parsed.
+var ErrMalformedReleaseDate = errors.New("release date is in unexpected format")
+
+// ErrUnknownBrowserFilter indicates that the filter is unknown.
+// Developers may need to update lib/gcpspanner/spanneradapters/bcdconsumertypes/types.go.
+var ErrUnknownBrowserFilter = errors.New("specified browser filter is unknown")
+
+// ErrNoBrowserFiltersPresent indicates that no filters are present.
+var ErrNoBrowserFiltersPresent = errors.New("no browser filters present")
+
+type BCDDataFilter struct{}
+
+func (f BCDDataFilter) checkBrowserFilters(filteredBrowsers []string) error {
+	if len(filteredBrowsers) == 0 {
+		return ErrNoBrowserFiltersPresent
+	}
+
+	for _, browser := range filteredBrowsers {
+		browserName := bcdconsumertypes.BrowserName(browser)
+		// exhaustive linter in golangci-lint will catch missing enums as they are added to
+		// lib/gcpspanner/spanneradapters/bcdconsumertypes/types.go.
+		switch browserName {
+		case bcdconsumertypes.Chrome,
+			bcdconsumertypes.Edge,
+			bcdconsumertypes.Firefox,
+			bcdconsumertypes.Safari:
+			continue
+		default:
+			return errors.Join(ErrUnknownBrowserFilter)
+		}
+	}
+
+	return nil
+}
+
+func (f BCDDataFilter) FilterData(
+	in *data.BCDData, filteredBrowsers []string) ([]bcdconsumertypes.BrowserRelease, error) {
+	err := f.checkBrowserFilters(filteredBrowsers)
+	if err != nil {
+		return nil, err
+	}
+
+	if in == nil {
+		return nil, nil
+	}
+	var ret []bcdconsumertypes.BrowserRelease
+	for _, browser := range filteredBrowsers {
+		browserData, found := in.BrowserData.Browsers[browser]
+		if !found {
+			return nil, errors.Join(ErrMissingBrowser, fmt.Errorf("unable to find browser %s", browser))
+		}
+
+		for release, releaseData := range browserData.Releases {
+			if releaseData.ReleaseDate == nil {
+				// Maybe this might happen if the browser release is anticipated but not released yet.
+				slog.Warn("data is incomplete. missing release date", "browser", browser, "release", release)
+
+				continue
+			}
+			releaseDate, err := time.Parse(time.DateOnly, *releaseData.ReleaseDate)
+			if err != nil {
+				slog.Error("unable to parse date", "browser", browser, "release", release, "date", *releaseData.ReleaseDate)
+
+				return nil, ErrMalformedReleaseDate
+			}
+			ret = append(ret, bcdconsumertypes.BrowserRelease{
+				BrowserName:    bcdconsumertypes.BrowserName(browser),
+				BrowserVersion: release,
+				ReleaseDate:    releaseDate,
+			})
+		}
+	}
+
+	return ret, nil
+}

--- a/workflows/steps/services/bcd_consumer/pkg/workflow/bcd_filter_data_test.go
+++ b/workflows/steps/services/bcd_consumer/pkg/workflow/bcd_filter_data_test.go
@@ -1,0 +1,197 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/bcdconsumertypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/jsonschema/mdn__browser_compat_data"
+	"github.com/GoogleChrome/webstatus.dev/workflows/steps/services/bcd_consumer/pkg/data"
+)
+
+func getAllSupportedFilters() []string {
+	return []string{
+		"chrome",
+		"edge",
+		"firefox",
+		"safari",
+	}
+}
+
+func TestCheckBrowserFilters(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         []string
+		expectedError error
+	}{
+		{
+			name:          "all supported filters",
+			input:         getAllSupportedFilters(),
+			expectedError: nil,
+		},
+		{
+			name:          "all supported filters and one bad filter",
+			input:         append(getAllSupportedFilters(), "bad"),
+			expectedError: ErrUnknownBrowserFilter,
+		},
+		{
+			name:          "no filters provided",
+			input:         nil,
+			expectedError: ErrNoBrowserFiltersPresent,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := BCDDataFilter{}
+			err := filter.checkBrowserFilters(tc.input)
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Unexpected error:\nGot: %v\nWant: %v", err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestFilterData(t *testing.T) {
+	testCases := []struct {
+		name             string
+		inputBCD         *data.BCDData
+		filteredBrowsers []string
+		expectedResult   []bcdconsumertypes.BrowserRelease
+		expectedError    error
+	}{
+		{
+			name: "Valid Input",
+			inputBCD: &data.BCDData{
+				// nolint: exhaustruct // WONTFIX. External struct.
+				BrowserData: mdn__browser_compat_data.BrowserData{
+					Browsers: map[string]mdn__browser_compat_data.BrowserStatement{
+						"chrome": {
+							Releases: map[string]mdn__browser_compat_data.ReleaseStatement{
+								"100.0.0": {ReleaseDate: valuePtr("2024-04-09")},
+								"101.0.0": {ReleaseDate: valuePtr("2024-05-12")},
+							},
+						},
+						"firefox": {
+							Releases: map[string]mdn__browser_compat_data.ReleaseStatement{
+								"110.0": {ReleaseDate: valuePtr("2024-04-20")},
+							},
+						},
+					},
+				},
+			},
+			filteredBrowsers: []string{"chrome", "firefox"},
+			expectedResult: []bcdconsumertypes.BrowserRelease{
+				{BrowserName: "chrome", BrowserVersion: "100.0.0", ReleaseDate: time.Date(2024, 4, 9, 0, 0, 0, 0, time.UTC)},
+				{BrowserName: "chrome", BrowserVersion: "101.0.0", ReleaseDate: time.Date(2024, 5, 12, 0, 0, 0, 0, time.UTC)},
+				{BrowserName: "firefox", BrowserVersion: "110.0", ReleaseDate: time.Date(2024, 4, 20, 0, 0, 0, 0, time.UTC)},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Non-existent Browser",
+			inputBCD: &data.BCDData{
+				// nolint: exhaustruct // WONTFIX. External struct.
+				BrowserData: mdn__browser_compat_data.BrowserData{
+					Browsers: map[string]mdn__browser_compat_data.BrowserStatement{
+						"firefox": {
+							Releases: map[string]mdn__browser_compat_data.ReleaseStatement{
+								"100.0.0": {ReleaseDate: valuePtr("2024-04-09")},
+							},
+						},
+					},
+				},
+			},
+			filteredBrowsers: []string{"firefox", "chrome"}, // 'chrome' not found
+			expectedResult:   nil,
+			expectedError:    ErrMissingBrowser,
+		},
+		{
+			name: "Invalid Release Date Format",
+			inputBCD: &data.BCDData{
+				// nolint: exhaustruct // WONTFIX. External struct.
+				BrowserData: mdn__browser_compat_data.BrowserData{
+					Browsers: map[string]mdn__browser_compat_data.BrowserStatement{
+						"firefox": {
+							Releases: map[string]mdn__browser_compat_data.ReleaseStatement{
+								"110.0": {ReleaseDate: valuePtr("2024-04-20")},
+								"111.0": {ReleaseDate: valuePtr("invalid-date")}, // Incorrect format
+							},
+						},
+					},
+				},
+			},
+			filteredBrowsers: []string{"firefox"},
+			expectedResult:   nil,
+			expectedError:    ErrMalformedReleaseDate,
+		},
+		{
+			name: "Release with No Date",
+			inputBCD: &data.BCDData{
+				// nolint: exhaustruct // WONTFIX. External struct.
+				BrowserData: mdn__browser_compat_data.BrowserData{
+					Browsers: map[string]mdn__browser_compat_data.BrowserStatement{
+						"firefox": {
+							Releases: map[string]mdn__browser_compat_data.ReleaseStatement{
+								"100.0.0": {ReleaseDate: valuePtr("2024-04-09")},
+								"101.0.0": {ReleaseDate: nil}, // Missing date
+							},
+						},
+					},
+				},
+			},
+			filteredBrowsers: []string{"firefox"},
+			expectedResult: []bcdconsumertypes.BrowserRelease{ // Release 101.0.0 should be excluded
+				{BrowserName: "firefox", BrowserVersion: "100.0.0", ReleaseDate: time.Date(2024, 4, 9, 0, 0, 0, 0, time.UTC)},
+			},
+			expectedError: nil,
+		},
+		{
+			name:             "Nil BCDData Input",
+			inputBCD:         nil,
+			filteredBrowsers: []string{"firefox"}, // Irrelevant with nil input
+			expectedResult:   nil,
+			expectedError:    nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := BCDDataFilter{}
+			result, err := filter.FilterData(tc.inputBCD, tc.filteredBrowsers)
+
+			// Sort the items to have stable output.
+			sort.Slice(result, func(i, j int) bool {
+				if result[i].BrowserName == result[j].BrowserName {
+					return result[i].ReleaseDate.Before(result[j].ReleaseDate)
+				}
+
+				return result[i].BrowserName < result[j].BrowserName
+			})
+
+			if !reflect.DeepEqual(result, tc.expectedResult) {
+				t.Errorf("Unexpected result:\nGot: %v\nWant: %v", result, tc.expectedResult)
+			}
+
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Unexpected error:\nGot: %v\nWant: %v", err, tc.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Purpose:

- Introduces a BCDDataFilter to extract browser release information from BCD data.
- Handles edge cases such as:
  - Missing browsers in the input data.
  - Malformed or missing release dates.

Changes:

- New Struct:
  - BCDDataFilter with a FilterData method.
- Error Handling:
  - ErrMissingBrowser: Returned when a requested browser is not found in the BCD data.
  - ErrMalformedReleaseDate: Returned when a release date cannot be parsed correctly.
- Data Filtering Logic:
  - Iterates through filteredBrowsers.
  - Checks for the existence of each browser in the BCDData
  - Parses release dates using time.Parse.
  - Logs warnings for missing release dates and errors when parsing release dates.
- Nil Handling: Gracefully handles nil input to FilterData.

