### PR TITLE
Add support for the wpt_metric_view query parameter in frontend

### DIFF
--- a/frontend/src/static/js/api/client.ts
+++ b/frontend/src/static/js/api/client.ts
@@ -25,6 +25,10 @@ export type FeatureSearchType = NonNullable<
   paths['/v1/features']['get']['parameters']['query']
 >['q'];
 
+export type FeatureWPTMetricViewType = NonNullable<
+  paths['/v1/features']['get']['parameters']['query']
+>['wpt_metric_view'];
+
 export type BrowsersParameter = components['parameters']['browserPathParam'];
 export type ChannelsParameter = components['parameters']['channelPathParam'];
 export type WPTRunMetric = components['schemas']['WPTRunMetric'];
@@ -59,11 +63,18 @@ export class APIClient {
   }
 
   public async getFeature(
-    featureId: string
+    featureId: string,
+    wptMetricView: FeatureWPTMetricViewType
   ): Promise<components['schemas']['Feature']> {
+    const qsParams: paths['/v1/features/{feature_id}']['get']['parameters']['query'] =
+      {};
+    if (wptMetricView) qsParams.wpt_metric_view = wptMetricView;
     const {data, error} = await this.client.GET('/v1/features/{feature_id}', {
       ...temporaryFetchOptions,
-      params: {path: {feature_id: featureId}},
+      params: {
+        path: {feature_id: featureId},
+        query: qsParams,
+      },
     });
     if (error !== undefined) {
       throw new Error(error?.message);
@@ -83,6 +94,7 @@ export class APIClient {
   public async getFeatures(
     q: FeatureSearchType,
     sort: FeatureSortOrderType,
+    wptMetricView?: FeatureWPTMetricViewType,
     offset?: number,
     pageSize?: number
   ): Promise<components['schemas']['FeaturePage']> {
@@ -93,6 +105,7 @@ export class APIClient {
       qsParams.page_token =
         this.createOffsetPaginationTokenForGetFeatures(offset);
     if (pageSize) qsParams.page_size = pageSize;
+    if (wptMetricView) qsParams.wpt_metric_view = wptMetricView;
     const {data, error} = await this.client.GET('/v1/features', {
       ...temporaryFetchOptions,
       params: {

--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -28,8 +28,12 @@ import {customElement, state} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {type components} from 'webstatus.dev-backend';
 
-import {type APIClient} from '../api/client.js';
-import {formatFeaturePageUrl, formatOverviewPageUrl} from '../utils/urls.js';
+import {FeatureWPTMetricViewType, type APIClient} from '../api/client.js';
+import {
+  formatFeaturePageUrl,
+  formatOverviewPageUrl,
+  getWPTMetricView,
+} from '../utils/urls.js';
 import {apiClientContext} from '../contexts/api-client-context.js';
 import {
   BASELINE_CHIP_CONFIGS,
@@ -132,7 +136,10 @@ export class FeaturePage extends LitElement {
       args: () => [this.apiClient, this.featureId],
       task: async ([apiClient, featureId]) => {
         if (typeof apiClient === 'object' && typeof featureId === 'string') {
-          this.feature = await apiClient.getFeature(featureId);
+          const wptMetricView = getWPTMetricView(
+            location
+          ) as FeatureWPTMetricViewType;
+          this.feature = await apiClient.getFeature(featureId, wptMetricView);
         }
         return this.feature;
       },

--- a/frontend/src/static/js/components/webstatus-overview-page.ts
+++ b/frontend/src/static/js/components/webstatus-overview-page.ts
@@ -25,11 +25,13 @@ import {
   getPaginationStart,
   getSearchQuery,
   getSortSpec,
+  getWPTMetricView,
 } from '../utils/urls.js';
 import {
   type APIClient,
   type FeatureSortOrderType,
   type FeatureSearchType,
+  FeatureWPTMetricViewType,
 } from '../api/client.js';
 import {apiClientContext} from '../contexts/api-client-context.js';
 import './webstatus-overview-content.js';
@@ -72,9 +74,13 @@ export class OverviewPage extends LitElement {
     const offset = getPaginationStart(routerLocation);
     const pageSize = getPageSize(routerLocation);
     this.totalCount = undefined;
+    const wptMetricView = getWPTMetricView(
+      routerLocation
+    ) as FeatureWPTMetricViewType;
     const respJson = await apiClient.getFeatures(
       searchQuery,
       sortSpec,
+      wptMetricView,
       offset,
       pageSize
     );

--- a/frontend/src/static/js/utils/test/urls.test.ts
+++ b/frontend/src/static/js/utils/test/urls.test.ts
@@ -21,6 +21,7 @@ import {
   getSearchQuery,
   formatOverviewPageUrl,
   formatFeaturePageUrl,
+  getWPTMetricView,
 } from '../urls.js';
 
 describe('getSearchQuery', () => {
@@ -74,6 +75,23 @@ describe('getSortSpec', () => {
   });
 });
 
+describe('getWPTMetricView', () => {
+  it('returns empty string when there was no wpt_metric_view= param', () => {
+    const cs = getWPTMetricView({search: ''});
+    assert.equal(cs, '');
+  });
+
+  it('returns empty string when the wpt_metric_view= param has no value', () => {
+    const cs = getWPTMetricView({search: '?wpt_metric_view='});
+    assert.equal(cs, '');
+  });
+
+  it('returns the string when the wpt_metric_view= param was set', () => {
+    const cs = getWPTMetricView({search: '?wpt_metric_view=subtest_counts'});
+    assert.equal(cs, 'subtest_counts');
+  });
+});
+
 describe('formatOverviewPageUrl', () => {
   it('returns a plain URL when no location is passed', () => {
     const url = formatOverviewPageUrl();
@@ -88,6 +106,13 @@ describe('formatOverviewPageUrl', () => {
   it('returns a URL with navigational params when they are set', () => {
     const url = formatOverviewPageUrl({search: '?q=css'});
     assert.equal(url, '/?q=css');
+  });
+
+  it('returns a URL with navigational params when wpt_metric_view param is set', () => {
+    const url = formatOverviewPageUrl({
+      search: '?wpt_metric_view=subtest_counts',
+    });
+    assert.equal(url, '/?wpt_metric_view=subtest_counts');
   });
 
   it('returns a URL with overrideparameters set', () => {
@@ -144,5 +169,12 @@ describe('formatFeaturePageUrl', () => {
   it('returns a URL with navigational params when they are set', () => {
     const url = formatFeaturePageUrl(feature, {search: '?q=css'});
     assert.equal(url, '/features/grid?q=css');
+  });
+
+  it('returns a URL with navigational params when wpt_metric_view param is set', () => {
+    const url = formatFeaturePageUrl(feature, {
+      search: '?wpt_metric_view=subtest_counts',
+    });
+    assert.equal(url, '/features/grid?wpt_metric_view=subtest_counts');
   });
 });

--- a/frontend/src/static/js/utils/urls.ts
+++ b/frontend/src/static/js/utils/urls.ts
@@ -37,6 +37,10 @@ export function getPaginationStart(location: {search: string}): number {
   return Number(getQueryParam(location.search, 'start'));
 }
 
+export function getWPTMetricView(location: {search: string}): string {
+  return getQueryParam(location.search, 'wpt_metric_view');
+}
+
 export const DEFAULT_ITEMS_PER_PAGE = 25;
 export function getPageSize(location: {search: string}): number {
   const num = Number(
@@ -51,6 +55,7 @@ type QueryStringOverrides = {
   num?: number;
   sort?: string;
   columns?: string[];
+  wpt_metric_view?: string;
 };
 
 /* Given the router location object, return a query string with
@@ -89,6 +94,14 @@ function getContextualQueryStringParams(
   const num = 'num' in overrides ? overrides.num : getPageSize(location);
   if (num !== DEFAULT_ITEMS_PER_PAGE) {
     searchParams.set('num', '' + num);
+  }
+
+  const wptMetricView =
+    'wpt_metric_view' in overrides
+      ? overrides.wpt_metric_view
+      : getWPTMetricView(location);
+  if (wptMetricView) {
+    searchParams.set('wpt_metric_view', wptMetricView);
   }
 
   return searchParams.toString() ? '?' + searchParams.toString() : '';


### PR DESCRIPTION
This change depends on #166.

It makes it so that the frontend's url can configure the wpt_metric_view value that is sent back for the overview and the feature detail page.

