### PR TITLE
Configure backend to use cache middleware

### DIFF
--- a/backend/manifests/pod.yaml
+++ b/backend/manifests/pod.yaml
@@ -40,6 +40,12 @@ spec:
           value: 'datastore:8085'
         - name: CORS_ALLOWED_ORIGIN
           value: 'http://localhost:5555'
+        - name: REDISHOST
+          value: redis
+        - name: REDISPORT
+          value: '6379'
+        - name: CACHE_TTL
+          value: 5m # Short TTL locally
       resources:
         limits:
           cpu: 250m


### PR DESCRIPTION
This change configures the backend server to use the redis cache.

Instead of applying only the CORS middleware, now the cache has been added to the middleware stack.
Inspired by:
https://github.com/web-platform-tests/wpt.fyi/blob/5ad8ebe1fb4475bd3dff73ae0fd22b827414510e/shared/cache.go

