### PR TITLE
Return spec info from the backend

### DIFF
--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -306,6 +306,7 @@ const (
 FROM WebFeatures wf
 LEFT OUTER JOIN FeatureBaselineStatus fbs ON wf.ID = fbs.WebFeatureID
 LEFT OUTER JOIN ExcludedFeatureKeys efk ON wf.FeatureKey = efk.FeatureKey
+LEFT OUTER JOIN FeatureSpecs fs ON wf.ID = fs.WebFeatureID
 `
 	gcpFSBaseQueryTemplate   = commonFSBaseQueryTemplate
 	localFSBaseQueryTemplate = commonFSBaseQueryTemplate
@@ -388,6 +389,7 @@ SELECT
 	fbs.Status,
 	fbs.LowDate,
 	fbs.HighDate,
+	fs.Links AS SpecLinks,
 	{{ .StableMetrics }},
 	{{ .ExperimentalMetrics }},
 	{{ .ImplementationStatus }}
@@ -448,6 +450,7 @@ SELECT
 	fbs.Status,
 	fbs.LowDate,
 	fbs.HighDate,
+	fs.Links AS SpecLinks,
 	{{ .StableMetrics }},
 	{{ .ExperimentalMetrics }},
 	{{ .ImplementationStatus }}

--- a/lib/gcpspanner/feature_search.go
+++ b/lib/gcpspanner/feature_search.go
@@ -39,6 +39,7 @@ type SpannerFeatureResult struct {
 	ImplementationStatuses []*ImplementationStatus `spanner:"ImplementationStatuses"`
 	LowDate                *time.Time              `spanner:"LowDate"`
 	HighDate               *time.Time              `spanner:"HighDate"`
+	SpecLinks              []string                `spanner:"SpecLinks"`
 }
 
 // BrowserImplementationStatus is an enumeration of the possible implementation states for a feature in a browser.
@@ -73,6 +74,7 @@ type FeatureResult struct {
 	ImplementationStatuses []*ImplementationStatus `spanner:"ImplementationStatuses"`
 	LowDate                *time.Time              `spanner:"LowDate"`
 	HighDate               *time.Time              `spanner:"HighDate"`
+	SpecLinks              []string                `spanner:"SpecLinks"`
 }
 
 // FeatureResultPage contains the details for the feature search request.
@@ -220,6 +222,10 @@ func (c *Client) getFeatureResult(
 			result.ImplementationStatuses = nil
 		}
 
+		if len(result.SpecLinks) == 0 {
+			result.SpecLinks = nil
+		}
+
 		actualResult := FeatureResult{
 			FeatureKey:             result.FeatureKey,
 			Name:                   result.Name,
@@ -229,6 +235,7 @@ func (c *Client) getFeatureResult(
 			ImplementationStatuses: result.ImplementationStatuses,
 			LowDate:                result.LowDate,
 			HighDate:               result.HighDate,
+			SpecLinks:              result.SpecLinks,
 		}
 		results = append(results, actualResult)
 	}

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -444,6 +444,37 @@ func setupRequiredTablesForFeaturesSearch(ctx context.Context,
 			t.Errorf("unexpected error during insert of metrics. %s", err.Error())
 		}
 	}
+
+	sampleSpecs := []struct {
+		featureKey string
+		spec       FeatureSpec
+	}{
+		{
+			featureKey: "feature1",
+			spec: FeatureSpec{
+				Links: []string{
+					"http://example1.com",
+					"http://example2.com",
+				},
+			},
+		},
+		{
+			featureKey: "feature3",
+			spec: FeatureSpec{
+				Links: []string{
+					"http://example3.com",
+					"http://example4.com",
+				},
+			},
+		},
+	}
+	for _, spec := range sampleSpecs {
+		err := client.UpsertFeatureSpec(
+			ctx, spec.featureKey, spec.spec)
+		if err != nil {
+			t.Errorf("unexpected error during insert of spec. %s", err.Error())
+		}
+	}
 }
 
 func defaultSorting() Sortable {
@@ -539,6 +570,10 @@ func getFeatureSearchTestFeature(testFeatureID FeatureSearchTestFeatureID) Featu
 					ImplementationDate:   valuePtr(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)),
 				},
 			},
+			SpecLinks: []string{
+				"http://example1.com",
+				"http://example2.com",
+			},
 		}
 	case FeatureSearchTestFId2:
 		ret = FeatureResult{
@@ -574,6 +609,7 @@ func getFeatureSearchTestFeature(testFeatureID FeatureSearchTestFeatureID) Featu
 					ImplementationDate:   valuePtr(time.Date(2000, time.March, 2, 0, 0, 0, 0, time.UTC)),
 				},
 			},
+			SpecLinks: nil,
 		}
 	case FeatureSearchTestFId3:
 		ret = FeatureResult{
@@ -596,6 +632,10 @@ func getFeatureSearchTestFeature(testFeatureID FeatureSearchTestFeatureID) Featu
 					ImplementationDate:   valuePtr(time.Date(2000, time.February, 1, 0, 0, 0, 0, time.UTC)),
 				},
 			},
+			SpecLinks: []string{
+				"http://example3.com",
+				"http://example4.com",
+			},
 		}
 	case FeatureSearchTestFId4:
 		ret = FeatureResult{
@@ -607,6 +647,7 @@ func getFeatureSearchTestFeature(testFeatureID FeatureSearchTestFeatureID) Featu
 			StableMetrics:          nil,
 			ExperimentalMetrics:    nil,
 			ImplementationStatuses: nil,
+			SpecLinks:              nil,
 		}
 	}
 
@@ -1597,7 +1638,12 @@ func AreFeatureResultsEqual(a, b FeatureResult) bool {
 		reflect.DeepEqual(a.HighDate, b.HighDate) &&
 		AreMetricsEqual(a.StableMetrics, b.StableMetrics) &&
 		AreMetricsEqual(a.ExperimentalMetrics, b.ExperimentalMetrics) &&
-		AreImplementationStatusesEqual(a.ImplementationStatuses, b.ImplementationStatuses)
+		AreImplementationStatusesEqual(a.ImplementationStatuses, b.ImplementationStatuses) &&
+		AreSpecLinksEqual(a.SpecLinks, b.SpecLinks)
+}
+
+func AreSpecLinksEqual(a, b []string) bool {
+	return slices.Equal(a, b)
 }
 
 func AreImplementationStatusesEqual(a, b []*ImplementationStatus) bool {
@@ -1639,6 +1685,7 @@ func PrettyPrintFeatureResult(result FeatureResult) string {
 	fmt.Fprintf(&builder, "\tStatus: %s\n", PrintNullableField(result.Status))
 	fmt.Fprintf(&builder, "\tLowDate: %s\n", PrintNullableField(result.LowDate))
 	fmt.Fprintf(&builder, "\tHighDate: %s\n", PrintNullableField(result.HighDate))
+	fmt.Fprintf(&builder, "\tSpecLinks: %s\n", result.SpecLinks)
 
 	fmt.Fprintln(&builder, "\tStable Metrics:")
 	for _, metric := range result.StableMetrics {

--- a/lib/gcpspanner/get_feature.go
+++ b/lib/gcpspanner/get_feature.go
@@ -78,6 +78,10 @@ func (c *Client) GetFeature(
 		result.ImplementationStatuses = nil
 	}
 
+	if len(result.SpecLinks) == 0 {
+		result.SpecLinks = nil
+	}
+
 	actualResult := FeatureResult{
 		FeatureKey:             result.FeatureKey,
 		Name:                   result.Name,
@@ -87,6 +91,7 @@ func (c *Client) GetFeature(
 		ImplementationStatuses: result.ImplementationStatuses,
 		LowDate:                result.LowDate,
 		HighDate:               result.HighDate,
+		SpecLinks:              result.SpecLinks,
 	}
 
 	return &actualResult, nil

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -351,6 +351,18 @@ func (s *Backend) convertFeatureResult(featureResult *gcpspanner.FeatureResult) 
 		ret.BrowserImplementations = &implementationMap
 	}
 
+	if len(featureResult.SpecLinks) > 0 {
+		links := make([]backend.SpecLink, 0, len(featureResult.SpecLinks))
+		for idx := range featureResult.SpecLinks {
+			links = append(links, backend.SpecLink{
+				Link: &featureResult.SpecLinks[idx],
+			})
+		}
+		ret.Spec = &backend.FeatureSpecInfo{
+			Links: &links,
+		}
+	}
+
 	return ret
 }
 

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -634,6 +634,7 @@ func TestFeaturesSearch(t *testing.T) {
 										time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)),
 								},
 							},
+							SpecLinks: nil,
 						},
 						{
 							Name:       "feature 2",
@@ -674,6 +675,10 @@ func TestFeaturesSearch(t *testing.T) {
 									ImplementationDate: valuePtr(
 										time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)),
 								},
+							},
+							SpecLinks: []string{
+								"link1",
+								"link2",
 							},
 						},
 					},
@@ -744,8 +749,17 @@ func TestFeaturesSearch(t *testing.T) {
 						},
 						FeatureId: "feature2",
 						Name:      "feature 2",
-						Spec:      nil,
-						Usage:     nil,
+						Spec: &backend.FeatureSpecInfo{
+							Links: &[]backend.SpecLink{
+								{
+									Link: valuePtr("link1"),
+								},
+								{
+									Link: valuePtr("link2"),
+								},
+							},
+						},
+						Usage: nil,
 						Wpt: &backend.FeatureWPTSnapshots{
 							Experimental: &map[string]backend.WPTFeatureData{
 								"browser1": {
@@ -946,6 +960,10 @@ func TestGetFeature(t *testing.T) {
 							ImplementationStatus: gcpspanner.Available,
 						},
 					},
+					SpecLinks: []string{
+						"link1",
+						"link2",
+					},
 				},
 				returnedError: nil,
 			},
@@ -959,8 +977,17 @@ func TestGetFeature(t *testing.T) {
 				},
 				FeatureId: "feature1",
 				Name:      "feature 1",
-				Spec:      nil,
-				Usage:     nil,
+				Spec: &backend.FeatureSpecInfo{
+					Links: &[]backend.SpecLink{
+						{
+							Link: valuePtr("link1"),
+						},
+						{
+							Link: valuePtr("link2"),
+						},
+					},
+				},
+				Usage: nil,
 				Wpt: &backend.FeatureWPTSnapshots{
 					Experimental: &map[string]backend.WPTFeatureData{
 						"browser3": {
@@ -1125,6 +1152,7 @@ func TestConvertFeatureResult(t *testing.T) {
 					},
 				},
 				ImplementationStatuses: nil,
+				SpecLinks:              nil,
 			},
 
 			expectedFeature: &backend.Feature{

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -565,6 +565,18 @@ components:
         high_date:
           type: string
           format: date
+    FeatureSpecInfo:
+      type: object
+      properties:
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/SpecLink'
+    SpecLink:
+      type: object
+      properties:
+        link:
+          type: string
     Feature:
       type: object
       properties:
@@ -577,9 +589,7 @@ components:
             Comes from FeatureData's 'name' field in
             https://github.com/web-platform-dx/web-features/blob/main/schemas/defs.schema.json
         spec:
-          type: array
-          items:
-            type: string
+          $ref: '#/components/schemas/FeatureSpecInfo'
         browser_implementations:
           type: object
           description: >


### PR DESCRIPTION
As mentioned in #215, we need spec info to help determine on the UI if we even expect WPT results for that feature.

This change modifies the base search query used by v1/features and v1/features/<id> to JOIN on the new table.

openapi changes:
- Modified spec section to have a a list of SpecLinks. That way we can add future fields about the link without breaking the contract

Depends on #215 