### PR TITLE
Consume the spec information from web features

### DIFF
--- a/infra/storage/spanner/migrations/000003.sql
+++ b/infra/storage/spanner/migrations/000003.sql
@@ -1,0 +1,20 @@
+-- Copyright 2024 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- FeatureSpecs contains spec information for a web feature.
+CREATE TABLE IF NOT EXISTS FeatureSpecs (
+    WebFeatureID STRING(36) NOT NULL,
+    Links ARRAY<STRING(128)>,
+    FOREIGN KEY (WebFeatureID) REFERENCES WebFeatures(ID),
+) PRIMARY KEY (WebFeatureID);

--- a/lib/gcpspanner/feature_specs.go
+++ b/lib/gcpspanner/feature_specs.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/grpc/codes"
+)
+
+const featureSpecsTable = "FeatureSpecs"
+
+// SpannerFeatureSpec is a wrapper for the feature spec
+// information for a feature stored in spanner.
+type SpannerFeatureSpec struct {
+	WebFeatureID string
+	FeatureSpec
+}
+
+// FeatureSpec contains availability information for a particular
+// feature in a browser.
+type FeatureSpec struct {
+	Links []string
+}
+
+// InsertFeatureSpec will insert the given feature spec information.
+// If the spec info, does not exist, it will insert a new spec info.
+// If the spec info exists, it currently overwrites the data.
+func (c *Client) UpsertFeatureSpec(
+	ctx context.Context,
+	webFeatureID string,
+	input FeatureSpec) error {
+	id, err := c.GetIDFromFeatureKey(ctx, NewFeatureKeyFilter(webFeatureID))
+	if err != nil {
+		return err
+	}
+	if id == nil {
+		return ErrInternalQueryFailure
+	}
+	_, err = c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		_, err := txn.ReadRow(
+			ctx,
+			featureSpecsTable,
+			spanner.Key{*id},
+			[]string{
+				"Links",
+			})
+		if err != nil {
+			// Received an error other than not found. Return now.
+			if spanner.ErrCode(err) != codes.NotFound {
+				return errors.Join(ErrInternalQueryFailure, err)
+			}
+		}
+		featureSpec := SpannerFeatureSpec{
+			WebFeatureID: *id,
+			FeatureSpec:  input,
+		}
+		m, err := spanner.InsertOrUpdateStruct(featureSpecsTable, featureSpec)
+		if err != nil {
+			return errors.Join(ErrInternalQueryFailure, err)
+		}
+		err = txn.BufferWrite([]*spanner.Mutation{m})
+		if err != nil {
+			return errors.Join(ErrInternalQueryFailure, err)
+		}
+
+		return nil
+
+	})
+	if err != nil {
+		return errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	return nil
+}

--- a/lib/gcpspanner/feature_specs_test.go
+++ b/lib/gcpspanner/feature_specs_test.go
@@ -1,0 +1,155 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func getSampleFeatureSpecs() []struct {
+	featureKey string
+	spec       FeatureSpec
+} {
+	return []struct {
+		featureKey string
+		spec       FeatureSpec
+	}{
+		{
+			featureKey: "feature1",
+			spec: FeatureSpec{
+				Links: nil,
+			},
+		},
+		{
+			featureKey: "feature2",
+			spec: FeatureSpec{
+				Links: []string{
+					"http://example1.com",
+					"http://example2.com",
+				},
+			},
+		},
+	}
+}
+
+func setupRequiredTablesForFeatureSpecs(ctx context.Context,
+	client *Client, t *testing.T) {
+	sampleFeatures := getSampleFeatures()
+	for _, feature := range sampleFeatures {
+		err := client.UpsertWebFeature(ctx, feature)
+		if err != nil {
+			t.Errorf("unexpected error during insert of features. %s", err.Error())
+		}
+	}
+}
+
+// Helper method to get all the statuses in a stable order.
+func (c *Client) ReadAllFeatureSpecs(ctx context.Context, _ *testing.T) ([]FeatureSpec, error) {
+	stmt := spanner.NewStatement("SELECT * FROM FeatureSpecs ORDER BY ARRAY_LENGTH(Links) ASC")
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []FeatureSpec
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var spec SpannerFeatureSpec
+		if err := row.ToStruct(&spec); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+
+		ret = append(ret, spec.FeatureSpec)
+	}
+
+	return ret, nil
+}
+
+func specEquality(left, right FeatureSpec) bool {
+	return slices.Equal(left.Links, right.Links)
+}
+
+func TestUpsertFeatureSpec(t *testing.T) {
+	client := getTestDatabase(t)
+	ctx := context.Background()
+	setupRequiredTablesForFeatureSpecs(ctx, client, t)
+	sampleSpecs := getSampleFeatureSpecs()
+
+	expectedSpecs := make([]FeatureSpec, 0, len(sampleSpecs))
+	for _, spec := range sampleSpecs {
+		expectedSpecs = append(expectedSpecs, spec.spec)
+		err := client.UpsertFeatureSpec(ctx, spec.featureKey, spec.spec)
+		if err != nil {
+			t.Errorf("unexpected error during insert. %s", err.Error())
+		}
+	}
+
+	specs, err := client.ReadAllFeatureSpecs(ctx, t)
+	if err != nil {
+		t.Errorf("unexpected error during read all. %s", err.Error())
+	}
+	if !slices.EqualFunc[[]FeatureSpec](
+		expectedSpecs,
+		specs, specEquality) {
+		t.Errorf("unequal status.\nexpected %+v\nreceived %+v", expectedSpecs, specs)
+	}
+
+	err = client.UpsertFeatureSpec(ctx, "feature1", FeatureSpec{
+		Links: []string{
+			"https://sample1.com",
+			"https://sample2.com",
+			"https://sample3.com",
+		},
+	})
+	if err != nil {
+		t.Errorf("unexpected error during update. %s", err.Error())
+	}
+
+	expectedPageAfterUpdate := []FeatureSpec{
+		{
+			Links: []string{
+				"http://example1.com",
+				"http://example2.com",
+			},
+		},
+		{
+			Links: []string{
+				"https://sample1.com",
+				"https://sample2.com",
+				"https://sample3.com",
+			},
+		},
+	}
+
+	specs, err = client.ReadAllFeatureSpecs(ctx, t)
+	if err != nil {
+		t.Errorf("unexpected error during read all after update. %s", err.Error())
+	}
+	if !slices.EqualFunc[[]FeatureSpec](
+		expectedPageAfterUpdate,
+		specs, specEquality) {
+		t.Errorf("unequal spec.\nexpected %+v\nreceived %+v", expectedPageAfterUpdate, specs)
+	}
+}


### PR DESCRIPTION
There are certain features that will never have a WPT score. And the UI will need a way to know which ones those are. Currently, the only information we have available is the spec links have a prefix to indicate that those features indeed will not have a WPT score.

This change modifies the pipeline so that we can store and read that information

Future changes include:
- Change to the feature search / get feature queries to return that information.

