### PR TITLE
Center the dashes

### DIFF
--- a/frontend/src/static/js/components/webstatus-overview-cells.ts
+++ b/frontend/src/static/js/components/webstatus-overview-cells.ts
@@ -131,15 +131,19 @@ const BROWSER_IMPL_ICONS: Record<
   available: 'check-circle',
 };
 
+function renderMissingPercentage(): TemplateResult {
+  return html`<span class="missing percent">${MISSING_VALUE}</span>`;
+}
+
 function renderPercentage(score?: number): TemplateResult {
   if (score === undefined) {
-    return MISSING_VALUE;
+    return renderMissingPercentage();
   }
   let percent = Number(score * 100).toFixed(1);
   if (percent === '100.0') {
     percent = '100';
   }
-  return html` <span class="percent">${percent}%</span> `;
+  return html`<span class="percent">${percent}%</span>`;
 }
 
 export const renderBrowserQuality: CellRenderer = (
@@ -152,7 +156,7 @@ export const renderBrowserQuality: CellRenderer = (
   const browserImpl =
     feature.browser_implementations?.[browser!]?.status || 'unavailable';
   if (browserImpl === 'unavailable') {
-    percentage = MISSING_VALUE;
+    percentage = renderMissingPercentage();
   }
   const iconName = BROWSER_IMPL_ICONS[browserImpl];
   return html`

--- a/frontend/src/static/js/components/webstatus-overview-table.ts
+++ b/frontend/src/static/js/components/webstatus-overview-table.ts
@@ -69,6 +69,9 @@ export class WebstatusOverviewTable extends LitElement {
           width: 6ex;
           text-align: right;
         }
+        .missing.percent {
+          text-align: center;
+        }
 
         td.message {
           height: 8em;


### PR DESCRIPTION
Missing value dashes are now centered in the same width of `<span>` that the actual percentages use.