### PR TITLE
Render informational message for TC39 features

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-overview-cells.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-overview-cells.test.ts
@@ -20,6 +20,7 @@ import {
   ColumnKey,
   parseColumnsSpec,
   DEFAULT_COLUMNS,
+  isJavaScriptFeature,
 } from '../webstatus-overview-cells.js';
 
 describe('parseColumnsSpec', () => {
@@ -31,5 +32,26 @@ describe('parseColumnsSpec', () => {
   it('returns an array when given a column spec', () => {
     const cols = parseColumnsSpec('name, baseline_status ');
     assert.deepEqual(cols, [ColumnKey.Name, ColumnKey.BaselineStatus]);
+  });
+});
+
+describe('isJavaScriptFeature', () => {
+  it('returns true for a JavaScript feature (link prefix match)', () => {
+    const featureSpecInfo = {
+      links: [{link: 'https://tc39.es/proposal-temporal'}],
+    };
+    assert.isTrue(isJavaScriptFeature(featureSpecInfo));
+  });
+
+  it('returns false for a non-JavaScript feature (no link match)', () => {
+    const featureSpecInfo = {
+      links: [{link: 'https://www.w3.org/TR/webgpu/'}],
+    };
+    assert.isFalse(isJavaScriptFeature(featureSpecInfo));
+  });
+
+  it('returns false if links are missing', () => {
+    const featureSpecInfo = {}; // No 'links' property
+    assert.isFalse(isJavaScriptFeature(featureSpecInfo));
   });
 });

--- a/frontend/src/static/js/components/webstatus-overview-cells.ts
+++ b/frontend/src/static/js/components/webstatus-overview-cells.ts
@@ -158,7 +158,7 @@ export const renderBrowserQuality: CellRenderer = (
   if (browserImpl === 'unavailable') {
     percentage = renderMissingPercentage();
   }
-  if (isJavaScriptFeature(feature)) {
+  if (feature.spec && isJavaScriptFeature(feature.spec)) {
     percentage = renderJavaScriptFeatureValue();
   }
   const iconName = BROWSER_IMPL_ICONS[browserImpl];
@@ -308,11 +308,17 @@ export function parseColumnsSpec(colSpec: string): ColumnKey[] {
 // WPT score.
 const JS_FEATURE_LINK_PREFIX = 'https://tc39.es/';
 
-function isJavaScriptFeature(
-  feature: components['schemas']['Feature']
-): boolean {
+// FeatureSpecInfo represents the specification information for a feature,
+// particularly the links that might indicate it's a JavaScript feature.
+interface FeatureSpecInfo {
+  links?: {
+    link?: string;
+  }[]; // Array of objects potentially containing a 'link' property
+}
+
+export function isJavaScriptFeature(featureSpecInfo: FeatureSpecInfo): boolean {
   return (
-    feature.spec?.links?.some(
+    featureSpecInfo?.links?.some(
       linkObj => linkObj.link?.startsWith(JS_FEATURE_LINK_PREFIX)
     ) ?? false
   );
@@ -322,9 +328,6 @@ function renderJavaScriptFeatureValue(): TemplateResult {
   return html` <sl-tooltip
     content="WPT metrics are not applicable to TC39 features."
   >
-    <sl-icon-button
-      name="info-circle"
-      label="TC39 feature"
-    ></sl-icon-button>
+    <sl-icon-button name="info-circle" label="TC39 feature"></sl-icon-button>
   </sl-tooltip>`;
 }


### PR DESCRIPTION
Given TC39 features do not have WPT metrics, show message instead of the default MISSING_VALUE.


![image](https://github.com/GoogleChrome/webstatus.dev/assets/7788930/9aa7fcb2-ce8a-4c88-bbe8-5780ea7ea47d)

