### PR TITLE
Set CI to trigger on merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@
 name: 'build'
 on: # rebuild any PRs and main branch changes
   pull_request:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
Currently, we require devs to have the latest branch before merging

This ensures that things like screenshots always have the correct golden files. But a lot of changes don't affect the screenshots so it slows down developer time because they have to continually update their branch before it merges.

We can leverage [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) to prevent that. It will create a temporary branch with the latest changes for the devs upon merging their PR. It will ony fail if:
- It can't pull in the latest changes to your branch
- The CI fails with the latest change and your PR

And those are good things to fail on.

So no more updating your branch manually. It will be handled automatically.

I will turn on merge queues after this change is merged. And I will turn off the requirement for updated branches before merging too after this is merged

