### PR TITLE
Refactor feature search query to use text/template

### DIFF
--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -95,7 +95,7 @@ func (t *BaseQueryTemplate) Execute(data any) string {
 	return buf.String()
 }
 
-type CommonmFSSelectTemplateData struct {
+type CommonFSSelectTemplateData struct {
 	BaseQueryFragment   string
 	StableMetrics       string
 	ExperimentalMetrics string
@@ -103,12 +103,12 @@ type CommonmFSSelectTemplateData struct {
 
 // GCPFSSelectTemplateData contains the template for gcpFSSelectQueryTemplate.
 type GCPFSSelectTemplateData struct {
-	CommonmFSSelectTemplateData
+	CommonFSSelectTemplateData
 }
 
 // LocalFSSelectTemplateData contains the template for localFSSelectQueryTemplate.
 type LocalFSSelectTemplateData struct {
-	CommonmFSSelectTemplateData
+	CommonFSSelectTemplateData
 }
 
 // GCPFSMetricsTemplateData contains the template for gcpFSMetricsSubQueryTemplate.
@@ -427,7 +427,7 @@ func (f GCPFeatureSearchBaseQuery) Query(prefilter FeatureSearchPrefilterResult)
 	})
 
 	return gcpFSSelectQueryTemplate.Execute(GCPFSSelectTemplateData{
-		CommonmFSSelectTemplateData: CommonmFSSelectTemplateData{
+		CommonFSSelectTemplateData: CommonFSSelectTemplateData{
 			BaseQueryFragment:   f.buildBaseQueryFragment(),
 			StableMetrics:       stableMetrics,
 			ExperimentalMetrics: experimentalMetrics,
@@ -490,7 +490,7 @@ func (f LocalFeatureBaseQuery) Query(_ FeatureSearchPrefilterResult) (string, ma
 	})
 
 	return localFSSelectQueryTemplate.Execute(LocalFSSelectTemplateData{
-		CommonmFSSelectTemplateData: CommonmFSSelectTemplateData{
+		CommonFSSelectTemplateData: CommonFSSelectTemplateData{
 			BaseQueryFragment:   f.buildBaseQueryFragment(),
 			StableMetrics:       stableMetrics,
 			ExperimentalMetrics: experimentalMetrics,


### PR DESCRIPTION
Before making further changes to the feature search query, it would be great to use a more powerful string builder such as the text/template.

We continue to use params for any values. But for the column names that cannot use spanner params, we leverage the text/template templating language to pass those in.

The templates are compiled once at module start up time in the init() method

Added a simple helper method called metricsPassRateColumn that returns the column name for the type of metrics we want. We will soon support different types of metrics and this method can be modified to accommodate that.

The refactoring is useful for #166 

