### PR TITLE
Expose browser implementation date from backend

### DIFF
--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -53,6 +53,7 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 					BrowserImplementations: &map[string]backend.BrowserImplementation{
 						"chrome": {
 							Status: valuePtr(backend.Available),
+							Date:   &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
 						},
 					},
 					FeatureId: "feature1",
@@ -77,6 +78,7 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 				BrowserImplementations: &map[string]backend.BrowserImplementation{
 					"chrome": {
 						Status: valuePtr(backend.Available),
+						Date:   &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				FeatureId: "feature1",
@@ -111,6 +113,7 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 					BrowserImplementations: &map[string]backend.BrowserImplementation{
 						"chrome": {
 							Status: valuePtr(backend.Available),
+							Date:   &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
 						},
 					},
 					FeatureId: "feature1",
@@ -135,6 +138,7 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 				BrowserImplementations: &map[string]backend.BrowserImplementation{
 					"chrome": {
 						Status: valuePtr(backend.Available),
+						Date:   &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
 					},
 				},
 				FeatureId: "feature1",

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -68,6 +68,7 @@ func TestGetV1Features(t *testing.T) {
 							BrowserImplementations: &map[string]backend.BrowserImplementation{
 								"browser1": {
 									Status: valuePtr(backend.Available),
+									Date:   nil,
 								},
 							},
 						},
@@ -96,6 +97,7 @@ func TestGetV1Features(t *testing.T) {
 						BrowserImplementations: &map[string]backend.BrowserImplementation{
 							"browser1": {
 								Status: valuePtr(backend.Available),
+								Date:   nil,
 							},
 						},
 					},
@@ -177,6 +179,8 @@ func TestGetV1Features(t *testing.T) {
 							BrowserImplementations: &map[string]backend.BrowserImplementation{
 								"chrome": {
 									Status: valuePtr(backend.Available),
+									Date: &openapi_types.Date{
+										Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
 								},
 							},
 						},
@@ -205,6 +209,8 @@ func TestGetV1Features(t *testing.T) {
 						BrowserImplementations: &map[string]backend.BrowserImplementation{
 							"chrome": {
 								Status: valuePtr(backend.Available),
+								Date: &openapi_types.Date{
+									Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
 							},
 						},
 					},

--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -399,27 +399,31 @@ COALESCE(
 	(
 		SELECT ARRAY_AGG(
 			STRUCT(
-				BrowserName,
+				bfa.BrowserName AS BrowserName,
 				COALESCE(
 					(
 						SELECT 'available'
-						FROM BrowserFeatureAvailabilities bfa
+						FROM BrowserFeatureAvailabilities bfa1
 						WHERE bfa.WebFeatureID = wf.ID
-							AND BrowserName = bfa.BrowserName
+							AND bfa1.BrowserName = bfa.BrowserName
 						LIMIT 1
 					),
 					'unavailable' -- Default if no match
-				) AS ImplementationStatus
+				) AS ImplementationStatus,
+				COALESCE(br.ReleaseDate, CAST(NULL AS TIMESTAMP)) AS ImplementationDate
 			)
 		)
 		FROM BrowserFeatureAvailabilities bfa
+		LEFT JOIN BrowserReleases br
+			ON bfa.BrowserName = br.BrowserName AND bfa.BrowserVersion = br.BrowserVersion
 		WHERE bfa.WebFeatureID = wf.ID
 	),
 	(
 		SELECT ARRAY(
 	   		SELECT AS STRUCT
 				'' BrowserName,
-				'unavailable' AS ImplementationStatus
+				'unavailable' AS ImplementationStatus,
+				CAST(NULL AS TIMESTAMP) AS ImplementationDate
 		)
 	)
 ) AS ImplementationStatuses

--- a/lib/gcpspanner/feature_search.go
+++ b/lib/gcpspanner/feature_search.go
@@ -53,6 +53,7 @@ const (
 type ImplementationStatus struct {
 	BrowserName          string                      `spanner:"BrowserName"`
 	ImplementationStatus BrowserImplementationStatus `spanner:"ImplementationStatus"`
+	ImplementationDate   *time.Time                  `spanner:"ImplementationDate"`
 }
 
 // FeatureResultMetric contains metric information for a feature result query.
@@ -259,5 +260,5 @@ func findImplementationStatusDefaultPlaceHolder(in *ImplementationStatus) bool {
 		return false
 	}
 
-	return in.BrowserName == "" && in.ImplementationStatus == Unavailable
+	return in.BrowserName == "" && in.ImplementationStatus == Unavailable && in.ImplementationDate == nil
 }

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -513,10 +513,12 @@ func getFeatureSearchTestFeature(testFeatureID FeatureSearchTestFeatureID) Featu
 				{
 					BrowserName:          "barBrowser",
 					ImplementationStatus: Available,
+					ImplementationDate:   valuePtr(time.Date(2000, time.February, 2, 0, 0, 0, 0, time.UTC)),
 				},
 				{
 					BrowserName:          "fooBrowser",
 					ImplementationStatus: Available,
+					ImplementationDate:   valuePtr(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)),
 				},
 			},
 		}
@@ -551,6 +553,7 @@ func getFeatureSearchTestFeature(testFeatureID FeatureSearchTestFeatureID) Featu
 				{
 					BrowserName:          "barBrowser",
 					ImplementationStatus: Available,
+					ImplementationDate:   valuePtr(time.Date(2000, time.March, 2, 0, 0, 0, 0, time.UTC)),
 				},
 			},
 		}
@@ -572,6 +575,7 @@ func getFeatureSearchTestFeature(testFeatureID FeatureSearchTestFeatureID) Featu
 				{
 					BrowserName:          "fooBrowser",
 					ImplementationStatus: Available,
+					ImplementationDate:   valuePtr(time.Date(2000, time.February, 1, 0, 0, 0, 0, time.UTC)),
 				},
 			},
 		}
@@ -1567,24 +1571,25 @@ func AreFeatureResultsSlicesEqual(a, b []FeatureResult) bool {
 }
 
 func AreFeatureResultsEqual(a, b FeatureResult) bool {
-	if a.FeatureKey != b.FeatureKey ||
-		a.Name != b.Name ||
-		!reflect.DeepEqual(a.Status, b.Status) ||
-		!reflect.DeepEqual(a.LowDate, b.LowDate) ||
-		!reflect.DeepEqual(a.HighDate, b.HighDate) ||
-		!AreMetricsEqual(a.StableMetrics, b.StableMetrics) ||
-		!AreMetricsEqual(a.ExperimentalMetrics, b.ExperimentalMetrics) ||
-		!AreImplementationStatusesEqual(a.ImplementationStatuses, b.ImplementationStatuses) {
-		return false
-	}
-
-	return true
+	return a.FeatureKey == b.FeatureKey &&
+		a.Name == b.Name &&
+		reflect.DeepEqual(a.Status, b.Status) &&
+		reflect.DeepEqual(a.LowDate, b.LowDate) &&
+		reflect.DeepEqual(a.HighDate, b.HighDate) &&
+		AreMetricsEqual(a.StableMetrics, b.StableMetrics) &&
+		AreMetricsEqual(a.ExperimentalMetrics, b.ExperimentalMetrics) &&
+		AreImplementationStatusesEqual(a.ImplementationStatuses, b.ImplementationStatuses)
 }
 
 func AreImplementationStatusesEqual(a, b []*ImplementationStatus) bool {
 	return slices.EqualFunc[[]*ImplementationStatus](a, b, func(a, b *ImplementationStatus) bool {
 		return a.BrowserName == b.BrowserName &&
-			(a.ImplementationStatus == b.ImplementationStatus)
+			(a.ImplementationStatus == b.ImplementationStatus) &&
+			((a.ImplementationDate == nil &&
+				b.ImplementationDate == nil) ||
+				(a.ImplementationDate != nil &&
+					b.ImplementationDate != nil &&
+					(*a.ImplementationDate).Equal(*b.ImplementationDate)))
 	})
 }
 
@@ -1641,6 +1646,7 @@ func PrettyPrintImplementationStatus(status *ImplementationStatus) string {
 	}
 	fmt.Fprintf(&builder, "\t\tBrowserName: %s\n", status.BrowserName)
 	fmt.Fprintf(&builder, "\t\tStatus: %s\n", status.ImplementationStatus)
+	fmt.Fprintf(&builder, "\t\tStatus: %s\n", status.ImplementationDate)
 
 	return builder.String()
 }

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -337,8 +337,13 @@ func (s *Backend) convertFeatureResult(featureResult *gcpspanner.FeatureResult) 
 		implementationMap := make(map[string]backend.BrowserImplementation, len(featureResult.ImplementationStatuses))
 		for _, status := range featureResult.ImplementationStatuses {
 			backendStatus := convertImplementationStatusToBackend(status.ImplementationStatus)
+			var date *openapi_types.Date
+			if status.ImplementationDate != nil {
+				date = &openapi_types.Date{Time: *status.ImplementationDate}
+			}
 			implementationMap[status.BrowserName] = backend.BrowserImplementation{
 				Status: &backendStatus,
+				Date:   date,
 			}
 		}
 		ret.BrowserImplementations = &implementationMap

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -618,6 +618,8 @@ func TestFeaturesSearch(t *testing.T) {
 								{
 									BrowserName:          "browser3",
 									ImplementationStatus: gcpspanner.Available,
+									ImplementationDate: valuePtr(
+										time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)),
 								},
 							},
 						},
@@ -651,10 +653,14 @@ func TestFeaturesSearch(t *testing.T) {
 								{
 									BrowserName:          "browser1",
 									ImplementationStatus: gcpspanner.Available,
+									ImplementationDate: valuePtr(
+										time.Date(1998, time.January, 1, 0, 0, 0, 0, time.UTC)),
 								},
 								{
 									BrowserName:          "browser2",
 									ImplementationStatus: gcpspanner.Available,
+									ImplementationDate: valuePtr(
+										time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)),
 								},
 							},
 						},
@@ -704,6 +710,8 @@ func TestFeaturesSearch(t *testing.T) {
 						BrowserImplementations: &map[string]backend.BrowserImplementation{
 							"browser3": {
 								Status: valuePtr(backend.Available),
+								Date: &openapi_types.Date{
+									Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
 							},
 						},
 					},
@@ -742,9 +750,13 @@ func TestFeaturesSearch(t *testing.T) {
 						BrowserImplementations: &map[string]backend.BrowserImplementation{
 							"browser1": {
 								Status: valuePtr(backend.Available),
+								Date: &openapi_types.Date{
+									Time: time.Date(1998, time.January, 1, 0, 0, 0, 0, time.UTC)},
 							},
 							"browser2": {
 								Status: valuePtr(backend.Available),
+								Date: &openapi_types.Date{
+									Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
 							},
 						},
 					},

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -499,6 +499,10 @@ components:
           x-enum-varnames:
             - Unavailable
             - Available
+        date:
+          type: string
+          format: date
+          description: The date on which the feature was implemented in a browser. (RFC 3339, section 5.6, for example, 2017-07-21)
     PageMetadata:
       type: object
       properties:


### PR DESCRIPTION
In order to support the feature detail page, we need to expose the date in which an individual browser implemented the feature.

This change does that.

Openapi has been modified to expose the data too so the frontend can use it.

![image](https://github.com/GoogleChrome/webstatus.dev/assets/7788930/c1595cda-6392-4ca4-86ca-269a166b713d)


