### PR TITLE
Use templates for FeatureSearch query & allow multiple sort values

### DIFF
--- a/lib/gcpspanner/feature_search.go
+++ b/lib/gcpspanner/feature_search.go
@@ -92,7 +92,7 @@ func (c *Client) FeaturesSearch(
 	var featureCursor *FeatureResultCursor
 	var err error
 	if pageToken != nil {
-		offsetCursor, featureCursor, err = decodeInputFeatureResultCursor(*pageToken, sortOrder)
+		offsetCursor, featureCursor, err = decodeInputFeatureResultCursor(*pageToken)
 		if err != nil {
 			return nil, errors.Join(ErrInternalQueryFailure, err)
 		}

--- a/lib/gcpspanner/get_feature_query.go
+++ b/lib/gcpspanner/get_feature_query.go
@@ -52,15 +52,24 @@ func (q GetFeatureQueryBuilder) Build(
 	filter Filterable) spanner.Statement {
 	filterParams := make(map[string]interface{})
 
+	queryArgs := FeatureSearchQueryArgs{
+		MetricView:  q.wptMetricView,
+		Filters:     nil,
+		PageFilters: nil,
+		Offset:      0,
+		PageSize:    1,
+		Prefilter:   prefilter,
+		SortClause:  "",
+	}
 	if filter != nil {
+		queryArgs.Filters = []string{filter.Clause()}
 		maps.Copy(filterParams, filter.Params())
 	}
 
-	sql, params := q.baseQuery.Query(prefilter, q.wptMetricView)
+	sql, params := q.baseQuery.Query(queryArgs)
 	maps.Copy(filterParams, params)
 
-	stmt := spanner.NewStatement(
-		sql + " WHERE " + filter.Clause() + " LIMIT 1")
+	stmt := spanner.NewStatement(sql)
 	stmt.Params = filterParams
 
 	return stmt


### PR DESCRIPTION
In preparation of sorting by "Browser Implementation", we will need to sort by multiple columns. That means the pagination token needs to allow encoding that information.

Now we have a new value for call FeaturesSearchSortTarget that tells you what the general sort operation is. The RawCursor no longer uses generics since in turns out that spanner can infer the type from any/interface{}.

Additionally, more of the query generation has been moved to templates.

