### PR TITLE
Adds feature count and feature lag metric endpoints

### DIFF
--- a/backend/pkg/httpserver/list_aggregated_feature_support.go
+++ b/backend/pkg/httpserver/list_aggregated_feature_support.go
@@ -1,0 +1,29 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// ListAggregatedFeatureSupport implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Signature generated from openapi
+func (s *Server) ListAggregatedFeatureSupport(
+	_ context.Context,
+	_ backend.ListAggregatedFeatureSupportRequestObject) (backend.ListAggregatedFeatureSupportResponseObject, error) {
+	panic("unimplemented")
+}

--- a/backend/pkg/httpserver/list_feature_lag_metrics.go
+++ b/backend/pkg/httpserver/list_feature_lag_metrics.go
@@ -1,0 +1,29 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// ListFeatureLagMetrics implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Signature generated from openapi
+func (s *Server) ListFeatureLagMetrics(
+	_ context.Context,
+	_ backend.ListFeatureLagMetricsRequestObject) (backend.ListFeatureLagMetricsResponseObject, error) {
+	panic("unimplemented")
+}

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -185,6 +185,106 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasicErrorModel'
+  /v1/stats/features/browsers/{browser}/feature_counts:
+    parameters:
+      - $ref: '#/components/parameters/browserPathParam'
+    get:
+      summary: >
+        Returns the count of features supported for a specified browser over time.
+        The timestamps for the individual metrics represent the releases of the
+        specified browser.
+      operationId: listAggregatedFeatureSupport
+      parameters:
+        - $ref: '#/components/parameters/startAtParam'
+        - $ref: '#/components/parameters/endAtParam'
+        - $ref: '#/components/parameters/paginationTokenParam'
+        - $ref: '#/components/parameters/paginationSizeParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BrowserReleaseFeatureMetricsPage'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '429':
+          description: Rate Limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+  /v1/stats/features/browsers/{browser}/feature_lag_counts:
+    parameters:
+      - $ref: '#/components/parameters/browserPathParam'
+    get:
+      summary: >
+        Returns the count of features where the specified browser has a feature
+        lag compared to other browsers at a given time. The timestamps represent
+        releases of the specified browser or one of the comparison browsers.
+      operationId: listFeatureLagMetrics
+      parameters:
+        - $ref: '#/components/parameters/startAtParam'
+        - $ref: '#/components/parameters/endAtParam'
+        - $ref: '#/components/parameters/paginationTokenParam'
+        - $ref: '#/components/parameters/paginationSizeParam'
+        - in: query
+          name: browsers
+          description: >
+            A comma-separated list of browsers to check if {browser} is lagging
+            behind on features.
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BrowserReleaseFeatureMetricsPage'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '429':
+          description: Rate Limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
   /v1/stats/wpt/browsers/{browser}/channels/{channel}/test_counts:
     parameters:
       - $ref: '#/components/parameters/browserPathParam'
@@ -297,6 +397,39 @@ components:
       required: false
       description: Number of results to return
   schemas:
+    BrowserReleaseFeatureMetric:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          description: >
+            The timestamp that correlates to an event that may influence the
+            count of features for a browser. This may be the release of the
+            browser itself (when a browser may support a new set of features),
+            or the release of another browser (when another browser supports
+            a feature but our specified browser is now lagging behind with a new
+            feature). Refer to the individual endpoint for more context on the
+            use of this component.
+        count:
+          type: integer
+          description: Total count of features.
+          format: int64
+      required:
+        # For now, only require timestamp in case the definition
+        # of the metric needs to change. Similar to WPTRunMetric.
+        - timestamp
+    BrowserReleaseFeatureMetricsPage:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/PageMetadata'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/BrowserReleaseFeatureMetric'
+      required:
+        - data
     WPTRunMetric:
       type: object
       properties:


### PR DESCRIPTION
Introduces two new endpoints to the OpenAPI document:
- /v1/stats/features/browsers/{browser}/feature_counts : Returns overall feature support count over time for a browser.
- /v1/stats/features/browsers/{browser}/feature_lag_counts: Returns feature lag counts over time, highlighting where a browser trails others in feature adoption.

Also, add generated unimplemented backend methods that will be implemented in the near future (without them, the backend won't compile)
