### PR TITLE
Modify query to get the latest metric for each feature

### DIFF
--- a/backend/pkg/httpserver/get_feature.go
+++ b/backend/pkg/httpserver/get_feature.go
@@ -33,6 +33,7 @@ func (s *Server) GetV1FeaturesFeatureId(
 ) (backend.GetV1FeaturesFeatureIdResponseObject, error) {
 	feature, err := s.wptMetricsStorer.GetFeature(ctx, request.FeatureId,
 		getWPTMetricViewOrDefault(request.Params.WptMetricView),
+		defaultBrowsers(),
 	)
 	if err != nil {
 		if errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {

--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -37,9 +37,16 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 	}{
 		{
 			name: "Success Case - no optional params - use defaults",
+			// nolint:dupl // WONTFIX - being explicit for short list of tests.
 			mockConfig: MockGetFeatureByIDConfig{
 				expectedFeatureID:     "feature1",
 				expectedWPTMetricView: backend.SubtestCounts,
+				expectedBrowsers: []backend.BrowserPathParam{
+					backend.Chrome,
+					backend.Edge,
+					backend.Firefox,
+					backend.Safari,
+				},
 				data: &backend.Feature{
 					Baseline: &backend.BaselineInfo{
 						Status: valuePtr(backend.Widely),
@@ -97,9 +104,16 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 		},
 		{
 			name: "Success Case - with optional params",
+			// nolint:dupl // WONTFIX - being explicit for short list of tests.
 			mockConfig: MockGetFeatureByIDConfig{
 				expectedFeatureID:     "feature1",
 				expectedWPTMetricView: backend.TestCounts,
+				expectedBrowsers: []backend.BrowserPathParam{
+					backend.Chrome,
+					backend.Edge,
+					backend.Firefox,
+					backend.Safari,
+				},
 				data: &backend.Feature{
 					Baseline: &backend.BaselineInfo{
 						Status: valuePtr(backend.Widely),
@@ -160,8 +174,14 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 			mockConfig: MockGetFeatureByIDConfig{
 				expectedFeatureID:     "feature1",
 				expectedWPTMetricView: backend.SubtestCounts,
-				data:                  nil,
-				err:                   gcpspanner.ErrQueryReturnedNoResults,
+				expectedBrowsers: []backend.BrowserPathParam{
+					backend.Chrome,
+					backend.Edge,
+					backend.Firefox,
+					backend.Safari,
+				},
+				data: nil,
+				err:  gcpspanner.ErrQueryReturnedNoResults,
 			},
 			expectedCallCount: 1,
 			expectedResponse: backend.GetV1FeaturesFeatureId404JSONResponse{
@@ -181,8 +201,14 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 			mockConfig: MockGetFeatureByIDConfig{
 				expectedFeatureID:     "feature1",
 				expectedWPTMetricView: backend.SubtestCounts,
-				data:                  nil,
-				err:                   errTest,
+				expectedBrowsers: []backend.BrowserPathParam{
+					backend.Chrome,
+					backend.Edge,
+					backend.Firefox,
+					backend.Safari,
+				},
+				data: nil,
+				err:  errTest,
 			},
 			expectedCallCount: 1,
 			expectedResponse: backend.GetV1FeaturesFeatureId500JSONResponse{

--- a/backend/pkg/httpserver/get_features.go
+++ b/backend/pkg/httpserver/get_features.go
@@ -61,6 +61,7 @@ func (s *Server) GetV1Features(
 		node,
 		req.Params.Sort,
 		getWPTMetricViewOrDefault(req.Params.WptMetricView),
+		defaultBrowsers(),
 	)
 
 	if err != nil {

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -44,6 +44,12 @@ func TestGetV1Features(t *testing.T) {
 				expectedSearchNode:    nil,
 				expectedSortBy:        nil,
 				expectedWPTMetricView: backend.SubtestCounts,
+				expectedBrowsers: []backend.BrowserPathParam{
+					backend.Chrome,
+					backend.Edge,
+					backend.Firefox,
+					backend.Safari,
+				},
 				page: &backend.FeaturePage{
 					Metadata: backend.PageMetadataWithTotal{
 						NextPageToken: nil,
@@ -124,6 +130,12 @@ func TestGetV1Features(t *testing.T) {
 				expectedPageToken:     inputPageToken,
 				expectedPageSize:      50,
 				expectedWPTMetricView: backend.TestCounts,
+				expectedBrowsers: []backend.BrowserPathParam{
+					backend.Chrome,
+					backend.Edge,
+					backend.Firefox,
+					backend.Safari,
+				},
 				expectedSearchNode: &searchtypes.SearchNode{
 					Keyword: searchtypes.KeywordRoot,
 					Term:    nil,
@@ -234,10 +246,16 @@ func TestGetV1Features(t *testing.T) {
 		{
 			name: "500 case",
 			mockConfig: MockFeaturesSearchConfig{
-				expectedPageToken:     nil,
-				expectedPageSize:      100,
-				expectedSearchNode:    nil,
-				expectedSortBy:        nil,
+				expectedPageToken:  nil,
+				expectedPageSize:   100,
+				expectedSearchNode: nil,
+				expectedSortBy:     nil,
+				expectedBrowsers: []backend.BrowserPathParam{
+					backend.Chrome,
+					backend.Edge,
+					backend.Firefox,
+					backend.Safari,
+				},
 				expectedWPTMetricView: backend.SubtestCounts,
 				page:                  nil,
 				err:                   errTest,
@@ -266,6 +284,7 @@ func TestGetV1Features(t *testing.T) {
 				expectedSearchNode:    nil,
 				expectedSortBy:        nil,
 				expectedWPTMetricView: backend.SubtestCounts,
+				expectedBrowsers:      nil,
 				page:                  nil,
 				err:                   errTest,
 			},
@@ -293,6 +312,7 @@ func TestGetV1Features(t *testing.T) {
 				expectedSearchNode:    nil,
 				expectedSortBy:        nil,
 				expectedWPTMetricView: backend.SubtestCounts,
+				expectedBrowsers:      nil,
 				page:                  nil,
 				err:                   errTest,
 			},

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -58,11 +58,13 @@ type WPTMetricsStorer interface {
 		searchNode *searchtypes.SearchNode,
 		sortOrder *backend.GetV1FeaturesParamsSort,
 		wptMetricType backend.WPTMetricView,
+		browsers []backend.BrowserPathParam,
 	) (*backend.FeaturePage, error)
 	GetFeature(
 		ctx context.Context,
 		featureID string,
 		wptMetricType backend.WPTMetricView,
+		browsers []backend.BrowserPathParam,
 	) (*backend.Feature, error)
 	ListBrowserFeatureCountMetric(
 		ctx context.Context,
@@ -77,6 +79,15 @@ type WPTMetricsStorer interface {
 type Server struct {
 	metadataStorer   WebFeatureMetadataStorer
 	wptMetricsStorer WPTMetricsStorer
+}
+
+func defaultBrowsers() []backend.BrowserPathParam {
+	return []backend.BrowserPathParam{
+		backend.Chrome,
+		backend.Edge,
+		backend.Firefox,
+		backend.Safari,
+	}
 }
 
 func getPageSizeOrDefault(pageSize *int) int {

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -62,6 +62,7 @@ type MockFeaturesSearchConfig struct {
 	expectedSearchNode    *searchtypes.SearchNode
 	expectedSortBy        *backend.GetV1FeaturesParamsSort
 	expectedWPTMetricView backend.WPTMetricView
+	expectedBrowsers      []backend.BrowserPathParam
 	page                  *backend.FeaturePage
 	err                   error
 }
@@ -69,6 +70,7 @@ type MockFeaturesSearchConfig struct {
 type MockGetFeatureByIDConfig struct {
 	expectedFeatureID     string
 	expectedWPTMetricView backend.WPTMetricView
+	expectedBrowsers      []backend.BrowserPathParam
 	data                  *backend.Feature
 	err                   error
 }
@@ -156,6 +158,7 @@ func (m *MockWPTMetricsStorer) FeaturesSearch(
 	node *searchtypes.SearchNode,
 	sortBy *backend.GetV1FeaturesParamsSort,
 	view backend.WPTMetricView,
+	browsers []backend.BrowserPathParam,
 ) (*backend.FeaturePage, error) {
 	m.callCountFeaturesSearch++
 
@@ -163,9 +166,10 @@ func (m *MockWPTMetricsStorer) FeaturesSearch(
 		pageSize != m.featuresSearchCfg.expectedPageSize ||
 		!reflect.DeepEqual(node, m.featuresSearchCfg.expectedSearchNode) ||
 		!reflect.DeepEqual(sortBy, m.featuresSearchCfg.expectedSortBy) ||
-		view != m.featuresSearchCfg.expectedWPTMetricView {
-		m.t.Errorf("Incorrect arguments. Expected: %v, Got: { %v %d %v %v %v }",
-			m.featuresSearchCfg, pageSize, pageToken, node, sortBy, view)
+		view != m.featuresSearchCfg.expectedWPTMetricView ||
+		!slices.Equal(browsers, m.featuresSearchCfg.expectedBrowsers) {
+		m.t.Errorf("Incorrect arguments. Expected: %v, Got: { %v %d %v %v %v %v }",
+			m.featuresSearchCfg, pageSize, pageToken, node, sortBy, view, browsers)
 	}
 
 	return m.featuresSearchCfg.page, m.featuresSearchCfg.err
@@ -175,13 +179,15 @@ func (m *MockWPTMetricsStorer) GetFeature(
 	_ context.Context,
 	featureID string,
 	view backend.WPTMetricView,
+	browsers []backend.BrowserPathParam,
 ) (*backend.Feature, error) {
 	m.callCountGetFeature++
 
 	if featureID != m.getFeatureByIDConfig.expectedFeatureID ||
-		view != m.getFeatureByIDConfig.expectedWPTMetricView {
-		m.t.Errorf("Incorrect arguments. Expected: %v, Got: { %s %v }",
-			m.getFeatureByIDConfig, featureID, view)
+		view != m.getFeatureByIDConfig.expectedWPTMetricView ||
+		!slices.Equal(browsers, m.getFeatureByIDConfig.expectedBrowsers) {
+		m.t.Errorf("Incorrect arguments. Expected: %v, Got: { %s %v %v }",
+			m.getFeatureByIDConfig, featureID, view, browsers)
 	}
 
 	return m.getFeatureByIDConfig.data, m.getFeatureByIDConfig.err

--- a/lib/gcpspanner/feature_search_query.go
+++ b/lib/gcpspanner/feature_search_query.go
@@ -257,6 +257,7 @@ type FeatureSearchQueryBuilder struct {
 	baseQuery     FeatureSearchBaseQuery
 	offsetCursor  *FeatureResultOffsetCursor
 	wptMetricView WPTMetricView
+	browsers      []string
 }
 
 func (q FeatureSearchQueryBuilder) CountQueryBuild(
@@ -280,7 +281,6 @@ func (q FeatureSearchQueryBuilder) CountQueryBuild(
 }
 
 func (q FeatureSearchQueryBuilder) Build(
-	prefilter FeatureSearchPrefilterResult,
 	filter *FeatureSearchCompiledFilter,
 	sort Sortable,
 	pageSize int) spanner.Statement {
@@ -307,7 +307,7 @@ func (q FeatureSearchQueryBuilder) Build(
 		PageFilters: nil,
 		Offset:      0,
 		PageSize:    pageSize,
-		Prefilter:   prefilter,
+		Browsers:    q.browsers,
 		SortClause:  sort.Clause(),
 		// Special Sort Targets.
 		SortByStableBrowserImpl: stableBrowserImplDetails,

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -30,6 +30,13 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+func getDefaultTestBrowserList() []string {
+	return []string{
+		"fooBrowser",
+		"barBrowser",
+	}
+}
+
 func setupRequiredTablesForFeaturesSearch(ctx context.Context,
 	client *Client, t *testing.T) {
 	//nolint: dupl // Okay to duplicate for tests
@@ -1558,6 +1565,7 @@ func assertFeatureSearch(
 		// TODO. When the tests assert both views, remove this and allow the test
 		// to pass this.
 		defaultWPTMetricView(),
+		getDefaultTestBrowserList(),
 	)
 	if err != nil {
 		t.Errorf("unexpected error during search of features %s", err.Error())

--- a/lib/gcpspanner/get_feature.go
+++ b/lib/gcpspanner/get_feature.go
@@ -27,18 +27,17 @@ func (c *Client) GetFeature(
 	ctx context.Context,
 	filter Filterable,
 	wptMetricView WPTMetricView,
+	browsers []string,
 ) (*FeatureResult, error) {
 	txn := c.ReadOnlyTransaction()
 	defer txn.Close()
-	prefilterResults, err := c.featureSearchQuery.Prefilter(ctx, txn)
-	if err != nil {
-		return nil, errors.Join(ErrInternalQueryFailure, err)
-	}
+
 	b := GetFeatureQueryBuilder{
 		baseQuery:     c.featureSearchQuery,
 		wptMetricView: wptMetricView,
+		browsers:      browsers,
 	}
-	stmt := b.Build(prefilterResults, filter)
+	stmt := b.Build(filter)
 
 	it := txn.Query(ctx, stmt)
 	defer it.Stop()

--- a/lib/gcpspanner/get_feature_query.go
+++ b/lib/gcpspanner/get_feature_query.go
@@ -45,10 +45,10 @@ func (f FeatureIDFilter) Params() map[string]interface{} {
 type GetFeatureQueryBuilder struct {
 	baseQuery     FeatureSearchBaseQuery
 	wptMetricView WPTMetricView
+	browsers      []string
 }
 
 func (q GetFeatureQueryBuilder) Build(
-	prefilter FeatureSearchPrefilterResult,
 	filter Filterable) spanner.Statement {
 	filterParams := make(map[string]interface{})
 
@@ -58,7 +58,7 @@ func (q GetFeatureQueryBuilder) Build(
 		PageFilters:             nil,
 		Offset:                  0,
 		PageSize:                1,
-		Prefilter:               prefilter,
+		Browsers:                q.browsers,
 		SortClause:              "",
 		SortByStableBrowserImpl: nil,
 		SortByExpBrowserImpl:    nil,

--- a/lib/gcpspanner/get_feature_test.go
+++ b/lib/gcpspanner/get_feature_test.go
@@ -27,7 +27,8 @@ func TestGetFeature(t *testing.T) {
 	setupRequiredTablesForFeaturesSearch(ctx, client, t)
 
 	// Test for present feature
-	result, err := client.GetFeature(ctx, NewFeatureKeyFilter("feature2"), defaultWPTMetricView())
+	result, err := client.GetFeature(ctx, NewFeatureKeyFilter("feature2"), defaultWPTMetricView(),
+		getDefaultTestBrowserList())
 	if err != nil {
 		t.Errorf("unexpected error. %s", err.Error())
 	}
@@ -54,7 +55,8 @@ func TestGetFeature(t *testing.T) {
 	}
 
 	// Test for non existent feature
-	result, err = client.GetFeature(ctx, NewFeatureKeyFilter("nopefeature2"), defaultWPTMetricView())
+	result, err = client.GetFeature(ctx, NewFeatureKeyFilter("nopefeature2"), defaultWPTMetricView(),
+		getDefaultTestBrowserList())
 	if !errors.Is(err, ErrQueryReturnedNoResults) {
 		t.Errorf("unexpected error. %s", err)
 	}


### PR DESCRIPTION
Previously, the query got the last run for the browser then got all the metrics for that run. But sometimes runs are incomplete runs

As a result, some metrics were missing

Instead, we now get the latest metric for that browser, skipping any incomplete runs.

Fixes #205

Check that issue for more details

