### PR TITLE
Fetch stats on feature detail page in parallel.

### DIFF
--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -326,7 +326,7 @@ export class FeaturePage extends LitElement {
     endDate: Date
   ) {
     if (typeof apiClient !== 'object') return;
-    for (const browser of ALL_BROWSERS) {
+    const fetchPromises = ALL_BROWSERS.map(async browser => {
       const channel = STABLE_CHANNEL;
       const wptRuns = await apiClient.getFeatureStatsByBrowserAndChannel(
         this.featureId,
@@ -335,8 +335,15 @@ export class FeaturePage extends LitElement {
         startDate,
         endDate
       );
+      return {browser, channel, wptRuns};
+    });
+
+    // Wait for all promises to resolve sequentially
+    for (const promise of fetchPromises) {
+      const {browser, channel, wptRuns} = await promise;
       this.featureSupport.set(featureSupportKey(browser, channel), wptRuns);
     }
+
     this.featureSupportChartDataObj = this.createFeatureSupportDataFromMap();
   }
 


### PR DESCRIPTION
This change addresses one of the improvements documented in #207 by fetching the browser-specific stats in parallel.

