### PR TITLE
Offset pagination token for v1/features calls in frontend

### DIFF
--- a/frontend/src/static/js/api/client.ts
+++ b/frontend/src/static/js/api/client.ts
@@ -71,11 +71,11 @@ export class APIClient {
     return data;
   }
 
-  // Internal client detail that how to construct the FeatureResultOffsetCursor from the Go backend.
-  // Typically, users of getFeatures can used the provided pagination token. However, to facilitate
-  // the desired UI where we have pages at the bottom, a secondary token is provided.
-  // Disclaimer: Outside readers of this code should know that this token can change at any moment and should not rely
-  // on it.
+  // Internal client detail for constructing a FeatureResultOffsetCursor pagination token.
+  // Typically, users of the /v1/features endpoint should use the provided pagination token.
+  // However, this token can be used to facilitate a UI with where we have selectable page numbers.
+  // Disclaimer: External users should be aware that the format of this token is subject to change and should not be
+  // treated as a stable interface. Instead, external users should rely on the returned pagination token long term.
   private createOffsetPaginationTokenForGetFeatures(offset: number): string {
     return base64urlEncode(JSON.stringify({offset: offset}));
   }

--- a/lib/gcpspanner/client.go
+++ b/lib/gcpspanner/client.go
@@ -87,8 +87,8 @@ type FeatureCursorLastSortValueType interface {
 
 // FeatureResultOffsetCursor: A numerical offset from the start of the result set. Enables the construction of
 // human-friendly URLs specifying an exact page offset.
-// Disclaimer: Outside readers of this code should know that this token can change at any moment and should not rely
-// on it. Instead, outside readers should rely on the returned pagination token long term.
+// Disclaimer: External users should be aware that the format of this token is subject to change and should not be
+// treated as a stable interface. Instead, external users should rely on the returned pagination token long term.
 type FeatureResultOffsetCursor struct {
 	Offset int `json:"offset"`
 }


### PR DESCRIPTION
This change adds logic to create the offset pagination tokens in the frontend

Given that it is not the default page token for the endpoint, I added a disclaimer for outside readers who may decide to do the same thing. That is we do not guarantee that the offset token structure will stay the same. Instead API users should rely on the default page token that is returned.

