### PR TITLE
Remove test-align:left because every cell has an icon now.

### DIFF
--- a/frontend/src/static/js/components/webstatus-overview-table.ts
+++ b/frontend/src/static/js/components/webstatus-overview-table.ts
@@ -69,9 +69,6 @@ export class WebstatusOverviewTable extends LitElement {
           width: 6ex;
           text-align: right;
         }
-        .browser-impl-unavailable .percent {
-          text-align: left;
-        }
 
         td.message {
           height: 8em;


### PR DESCRIPTION
I believe this difference in alignment was a way to compensate for some cells not having icons, but now that they all have icons, they should all be aligned the same way.