### PR TITLE
Add infrastructure to deploy BCD job

### DIFF
--- a/infra/ingestion/workflows.tf
+++ b/infra/ingestion/workflows.tf
@@ -41,3 +41,16 @@ module "wpt_workflow" {
   spanner_datails           = var.spanner_datails
   docker_repository_details = var.docker_repository_details
 }
+
+module "bcd_workflow" {
+  source = "./workflows/bcd"
+  providers = {
+    google.internal_project = google.internal_project
+    google.public_project   = google.public_project
+  }
+
+  regions                   = var.regions
+  env_id                    = var.env_id
+  spanner_datails           = var.spanner_datails
+  docker_repository_details = var.docker_repository_details
+}

--- a/infra/ingestion/workflows/bcd/job.tf
+++ b/infra/ingestion/workflows/bcd/job.tf
@@ -1,0 +1,99 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  service_dir = "workflows/steps/services/bcd_consumer"
+}
+resource "docker_image" "bcd_consumer_image" {
+  name = "${var.docker_repository_details.url}/bcd_consumer_image"
+  build {
+    context = "${path.cwd}/.."
+    build_args = {
+      service_dir : local.service_dir
+      MAIN_BINARY : "job"
+    }
+    dockerfile = "images/go_service.Dockerfile"
+  }
+  triggers = {
+    dir_sha1 = sha1(join("", [for f in fileset(path.cwd, "/../${local.service_dir}/**") : filesha1(f)], [for f in fileset(path.cwd, "/../lib/**") : filesha1(f)]))
+  }
+}
+resource "docker_registry_image" "bcd_consumer_remote_image" {
+  name          = docker_image.bcd_consumer_image.name
+  keep_remotely = true
+  triggers = {
+    dir_sha1 = sha1(join("", [for f in fileset(path.cwd, "/../${local.service_dir}/**") : filesha1(f)], [for f in fileset(path.cwd, "/../lib/**") : filesha1(f)]))
+  }
+}
+
+resource "google_service_account" "bcd_consumer_service_account" {
+  provider     = google.internal_project
+  account_id   = "bcd-consumer-${var.env_id}"
+  display_name = "BCD Consumer service account for ${var.env_id}"
+}
+
+resource "google_project_iam_member" "gcp_spanner_user" {
+  provider = google.internal_project
+  role     = "roles/spanner.databaseUser"
+  project  = var.spanner_datails.project_id
+  member   = google_service_account.bcd_consumer_service_account.member
+}
+
+
+resource "google_cloud_run_v2_job" "bcd" {
+  provider = google.internal_project
+  count    = length(var.regions)
+  name     = "${var.env_id}-${var.regions[count.index]}-bcd-consumer"
+  location = var.regions[count.index]
+
+  template {
+    template {
+      timeout = format("%ds", var.timeout_seconds)
+      containers {
+        image = "${docker_image.bcd_consumer_image.name}@${docker_registry_image.bcd_consumer_remote_image.sha256_digest}"
+        env {
+          name  = "PROJECT_ID"
+          value = var.spanner_datails.project_id
+        }
+        env {
+          name  = "SPANNER_DATABASE"
+          value = var.spanner_datails.database
+        }
+        env {
+          name  = "SPANNER_INSTANCE"
+          value = var.spanner_datails.instance
+        }
+      }
+      service_account = google_service_account.bcd_consumer_service_account.email
+    }
+  }
+}
+
+resource "google_cloud_run_v2_job_iam_member" "bcd_step_invoker" {
+  count    = length(var.regions)
+  provider = google.internal_project
+  location = var.regions[count.index]
+  name     = google_cloud_run_v2_job.bcd[count.index].name
+  role     = "roles/run.invoker"
+  member   = google_service_account.service_account.member
+}
+
+resource "google_cloud_run_v2_job_iam_member" "bcd_step_status" {
+  count    = length(var.regions)
+  provider = google.internal_project
+  location = var.regions[count.index]
+  name     = google_cloud_run_v2_job.bcd[count.index].name
+  role     = "roles/run.viewer"
+  member   = google_service_account.service_account.member
+}

--- a/infra/ingestion/workflows/bcd/main.tf
+++ b/infra/ingestion/workflows/bcd/main.tf
@@ -1,0 +1,36 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_service_account" "service_account" {
+  account_id   = "bcd-${var.env_id}"
+  provider     = google.internal_project
+  display_name = "BCD Workflow service account for ${var.env_id}"
+}
+
+resource "google_workflows_workflow" "workflow" {
+  count           = length(var.regions)
+  provider        = google.internal_project
+  name            = "${var.env_id}-bcd-${var.regions[count.index]}"
+  region          = var.regions[count.index]
+  description     = "BCD Workflow. Env id: ${var.env_id}"
+  service_account = google_service_account.service_account.id
+  source_contents = templatefile(
+    "${path.root}/../workflows/bcd/workflows.yaml.tftpl",
+    {
+      project_id   = google_cloud_run_v2_job.bcd[count.index].project
+      job_name     = google_cloud_run_v2_job.bcd[count.index].name
+      job_location = google_cloud_run_v2_job.bcd[count.index].location
+    }
+  )
+}

--- a/infra/ingestion/workflows/bcd/providers.tf
+++ b/infra/ingestion/workflows/bcd/providers.tf
@@ -1,0 +1,28 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+    google = {
+      source = "hashicorp/google"
+      configuration_aliases = [
+        google.internal_project,
+        google.public_project,
+      ]
+    }
+  }
+}

--- a/infra/ingestion/workflows/bcd/variables.tf
+++ b/infra/ingestion/workflows/bcd/variables.tf
@@ -1,0 +1,47 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Variables specific to this module.
+variable "timeout_seconds" {
+  description = "Timeout for the BCD job. Details here: https://cloud.google.com/run/docs/configuring/request-timeout#terraform"
+  type        = number
+  default     = "300" # 5 minutes
+}
+
+# Variables from parent modules.
+# Refer to the parent modules for more details
+variable "env_id" {
+  type = string
+}
+
+variable "regions" {
+  type = list(string)
+}
+
+variable "spanner_datails" {
+  type = object({
+    instance   = string
+    database   = string
+    project_id = string
+  })
+}
+
+variable "docker_repository_details" {
+  type = object({
+    hostname = string
+    url      = string
+    location = string
+    name     = string
+  })
+}

--- a/workflows/bcd/workflows.yaml.tftpl
+++ b/workflows/bcd/workflows.yaml.tftpl
@@ -1,0 +1,10 @@
+main:
+  steps:
+    - run_job:
+        call: googleapis.run.v1.namespaces.jobs.run
+        args:
+            name: namespaces/${project_id}/jobs/${job_name}
+            location: ${job_location}
+        result: job_execution
+    - finish:
+        return: $${job_execution}


### PR DESCRIPTION
This change adds the terraform to deploy the job.

This is similar to #136 which deployed the WPT job.

Also added the template for the workflow. It is a simple workflow that just calls the cloud run job.

