### PR TITLE
Web Features workflow ingests browser versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,12 +296,14 @@ clean-node:
 ################################
 # Local Data / Workflows
 ################################
-dev_workflows: web_feature_local_workflow
+dev_workflows: bcd_workflow web_feature_local_workflow wpt_workflow
 web_feature_local_workflow: FLAGS := -web_consumer_host=http://localhost:8092
 web_feature_local_workflow: port-forward-manual
 	go run ./util/cmd/local_web_feature_workflow/main.go $(FLAGS)
+wpt_workflow:
 	./util/run_job.sh wpt-consumer images/go_service.Dockerfile workflows/steps/services/wpt_consumer \
 		workflows/steps/services/wpt_consumer/manifests/job.yaml wpt-consumer
+bcd_workflow:
 	./util/run_job.sh bcd-consumer images/go_service.Dockerfile workflows/steps/services/bcd_consumer \
 		workflows/steps/services/bcd_consumer/manifests/job.yaml bcd-consumer
 dev_fake_data: is_local_migration_ready


### PR DESCRIPTION
Previously, the workflow only ingested the web feature name and baseline status into their respective tables.

Now we add ingest the browser version in which the browser supported a particular feature. [Example](https://github.com/web-platform-dx/web-features/blob/8ab08d00b9bdb505af37c435204eb6fe819dfaab/feature-group-definitions/array.yml#L25-L31)

This combined with the BrowserRelease Data from BCD will allow us to do browser feature support over time.

Other changes:
- Reordered the dev workflows around in the Makefile so that the bcd workflow runs first since we need the browser versions first.

