### PR TITLE
Modify UpsertWebFeature to return the generated id

### DIFF
--- a/jsonschema/web-platform-dx_web-features/defs.schema.json
+++ b/jsonschema/web-platform-dx_web-features/defs.schema.json
@@ -44,6 +44,14 @@
           },
           "type": "array"
         },
+        "description": {
+          "description": "Short description of the feature, as a plain text string",
+          "type": "string"
+        },
+        "description_html": {
+          "description": "Short description of the feature, as an HTML string",
+          "type": "string"
+        },
         "name": {
           "description": "Short name",
           "type": "string"
@@ -126,6 +134,9 @@
               "type": "object"
             }
           },
+          "required": [
+            "baseline"
+          ],
           "type": "object"
         },
         "usage_stats": {
@@ -150,6 +161,8 @@
       },
       "required": [
         "name",
+        "description",
+        "description_html",
         "spec"
       ],
       "type": "object"

--- a/lib/gcpspanner/baseline_status_test.go
+++ b/lib/gcpspanner/baseline_status_test.go
@@ -57,7 +57,7 @@ func setupRequiredTablesForBaselineStatus(ctx context.Context,
 	client *Client, t *testing.T) {
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}

--- a/lib/gcpspanner/browser_availabilities_test.go
+++ b/lib/gcpspanner/browser_availabilities_test.go
@@ -84,7 +84,7 @@ func setupRequiredTablesForBrowserFeatureAvailability(
 	}
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}

--- a/lib/gcpspanner/browser_feature_count_test.go
+++ b/lib/gcpspanner/browser_feature_count_test.go
@@ -29,7 +29,7 @@ func loadDataForListBrowserFeatureCountMetric(ctx context.Context, t *testing.T,
 		{FeatureKey: "FeatureW", Name: "Amazing API"},
 	}
 	for _, feature := range webFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -63,7 +63,7 @@ func setupRequiredTablesForFeaturesSearch(ctx context.Context,
 		},
 	}
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}

--- a/lib/gcpspanner/feature_specs_test.go
+++ b/lib/gcpspanner/feature_specs_test.go
@@ -54,7 +54,7 @@ func setupRequiredTablesForFeatureSpecs(ctx context.Context,
 	client *Client, t *testing.T) {
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -77,7 +77,7 @@ type BackendSpannerClient interface {
 	) (*gcpspanner.BrowserFeatureCountResultPage, error)
 }
 
-// Backend converts queries to spaner to useable entities for the backend
+// Backend converts queries to spanner to useable entities for the backend
 // service.
 type Backend struct {
 	client BackendSpannerClient

--- a/lib/gcpspanner/web_features_test.go
+++ b/lib/gcpspanner/web_features_test.go
@@ -78,7 +78,7 @@ func TestUpsertWebFeature(t *testing.T) {
 	ctx := context.Background()
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert. %s", err.Error())
 		}
@@ -91,7 +91,7 @@ func TestUpsertWebFeature(t *testing.T) {
 		t.Errorf("unequal features. expected %+v actual %+v", sampleFeatures, features)
 	}
 
-	err = client.UpsertWebFeature(ctx, WebFeature{
+	_, err = client.UpsertWebFeature(ctx, WebFeature{
 		Name:       "Feature 1!!",
 		FeatureKey: "feature1",
 	})

--- a/lib/gcpspanner/wpt_run_feature_metric_test.go
+++ b/lib/gcpspanner/wpt_run_feature_metric_test.go
@@ -261,7 +261,7 @@ func TestUpsertWPTRunFeatureMetric(t *testing.T) {
 	}
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}
@@ -403,7 +403,7 @@ func TestListMetricsForFeatureIDBrowserAndChannel(t *testing.T) {
 	// Load up runs, metrics and features.
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}
@@ -805,7 +805,7 @@ func TestListMetricsOverTimeWithAggregatedTotals(t *testing.T) {
 	// Load up runs, metrics and features.
 	sampleFeatures := getSampleFeatures()
 	for _, feature := range sampleFeatures {
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			t.Errorf("unexpected error during insert of features. %s", err.Error())
 		}

--- a/util/cmd/load_fake_data/main.go
+++ b/util/cmd/load_fake_data/main.go
@@ -98,7 +98,7 @@ func generateFeatures(ctx context.Context, client *gcpspanner.Client) ([]gcpspan
 			Name:       featureName,
 			FeatureKey: featureID,
 		}
-		err := client.UpsertWebFeature(ctx, feature)
+		_, err := client.UpsertWebFeature(ctx, feature)
 		if err != nil {
 			return nil, err
 		}

--- a/workflows/steps/services/web_feature_consumer/pkg/httpserver/server.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/httpserver/server.go
@@ -47,7 +47,7 @@ type AssetParser interface {
 type WebFeatureStorer interface {
 	InsertWebFeatures(
 		ctx context.Context,
-		data map[string]web_platform_dx__web_features.FeatureData) error
+		data map[string]web_platform_dx__web_features.FeatureData) (map[string]string, error)
 }
 
 type Server struct {
@@ -90,7 +90,8 @@ func (s *Server) PostV1WebFeatures(
 		}, nil
 	}
 
-	err = s.storer.InsertWebFeatures(ctx, data)
+	// TODO use the mapping in the future for storing metadata
+	_, err = s.storer.InsertWebFeatures(ctx, data)
 	if err != nil {
 		slog.Error("unable to store data", "error", err)
 

--- a/workflows/steps/services/web_feature_consumer/pkg/httpserver/server_test.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/httpserver/server_test.go
@@ -76,8 +76,9 @@ func (m *mockAssetParser) Parse(file io.ReadCloser) (map[string]web_platform_dx_
 }
 
 type mockInsertWebFeaturesConfig struct {
-	expectedData map[string]web_platform_dx__web_features.FeatureData
-	returnError  error
+	expectedData    map[string]web_platform_dx__web_features.FeatureData
+	returnedMapping map[string]string
+	returnError     error
 }
 
 type mockWebFeatureStorer struct {
@@ -86,12 +87,12 @@ type mockWebFeatureStorer struct {
 }
 
 func (m *mockWebFeatureStorer) InsertWebFeatures(
-	_ context.Context, data map[string]web_platform_dx__web_features.FeatureData) error {
+	_ context.Context, data map[string]web_platform_dx__web_features.FeatureData) (map[string]string, error) {
 	if !reflect.DeepEqual(data, m.mockInsertWebFeaturesCfg.expectedData) {
 		m.t.Error("unexpected data")
 	}
 
-	return m.mockInsertWebFeaturesCfg.returnError
+	return m.mockInsertWebFeaturesCfg.returnedMapping, m.mockInsertWebFeaturesCfg.returnError
 }
 
 const (
@@ -121,13 +122,15 @@ func TestPostV1WebFeatures(t *testing.T) {
 				expectedFileContents: "hi features",
 				returnData: map[string]web_platform_dx__web_features.FeatureData{
 					"feature1": {
-						Name:           "Feature 1",
-						Alias:          nil,
-						Caniuse:        nil,
-						CompatFeatures: nil,
-						Spec:           nil,
-						Status:         nil,
-						UsageStats:     nil,
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
 					},
 				},
 				returnError: nil,
@@ -135,14 +138,19 @@ func TestPostV1WebFeatures(t *testing.T) {
 			mockInsertWebFeaturesCfg: mockInsertWebFeaturesConfig{
 				expectedData: map[string]web_platform_dx__web_features.FeatureData{
 					"feature1": {
-						Name:           "Feature 1",
-						Alias:          nil,
-						Caniuse:        nil,
-						CompatFeatures: nil,
-						Spec:           nil,
-						Status:         nil,
-						UsageStats:     nil,
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
 					},
+				},
+				returnedMapping: map[string]string{
+					"feature1": "id-1",
 				},
 				returnError: nil,
 			},
@@ -163,8 +171,9 @@ func TestPostV1WebFeatures(t *testing.T) {
 				returnError:          nil,
 			},
 			mockInsertWebFeaturesCfg: mockInsertWebFeaturesConfig{
-				expectedData: nil,
-				returnError:  nil,
+				expectedData:    nil,
+				returnedMapping: nil,
+				returnError:     nil,
 			},
 			expectedResponse: web_feature_consumer.PostV1WebFeatures500JSONResponse{
 				Code:    500,
@@ -184,20 +193,23 @@ func TestPostV1WebFeatures(t *testing.T) {
 				expectedFileContents: "hi features",
 				returnData: map[string]web_platform_dx__web_features.FeatureData{
 					"feature1": {
-						Name:           "Feature 1",
-						Alias:          nil,
-						Caniuse:        nil,
-						CompatFeatures: nil,
-						Spec:           nil,
-						Status:         nil,
-						UsageStats:     nil,
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
 					},
 				},
 				returnError: errors.New("cannot parse data"),
 			},
 			mockInsertWebFeaturesCfg: mockInsertWebFeaturesConfig{
-				expectedData: nil,
-				returnError:  nil,
+				expectedData:    nil,
+				returnedMapping: nil,
+				returnError:     nil,
 			},
 			expectedResponse: web_feature_consumer.PostV1WebFeatures500JSONResponse{
 				Code:    500,
@@ -217,13 +229,15 @@ func TestPostV1WebFeatures(t *testing.T) {
 				expectedFileContents: "hi features",
 				returnData: map[string]web_platform_dx__web_features.FeatureData{
 					"feature1": {
-						Name:           "Feature 1",
-						Alias:          nil,
-						Caniuse:        nil,
-						CompatFeatures: nil,
-						Spec:           nil,
-						Status:         nil,
-						UsageStats:     nil,
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
 					},
 				},
 				returnError: nil,
@@ -231,14 +245,19 @@ func TestPostV1WebFeatures(t *testing.T) {
 			mockInsertWebFeaturesCfg: mockInsertWebFeaturesConfig{
 				expectedData: map[string]web_platform_dx__web_features.FeatureData{
 					"feature1": {
-						Name:           "Feature 1",
-						Alias:          nil,
-						Caniuse:        nil,
-						CompatFeatures: nil,
-						Spec:           nil,
-						Status:         nil,
-						UsageStats:     nil,
+						Name:            "Feature 1",
+						Alias:           nil,
+						Caniuse:         nil,
+						CompatFeatures:  nil,
+						Spec:            nil,
+						Status:          nil,
+						UsageStats:      nil,
+						Description:     "text",
+						DescriptionHTML: "<html>",
 					},
+				},
+				returnedMapping: map[string]string{
+					"feature1": "id-1",
 				},
 				returnError: errors.New("uh-oh"),
 			},


### PR DESCRIPTION
This will allow us to use that ID when inserting into datastore.

Additionally, we have the InsertWebFeatures spanneradapters return the mapping. This mapping is the external feature ID / feature key to the generated ID in spanner.

Other changes:
- Update defs.schema.json from the web features repo.

This is part of splitting up https://github.com/GoogleChrome/webstatus.dev/pull/229

