### PR TITLE
Ignore subtests for a feature if there is a crash

### DIFF
--- a/lib/gcpspanner/wpt_run_feature_metric.go
+++ b/lib/gcpspanner/wpt_run_feature_metric.go
@@ -55,6 +55,8 @@ const (
 	LEFT OUTER JOIN WebFeatures wf ON wf.ID = wpfm.WebFeatureID
 	LEFT OUTER JOIN ExcludedFeatureKeys efk ON wf.FeatureKey = efk.FeatureKey
 	WHERE r.BrowserName = @browserName
+		AND wpfm.{{ .TotalColumn }} IS NOT NULL
+		AND wpfm.{{ .PassColumn }} IS NOT NULL
 {{ if .FeatureKeyFilter }}
 		{{ .FeatureKeyFilter }}
 {{ end }}
@@ -247,8 +249,9 @@ func (c *Client) UpsertWPTRunFeatureMetrics(
 				existingMetric.TestPass = cmp.Or[*int64](metric.TestPass, existingMetric.TestPass, nil)
 				existingMetric.TotalTests = cmp.Or[*int64](metric.TotalTests, existingMetric.TotalTests, nil)
 				existingMetric.TestPassRate = getPassRate(existingMetric.TestPass, existingMetric.TotalTests)
-				existingMetric.SubtestPass = cmp.Or[*int64](metric.SubtestPass, existingMetric.SubtestPass, nil)
-				existingMetric.TotalSubtests = cmp.Or[*int64](metric.TotalSubtests, existingMetric.TotalSubtests, nil)
+				// Allow subtest metrics to be reset to nil.
+				existingMetric.SubtestPass = metric.SubtestPass
+				existingMetric.TotalSubtests = metric.TotalSubtests
 				existingMetric.SubtestPassRate = getPassRate(existingMetric.SubtestPass, existingMetric.TotalSubtests)
 				m, err = spanner.InsertOrUpdateStruct(WPTRunFeatureMetricTable, existingMetric)
 				if err != nil {

--- a/workflows/steps/services/wpt_consumer/pkg/workflow/score_webfeature_test.go
+++ b/workflows/steps/services/wpt_consumer/pkg/workflow/score_webfeature_test.go
@@ -75,6 +75,24 @@ func getComplexWebFeaturesData() shared.WebFeaturesData {
 		"malformed-counts-test.html": {
 			"feature5": nil,
 		},
+		"test4.html": {
+			"feature6": nil,
+			"feature7": nil,
+		},
+		"test5-not-passing.html": {
+			"feature6": nil,
+			"feature7": nil,
+		},
+		"test6-crash.html": {
+			"feature6": nil,
+		},
+		"test7.html": {
+			"feature6": nil,
+			"feature7": nil,
+		},
+		"test8-crash.html": {
+			"feature6": nil,
+		},
 	}
 }
 
@@ -104,6 +122,27 @@ func getComplexSummary() ResultsSummaryFileV2 {
 		"passing-but-test-not-mapped-in-webfeatures-test.html": query.SummaryResult{
 			Status: string(WPTStatusPass),
 			Counts: []int{10, 10},
+		},
+		// Skippable feature due to one crash
+		"test4.html": query.SummaryResult{
+			Status: string(WPTStatusPass),
+			Counts: []int{1, 1},
+		},
+		"test5-not-passing.html": query.SummaryResult{
+			Status: string(WPTStatusFail),
+			Counts: []int{1, 11},
+		},
+		"test6-crash.html": query.SummaryResult{
+			Status: string(WPTStatusCrash),
+			Counts: []int{100, 100},
+		},
+		"test7.html": query.SummaryResult{
+			Status: string(WPTStatusPass),
+			Counts: []int{100, 100},
+		},
+		"test8-crash.html": query.SummaryResult{
+			Status: string(WPTStatusCrash),
+			Counts: []int{100, 100},
 		},
 	}
 }
@@ -162,6 +201,18 @@ func TestScore(t *testing.T) {
 					TestPass:      valuePtr[int64](1),
 					TotalSubtests: valuePtr[int64](100),
 					SubtestPass:   valuePtr[int64](100),
+				},
+				"feature6": {
+					TotalTests:    valuePtr[int64](5),
+					TestPass:      valuePtr[int64](4),
+					TotalSubtests: nil,
+					SubtestPass:   nil,
+				},
+				"feature7": {
+					TotalTests:    valuePtr[int64](3),
+					TestPass:      valuePtr[int64](2),
+					TotalSubtests: valuePtr[int64](112),
+					SubtestPass:   valuePtr[int64](102),
 				},
 			},
 		},


### PR DESCRIPTION
In WPT, if a test crashes, it does not record the correct number of subtests (it does for tests though).

Instead of recording the wrong number for subtests from WPT, ignore that feature's subtests count

For the timeseries data that is returned, ignore those data points.

For the feature search which gets the latest, it will get the latest data as-is (so it could be null)
- This prevents the search from having to go back N runs for a given feature to find a non null metric.
- Logic: if metric for browser is null but another browser has a metric print the following message: `This feature's metric for the browser is unavailable. This could be due to a crash. Refer to wpt.fyi for more details.` 

This should fix the jaggedness of the total line since we are ignoring the crash tests.

Not included in this PR:
- Any frontend changes to discuss why the metric is missing.

