### PR TITLE
Modify terraform to deploy redis.

### DIFF
--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -42,3 +42,5 @@ frontend_domains_for_gcp_managed_certificates = ["webstatus.dev", "www.webstatus
 ssl_certificates                              = []
 
 spanner_region_override = "nam-eur-asia1"
+
+cache_duration = "5m"

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -42,3 +42,5 @@ frontend_domains_for_gcp_managed_certificates = []
 
 # Temporary for UB.
 ssl_certificates = ["ub-self-sign"]
+
+cache_duration = "5m"

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -75,14 +75,26 @@ resource "google_cloud_run_v2_service" "service" {
         name  = "CORS_ALLOWED_ORIGIN"
         value = "https://website-webstatus-dev.corp.goog"
       }
+      env {
+        name  = "REDISHOST"
+        value = var.redis_env_vars[each.key].host
+      }
+      env {
+        name  = "REDISPORT"
+        value = var.redis_env_vars[each.key].port
+      }
+      env {
+        name  = "CACHE_TTL"
+        value = var.cache_duration
+      }
     }
-    # vpc_access {
-    #   network_interfaces {
-    #     network    = "projects/${data.google_project.host_project.name}/global/networks/${var.vpc_name}"
-    #     subnetwork = "projects/${data.google_project.host_project.name}/regions/${each.key}/subnetworks/${each.value.public}"
-    #   }
-    #   egress = "ALL_TRAFFIC"
-    # }
+    vpc_access {
+      network_interfaces {
+        network    = "projects/${data.google_project.host_project.name}/global/networks/${var.vpc_name}"
+        subnetwork = "projects/${data.google_project.host_project.name}/regions/${each.key}/subnetworks/${each.value.public}"
+      }
+      egress = "PRIVATE_RANGES_ONLY"
+    }
     service_account = google_service_account.backend.email
   }
   depends_on = [

--- a/infra/backend/variables.tf
+++ b/infra/backend/variables.tf
@@ -66,3 +66,15 @@ variable "projects" {
     public   = string
   })
 }
+
+variable "redis_env_vars" {
+  type = map(object({
+    host = string
+    port = number
+  }))
+  description = "Map of Redis host and port per region"
+}
+
+variable "cache_duration" {
+  type = string
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -44,12 +44,14 @@ module "storage" {
   env_id              = var.env_id
   deletion_protection = false
   # `gcloud spanner instance-configs list --project=<PROJECT>` returns the available configs
-  spanner_region_id        = local.spanner_repository_region
-  datastore_region_id      = var.datastore_region_id
-  spanner_processing_units = var.spanner_processing_units
-  docker_repository_region = local.docker_repository_region
-  projects                 = var.projects
-  depends_on               = [module.services]
+  spanner_region_id         = local.spanner_repository_region
+  datastore_region_id       = var.datastore_region_id
+  spanner_processing_units  = var.spanner_processing_units
+  docker_repository_region  = local.docker_repository_region
+  projects                  = var.projects
+  depends_on                = [module.services]
+  vpc_id                    = module.network.vpc_id
+  region_to_subnet_info_map = module.network.region_to_subnet_info_map
 }
 
 module "ingestion" {
@@ -86,6 +88,8 @@ module "backend" {
   ssl_certificates                     = var.ssl_certificates
   domains_for_gcp_managed_certificates = var.backend_domains_for_gcp_managed_certificates
   projects                             = var.projects
+  cache_duration                       = var.cache_duration
+  redis_env_vars                       = module.storage.redis_env_vars
 }
 
 module "frontend" {

--- a/infra/network/outputs.tf
+++ b/infra/network/outputs.tf
@@ -25,3 +25,6 @@ output "region_to_subnet_info_map" {
 output "vpc_name" {
   value = google_compute_network.shared_vpc.name
 }
+output "vpc_id" {
+  value = google_compute_network.shared_vpc.id
+}

--- a/infra/services/internal_project_services.tf
+++ b/infra/services/internal_project_services.tf
@@ -67,3 +67,27 @@ resource "google_project_service" "internal_scheduler" {
   disable_dependent_services = true
   disable_on_destroy         = false
 }
+
+resource "google_project_service" "internal_redis" {
+  provider = google.internal_project
+  service  = "redis.googleapis.com"
+
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "internal_private_service_access" {
+  provider = google.internal_project
+  service  = "servicenetworking.googleapis.com"
+
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}
+
+resource "google_project_service" "host_private_service_access" {
+  provider = google
+  service  = "servicenetworking.googleapis.com"
+
+  disable_dependent_services = true
+  disable_on_destroy         = false
+}

--- a/infra/storage/outputs.tf
+++ b/infra/storage/outputs.tf
@@ -42,3 +42,13 @@ output "buckets" {
     repo_download_bucket = google_storage_bucket.repo_storage_bucket.name
   }
 }
+
+output "redis_env_vars" {
+  value = {
+    for region, _ in var.region_to_subnet_info_map :
+    region => {
+      host = google_redis_instance.redis_instances[region].host
+      port = google_redis_instance.redis_instances[region].port
+    }
+  }
+}

--- a/infra/storage/redis.tf
+++ b/infra/storage/redis.tf
@@ -12,3 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+resource "google_redis_instance" "redis_instances" {
+  project  = var.projects.internal
+  for_each = var.region_to_subnet_info_map
+
+  name               = "${var.env_id}-redis-${each.key}"
+  region             = each.key
+  memory_size_gb     = 1
+  authorized_network = var.vpc_id
+  connect_mode       = "PRIVATE_SERVICE_ACCESS"
+  redis_version      = "REDIS_7_2"
+}

--- a/infra/storage/variables.tf
+++ b/infra/storage/variables.tf
@@ -53,3 +53,14 @@ variable "projects" {
     public   = string
   })
 }
+
+variable "region_to_subnet_info_map" {
+  type = map(object({
+    internal = string
+    public   = string
+  }))
+}
+
+variable "vpc_id" {
+  type = string
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -112,3 +112,8 @@ variable "backend_domains_for_gcp_managed_certificates" {
   type        = list(string)
   description = "List of domains for the backend that GCP should manage certs for."
 }
+
+variable "cache_duration" {
+  type        = string
+  description = "TTL for entries that are cached"
+}


### PR DESCRIPTION
This change modifies terraform to deploy redis.
Given redis is a regional service and we are multi-region, we leverage the existing region-to-subnet map to know which regions to create redis in.

In the meantime, we can have a quick TTL for redis.

An issue to follow up on this in #225 has been filed.

We can probably increase the TTL for prod soon. But while data is still changing before launch, we can keep it quick. Open to suggestions for the initial TTL.

About the terraform changes itself:
- Because the project spans multiple projects, we have a shared VPC. This is because Memorystore is different from other services like spanner. Spanner instances do not live in our IP space. But Memorystore instances do. As a result, we have to set up "Private Services Access" by giving it a slice of IPs for the service to deploy the service into. More here in the blue banner at the top of [1] and [2].
- The TTL for prod and staging are set to 5minutes. We can increase this in the future as we get closer to launch.

Other changes:
- Tell terraform to enable needed APIs.

[1] https://cloud.google.com/memorystore/docs/redis/networking
[2] https://cloud.google.com/memorystore/docs/redis/networking#private_services_access

