### PR TITLE
Support baseline_date search term

### DIFF
--- a/antlr/FeatureSearch.g4
+++ b/antlr/FeatureSearch.g4
@@ -15,6 +15,7 @@ WS: [ \t\r\n]+ -> skip;
 BASELINE_STATUS: 'limited' | 'newly' | 'widely';
 BROWSER_NAME: 'chrome' | 'firefox' | 'edge' | 'safari';
 BROWSER_LIST: BROWSER_NAME (',' BROWSER_NAME)*;
+DATE: [2][0-9][0-9][0-9]'-'[01][0-9]'-'[0-3][0-9]; // YYYY-MM-DD (starting from 2000)
 ANY_VALUE:
 	'"' [a-zA-Z][a-zA-Z0-9_ -]* '"' // Words with spaces.
 	| [a-zA-Z][a-zA-Z0-9_-]*; // Single words
@@ -22,8 +23,12 @@ ANY_VALUE:
 // Terms
 available_on_term: 'available_on' COLON BROWSER_NAME;
 baseline_status_term: 'baseline_status' COLON BASELINE_STATUS;
+// In the future support other operators by doing something like (date_operator_query | date_range_query)
+baseline_date_term: 'baseline_date' COLON (date_range_query);
 name_term: 'name' COLON ANY_VALUE;
-term: available_on_term | baseline_status_term | name_term;
+term: available_on_term | baseline_status_term | baseline_date_term | name_term;
+
+date_range_query: startDate=DATE '..' endDate=DATE;
 
 generic_search_term: (NOT)? term;
 

--- a/antlr/FeatureSearch.md
+++ b/antlr/FeatureSearch.md
@@ -33,6 +33,8 @@ This query language enables you to construct flexible searches to find features 
     - Examples:
       - `name:grid`
       - `name:"CSS Grid"`
+  - `baseline_date`: Represents the date a feature reached baseline.
+    - Option 1: Searches for an inclusive date range (DATE..DATE) where features reached baseline.
   - `missing_in_one_of`: Searches for features that are almost universally supported, meaning they are available on all
     browsers **except one**. Expects a browser list (BROWSER_LIST) as its value. Not compatible with the `-` negation prefix.
     - Example:
@@ -53,6 +55,7 @@ This query language enables you to construct flexible searches to find features 
 - `-available_on:firefox` - Find features not available on Firefox.
 - `baseline_status:high` - Find features with a high baseline status.
 - `name:"Dark Mode"` - Find features named "Dark Mode" (including spaces).
+- `baseline_date:2023-01-01..2023-12-31` - Searches for all features that reached baseline in 2023.
 
 ### Complex Queries
 

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -123,28 +123,30 @@ func TestGetV1Features(t *testing.T) {
 				expectedPageSize:      50,
 				expectedWPTMetricView: backend.TestCounts,
 				expectedSearchNode: &searchtypes.SearchNode{
-					Operator: searchtypes.OperatorRoot,
-					Term:     nil,
+					Keyword: searchtypes.KeywordRoot,
+					Term:    nil,
 					Children: []*searchtypes.SearchNode{
 						{
-							Operator: searchtypes.OperatorAND,
-							Term:     nil,
+							Keyword: searchtypes.KeywordAND,
+							Term:    nil,
 							Children: []*searchtypes.SearchNode{
 								{
 									Children: nil,
 									Term: &searchtypes.SearchTerm{
 										Identifier: searchtypes.IdentifierAvailableOn,
 										Value:      "chrome",
+										Operator:   searchtypes.OperatorEq,
 									},
-									Operator: searchtypes.OperatorNone,
+									Keyword: searchtypes.KeywordNone,
 								},
 								{
 									Children: nil,
 									Term: &searchtypes.SearchTerm{
 										Identifier: searchtypes.IdentifierName,
 										Value:      "grid",
+										Operator:   searchtypes.OperatorEq,
 									},
-									Operator: searchtypes.OperatorNone,
+									Keyword: searchtypes.KeywordNone,
 								},
 							},
 						},

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -672,6 +672,7 @@ func testFeatureSearchFilters(ctx context.Context, t *testing.T, client *Client)
 	testFeatureCommonFilterCombos(ctx, t, client)
 	testFeatureNameFilters(ctx, t, client)
 	testFeatureBaselineStatusFilters(ctx, t, client)
+	testFeatureBaselineStatusDateFilters(ctx, t, client)
 }
 
 func testFeatureCommonFilterCombos(ctx context.Context, t *testing.T, client *Client) {
@@ -685,28 +686,30 @@ func testFeatureCommonFilterCombos(ctx context.Context, t *testing.T, client *Cl
 			name: "Available and not available filters",
 			// available on barBrowser AND not available on fooBrowser
 			searchNode: &searchtypes.SearchNode{
-				Operator: searchtypes.OperatorRoot,
-				Term:     nil,
+				Keyword: searchtypes.KeywordRoot,
+				Term:    nil,
 				Children: []*searchtypes.SearchNode{
 					{
-						Operator: searchtypes.OperatorAND,
-						Term:     nil,
+						Keyword: searchtypes.KeywordAND,
+						Term:    nil,
 						Children: []*searchtypes.SearchNode{
 							{
 								Children: nil,
 								Term: &searchtypes.SearchTerm{
 									Identifier: searchtypes.IdentifierAvailableOn,
 									Value:      "barBrowser",
+									Operator:   searchtypes.OperatorEq,
 								},
-								Operator: searchtypes.OperatorNone,
+								Keyword: searchtypes.KeywordNone,
 							},
 							{
 								Children: nil,
 								Term: &searchtypes.SearchTerm{
 									Identifier: searchtypes.IdentifierAvailableOn,
 									Value:      "fooBrowser",
+									Operator:   searchtypes.OperatorNeq,
 								},
-								Operator: searchtypes.OperatorNegation,
+								Keyword: searchtypes.KeywordNone,
 							},
 						},
 					},
@@ -746,16 +749,17 @@ func testFeatureNotAvailableSearchFilters(ctx context.Context, t *testing.T, cli
 		{
 			name: "single browser: not available on fooBrowser",
 			searchNode: &searchtypes.SearchNode{
-				Operator: searchtypes.OperatorRoot,
-				Term:     nil,
+				Keyword: searchtypes.KeywordRoot,
+				Term:    nil,
 				Children: []*searchtypes.SearchNode{
 					{
 						Children: nil,
 						Term: &searchtypes.SearchTerm{
 							Identifier: searchtypes.IdentifierAvailableOn,
 							Value:      "fooBrowser",
+							Operator:   searchtypes.OperatorNeq,
 						},
-						Operator: searchtypes.OperatorNegation,
+						Keyword: searchtypes.KeywordNone,
 					},
 				},
 			},
@@ -794,16 +798,17 @@ func testFeatureAvailableSearchFilters(ctx context.Context, t *testing.T, client
 			name: "single browser: available on barBrowser",
 			// available on barBrowser
 			searchNode: &searchtypes.SearchNode{
-				Operator: searchtypes.OperatorRoot,
-				Term:     nil,
+				Keyword: searchtypes.KeywordRoot,
+				Term:    nil,
 				Children: []*searchtypes.SearchNode{
 					{
 						Children: nil,
 						Term: &searchtypes.SearchTerm{
 							Identifier: searchtypes.IdentifierAvailableOn,
 							Value:      "barBrowser",
+							Operator:   searchtypes.OperatorEq,
 						},
-						Operator: searchtypes.OperatorNone,
+						Keyword: searchtypes.KeywordNone,
 					},
 				},
 			},
@@ -820,28 +825,30 @@ func testFeatureAvailableSearchFilters(ctx context.Context, t *testing.T, client
 			name: "multiple browsers: available on either barBrowser OR fooBrowser",
 			// available on either barBrowser OR fooBrowser
 			searchNode: &searchtypes.SearchNode{
-				Operator: searchtypes.OperatorRoot,
-				Term:     nil,
+				Keyword: searchtypes.KeywordRoot,
+				Term:    nil,
 				Children: []*searchtypes.SearchNode{
 					{
-						Operator: searchtypes.OperatorOR,
-						Term:     nil,
+						Keyword: searchtypes.KeywordOR,
+						Term:    nil,
 						Children: []*searchtypes.SearchNode{
 							{
 								Children: nil,
 								Term: &searchtypes.SearchTerm{
 									Identifier: searchtypes.IdentifierAvailableOn,
 									Value:      "barBrowser",
+									Operator:   searchtypes.OperatorEq,
 								},
-								Operator: searchtypes.OperatorNone,
+								Keyword: searchtypes.KeywordNone,
 							},
 							{
 								Children: nil,
 								Term: &searchtypes.SearchTerm{
 									Identifier: searchtypes.IdentifierAvailableOn,
 									Value:      "fooBrowser",
+									Operator:   searchtypes.OperatorEq,
 								},
-								Operator: searchtypes.OperatorNone,
+								Keyword: searchtypes.KeywordNone,
 							},
 						},
 					},
@@ -882,14 +889,15 @@ func testFeatureNameFilters(ctx context.Context, t *testing.T, client *Client) {
 		getFeatureSearchTestFeature(FeatureSearchTestFId4),
 	}
 	node := &searchtypes.SearchNode{
-		Operator: searchtypes.OperatorRoot,
-		Term:     nil,
+		Keyword: searchtypes.KeywordRoot,
+		Term:    nil,
 		Children: []*searchtypes.SearchNode{
 			{
-				Operator: searchtypes.OperatorNone,
+				Keyword: searchtypes.KeywordNone,
 				Term: &searchtypes.SearchTerm{
 					Identifier: searchtypes.IdentifierName,
 					Value:      "feature",
+					Operator:   searchtypes.OperatorEq,
 				},
 				Children: nil,
 			},
@@ -914,14 +922,15 @@ func testFeatureNameFilters(ctx context.Context, t *testing.T, client *Client) {
 
 	// All upper case with partial "FEATURE" name. Should return same results (all).
 	node = &searchtypes.SearchNode{
-		Operator: searchtypes.OperatorRoot,
-		Term:     nil,
+		Keyword: searchtypes.KeywordRoot,
+		Term:    nil,
 		Children: []*searchtypes.SearchNode{
 			{
-				Operator: searchtypes.OperatorNone,
+				Keyword: searchtypes.KeywordNone,
 				Term: &searchtypes.SearchTerm{
 					Identifier: searchtypes.IdentifierName,
 					Value:      "FEATURE",
+					Operator:   searchtypes.OperatorEq,
 				},
 				Children: nil,
 			},
@@ -948,16 +957,120 @@ func testFeatureNameFilters(ctx context.Context, t *testing.T, client *Client) {
 		Features:      expectedResults,
 	}
 	node = &searchtypes.SearchNode{
-		Operator: searchtypes.OperatorRoot,
-		Term:     nil,
+		Keyword: searchtypes.KeywordRoot,
+		Term:    nil,
 		Children: []*searchtypes.SearchNode{
 			{
-				Operator: searchtypes.OperatorNone,
+				Keyword: searchtypes.KeywordNone,
 				Term: &searchtypes.SearchTerm{
 					Identifier: searchtypes.IdentifierName,
 					Value:      "4",
+					Operator:   searchtypes.OperatorEq,
 				},
 				Children: nil,
+			},
+		},
+	}
+
+	assertFeatureSearch(ctx, t, client,
+		featureSearchArgs{
+			pageToken: nil,
+			pageSize:  100,
+			node:      node,
+			sort:      defaultSorting(),
+		},
+		&expectedPage,
+	)
+}
+
+func testFeatureBaselineStatusDateFilters(ctx context.Context, t *testing.T, client *Client) {
+	// Baseline Date 2000-01-04..2000-01-05
+	expectedResults := []FeatureResult{
+		getFeatureSearchTestFeature(FeatureSearchTestFId1),
+		getFeatureSearchTestFeature(FeatureSearchTestFId2),
+	}
+	expectedPage := FeatureResultPage{
+		Total:         2,
+		NextPageToken: nil,
+		Features:      expectedResults,
+	}
+	node := &searchtypes.SearchNode{
+		Keyword: searchtypes.KeywordRoot,
+		Term:    nil,
+		Children: []*searchtypes.SearchNode{
+			{
+				Keyword: searchtypes.KeywordAND,
+				Term:    nil,
+				Children: []*searchtypes.SearchNode{
+					{
+						Keyword: searchtypes.KeywordNone,
+						Term: &searchtypes.SearchTerm{
+							Identifier: searchtypes.IdentifierBaselineDate,
+							Value:      "2000-01-04",
+							Operator:   searchtypes.OperatorGtEq,
+						},
+						Children: nil,
+					},
+					{
+						Keyword: searchtypes.KeywordNone,
+						Term: &searchtypes.SearchTerm{
+							Identifier: searchtypes.IdentifierBaselineDate,
+							Value:      "2000-01-05",
+							Operator:   searchtypes.OperatorLtEq,
+						},
+						Children: nil,
+					},
+				},
+			},
+		},
+	}
+
+	assertFeatureSearch(ctx, t, client,
+		featureSearchArgs{
+			pageToken: nil,
+			pageSize:  100,
+			node:      node,
+			sort:      defaultSorting(),
+		},
+		&expectedPage,
+	)
+
+	// Baseline Date 2000-01-01..2000-01-04
+	expectedResults = []FeatureResult{
+		getFeatureSearchTestFeature(FeatureSearchTestFId2),
+	}
+	expectedPage = FeatureResultPage{
+		Total:         1,
+		NextPageToken: nil,
+		Features:      expectedResults,
+	}
+	node = &searchtypes.SearchNode{
+		Keyword: searchtypes.KeywordRoot,
+		Term:    nil,
+		Children: []*searchtypes.SearchNode{
+			{
+				Keyword: searchtypes.KeywordAND,
+				Term:    nil,
+				Children: []*searchtypes.SearchNode{
+					{
+						Keyword: searchtypes.KeywordNone,
+						Term: &searchtypes.SearchTerm{
+							Identifier: searchtypes.IdentifierBaselineDate,
+							Value:      "2000-01-01",
+							Operator:   searchtypes.OperatorGtEq,
+						},
+						Children: nil,
+					},
+					{
+						Keyword: searchtypes.KeywordNone,
+						Term: &searchtypes.SearchTerm{
+							Identifier: searchtypes.IdentifierBaselineDate,
+							Value:      "2000-01-04",
+							Operator:   searchtypes.OperatorLtEq,
+						},
+						Children: nil,
+					},
+				},
 			},
 		},
 	}
@@ -984,14 +1097,15 @@ func testFeatureBaselineStatusFilters(ctx context.Context, t *testing.T, client 
 		Features:      expectedResults,
 	}
 	node := &searchtypes.SearchNode{
-		Operator: searchtypes.OperatorRoot,
-		Term:     nil,
+		Keyword: searchtypes.KeywordRoot,
+		Term:    nil,
 		Children: []*searchtypes.SearchNode{
 			{
-				Operator: searchtypes.OperatorNone,
+				Keyword: searchtypes.KeywordNone,
 				Term: &searchtypes.SearchTerm{
 					Identifier: searchtypes.IdentifierBaselineStatus,
 					Value:      "newly",
+					Operator:   searchtypes.OperatorEq,
 				},
 				Children: nil,
 			},
@@ -1018,14 +1132,15 @@ func testFeatureBaselineStatusFilters(ctx context.Context, t *testing.T, client 
 		Features:      expectedResults,
 	}
 	node = &searchtypes.SearchNode{
-		Operator: searchtypes.OperatorRoot,
-		Term:     nil,
+		Keyword: searchtypes.KeywordRoot,
+		Term:    nil,
 		Children: []*searchtypes.SearchNode{
 			{
-				Operator: searchtypes.OperatorNone,
+				Keyword: searchtypes.KeywordNone,
 				Term: &searchtypes.SearchTerm{
 					Identifier: searchtypes.IdentifierBaselineStatus,
 					Value:      "widely",
+					Operator:   searchtypes.OperatorEq,
 				},
 				Children: nil,
 			},
@@ -1052,14 +1167,15 @@ func testFeatureBaselineStatusFilters(ctx context.Context, t *testing.T, client 
 		Features:      expectedResults,
 	}
 	node = &searchtypes.SearchNode{
-		Operator: searchtypes.OperatorRoot,
-		Term:     nil,
+		Keyword: searchtypes.KeywordRoot,
+		Term:    nil,
 		Children: []*searchtypes.SearchNode{
 			{
-				Operator: searchtypes.OperatorNone,
+				Keyword: searchtypes.KeywordNone,
 				Term: &searchtypes.SearchTerm{
 					Identifier: searchtypes.IdentifierBaselineStatus,
 					Value:      "limited",
+					Operator:   searchtypes.OperatorEq,
 				},
 				Children: nil,
 			},

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -30,16 +30,35 @@ func TestParseQuery(t *testing.T) {
 		{
 			InputQuery: "available_on:chrome",
 			ExpectedTree: &SearchNode{
-				Operator: OperatorRoot,
-				Term:     nil,
+				Keyword: KeywordRoot,
+				Term:    nil,
 				Children: []*SearchNode{
 					{
 						Term: &SearchTerm{
 							Identifier: IdentifierAvailableOn,
 							Value:      "chrome",
+							Operator:   OperatorEq,
 						},
 						Children: nil,
-						Operator: OperatorNone,
+						Keyword:  KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: "-available_on:chrome",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Term: &SearchTerm{
+							Identifier: IdentifierAvailableOn,
+							Value:      "chrome",
+							Operator:   OperatorNeq,
+						},
+						Children: nil,
+						Keyword:  KeywordNone,
 					},
 				},
 			},
@@ -47,28 +66,30 @@ func TestParseQuery(t *testing.T) {
 		{
 			InputQuery: "available_on:chrome AND baseline_status:widely",
 			ExpectedTree: &SearchNode{
-				Operator: OperatorRoot,
-				Term:     nil,
+				Keyword: KeywordRoot,
+				Term:    nil,
 				Children: []*SearchNode{
 					{
-						Operator: OperatorAND,
-						Term:     nil,
+						Keyword: KeywordAND,
+						Term:    nil,
 						Children: []*SearchNode{
 							{
 								Children: nil,
 								Term: &SearchTerm{
 									Identifier: IdentifierAvailableOn,
 									Value:      "chrome",
+									Operator:   OperatorEq,
 								},
-								Operator: OperatorNone,
+								Keyword: KeywordNone,
 							},
 							{
 								Children: nil,
 								Term: &SearchTerm{
 									Identifier: IdentifierBaselineStatus,
 									Value:      "widely",
+									Operator:   OperatorEq,
 								},
-								Operator: OperatorNone,
+								Keyword: KeywordNone,
 							},
 						},
 					},
@@ -78,28 +99,30 @@ func TestParseQuery(t *testing.T) {
 		{
 			InputQuery: "available_on:chrome baseline_status:widely",
 			ExpectedTree: &SearchNode{
-				Operator: OperatorRoot,
-				Term:     nil,
+				Keyword: KeywordRoot,
+				Term:    nil,
 				Children: []*SearchNode{
 					{
-						Operator: OperatorAND,
-						Term:     nil,
+						Keyword: KeywordAND,
+						Term:    nil,
 						Children: []*SearchNode{
 							{
 								Children: nil,
 								Term: &SearchTerm{
 									Identifier: IdentifierAvailableOn,
 									Value:      "chrome",
+									Operator:   OperatorEq,
 								},
-								Operator: OperatorNone,
+								Keyword: KeywordNone,
 							},
 							{
 								Children: nil,
 								Term: &SearchTerm{
 									Identifier: IdentifierBaselineStatus,
 									Value:      "widely",
+									Operator:   OperatorEq,
 								},
-								Operator: OperatorNone,
+								Keyword: KeywordNone,
 							},
 						},
 					},
@@ -109,32 +132,34 @@ func TestParseQuery(t *testing.T) {
 		{
 			InputQuery: "available_on:chrome AND baseline_status:widely OR name:grid",
 			ExpectedTree: &SearchNode{
-				Operator: OperatorRoot,
-				Term:     nil,
+				Keyword: KeywordRoot,
+				Term:    nil,
 				Children: []*SearchNode{
 					{
-						Operator: OperatorOR,
-						Term:     nil,
+						Keyword: KeywordOR,
+						Term:    nil,
 						Children: []*SearchNode{
 							{
-								Operator: OperatorAND,
-								Term:     nil,
+								Keyword: KeywordAND,
+								Term:    nil,
 								Children: []*SearchNode{
 									{
 										Children: nil,
 										Term: &SearchTerm{
 											Identifier: IdentifierAvailableOn,
 											Value:      "chrome",
+											Operator:   OperatorEq,
 										},
-										Operator: OperatorNone,
+										Keyword: KeywordNone,
 									},
 									{
 										Children: nil,
 										Term: &SearchTerm{
 											Identifier: IdentifierBaselineStatus,
 											Value:      "widely",
+											Operator:   OperatorEq,
 										},
-										Operator: OperatorNone,
+										Keyword: KeywordNone,
 									},
 								},
 							},
@@ -142,8 +167,9 @@ func TestParseQuery(t *testing.T) {
 								Term: &SearchTerm{
 									Identifier: IdentifierName,
 									Value:      "grid",
+									Operator:   OperatorEq,
 								},
-								Operator: OperatorNone,
+								Keyword: KeywordNone,
 							},
 						},
 					},
@@ -153,29 +179,31 @@ func TestParseQuery(t *testing.T) {
 		{
 			InputQuery: "(available_on:chrome AND baseline_status:widely) OR name:grid",
 			ExpectedTree: &SearchNode{
-				Operator: OperatorRoot,
-				Term:     nil,
+				Keyword: KeywordRoot,
+				Term:    nil,
 				Children: []*SearchNode{
 					{
-						Operator: OperatorOR,
-						Term:     nil,
+						Keyword: KeywordOR,
+						Term:    nil,
 						Children: []*SearchNode{
 							{
-								Operator: OperatorAND,
+								Keyword: KeywordAND,
 								Children: []*SearchNode{
 									{
 										Term: &SearchTerm{
 											Identifier: IdentifierAvailableOn,
 											Value:      "chrome",
+											Operator:   OperatorEq,
 										},
-										Operator: OperatorNone,
+										Keyword: KeywordNone,
 									},
 									{
 										Term: &SearchTerm{
 											Identifier: IdentifierBaselineStatus,
 											Value:      "widely",
+											Operator:   OperatorEq,
 										},
-										Operator: OperatorNone,
+										Keyword: KeywordNone,
 									},
 								},
 							},
@@ -183,8 +211,9 @@ func TestParseQuery(t *testing.T) {
 								Term: &SearchTerm{
 									Identifier: IdentifierName,
 									Value:      "grid",
+									Operator:   OperatorEq,
 								},
-								Operator: OperatorNone,
+								Keyword: KeywordNone,
 							},
 						},
 					},
@@ -194,44 +223,56 @@ func TestParseQuery(t *testing.T) {
 		{
 			InputQuery: "(available_on:chrome AND baseline_status:widely OR name:avif) OR name:grid",
 			ExpectedTree: &SearchNode{
-				Operator: OperatorRoot,
-				Term:     nil,
+				Keyword: KeywordRoot,
+				Term:    nil,
 				Children: []*SearchNode{
 					{
-						Operator: OperatorOR,
-						Term:     nil,
+						Keyword: KeywordOR,
+						Term:    nil,
 						Children: []*SearchNode{
 							{
-								Operator: OperatorOR,
-								Term:     nil,
+								Keyword: KeywordOR,
+								Term:    nil,
 								Children: []*SearchNode{
 									{
-										Operator: OperatorAND,
-										Term:     nil,
+										Keyword: KeywordAND,
+										Term:    nil,
 										Children: []*SearchNode{
 											{
-												Operator: OperatorNone,
+												Keyword:  KeywordNone,
 												Children: nil,
-												Term:     &SearchTerm{Identifier: IdentifierAvailableOn, Value: "chrome"},
+												Term: &SearchTerm{
+													Identifier: IdentifierAvailableOn,
+													Value:      "chrome",
+													Operator:   OperatorEq,
+												},
 											},
 											{
-												Operator: OperatorNone,
+												Keyword:  KeywordNone,
 												Children: nil,
-												Term:     &SearchTerm{Identifier: IdentifierBaselineStatus, Value: "widely"},
+												Term: &SearchTerm{
+													Identifier: IdentifierBaselineStatus,
+													Value:      "widely",
+													Operator:   OperatorEq,
+												},
 											},
 										},
 									},
 									{
-										Operator: OperatorNone,
+										Keyword:  KeywordNone,
 										Children: nil,
-										Term:     &SearchTerm{Identifier: IdentifierName, Value: "avif"},
+										Term: &SearchTerm{
+											Identifier: IdentifierName,
+											Value:      "avif",
+											Operator:   OperatorEq,
+										},
 									},
 								},
 							},
 							{
-								Operator: OperatorNone,
+								Keyword:  KeywordNone,
 								Children: nil,
-								Term:     &SearchTerm{Identifier: IdentifierName, Value: "grid"},
+								Term:     &SearchTerm{Identifier: IdentifierName, Value: "grid", Operator: OperatorEq},
 							},
 						},
 					},
@@ -241,44 +282,56 @@ func TestParseQuery(t *testing.T) {
 		{
 			InputQuery: "available_on:chrome (baseline_status:widely OR name:avif) OR name:grid",
 			ExpectedTree: &SearchNode{
-				Operator: OperatorRoot,
-				Term:     nil,
+				Keyword: KeywordRoot,
+				Term:    nil,
 				Children: []*SearchNode{
 					{
-						Operator: OperatorOR,
-						Term:     nil,
+						Keyword: KeywordOR,
+						Term:    nil,
 						Children: []*SearchNode{
 							{
-								Operator: OperatorAND,
-								Term:     nil,
+								Keyword: KeywordAND,
+								Term:    nil,
 								Children: []*SearchNode{
 									{
-										Operator: OperatorNone,
+										Keyword:  KeywordNone,
 										Children: nil,
-										Term:     &SearchTerm{Identifier: IdentifierAvailableOn, Value: "chrome"},
+										Term: &SearchTerm{
+											Identifier: IdentifierAvailableOn,
+											Value:      "chrome",
+											Operator:   OperatorEq,
+										},
 									},
 									{
-										Operator: OperatorOR,
-										Term:     nil,
+										Keyword: KeywordOR,
+										Term:    nil,
 										Children: []*SearchNode{
 											{
-												Operator: OperatorNone,
+												Keyword:  KeywordNone,
 												Children: nil,
-												Term:     &SearchTerm{Identifier: IdentifierBaselineStatus, Value: "widely"},
+												Term: &SearchTerm{
+													Identifier: IdentifierBaselineStatus,
+													Value:      "widely",
+													Operator:   OperatorEq,
+												},
 											},
 											{
-												Operator: OperatorNone,
+												Keyword:  KeywordNone,
 												Children: nil,
-												Term:     &SearchTerm{Identifier: IdentifierName, Value: "avif"},
+												Term: &SearchTerm{
+													Identifier: IdentifierName,
+													Value:      "avif",
+													Operator:   OperatorEq,
+												},
 											},
 										},
 									},
 								},
 							},
 							{
-								Operator: OperatorNone,
+								Keyword:  KeywordNone,
 								Children: nil,
-								Term:     &SearchTerm{Identifier: IdentifierName, Value: "grid"},
+								Term:     &SearchTerm{Identifier: IdentifierName, Value: "grid", Operator: OperatorEq},
 							},
 						},
 					},
@@ -288,16 +341,17 @@ func TestParseQuery(t *testing.T) {
 		{
 			InputQuery: "name:grid",
 			ExpectedTree: &SearchNode{
-				Operator: OperatorRoot,
-				Term:     nil,
+				Keyword: KeywordRoot,
+				Term:    nil,
 				Children: []*SearchNode{
 					{
 						Children: nil,
 						Term: &SearchTerm{
 							Identifier: IdentifierName,
 							Value:      "grid",
+							Operator:   OperatorEq,
 						},
-						Operator: OperatorNone,
+						Keyword: KeywordNone,
 					},
 				},
 			},
@@ -306,16 +360,17 @@ func TestParseQuery(t *testing.T) {
 			// Should remove the quotes
 			InputQuery: `name:"CSS Grid"`,
 			ExpectedTree: &SearchNode{
-				Operator: OperatorRoot,
-				Term:     nil,
+				Keyword: KeywordRoot,
+				Term:    nil,
 				Children: []*SearchNode{
 					{
 						Children: nil,
 						Term: &SearchTerm{
 							Identifier: IdentifierName,
 							Value:      "CSS Grid",
+							Operator:   OperatorEq,
 						},
-						Operator: OperatorNone,
+						Keyword: KeywordNone,
 					},
 				},
 			},
@@ -323,15 +378,16 @@ func TestParseQuery(t *testing.T) {
 		{
 			InputQuery: "grid",
 			ExpectedTree: &SearchNode{
-				Operator: OperatorRoot,
-				Term:     nil,
+				Keyword: KeywordRoot,
+				Term:    nil,
 				Children: []*SearchNode{
 					{
 						Term: &SearchTerm{
 							Identifier: IdentifierName,
 							Value:      "grid",
+							Operator:   OperatorEq,
 						},
-						Operator: OperatorNone,
+						Keyword:  KeywordNone,
 						Children: nil,
 					},
 				},
@@ -340,16 +396,131 @@ func TestParseQuery(t *testing.T) {
 		{
 			InputQuery: `"CSS Grid"`,
 			ExpectedTree: &SearchNode{
-				Operator: OperatorRoot,
-				Term:     nil,
+				Keyword: KeywordRoot,
+				Term:    nil,
 				Children: []*SearchNode{
 					{
 						Term: &SearchTerm{
 							Identifier: IdentifierName,
 							Value:      "CSS Grid",
+							Operator:   OperatorEq,
 						},
-						Operator: OperatorNone,
+						Keyword:  KeywordNone,
 						Children: nil,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: "baseline_date:2000-01-01..2000-12-31",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Keyword: KeywordAND,
+						Term:    nil,
+						Children: []*SearchNode{
+							{
+								Keyword: KeywordNone,
+								Term: &SearchTerm{
+									Identifier: IdentifierBaselineDate,
+									Value:      "2000-01-01",
+									Operator:   OperatorGtEq,
+								},
+								Children: nil,
+							},
+							{
+								Keyword: KeywordNone,
+								Term: &SearchTerm{
+									Identifier: IdentifierBaselineDate,
+									Value:      "2000-12-31",
+									Operator:   OperatorLtEq,
+								},
+								Children: nil,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			InputQuery: "-baseline_date:2000-01-01..2000-12-31",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Keyword: KeywordOR,
+						Term:    nil,
+						Children: []*SearchNode{
+							{
+								Keyword: KeywordNone,
+								Term: &SearchTerm{
+									Identifier: IdentifierBaselineDate,
+									Value:      "2000-01-01",
+									Operator:   OperatorLt,
+								},
+								Children: nil,
+							},
+							{
+								Keyword: KeywordNone,
+								Term: &SearchTerm{
+									Identifier: IdentifierBaselineDate,
+									Value:      "2000-12-31",
+									Operator:   OperatorGt,
+								},
+								Children: nil,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			InputQuery: `baseline_date:2000-01-01..2000-12-31 OR "CSS Grid"`,
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Keyword: KeywordOR,
+						Term:    nil,
+						Children: []*SearchNode{
+							{
+								Keyword: KeywordAND,
+								Term:    nil,
+								Children: []*SearchNode{
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierBaselineDate,
+											Value:      "2000-01-01",
+											Operator:   OperatorGtEq,
+										},
+										Children: nil,
+									},
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierBaselineDate,
+											Value:      "2000-12-31",
+											Operator:   OperatorLtEq,
+										},
+										Children: nil,
+									},
+								},
+							},
+							{
+								Keyword:  KeywordNone,
+								Children: nil,
+								Term: &SearchTerm{
+									Identifier: IdentifierName,
+									Value:      "CSS Grid",
+									Operator:   OperatorEq,
+								},
+							},
+						},
 					},
 				},
 			},
@@ -357,26 +528,28 @@ func TestParseQuery(t *testing.T) {
 		{
 			InputQuery: "-available_on:chrome OR baseline_status:widely",
 			ExpectedTree: &SearchNode{
-				Operator: OperatorRoot,
-				Term:     nil,
+				Keyword: KeywordRoot,
+				Term:    nil,
 				Children: []*SearchNode{
 					{
-						Operator: OperatorOR,
-						Term:     nil,
+						Keyword: KeywordOR,
+						Term:    nil,
 						Children: []*SearchNode{
 							{
-								Operator: OperatorNegation,
+								Keyword: KeywordNone,
 								Term: &SearchTerm{
 									Identifier: IdentifierAvailableOn,
 									Value:      "chrome",
+									Operator:   OperatorNeq,
 								},
 								Children: nil,
 							},
 							{
-								Operator: OperatorNone,
+								Keyword: KeywordNone,
 								Term: &SearchTerm{
 									Identifier: IdentifierBaselineStatus,
 									Value:      "widely",
+									Operator:   OperatorEq,
 								},
 								Children: nil,
 							},
@@ -409,14 +582,19 @@ func (node *SearchNode) PrettyPrint() string {
 }
 
 func printNode(builder *strings.Builder, node *SearchNode, indent string) {
+	if node == nil {
+		builder.WriteString("NIL NODE")
+
+		return
+	}
 	operatorStr := ""
-	if node.Operator != OperatorNone {
-		operatorStr = fmt.Sprintf(" (%s)", node.Operator)
+	if node.Keyword != KeywordNone {
+		operatorStr = fmt.Sprintf(" (%s)", node.Keyword)
 	}
 
 	var termStr string
 	if node.Term != nil {
-		termStr = fmt.Sprintf("%s:%s", node.Term.Identifier, node.Term.Value)
+		termStr = fmt.Sprintf("%s:%s (%s)", node.Term.Identifier, node.Term.Value, node.Term.Operator)
 	}
 
 	builder.WriteString(indent + termStr + operatorStr + "\n")

--- a/lib/gcpspanner/searchtypes/searchtypes.go
+++ b/lib/gcpspanner/searchtypes/searchtypes.go
@@ -14,28 +14,69 @@
 
 package searchtypes
 
+type SearchKeyword string
+
+const (
+	KeywordAND  SearchKeyword = "AND"
+	KeywordOR   SearchKeyword = "OR"
+	KeywordRoot SearchKeyword = "ROOT"
+	// Placeholder for nil.
+	KeywordNone SearchKeyword = "NONE"
+)
+
+func (k *SearchKeyword) Invert() {
+	switch *k {
+	case KeywordAND:
+		*k = KeywordOR
+	case KeywordOR:
+		*k = KeywordAND
+	case KeywordRoot, KeywordNone:
+		// Do nothing
+		return
+	}
+}
+
 type SearchOperator string
 
 const (
-	OperatorNone     SearchOperator = "NONE"
-	OperatorAND      SearchOperator = "AND"
-	OperatorOR       SearchOperator = "OR"
-	OperatorNegation SearchOperator = "NEGATION"
-	OperatorRoot     SearchOperator = "ROOT"
+	OperatorGtEq SearchOperator = "GT_EQ"
+	OperatorGt   SearchOperator = "GT"
+	OperatorLtEq SearchOperator = "LT_EQ"
+	OperatorLt   SearchOperator = "LT"
+	OperatorEq   SearchOperator = "EQ"
+	OperatorNeq  SearchOperator = "NEQ"
 )
 
+func (o *SearchOperator) Invert() {
+	switch *o {
+	case OperatorEq:
+		*o = OperatorNeq
+	case OperatorGt:
+		*o = OperatorLtEq
+	case OperatorGtEq:
+		*o = OperatorLt
+	case OperatorLt:
+		*o = OperatorGtEq
+	case OperatorLtEq:
+		*o = OperatorGt
+	case OperatorNeq:
+		*o = OperatorEq
+	}
+}
+
 type SearchNode struct {
-	Operator SearchOperator
+	Keyword  SearchKeyword
 	Term     *SearchTerm
 	Children []*SearchNode
 }
 
-func (n SearchNode) IsOperator() bool {
-	return n.Operator == OperatorAND || n.Operator == OperatorOR
+func (n SearchNode) IsKeyword() bool {
+	return n.Keyword == KeywordAND || n.Keyword == KeywordOR
 }
 
 type SearchTerm struct {
 	Identifier SearchIdentifier
+	Operator   SearchOperator
 	Value      string
 }
 
@@ -43,6 +84,7 @@ type SearchIdentifier string
 
 const (
 	IdentifierAvailableOn    SearchIdentifier = "available_on"
+	IdentifierBaselineDate   SearchIdentifier = "baseline_date"
 	IdentifierBaselineStatus SearchIdentifier = "baseline_status"
 	IdentifierName           SearchIdentifier = "name"
 )

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -580,7 +580,7 @@ func TestFeaturesSearch(t *testing.T) {
 				expectedPageToken: nonNilInputPageToken,
 				expectedPageSize:  100,
 				expectedNode: &searchtypes.SearchNode{
-					Operator: searchtypes.OperatorRoot,
+					Keyword:  searchtypes.KeywordRoot,
 					Term:     nil,
 					Children: nil,
 				},
@@ -659,7 +659,7 @@ func TestFeaturesSearch(t *testing.T) {
 			inputPageToken: nonNilInputPageToken,
 			inputPageSize:  100,
 			searchNode: &searchtypes.SearchNode{
-				Operator: searchtypes.OperatorRoot,
+				Keyword:  searchtypes.KeywordRoot,
 				Term:     nil,
 				Children: nil,
 			},


### PR DESCRIPTION
This PR adds support for `baseline_date`. Currently, this only supports the discussed range operator `..`. The range is inclusive on both the start and end date to mimic what GitHub does for search as discussed too.

This term needed support for the `>=` and `<=` on the backend. So these operators were added.

Other changes:

During the implementation of this, I saw that I needed to have split up AND & OR from the new operators. AND & OR (and ROOT and NONE) are now called keywords.

As a result of adding the `>=`, `<=` operators, I also added `=`, `!=`, `>`, and `<`.

These operators impact the term and a field called Operator was introduced to the SearchTerm object.

The `=` is the default operator that was used for the existing terms so existing code was refactored to explicitly use the "-" operator

It became hard to handle negation with these new operators with the existing code. The visitor code calls Invert() on the Keyword and Operators to negate them. The feature search tests proved that this yielded the same expected results.

