### PR TITLE
Increase Spanner Memory & Misc. fixes

### DIFF
--- a/.dev/spanner/manifests/pod.yaml
+++ b/.dev/spanner/manifests/pod.yaml
@@ -30,7 +30,7 @@ spec:
       resources:
         limits:
           cpu: '2'
-          memory: '1.5Gi'
+          memory: '2.5Gi'
         requests:
           cpu: '300m'
           memory: '256Mi'

--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics.go
@@ -27,8 +27,6 @@ func (s *Server) ListAggregatedWPTMetrics(
 	ctx context.Context,
 	request backend.ListAggregatedWPTMetricsRequestObject,
 ) (backend.ListAggregatedWPTMetricsResponseObject, error) {
-	slog.Info("parameters", "feature", getFeatureIDsOrDefault(request.Params.FeatureIds))
-
 	metrics, nextPageToken, err := s.wptMetricsStorer.ListMetricsOverTimeWithAggregatedTotals(
 		ctx,
 		getFeatureIDsOrDefault(request.Params.FeatureIds),

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -15,6 +15,7 @@
 package spanneradapters
 
 import (
+	"cmp"
 	"context"
 	"log/slog"
 	"time"
@@ -233,11 +234,20 @@ func convertImplementationStatusToBackend(
 }
 
 func (s *Backend) convertFeatureResult(featureResult *gcpspanner.FeatureResult) *backend.Feature {
-	var experimentalMetricsMap map[string]backend.WPTFeatureData
-	var stableMetricsMap map[string]backend.WPTFeatureData
-	var implementationMap map[string]backend.BrowserImplementation
+	// Initialize the returned feature with the default values.
+	// The logic below will fill in nullable fields.
+	ret := &backend.Feature{
+		FeatureId:              featureResult.FeatureID,
+		Name:                   featureResult.Name,
+		BaselineStatus:         convertBaselineStatusSpannerToBackend(gcpspanner.BaselineStatus(featureResult.Status)),
+		Wpt:                    nil,
+		Spec:                   nil,
+		Usage:                  nil,
+		BrowserImplementations: nil,
+	}
+
 	if len(featureResult.ExperimentalMetrics) > 0 {
-		experimentalMetricsMap = make(map[string]backend.WPTFeatureData, len(featureResult.ExperimentalMetrics))
+		experimentalMetricsMap := make(map[string]backend.WPTFeatureData, len(featureResult.ExperimentalMetrics))
 		for _, metric := range featureResult.ExperimentalMetrics {
 			if metric.PassRate == nil {
 				continue
@@ -247,43 +257,61 @@ func (s *Backend) convertFeatureResult(featureResult *gcpspanner.FeatureResult) 
 				Score: &passRate,
 			}
 		}
+
+		// The database implementation should only return metrics that have PassRate.
+		// The logic below is only proactive in case something changes where we return
+		// a BrowserName without a PassRate. This will prevent the code from returning
+		// an initialized, but empty map by only overriding the default map when it actually
+		// has a value.
+		if len(experimentalMetricsMap) > 0 {
+			wpt := cmp.Or(ret.Wpt, &backend.FeatureWPTSnapshots{
+				Stable:       nil,
+				Experimental: nil,
+			})
+			wpt.Experimental = &experimentalMetricsMap
+			ret.Wpt = wpt
+		}
 	}
 
 	if len(featureResult.StableMetrics) > 0 {
-		stableMetricsMap = make(map[string]backend.WPTFeatureData, len(featureResult.StableMetrics))
+		stableMetricsMap := make(map[string]backend.WPTFeatureData, len(featureResult.StableMetrics))
 		for _, metric := range featureResult.StableMetrics {
-			passRate, _ := metric.PassRate.Float64()
 			if metric.PassRate == nil {
 				continue
 			}
+			passRate, _ := metric.PassRate.Float64()
 			stableMetricsMap[metric.BrowserName] = backend.WPTFeatureData{
 				Score: &passRate,
 			}
 		}
+
+		// The database implementation should only return metrics that have PassRate.
+		// The logic below is only proactive in case something changes where we return
+		// a BrowserName without a PassRate. This will prevent the code from returning
+		// an initialized, but empty map by only overriding the default map when it actually
+		// has a value.
+		if len(stableMetricsMap) > 0 {
+			wpt := cmp.Or(ret.Wpt, &backend.FeatureWPTSnapshots{
+				Stable:       nil,
+				Experimental: nil,
+			})
+			wpt.Stable = &stableMetricsMap
+			ret.Wpt = wpt
+		}
 	}
 
 	if len(featureResult.ImplementationStatuses) > 0 {
-		implementationMap = make(map[string]backend.BrowserImplementation, len(featureResult.ImplementationStatuses))
+		implementationMap := make(map[string]backend.BrowserImplementation, len(featureResult.ImplementationStatuses))
 		for _, status := range featureResult.ImplementationStatuses {
 			backendStatus := convertImplementationStatusToBackend(status.ImplementationStatus)
 			implementationMap[status.BrowserName] = backend.BrowserImplementation{
 				Status: &backendStatus,
 			}
 		}
+		ret.BrowserImplementations = &implementationMap
 	}
 
-	return &backend.Feature{
-		FeatureId:      featureResult.FeatureID,
-		Name:           featureResult.Name,
-		BaselineStatus: convertBaselineStatusSpannerToBackend(gcpspanner.BaselineStatus(featureResult.Status)),
-		Wpt: &backend.FeatureWPTSnapshots{
-			Experimental: &experimentalMetricsMap,
-			Stable:       &stableMetricsMap,
-		},
-		Spec:                   nil,
-		Usage:                  nil,
-		BrowserImplementations: &implementationMap,
-	}
+	return ret
 }
 
 func getSpannerWPTMetricView(wptMetricView backend.WPTMetricView) gcpspanner.WPTMetricView {

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -896,3 +896,53 @@ func TestGetFeatureSearchSortOrder(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertFeatureResult(t *testing.T) {
+	testCases := []struct {
+		name            string
+		featureResult   *gcpspanner.FeatureResult
+		expectedFeature *backend.Feature
+	}{
+		{
+			name: "nil PassRate edge case",
+			featureResult: &gcpspanner.FeatureResult{
+				Name:      "feature 1",
+				FeatureID: "feature1",
+				Status:    "low",
+				StableMetrics: []*gcpspanner.FeatureResultMetric{
+					{
+						BrowserName: "browser3",
+						PassRate:    nil,
+					},
+				},
+				ExperimentalMetrics: []*gcpspanner.FeatureResultMetric{
+					{
+						BrowserName: "browser3",
+						PassRate:    nil,
+					},
+				},
+				ImplementationStatuses: nil,
+			},
+
+			expectedFeature: &backend.Feature{
+				BaselineStatus:         backend.Newly,
+				FeatureId:              "feature1",
+				Name:                   "feature 1",
+				Spec:                   nil,
+				Usage:                  nil,
+				Wpt:                    nil,
+				BrowserImplementations: nil,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := Backend{client: nil}
+			feature := b.convertFeatureResult(tc.featureResult)
+			if !CompareFeatures(*tc.expectedFeature, *feature) {
+				t.Errorf("unexpected feature %v", *feature)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Main fix:
- Increase the database memory to 2.5gb. Due to the amount of data that is loaded for the fake data script, the kubernetes cluster may kill the spanner pod. This may be due to a recently added index. After increasing the memory, my spanner pod no longer terminates

The way I finally found out the problem: `kubectl describe pod spanner` told me that it was OOMKilled recently after replicating the bug.

![image](https://github.com/GoogleChrome/webstatus.dev/assets/7788930/7f77cbc4-d525-42c3-8211-e792b4bc35bb)


Other fixes (I found these while looking into the spanner issue):
- Lazily initialize optional attributes for backend.Feature
- Remove extra logging
- Fix nil check for stable metrics to match experimental metrics
- Prevent returning an empty map if there are no PassRates returned (shouldn't be a problem now. More so proactive check while looking through code)

