### PR TITLE
Miscellaneous fixes for Stats page

### DIFF
--- a/frontend/src/static/js/api/client.ts
+++ b/frontend/src/static/js/api/client.ts
@@ -108,10 +108,10 @@ export class APIClient {
       if (error !== undefined) {
         throw new Error(error?.message);
       }
-      const data: WPTRunMetricsPage = response.data as WPTRunMetricsPage;
-      nextPageToken = data?.metadata?.next_page_token;
-      if (data != null) {
-        allData.push(...data.data);
+      const page: WPTRunMetricsPage = response.data as WPTRunMetricsPage;
+      nextPageToken = page?.metadata?.next_page_token;
+      if (page != null) {
+        allData.push(...page.data);
       }
     } while (nextPageToken !== undefined);
 

--- a/frontend/src/static/js/components/webstatus-stats-page.ts
+++ b/frontend/src/static/js/components/webstatus-stats-page.ts
@@ -140,7 +140,7 @@ export class StatsPage extends LitElement {
 
   globalFeatureSupportResizeObserver: ResizeObserver | null = null;
 
-  setupResizeObsercer() {
+  setupResizeObserver() {
     // Set up ResizeObserver one time to redraw chart when container resizes.
     if (!this.globalFeatureSupportResizeObserver) {
       const gfsChartElement = this.shadowRoot!.getElementById(
@@ -274,7 +274,7 @@ export class StatsPage extends LitElement {
       'global-feature-support-chart'
     );
     if (!gfsChartElement) return;
-    this.setupResizeObsercer();
+    this.setupResizeObserver();
 
     const datatable = this.createGlobalFeatureSupportDataTableFromMap();
 


### PR DESCRIPTION
This PR does the following:

* Avoid a possible infinite loop when fetching pages of data.
* Use sl-change on the start and end date selectors instead of sl-blur
* Use ResizeObserver on chart container to redraw the chart.
