### PR TITLE
Add explorer mode to feature details chart

### DIFF
--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -381,7 +381,7 @@ export class FeaturePage extends LitElement {
         keepInBoundsX: true,
         keepInBoundsY: true,
         zoomDelta: 0.01,
-      }
+      },
     } as google.visualization.LineChartOptions;
 
     this.featureSupportChartOptions = options;


### PR DESCRIPTION
This PR adds the "explorer" mode to the feature details chart, which is the same as available on https://wpt.fyi/.
To use this mode, left-click and drag across a range of the chart, either to the left or right.  The chart will be redrawn after zooming into that date range.  A right-click will reset to the initial date range.