### PR TITLE
Add BCD Workflow Spanner Adapter

### DIFF
--- a/lib/gcpspanner/spanneradapters/bcd_consumer.go
+++ b/lib/gcpspanner/spanneradapters/bcd_consumer.go
@@ -1,0 +1,55 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"errors"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/bcdconsumertypes"
+)
+
+// NewBCDWorkflowConsumer constructs an adapter for the bcd consumer service.
+func NewBCDWorkflowConsumer(client BCDWorkflowSpannerClient) *BCDConsumer {
+	return &BCDConsumer{client: client}
+}
+
+// BCDWorkflowSpannerClient expects a subset of the functionality from lib/gcpspanner that
+// only apply to inserting BCD data.
+type BCDWorkflowSpannerClient interface {
+	InsertBrowserRelease(ctx context.Context, release gcpspanner.BrowserRelease) error
+}
+
+// BCDConsumer is the adapter that takes data from the BCD workflow and prepares
+// it to be stored in the spanner database.
+type BCDConsumer struct {
+	client BCDWorkflowSpannerClient
+}
+
+func (b *BCDConsumer) InsertBrowserReleases(ctx context.Context, releases []bcdconsumertypes.BrowserRelease) error {
+	for _, release := range releases {
+		err := b.client.InsertBrowserRelease(ctx, gcpspanner.BrowserRelease{
+			BrowserName:    string(release.BrowserName),
+			BrowserVersion: release.BrowserVersion,
+			ReleaseDate:    release.ReleaseDate,
+		})
+		if err != nil {
+			return errors.Join(bcdconsumertypes.ErrUnableToStoreBrowserRelease, err)
+		}
+	}
+
+	return nil
+}

--- a/lib/gcpspanner/spanneradapters/bcd_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/bcd_consumer_test.go
@@ -1,0 +1,110 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/bcdconsumertypes"
+)
+
+type MockSpannerClient struct {
+	callHistory []gcpspanner.BrowserRelease
+}
+
+func getFailureRelease() bcdconsumertypes.BrowserRelease {
+	return bcdconsumertypes.BrowserRelease{
+		BrowserName:    "failureBrowser",
+		BrowserVersion: "failureVersion",
+		ReleaseDate:    time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func (m *MockSpannerClient) InsertBrowserRelease(_ context.Context, release gcpspanner.BrowserRelease) error {
+	m.callHistory = append(m.callHistory, release)
+	// Check if the release matches the failure condition
+	if strings.Contains(release.BrowserName, "fail") {
+		return errors.New("Simulated Spanner error")
+	}
+
+	return nil
+}
+
+func TestInsertBrowserReleases(t *testing.T) {
+	testCases := []struct {
+		name          string
+		releases      []bcdconsumertypes.BrowserRelease
+		expectedError error
+	}{
+		{
+			name: "Success",
+			releases: []bcdconsumertypes.BrowserRelease{
+				{
+					BrowserName:    "Chrome",
+					BrowserVersion: "100",
+					ReleaseDate:    time.Date(2024, time.January, 2, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Unable to store release",
+			releases: []bcdconsumertypes.BrowserRelease{
+				{
+					BrowserName:    "Chrome",
+					BrowserVersion: "100",
+					ReleaseDate:    time.Date(2024, time.January, 2, 0, 0, 0, 0, time.UTC),
+				},
+				getFailureRelease(),
+			},
+			expectedError: bcdconsumertypes.ErrUnableToStoreBrowserRelease,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := &MockSpannerClient{
+				callHistory: []gcpspanner.BrowserRelease{},
+			}
+			consumer := NewBCDWorkflowConsumer(mockClient)
+
+			err := consumer.InsertBrowserReleases(context.Background(), tc.releases)
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if len(mockClient.callHistory) != len(tc.releases) {
+				t.Errorf("Call count mismatch. Expected: %d, got: %d", len(tc.releases), len(mockClient.callHistory))
+			} else {
+				for i, release := range tc.releases {
+					if !compareReleases(release, mockClient.callHistory[i]) {
+						t.Errorf("Call argument mismatch at index %d", i)
+					}
+				}
+			}
+		})
+	}
+}
+
+func compareReleases(r1 bcdconsumertypes.BrowserRelease, r2 gcpspanner.BrowserRelease) bool {
+	return string(r1.BrowserName) == r2.BrowserName &&
+		r1.BrowserVersion == r2.BrowserVersion &&
+		r1.ReleaseDate.Equal(r2.ReleaseDate)
+}

--- a/lib/gcpspanner/spanneradapters/bcdconsumertypes/types.go
+++ b/lib/gcpspanner/spanneradapters/bcdconsumertypes/types.go
@@ -14,7 +14,10 @@
 
 package bcdconsumertypes
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 // BrowserRelease is the representation of the metric that comes from the BCD Consumer
 // This is located in the shared lib package so that it can be used in the adapter and the workflow.
@@ -35,3 +38,7 @@ const (
 	Firefox BrowserName = "firefox"
 	Safari  BrowserName = "safari"
 )
+
+// ErrUnableToStoreBrowserRelease indicates that the storage layer was unable to save
+// the browser release.
+var ErrUnableToStoreBrowserRelease = errors.New("unable to store browser release")


### PR DESCRIPTION
This logic converts the generated jsonschema models to the spanner models for insertion of the browser release data.

Add some new errors that we can bubble up and compare in the future.

