### PR TITLE
Add temporary table to handle ignoring features.

### DIFF
--- a/infra/storage/spanner/migrations/000002.sql
+++ b/infra/storage/spanner/migrations/000002.sql
@@ -1,0 +1,21 @@
+-- Copyright 2024 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- ExcludedFeatureKeys contains a list of feature keys that we should exclude
+-- from queries. These feature keys can be current feature keys or future feature keys.
+-- We use the FeatureKey instead of ID from WebFeatures so that admins
+-- can easily add the features into the table in GCP without looking up the UUID.
+CREATE TABLE IF NOT EXISTS ExcludedFeatureKeys (
+    FeatureKey STRING(64) NOT NULL, -- From web features repo.
+) PRIMARY KEY (FeatureKey);

--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -389,6 +389,7 @@ const (
 	commonFSBaseQueryTemplate = `
 FROM WebFeatures wf
 LEFT OUTER JOIN FeatureBaselineStatus fbs ON wf.ID = fbs.WebFeatureID
+LEFT OUTER JOIN ExcludedFeatureKeys efk ON wf.FeatureKey = efk.FeatureKey
 `
 	gcpFSBaseQueryTemplate   = commonFSBaseQueryTemplate
 	localFSBaseQueryTemplate = commonFSBaseQueryTemplate

--- a/lib/gcpspanner/get_feature_query.go
+++ b/lib/gcpspanner/get_feature_query.go
@@ -63,8 +63,9 @@ func (q GetFeatureQueryBuilder) Build(
 		SortByStableBrowserImpl: nil,
 		SortByExpBrowserImpl:    nil,
 	}
+	queryArgs.Filters = defaultFeatureSearchFilters()
 	if filter != nil {
-		queryArgs.Filters = []string{filter.Clause()}
+		queryArgs.Filters = append(queryArgs.Filters, filter.Clause())
 		maps.Copy(filterParams, filter.Params())
 	}
 

--- a/lib/gcpspanner/wpt_run_feature_metric.go
+++ b/lib/gcpspanner/wpt_run_feature_metric.go
@@ -53,9 +53,13 @@ const (
 	FROM WPTRuns r
 	JOIN WPTRunFeatureMetrics wpfm ON r.ID = wpfm.ID
 	LEFT OUTER JOIN WebFeatures wf ON wf.ID = wpfm.WebFeatureID
+	LEFT OUTER JOIN ExcludedFeatureKeys efk ON wf.FeatureKey = efk.FeatureKey
 	WHERE r.BrowserName = @browserName
 {{ if .FeatureKeyFilter }}
 		{{ .FeatureKeyFilter }}
+{{ end }}
+{{ if .ExtraFilter }}
+		{{ .ExtraFilter }}
 {{ end }}
 		AND r.Channel = @channel
 		AND r.TimeStart >= @startAt AND r.TimeStart < @endAt
@@ -81,6 +85,7 @@ type FeatureMetricsTemplateData struct {
 	PassColumn       string
 	PageFilter       string
 	FeatureKeyFilter string
+	ExtraFilter      string
 	IsSingleFeature  bool
 }
 
@@ -330,6 +335,7 @@ func (c *Client) ListMetricsForFeatureIDBrowserAndChannel(
 		PassColumn:       metricsTestPassColumn(metric),
 		PageFilter:       "",
 		FeatureKeyFilter: singleFeatureMetricSubsetRawTemplate,
+		ExtraFilter:      removeExcludedKeyFilterAND,
 		IsSingleFeature:  true,
 	}
 
@@ -416,6 +422,7 @@ func (c *Client) ListMetricsOverTimeWithAggregatedTotals(
 		PassColumn:       metricsTestPassColumn(metric),
 		PageFilter:       "",
 		FeatureKeyFilter: "",
+		ExtraFilter:      removeExcludedKeyFilterAND,
 		IsSingleFeature:  false,
 	}
 


### PR DESCRIPTION
Sometimes features may be consumed and we need to remove them.

This is more so to hide those features until we do more investigation into what is going on.

Why not add a new column to the existing Web Features Table?

- Hopefully we don't need this mechanism long term and we can fix problems before we ingest it. When we are done, just drop this table.

Examples
- Sometimes features that are published are later marked as draft [[1](https://github.com/web-platform-dx/web-features/pull/1014)]
- Or, sometimes, features are deleted altogether [[2](https://github.com/web-platform-dx/web-features/pull/1000)]
