### PR TITLE
Ingest and expose non-relational web feature metadata

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters"
 	"github.com/GoogleChrome/webstatus.dev/lib/gds"
+	"github.com/GoogleChrome/webstatus.dev/lib/gds/datastoreadapters"
 	"github.com/GoogleChrome/webstatus.dev/lib/httpmiddlewares"
 	"github.com/GoogleChrome/webstatus.dev/lib/rediscache"
 	"github.com/go-chi/cors"
@@ -97,7 +98,7 @@ func main() {
 
 	srv, err := httpserver.NewHTTPServer(
 		"8080",
-		fs,
+		datastoreadapters.NewBackend(fs),
 		spanneradapters.NewBackend(spannerClient),
 		[]func(http.Handler) http.Handler{
 			cors.Handler(

--- a/backend/pkg/httpserver/get_feature_metadata.go
+++ b/backend/pkg/httpserver/get_feature_metadata.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// GetFeatureMetadata implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Name generated from openapi
+func (s *Server) GetFeatureMetadata(ctx context.Context,
+	request backend.GetFeatureMetadataRequestObject) (backend.GetFeatureMetadataResponseObject, error) {
+	featureId, err := s.wptMetricsStorer.GetIDFromFeatureKey(ctx, request.FeatureId)
+	if err != nil {
+		if errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {
+			return backend.GetFeatureMetadata404JSONResponse{
+				Code:    http.StatusNotFound,
+				Message: fmt.Sprintf("feature id %s is not found", request.FeatureId),
+			}, nil
+		}
+		// Catch all for all other errors.
+		slog.Error("unable to check feature before fetching metadata", "error", err)
+
+		return backend.GetFeatureMetadata500JSONResponse{
+			Code:    500,
+			Message: "unable to get feature metadata",
+		}, nil
+	}
+
+	metadata, err := s.metadataStorer.GetFeatureMetadata(ctx, *featureId)
+	if err != nil {
+		// Catch all for all other errors.
+		slog.Error("unable to get feature metadata", "error", err)
+
+		return backend.GetFeatureMetadata500JSONResponse{
+			Code:    500,
+			Message: "unable to get feature metadata",
+		}, nil
+	}
+
+	return backend.GetFeatureMetadata200JSONResponse(*metadata), nil
+}

--- a/backend/pkg/httpserver/get_feature_metadata_test.go
+++ b/backend/pkg/httpserver/get_feature_metadata_test.go
@@ -1,0 +1,101 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestGetFeatureMetadata(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		mockGetIDConfig       MockGetIDFromFeatureKeyConfig
+		mockGetMetadataConfig MockGetFeatureMetadataConfig
+		request               backend.GetFeatureMetadataRequestObject
+		expectedResponse      backend.GetFeatureMetadataResponseObject
+		expectedError         error
+	}{
+		{
+			name: "success",
+			mockGetIDConfig: MockGetIDFromFeatureKeyConfig{
+				expectedFeatureKey: "key1",
+				result:             valuePtr("id1"),
+				err:                nil,
+			},
+			mockGetMetadataConfig: MockGetFeatureMetadataConfig{
+				expectedFeatureID: "id1",
+				result: &backend.FeatureMetadata{
+					CanIUse: &backend.CanIUseInfo{
+						Items: &[]backend.CanIUseItem{
+							{
+								Id: valuePtr("caniuse1"),
+							},
+						},
+					},
+					Description: valuePtr("desc"),
+				},
+				err: nil,
+			},
+			request: backend.GetFeatureMetadataRequestObject{
+				FeatureId: "key1",
+			},
+			expectedResponse: backend.GetFeatureMetadata200JSONResponse(
+				backend.FeatureMetadata{
+					CanIUse: &backend.CanIUseInfo{
+						Items: &[]backend.CanIUseItem{
+							{
+								Id: valuePtr("caniuse1"),
+							},
+						},
+					},
+					Description: valuePtr("desc"),
+				},
+			),
+			expectedError: nil,
+		},
+		// TODO(jcscottiii). Add more test cases later.
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// nolint: exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				getIDFromFeatureKeyConfig: tc.mockGetIDConfig,
+				t:                         t,
+			}
+			mockMetadataStorer := &MockWebFeatureMetadataStorer{
+				mockGetFeatureMetadataCfg: tc.mockGetMetadataConfig,
+				t:                         t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: mockMetadataStorer}
+
+			// Call the function under test
+			resp, err := myServer.GetFeatureMetadata(context.Background(), tc.request)
+
+			// Assertions
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tc.expectedResponse, resp) {
+				t.Errorf("Unexpected response: %v", resp)
+			}
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -27,7 +27,12 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-type WebFeatureMetadataStorer interface{}
+type WebFeatureMetadataStorer interface {
+	GetFeatureMetadata(
+		ctx context.Context,
+		featureID string,
+	) (*backend.FeatureMetadata, error)
+}
 
 type WPTMetricsStorer interface {
 	ListMetricsForFeatureIDBrowserAndChannel(
@@ -73,6 +78,10 @@ type WPTMetricsStorer interface {
 		pageSize int,
 		pageToken *string,
 	) (*backend.BrowserReleaseFeatureMetricsPage, error)
+	GetIDFromFeatureKey(
+		ctx context.Context,
+		featureID string,
+	) (*string, error)
 }
 
 type Server struct {

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -28,6 +28,28 @@ import (
 
 func valuePtr[T any](in T) *T { return &in }
 
+type MockGetFeatureMetadataConfig struct {
+	expectedFeatureID string
+	result            *backend.FeatureMetadata
+	err               error
+}
+
+type MockWebFeatureMetadataStorer struct {
+	t                         *testing.T
+	mockGetFeatureMetadataCfg MockGetFeatureMetadataConfig
+}
+
+func (s *MockWebFeatureMetadataStorer) GetFeatureMetadata(
+	_ context.Context,
+	featureID string,
+) (*backend.FeatureMetadata, error) {
+	if featureID != s.mockGetFeatureMetadataCfg.expectedFeatureID {
+		s.t.Error("unexpected feature id")
+	}
+
+	return s.mockGetFeatureMetadataCfg.result, s.mockGetFeatureMetadataCfg.err
+}
+
 type MockListMetricsForFeatureIDBrowserAndChannelConfig struct {
 	expectedFeatureID string
 	expectedBrowser   string
@@ -75,6 +97,12 @@ type MockGetFeatureByIDConfig struct {
 	err                   error
 }
 
+type MockGetIDFromFeatureKeyConfig struct {
+	expectedFeatureKey string
+	result             *string
+	err                error
+}
+
 type MockListBrowserFeatureCountMetricConfig struct {
 	expectedBrowser   string
 	expectedStartAt   time.Time
@@ -92,12 +120,24 @@ type MockWPTMetricsStorer struct {
 	featuresSearchCfg                                 MockFeaturesSearchConfig
 	listBrowserFeatureCountMetricCfg                  MockListBrowserFeatureCountMetricConfig
 	getFeatureByIDConfig                              MockGetFeatureByIDConfig
+	getIDFromFeatureKeyConfig                         MockGetIDFromFeatureKeyConfig
 	t                                                 *testing.T
 	callCountListBrowserFeatureCountMetric            int
 	callCountFeaturesSearch                           int
 	callCountListMetricsForFeatureIDBrowserAndChannel int
 	callCountListMetricsOverTimeWithAggregatedTotals  int
 	callCountGetFeature                               int
+}
+
+func (m *MockWPTMetricsStorer) GetIDFromFeatureKey(
+	_ context.Context,
+	featureID string,
+) (*string, error) {
+	if featureID != m.getIDFromFeatureKeyConfig.expectedFeatureKey {
+		m.t.Errorf("unexpected feature key %s", featureID)
+	}
+
+	return m.getIDFromFeatureKeyConfig.result, m.getIDFromFeatureKeyConfig.err
 }
 
 func (m *MockWPTMetricsStorer) ListMetricsForFeatureIDBrowserAndChannel(_ context.Context,

--- a/jsonschema/web-platform-dx_web-features/defs.schema.json
+++ b/jsonschema/web-platform-dx_web-features/defs.schema.json
@@ -44,6 +44,14 @@
           },
           "type": "array"
         },
+        "description": {
+          "description": "Short description of the feature, as a plain text string",
+          "type": "string"
+        },
+        "description_html": {
+          "description": "Short description of the feature, as an HTML string",
+          "type": "string"
+        },
         "name": {
           "description": "Short name",
           "type": "string"
@@ -126,6 +134,9 @@
               "type": "object"
             }
           },
+          "required": [
+            "baseline"
+          ],
           "type": "object"
         },
         "usage_stats": {
@@ -150,6 +161,8 @@
       },
       "required": [
         "name",
+        "description",
+        "description_html",
         "spec"
       ],
       "type": "object"

--- a/lib/gcpspanner/baseline_status_test.go
+++ b/lib/gcpspanner/baseline_status_test.go
@@ -57,7 +57,7 @@ func setupRequiredTablesForBaselineStatus(ctx context.Context,
 	client *Client, t *testing.T) {
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}

--- a/lib/gcpspanner/browser_availabilities_test.go
+++ b/lib/gcpspanner/browser_availabilities_test.go
@@ -84,7 +84,7 @@ func setupRequiredTablesForBrowserFeatureAvailability(
 	}
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}

--- a/lib/gcpspanner/browser_feature_count_test.go
+++ b/lib/gcpspanner/browser_feature_count_test.go
@@ -29,7 +29,7 @@ func loadDataForListBrowserFeatureCountMetric(ctx context.Context, t *testing.T,
 		{FeatureKey: "FeatureW", Name: "Amazing API"},
 	}
 	for _, feature := range webFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -63,7 +63,7 @@ func setupRequiredTablesForFeaturesSearch(ctx context.Context,
 		},
 	}
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}

--- a/lib/gcpspanner/feature_specs_test.go
+++ b/lib/gcpspanner/feature_specs_test.go
@@ -54,7 +54,7 @@ func setupRequiredTablesForFeatureSpecs(ctx context.Context,
 	client *Client, t *testing.T) {
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -77,7 +77,7 @@ type BackendSpannerClient interface {
 	) (*gcpspanner.BrowserFeatureCountResultPage, error)
 }
 
-// Backend converts queries to spaner to useable entities for the backend
+// Backend converts queries to spanner to useable entities for the backend
 // service.
 type Backend struct {
 	client BackendSpannerClient

--- a/lib/gcpspanner/web_features_test.go
+++ b/lib/gcpspanner/web_features_test.go
@@ -78,7 +78,7 @@ func TestUpsertWebFeature(t *testing.T) {
 	ctx := context.Background()
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert. %s", err.Error())
 		}
@@ -91,7 +91,7 @@ func TestUpsertWebFeature(t *testing.T) {
 		t.Errorf("unequal features. expected %+v actual %+v", sampleFeatures, features)
 	}
 
-	err = client.UpsertWebFeature(ctx, WebFeature{
+	_, err = client.UpsertWebFeature(ctx, WebFeature{
 		Name:       "Feature 1!!",
 		FeatureKey: "feature1",
 	})

--- a/lib/gcpspanner/wpt_run_feature_metric_test.go
+++ b/lib/gcpspanner/wpt_run_feature_metric_test.go
@@ -261,7 +261,7 @@ func TestUpsertWPTRunFeatureMetric(t *testing.T) {
 	}
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}
@@ -403,7 +403,7 @@ func TestListMetricsForFeatureIDBrowserAndChannel(t *testing.T) {
 	// Load up runs, metrics and features.
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}
@@ -805,7 +805,7 @@ func TestListMetricsOverTimeWithAggregatedTotals(t *testing.T) {
 	// Load up runs, metrics and features.
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}

--- a/lib/gds/datastoreadapters/backend.go
+++ b/lib/gds/datastoreadapters/backend.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastoreadapters
+
+import (
+	"context"
+	"errors"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gds"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+type BackendDatastoreClient interface {
+	GetWebFeatureMetadata(ctx context.Context, webFeatureID string) (*gds.FeatureMetadata, error)
+}
+
+// Backend converts queries to datastore to useable entities for the backend
+// service.
+type Backend struct {
+	client BackendDatastoreClient
+}
+
+// NewBackend constructs an adapter for the backend service.
+func NewBackend(client BackendDatastoreClient) *Backend {
+	return &Backend{client: client}
+}
+
+func (d *Backend) GetFeatureMetadata(
+	ctx context.Context,
+	featureID string,
+) (*backend.FeatureMetadata, error) {
+	metadata, err := d.client.GetWebFeatureMetadata(ctx, featureID)
+	if errors.Is(err, gds.ErrEntityNotFound) {
+		// Return an empty metadata for now.
+		// The feature exists but datastore doesn't have any metadata for it.
+		// This could be because the feature's metadata has not been stored yet.
+		return &backend.FeatureMetadata{
+			CanIUse:     nil,
+			Description: nil,
+		}, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	var canIUse *backend.CanIUseInfo
+	if len(metadata.CanIUseIDs) > 0 {
+		items := make([]backend.CanIUseItem, 0, len(metadata.CanIUseIDs))
+		for idx := range metadata.CanIUseIDs {
+			items = append(items, backend.CanIUseItem{
+				Id: &metadata.CanIUseIDs[idx],
+			})
+		}
+		canIUse = &backend.CanIUseInfo{
+			Items: &items,
+		}
+	}
+
+	return &backend.FeatureMetadata{
+		CanIUse:     canIUse,
+		Description: &metadata.Description,
+	}, nil
+}

--- a/lib/gds/datastoreadapters/backend_test.go
+++ b/lib/gds/datastoreadapters/backend_test.go
@@ -1,0 +1,151 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastoreadapters
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gds"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+type mockGetFeatureMetadataConfig struct {
+	expectedFeatureID string
+	result            *gds.FeatureMetadata
+	err               error
+}
+
+type mockBackendDatastoreClient struct {
+	t                         *testing.T
+	mockGetFeatureMetadataCfg mockGetFeatureMetadataConfig
+}
+
+func (c mockBackendDatastoreClient) GetWebFeatureMetadata(
+	_ context.Context, webFeatureID string) (*gds.FeatureMetadata, error) {
+	if c.mockGetFeatureMetadataCfg.expectedFeatureID != webFeatureID {
+		c.t.Error("unexpected input to mock")
+	}
+
+	return c.mockGetFeatureMetadataCfg.result, c.mockGetFeatureMetadataCfg.err
+}
+
+func valuePtr[T any](in T) *T { return &in }
+
+var errGetMetadataTestError = errors.New("get feature metadata tests error")
+
+func TestGetFeatureMetadata(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		featureID                 string
+		mockGetFeatureMetadataCfg mockGetFeatureMetadataConfig
+		expectedMetadata          *backend.FeatureMetadata
+		expectedErr               error
+	}{
+		{
+			name:      "success - no can i use ids",
+			featureID: "id-1",
+			mockGetFeatureMetadataCfg: mockGetFeatureMetadataConfig{
+				expectedFeatureID: "id-1",
+				result: &gds.FeatureMetadata{
+					WebFeatureID: "id-1",
+					Description:  "desc",
+					CanIUseIDs:   nil,
+				},
+				err: nil,
+			},
+			expectedMetadata: &backend.FeatureMetadata{
+				Description: valuePtr("desc"),
+				CanIUse:     nil,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:      "success - with can i use ids",
+			featureID: "id-1",
+			mockGetFeatureMetadataCfg: mockGetFeatureMetadataConfig{
+				expectedFeatureID: "id-1",
+				result: &gds.FeatureMetadata{
+					WebFeatureID: "id-1",
+					Description:  "desc",
+					CanIUseIDs: []string{
+						"caniuse1",
+						"caniuse2",
+					},
+				},
+				err: nil,
+			},
+			expectedMetadata: &backend.FeatureMetadata{
+				Description: valuePtr("desc"),
+				CanIUse: &backend.CanIUseInfo{
+					Items: &[]backend.CanIUseItem{
+						{
+							Id: valuePtr("caniuse1"),
+						},
+						{
+							Id: valuePtr("caniuse2"),
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:      "success - default metadata",
+			featureID: "id-1",
+			mockGetFeatureMetadataCfg: mockGetFeatureMetadataConfig{
+				expectedFeatureID: "id-1",
+				result:            nil,
+				err:               gds.ErrEntityNotFound,
+			},
+			expectedMetadata: &backend.FeatureMetadata{
+				Description: nil,
+				CanIUse:     nil,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			name:      "error",
+			featureID: "id-1",
+			mockGetFeatureMetadataCfg: mockGetFeatureMetadataConfig{
+				expectedFeatureID: "id-1",
+				result:            nil,
+				err:               errGetMetadataTestError,
+			},
+			expectedMetadata: nil,
+			expectedErr:      errGetMetadataTestError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := mockBackendDatastoreClient{
+				t:                         t,
+				mockGetFeatureMetadataCfg: tc.mockGetFeatureMetadataCfg,
+			}
+			b := NewBackend(mock)
+			metadata, err := b.GetFeatureMetadata(context.Background(), tc.featureID)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Error("unexpected error")
+			}
+			if !reflect.DeepEqual(metadata, tc.expectedMetadata) {
+				t.Error("unexpected metadata")
+			}
+		})
+	}
+}

--- a/lib/gds/datastoreadapters/web_features_consumer.go
+++ b/lib/gds/datastoreadapters/web_features_consumer.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastoreadapters
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gds"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/jsonschema/web_platform_dx__web_features"
+)
+
+// WebFeatureDatastoreClient expects a subset of the functionality from lib/gds that only apply to WebFeatures.
+type WebFeatureDatastoreClient interface {
+	UpsertFeatureMetadata(
+		ctx context.Context,
+		data gds.FeatureMetadata,
+	) error
+}
+
+// NewWebFeaturesConsumer constructs an adapter for the web features consumer service.
+func NewWebFeaturesConsumer(client WebFeatureDatastoreClient) *WebFeaturesConsumer {
+	return &WebFeaturesConsumer{client: client}
+}
+
+// WebFeaturesConsumer handles the conversion of web feature data between the workflow/API input
+// format and the format used by the GCP Datastore client.
+type WebFeaturesConsumer struct {
+	client WebFeatureDatastoreClient
+}
+
+func (c *WebFeaturesConsumer) InsertWebFeaturesMetadata(
+	ctx context.Context,
+	featureKeyToID map[string]string,
+	data map[string]web_platform_dx__web_features.FeatureData) error {
+	for featureKey, featureData := range data {
+		featureID, found := featureKeyToID[featureKey]
+		if !found {
+			// Should never happen but let's log it out.
+			slog.Warn("unable to find internal ID for featue key", "feature key", featureKey)
+
+			continue
+		}
+		var canIUseIDs []string
+		if featureData.Caniuse != nil && featureData.Caniuse.String != nil {
+			canIUseIDs = []string{*featureData.Caniuse.String}
+		} else if len(featureData.Caniuse.StringArray) > 0 {
+			canIUseIDs = featureData.Caniuse.StringArray
+		}
+		err := c.client.UpsertFeatureMetadata(ctx,
+			gds.FeatureMetadata{
+				WebFeatureID: featureID,
+				Description:  featureData.Description,
+				CanIUseIDs:   canIUseIDs,
+			},
+		)
+		if err != nil {
+			slog.Error("unable to upsert web feature metadata",
+				"feature key", featureKey, "feature id", featureID, "error", err)
+
+			return err
+		}
+	}
+
+	return nil
+}

--- a/lib/gds/feature_metadata.go
+++ b/lib/gds/feature_metadata.go
@@ -1,0 +1,94 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gds
+
+import (
+	"cmp"
+	"context"
+
+	"cloud.google.com/go/datastore"
+)
+
+const featureMetadataKey = "FeatureMetadataKey"
+
+// FeatureMetadata contains useful metadata about the feature.
+// This information is not stored in the relational database because it is not used in complex queries for
+// the overview page.
+type FeatureMetadata struct {
+	// The ID from WebFeatures table in spanner. Not the web features key.
+	WebFeatureID string `datastore:"web_feature_id"`
+	// Non-null fields from https://github.com/web-platform-dx/web-features/blob/main/schemas/defs.schema.json
+	Description string `datastore:"description"`
+	// Nullable fields from https://github.com/web-platform-dx/web-features/blob/main/schemas/defs.schema.json
+	CanIUseIDs []string `datastore:"can_i_use_ids"`
+}
+
+// webFeaturesMetadataFilter implements Filterable to filter by web_feature_id.
+// Compatible kinds:
+// - featureMetadataKey.
+type webFeaturesMetadataFilter struct {
+	webFeatureID string
+}
+
+func (f webFeaturesMetadataFilter) FilterQuery(query *datastore.Query) *datastore.Query {
+	return query.FilterField("web_feature_id", "=", f.webFeatureID)
+}
+
+// webFeatureMetadataMerge implements Mergeable for FeatureMetadata.
+type webFeatureMetadataMerge struct{}
+
+func (m webFeatureMetadataMerge) Merge(existing *FeatureMetadata, new *FeatureMetadata) *FeatureMetadata {
+	canIUseIDs := existing.CanIUseIDs
+	if len(new.CanIUseIDs) > 0 {
+		canIUseIDs = new.CanIUseIDs
+	}
+
+	return &FeatureMetadata{
+		Description: cmp.Or[string](new.Description, existing.Description, ""),
+		CanIUseIDs:  canIUseIDs,
+		// The below fields cannot be overridden during a merge.
+		WebFeatureID: existing.WebFeatureID,
+	}
+}
+
+// UpsertFeatureMetadata inserts/updates metadata for the given web feature.
+func (c *Client) UpsertFeatureMetadata(
+	ctx context.Context,
+	data FeatureMetadata,
+) error {
+	entityClient := entityClient[FeatureMetadata]{c}
+
+	return entityClient.upsert(ctx,
+		featureMetadataKey,
+		&data,
+		webFeatureMetadataMerge{},
+		webFeaturesMetadataFilter{
+			webFeatureID: data.WebFeatureID,
+		},
+	)
+}
+
+// GetWebFeatureMetadata atttempts to get data for a given web feature.
+func (c *Client) GetWebFeatureMetadata(ctx context.Context, webFeatureID string) (*FeatureMetadata, error) {
+	entityClient := entityClient[FeatureMetadata]{c}
+	featureData, err := entityClient.get(ctx, featureMetadataKey, webFeaturesMetadataFilter{
+		webFeatureID: webFeatureID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return featureData, nil
+}

--- a/lib/gds/feature_metadata_test.go
+++ b/lib/gds/feature_metadata_test.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gds
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestFeatureDataOperations(t *testing.T) {
+	ctx := context.Background()
+	client, cleanup := getTestDatabase(ctx, t)
+	defer cleanup()
+
+	// Part 0. Try to get id that does not exist yet.
+	data, err := client.GetWebFeatureMetadata(ctx, "id-1")
+	if !errors.Is(err, ErrEntityNotFound) {
+		t.Errorf("unexpected error %v", err)
+	}
+	if data != nil {
+		t.Error("expected nil data")
+	}
+
+	// Part 1. Try to insert the first version
+	version1 := &FeatureMetadata{
+		WebFeatureID: "id-1",
+		Description:  "initial-description",
+		CanIUseIDs:   nil, // not required on first try
+	}
+	err = client.UpsertFeatureMetadata(ctx, *version1)
+	if err != nil {
+		t.Errorf("failed to upsert %s", err.Error())
+	}
+	data, err = client.GetWebFeatureMetadata(ctx, "id-1")
+	if err != nil {
+		t.Errorf("failed to get feature metadata %s", err.Error())
+	}
+	if !reflect.DeepEqual(version1, data) {
+		t.Errorf("unexpected metadata %v", data)
+	}
+
+	// Part 2. Upsert the second version
+	partialVersion2 := FeatureMetadata{
+		WebFeatureID: "id-1",
+		Description:  "", // Do not override description
+		CanIUseIDs:   []string{"can-i-use-1", "can-i-use-2"},
+	}
+	err = client.UpsertFeatureMetadata(ctx, partialVersion2)
+	if err != nil {
+		t.Errorf("failed to upsert again %s", err.Error())
+	}
+
+	expectedVersion2 := &FeatureMetadata{
+		WebFeatureID: "id-1",
+		Description:  "initial-description",
+		CanIUseIDs:   []string{"can-i-use-1", "can-i-use-2"},
+	}
+
+	data, err = client.GetWebFeatureMetadata(ctx, "id-1")
+	if err != nil {
+		t.Errorf("failed to get feature metadata %s", err.Error())
+	}
+	if !reflect.DeepEqual(expectedVersion2, data) {
+		t.Errorf("unexpected metadata %v", data)
+	}
+}

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -144,6 +144,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasicErrorModel'
+  /v1/features/{feature_id}/feature-metadata:
+    parameters:
+      - name: feature_id
+        in: path
+        description: Feature ID
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get metadata for a given feature from github.com/web-platform-dx/web-features
+      operationId: getFeatureMetadata
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureMetadata'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '429':
+          description: Rate Limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
   /v1/features/{feature_id}/stats/wpt/browsers/{browser}/channels/{channel}/{metric_view}:
     parameters:
       - name: feature_id
@@ -576,6 +618,24 @@ components:
       type: object
       properties:
         link:
+          type: string
+    FeatureMetadata:
+      type: object
+      properties:
+        can_i_use:
+          $ref: '#/components/schemas/CanIUseInfo'
+        description:
+          type: string
+    CanIUseInfo:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/CanIUseItem'
+    CanIUseItem:
+      properties:
+        id:
           type: string
     Feature:
       type: object

--- a/util/cmd/load_fake_data/main.go
+++ b/util/cmd/load_fake_data/main.go
@@ -98,7 +98,7 @@ func generateFeatures(ctx context.Context, client *gcpspanner.Client) ([]gcpspan
 			Name:       featureName,
 			FeatureKey: featureID,
 		}
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			return nil, err
 		}

--- a/workflows/steps/services/web_feature_consumer/cmd/server/main.go
+++ b/workflows/steps/services/web_feature_consumer/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters"
 	"github.com/GoogleChrome/webstatus.dev/lib/gds"
+	"github.com/GoogleChrome/webstatus.dev/lib/gds/datastoreadapters"
 	"github.com/GoogleChrome/webstatus.dev/lib/gh"
 	"github.com/GoogleChrome/webstatus.dev/workflows/steps/services/web_feature_consumer/pkg/httpserver"
 )
@@ -35,7 +36,6 @@ func main() {
 		slog.Error("failed to create datastore client", "error", err.Error())
 		os.Exit(1)
 	}
-	_ = fs
 
 	projectID := os.Getenv("PROJECT_ID")
 	spannerDB := os.Getenv("SPANNER_DATABASE")
@@ -53,6 +53,7 @@ func main() {
 		"8080",
 		gh.NewClient(token),
 		spanneradapters.NewWebFeaturesConsumer(spannerClient),
+		datastoreadapters.NewWebFeaturesConsumer(fs),
 		"data.json",
 		"web-platform-dx",
 		"web-features",

--- a/workflows/steps/services/web_feature_consumer/pkg/httpserver/server_test.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/httpserver/server_test.go
@@ -76,8 +76,9 @@ func (m *mockAssetParser) Parse(file io.ReadCloser) (map[string]web_platform_dx_
 }
 
 type mockInsertWebFeaturesConfig struct {
-	expectedData map[string]web_platform_dx__web_features.FeatureData
-	returnError  error
+	expectedData    map[string]web_platform_dx__web_features.FeatureData
+	returnedMapping map[string]string
+	returnError     error
 }
 
 type mockWebFeatureStorer struct {
@@ -86,12 +87,35 @@ type mockWebFeatureStorer struct {
 }
 
 func (m *mockWebFeatureStorer) InsertWebFeatures(
-	_ context.Context, data map[string]web_platform_dx__web_features.FeatureData) error {
+	_ context.Context, data map[string]web_platform_dx__web_features.FeatureData) (map[string]string, error) {
 	if !reflect.DeepEqual(data, m.mockInsertWebFeaturesCfg.expectedData) {
 		m.t.Error("unexpected data")
 	}
 
-	return m.mockInsertWebFeaturesCfg.returnError
+	return m.mockInsertWebFeaturesCfg.returnedMapping, m.mockInsertWebFeaturesCfg.returnError
+}
+
+type mockInsertWebFeaturesMetadataConfig struct {
+	expectedData    map[string]web_platform_dx__web_features.FeatureData
+	expectedMapping map[string]string
+	returnError     error
+}
+
+type mockWebFeatureMetadataStorer struct {
+	t                                *testing.T
+	mockInsertWebFeaturesMetadataCfg mockInsertWebFeaturesMetadataConfig
+}
+
+func (m *mockWebFeatureMetadataStorer) InsertWebFeaturesMetadata(
+	_ context.Context,
+	featureKeyToID map[string]string,
+	data map[string]web_platform_dx__web_features.FeatureData) error {
+	if !reflect.DeepEqual(data, m.mockInsertWebFeaturesMetadataCfg.expectedData) ||
+		!reflect.DeepEqual(featureKeyToID, m.mockInsertWebFeaturesMetadataCfg.expectedMapping) {
+		m.t.Error("unexpected input")
+	}
+
+	return m.mockInsertWebFeaturesMetadataCfg.returnError
 }
 
 const (
@@ -102,11 +126,12 @@ const (
 
 func TestPostV1WebFeatures(t *testing.T) {
 	testCases := []struct {
-		name                           string
-		mockDownloadFileFromReleaseCfg mockDownloadFileFromReleaseConfig
-		mockParseCfg                   mockParseConfig
-		mockInsertWebFeaturesCfg       mockInsertWebFeaturesConfig
-		expectedResponse               web_feature_consumer.PostV1WebFeaturesResponseObject
+		name                             string
+		mockDownloadFileFromReleaseCfg   mockDownloadFileFromReleaseConfig
+		mockParseCfg                     mockParseConfig
+		mockInsertWebFeaturesCfg         mockInsertWebFeaturesConfig
+		mockInsertWebFeaturesMetadataCfg mockInsertWebFeaturesMetadataConfig
+		expectedResponse                 web_feature_consumer.PostV1WebFeaturesResponseObject
 	}{
 		{
 			name: "success",
@@ -121,13 +146,15 @@ func TestPostV1WebFeatures(t *testing.T) {
 				expectedFileContents: "hi features",
 				returnData: map[string]web_platform_dx__web_features.FeatureData{
 					"feature1": {
-						Name:           "Feature 1",
-						Alias:          nil,
-						Caniuse:        nil,
-						CompatFeatures: nil,
-						Spec:           nil,
-						Status:         nil,
-						UsageStats:     nil,
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
 					},
 				},
 				returnError: nil,
@@ -135,14 +162,38 @@ func TestPostV1WebFeatures(t *testing.T) {
 			mockInsertWebFeaturesCfg: mockInsertWebFeaturesConfig{
 				expectedData: map[string]web_platform_dx__web_features.FeatureData{
 					"feature1": {
-						Name:           "Feature 1",
-						Alias:          nil,
-						Caniuse:        nil,
-						CompatFeatures: nil,
-						Spec:           nil,
-						Status:         nil,
-						UsageStats:     nil,
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
 					},
+				},
+				returnedMapping: map[string]string{
+					"feature1": "id-1",
+				},
+				returnError: nil,
+			},
+			mockInsertWebFeaturesMetadataCfg: mockInsertWebFeaturesMetadataConfig{
+				expectedData: map[string]web_platform_dx__web_features.FeatureData{
+					"feature1": {
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
+					},
+				},
+				expectedMapping: map[string]string{
+					"feature1": "id-1",
 				},
 				returnError: nil,
 			},
@@ -163,8 +214,14 @@ func TestPostV1WebFeatures(t *testing.T) {
 				returnError:          nil,
 			},
 			mockInsertWebFeaturesCfg: mockInsertWebFeaturesConfig{
-				expectedData: nil,
-				returnError:  nil,
+				expectedData:    nil,
+				returnedMapping: nil,
+				returnError:     nil,
+			},
+			mockInsertWebFeaturesMetadataCfg: mockInsertWebFeaturesMetadataConfig{
+				expectedData:    nil,
+				expectedMapping: nil,
+				returnError:     nil,
 			},
 			expectedResponse: web_feature_consumer.PostV1WebFeatures500JSONResponse{
 				Code:    500,
@@ -184,20 +241,28 @@ func TestPostV1WebFeatures(t *testing.T) {
 				expectedFileContents: "hi features",
 				returnData: map[string]web_platform_dx__web_features.FeatureData{
 					"feature1": {
-						Name:           "Feature 1",
-						Alias:          nil,
-						Caniuse:        nil,
-						CompatFeatures: nil,
-						Spec:           nil,
-						Status:         nil,
-						UsageStats:     nil,
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
 					},
 				},
 				returnError: errors.New("cannot parse data"),
 			},
 			mockInsertWebFeaturesCfg: mockInsertWebFeaturesConfig{
-				expectedData: nil,
-				returnError:  nil,
+				expectedData:    nil,
+				returnedMapping: nil,
+				returnError:     nil,
+			},
+			mockInsertWebFeaturesMetadataCfg: mockInsertWebFeaturesMetadataConfig{
+				expectedData:    nil,
+				expectedMapping: nil,
+				returnError:     nil,
 			},
 			expectedResponse: web_feature_consumer.PostV1WebFeatures500JSONResponse{
 				Code:    500,
@@ -217,13 +282,15 @@ func TestPostV1WebFeatures(t *testing.T) {
 				expectedFileContents: "hi features",
 				returnData: map[string]web_platform_dx__web_features.FeatureData{
 					"feature1": {
-						Name:           "Feature 1",
-						Alias:          nil,
-						Caniuse:        nil,
-						CompatFeatures: nil,
-						Spec:           nil,
-						Status:         nil,
-						UsageStats:     nil,
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
 					},
 				},
 				returnError: nil,
@@ -231,20 +298,99 @@ func TestPostV1WebFeatures(t *testing.T) {
 			mockInsertWebFeaturesCfg: mockInsertWebFeaturesConfig{
 				expectedData: map[string]web_platform_dx__web_features.FeatureData{
 					"feature1": {
-						Name:           "Feature 1",
-						Alias:          nil,
-						Caniuse:        nil,
-						CompatFeatures: nil,
-						Spec:           nil,
-						Status:         nil,
-						UsageStats:     nil,
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
 					},
+				},
+				returnedMapping: map[string]string{
+					"feature1": "id-1",
+				},
+				returnError: errors.New("uh-oh"),
+			},
+			mockInsertWebFeaturesMetadataCfg: mockInsertWebFeaturesMetadataConfig{
+				expectedData:    nil,
+				expectedMapping: nil,
+				returnError:     nil,
+			},
+			expectedResponse: web_feature_consumer.PostV1WebFeatures500JSONResponse{
+				Code:    500,
+				Message: "unable to store data",
+			},
+		},
+		{
+			name: "fail to store metadata",
+			mockDownloadFileFromReleaseCfg: mockDownloadFileFromReleaseConfig{
+				expectedOwner:    testRepoOwner,
+				expectedRepo:     testRepoName,
+				expectedFileName: testFileName,
+				returnReadCloser: io.NopCloser(strings.NewReader("hi features")),
+				returnError:      nil,
+			},
+			mockParseCfg: mockParseConfig{
+				expectedFileContents: "hi features",
+				returnData: map[string]web_platform_dx__web_features.FeatureData{
+					"feature1": {
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
+					},
+				},
+				returnError: nil,
+			},
+			mockInsertWebFeaturesCfg: mockInsertWebFeaturesConfig{
+				expectedData: map[string]web_platform_dx__web_features.FeatureData{
+					"feature1": {
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
+					},
+				},
+				returnedMapping: map[string]string{
+					"feature1": "id-1",
+				},
+				returnError: nil,
+			},
+			mockInsertWebFeaturesMetadataCfg: mockInsertWebFeaturesMetadataConfig{
+				expectedData: map[string]web_platform_dx__web_features.FeatureData{
+					"feature1": {
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
+					},
+				},
+				expectedMapping: map[string]string{
+					"feature1": "id-1",
 				},
 				returnError: errors.New("uh-oh"),
 			},
 			expectedResponse: web_feature_consumer.PostV1WebFeatures500JSONResponse{
 				Code:    500,
-				Message: "unable to store data",
+				Message: "unable to store metadata",
 			},
 		},
 	}
@@ -262,10 +408,15 @@ func TestPostV1WebFeatures(t *testing.T) {
 				t:                        t,
 				mockInsertWebFeaturesCfg: tc.mockInsertWebFeaturesCfg,
 			}
+			mockMetadataStorer := &mockWebFeatureMetadataStorer{
+				t:                                t,
+				mockInsertWebFeaturesMetadataCfg: tc.mockInsertWebFeaturesMetadataCfg,
+			}
 
 			server := &Server{
 				assetGetter:           mockGetter,
 				storer:                mockStorer,
+				metadataStorer:        mockMetadataStorer,
 				webFeaturesDataParser: mockParser,
 				defaultAssetName:      testFileName,
 				defaultRepoOwner:      testRepoOwner,


### PR DESCRIPTION
There exists additional metadata that we always wanted to ingest for a feature. Such as a the description, html-description, CanIUse IDs.

However, putting that information in spanner doesn't make too much sense given that we do not need to do any relational joins against it. Plus, the data is likely to change shape. This makes maintenance of this data very hard.

As a result, we put this in something more suitable, datastore.

This change begins the ingestion of the the can i use IDs and description. We also want to store the html description but we should discuss that to make sure render that safely.

On the API side, a new endpoint exists /v1/features/{feature_id}/feature-metadata to expose that data. For now, it only returns Can I Use IDs. The returned object, while bulky, is structured in case we want to add any information without breaking our schema in the future.

Other changes:
- Update UpsertWebFeature to return the generated ID and use that as the web feature id in datastore.
- Update the defs.schema.json file from the web features repo. This allows us to get the description.

Change-Id: I0783787531c9e183c8c8d9b7759f1285cceac3d5