### PR TITLE
Remove the updated date at the top of the overview page.

### DIFF
--- a/frontend/src/static/js/components/webstatus-overview-content.ts
+++ b/frontend/src/static/js/components/webstatus-overview-content.ts
@@ -57,18 +57,8 @@ export class WebstatusOverviewContent extends LitElement {
       return html`Loading features...`;
     }
 
-    const date = new Date().toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-
     return html`
       <span class="stats-summary"> ${this.totalCount} features </span>
-      <span class="stats-summary">
-        <sl-icon library="phosphor" name="clock-clockwise"></sl-icon>
-        Updated ${date}
-      </span>
     `;
   }
 


### PR DESCRIPTION
Since we don't have this data, don't show anything in that area.

Screenshot:
![image](https://github.com/GoogleChrome/webstatus.dev/assets/17365/30fc1175-7efa-42e9-9717-6e03044cd539)
