### PR TITLE
Ignore tentative tests for WPT

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {expect, fixture} from '@open-wc/testing';
+import {FeaturePage} from '../webstatus-feature-page.js';
+import '../webstatus-feature-page.js';
+
+describe('webstatus-feature-page', () => {
+  let el: FeaturePage;
+  beforeEach(async () => {
+    el = await fixture<FeaturePage>(
+      '<webstatus-feature-page></webstatus-feature-page>'
+    );
+
+    await el.updateComplete;
+  });
+  it('builds the WPT link correctly', async () => {
+    const link = el.buildWPTLink('declarative-shadow-dom');
+    expect(link).to.eq(
+      'https://wpt.fyi/results?label=master&label=stable&aligned=&q=feature%3Adeclarative-shadow-dom%21is%3Atentative'
+    );
+  });
+});

--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -482,13 +482,19 @@ export class FeaturePage extends LitElement {
     `;
   }
 
+  buildWPTLink(featureId: string): string {
+    const wptLinkURL = new URL('https://wpt.fyi/results');
+    const query = `feature:${featureId}!is:tentative`;
+    wptLinkURL.searchParams.append('label', 'master');
+    wptLinkURL.searchParams.append('label', 'stable');
+    wptLinkURL.searchParams.append('aligned', '');
+    wptLinkURL.searchParams.append('q', query);
+    return wptLinkURL.toString();
+  }
+
   renderNameAndOffsiteLinks(): TemplateResult {
     const featureId = this.feature?.feature_id || this.featureId;
-    const wptLink =
-      'https://wpt.fyi/results' +
-      '?label=master&label=stable&aligned' +
-      '&q=feature%3A' +
-      featureId;
+    const wptLink = this.buildWPTLink(featureId);
     const wptLogo = '/public/img/wpt-logo.svg';
 
     return html`

--- a/workflows/steps/services/wpt_consumer/pkg/workflow/score_webfeature.go
+++ b/workflows/steps/services/wpt_consumer/pkg/workflow/score_webfeature.go
@@ -17,6 +17,8 @@ package workflow
 import (
 	"cmp"
 	"context"
+	"slices"
+	"strings"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/wptconsumertypes"
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -51,6 +53,9 @@ func (s ResultsSummaryFileV2) Score(
 			// Need at least the number of subtests passes and the number of subtests
 			continue
 		}
+		if isTestTentative(test) {
+			continue
+		}
 		s.scoreTest(ctx, test, scoreMap, testToWebFeatures,
 			testSummary.Counts[0], testSummary.Counts[1], testSummary.Status)
 		s.scoreSubtests(
@@ -59,6 +64,15 @@ func (s ResultsSummaryFileV2) Score(
 	}
 
 	return scoreMap
+}
+
+func isTestTentative(test string) bool {
+	// More info: https://web-platform-tests.org/writing-tests/file-names.html
+	return strings.Contains(test, ".tentative") ||
+		// nolint:lll // WONTFIX: comment contains long line for pinned functionality.
+		// The results file uses "/" as the path separator.
+		// Example: https://storage.googleapis.com/wptd/536297144c737f84096d1f448e790de0fb654956/chrome-124.0.6367.91-linux-20.04-ed25fd18da-summary_v2.json.gz
+		slices.Contains(strings.Split(test, "/"), "tentative")
 }
 
 // scoreSubtests calculates the metrics for a test using the "default/subtests" methodology.

--- a/workflows/steps/services/wpt_consumer/pkg/workflow/score_webfeature_test.go
+++ b/workflows/steps/services/wpt_consumer/pkg/workflow/score_webfeature_test.go
@@ -93,6 +93,12 @@ func getComplexWebFeaturesData() shared.WebFeaturesData {
 		"test8-crash.html": {
 			"feature6": nil,
 		},
+		"test9.tentative.html": {
+			"feature1": nil,
+		},
+		"dir/tentative/test10.html": {
+			"feature1": nil,
+		},
 	}
 }
 
@@ -143,6 +149,15 @@ func getComplexSummary() ResultsSummaryFileV2 {
 		"test8-crash.html": query.SummaryResult{
 			Status: string(WPTStatusCrash),
 			Counts: []int{100, 100},
+		},
+		// Tentative tests should not count
+		"test9.tentative.html": query.SummaryResult{
+			Status: string(WPTStatusPass),
+			Counts: []int{222, 222},
+		},
+		"dir/tentative/test10.html": query.SummaryResult{
+			Status: string(WPTStatusPass),
+			Counts: []int{111, 111},
 		},
 	}
 }


### PR DESCRIPTION
Counting tentative tests leads to bad counts.

This change:
- Modifies the ingestion workflow to skip over tentative tests.
- Modifies the link out to include the !is:tentative query parameter

