### PR TITLE
Add the logic to store and get web feature metadata

### DIFF
--- a/lib/gds/datastoreadapters/web_features_consumer.go
+++ b/lib/gds/datastoreadapters/web_features_consumer.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastoreadapters
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gds"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/jsonschema/web_platform_dx__web_features"
+)
+
+// WebFeatureDatastoreClient expects a subset of the functionality from lib/gds that only apply to WebFeatures.
+type WebFeatureDatastoreClient interface {
+	UpsertFeatureMetadata(
+		ctx context.Context,
+		data gds.FeatureMetadata,
+	) error
+}
+
+// NewWebFeaturesConsumer constructs an adapter for the web features consumer service.
+func NewWebFeaturesConsumer(client WebFeatureDatastoreClient) *WebFeaturesConsumer {
+	return &WebFeaturesConsumer{client: client}
+}
+
+// WebFeaturesConsumer handles the conversion of web feature data between the workflow/API input
+// format and the format used by the GCP Datastore client.
+type WebFeaturesConsumer struct {
+	client WebFeatureDatastoreClient
+}
+
+func (c *WebFeaturesConsumer) InsertWebFeaturesMetadata(
+	ctx context.Context,
+	featureKeyToID map[string]string,
+	data map[string]web_platform_dx__web_features.FeatureData) error {
+	for featureKey, featureData := range data {
+		featureID, found := featureKeyToID[featureKey]
+		if !found {
+			// Should never happen but let's log it out.
+			slog.Warn("unable to find internal ID for featue key", "feature key", featureKey)
+
+			continue
+		}
+		var canIUseIDs []string
+		if featureData.Caniuse != nil && featureData.Caniuse.String != nil {
+			canIUseIDs = []string{*featureData.Caniuse.String}
+		} else if featureData.Caniuse != nil && len(featureData.Caniuse.StringArray) > 0 {
+			canIUseIDs = featureData.Caniuse.StringArray
+		}
+		err := c.client.UpsertFeatureMetadata(ctx,
+			gds.FeatureMetadata{
+				WebFeatureID: featureID,
+				Description:  featureData.Description,
+				CanIUseIDs:   canIUseIDs,
+			},
+		)
+		if err != nil {
+			slog.Error("unable to upsert web feature metadata",
+				"feature key", featureKey, "feature id", featureID, "error", err)
+
+			return err
+		}
+	}
+
+	return nil
+}

--- a/lib/gds/datastoreadapters/web_features_consumer_test.go
+++ b/lib/gds/datastoreadapters/web_features_consumer_test.go
@@ -1,0 +1,167 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastoreadapters
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gds"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/jsonschema/web_platform_dx__web_features"
+)
+
+// MockWebFeatureDatastoreClient allows us to control UpsertFeatureMetadata behavior.
+type MockWebFeatureDatastoreClient struct {
+	UpsertedData  map[string]gds.FeatureMetadata
+	ErrorToReturn error
+}
+
+func (m *MockWebFeatureDatastoreClient) UpsertFeatureMetadata(_ context.Context, data gds.FeatureMetadata) error {
+	if m.ErrorToReturn != nil {
+		return m.ErrorToReturn
+	}
+	m.UpsertedData[data.WebFeatureID] = data
+
+	return nil
+}
+
+func valuePtr[T any](in T) *T { return &in }
+
+func TestInsertWebFeaturesMetadata(t *testing.T) {
+	testCases := []struct {
+		name                string
+		featureKeyToID      map[string]string
+		inputFeatureData    map[string]web_platform_dx__web_features.FeatureData
+		expectedUpserts     map[string]gds.FeatureMetadata
+		mockClientError     error
+		expectedErrorReturn error
+	}{
+		{
+			name:           "Success with single CanIUse ID",
+			featureKeyToID: map[string]string{"feature1": "id1"},
+			inputFeatureData: map[string]web_platform_dx__web_features.FeatureData{
+				"feature1": {
+					Alias:          nil,
+					CompatFeatures: nil,
+					Name:           "feature 1",
+					Description:    "Feature 1 description",
+					Caniuse: &web_platform_dx__web_features.Alias{
+						String:      valuePtr("caniuse-id1"),
+						StringArray: nil,
+					},
+					DescriptionHTML: "<html>1",
+					Status:          nil,
+					UsageStats:      nil,
+					Spec:            nil,
+				},
+			},
+			expectedUpserts: map[string]gds.FeatureMetadata{
+				"id1": {WebFeatureID: "id1", Description: "Feature 1 description", CanIUseIDs: []string{"caniuse-id1"}},
+			},
+			mockClientError:     nil,
+			expectedErrorReturn: nil,
+		},
+		{
+			name:           "Success with multiple CanIUse IDs",
+			featureKeyToID: map[string]string{"feature2": "id2"},
+			inputFeatureData: map[string]web_platform_dx__web_features.FeatureData{
+				"feature2": {
+					Alias:          nil,
+					CompatFeatures: nil,
+					Name:           "feature 2",
+					Description:    "Feature 2 description",
+					Caniuse: &web_platform_dx__web_features.Alias{
+						String:      nil,
+						StringArray: []string{"caniuse-id2a", "caniuse-id2b"},
+					},
+					DescriptionHTML: "<html>2",
+					Status:          nil,
+					UsageStats:      nil,
+					Spec:            nil,
+				},
+			},
+			expectedUpserts: map[string]gds.FeatureMetadata{
+				"id2": {
+					WebFeatureID: "id2",
+					Description:  "Feature 2 description",
+					CanIUseIDs:   []string{"caniuse-id2a", "caniuse-id2b"},
+				},
+			},
+			mockClientError:     nil,
+			expectedErrorReturn: nil,
+		},
+		{
+			name:           "Missing feature ID",
+			featureKeyToID: map[string]string{},
+			inputFeatureData: map[string]web_platform_dx__web_features.FeatureData{
+				"feature3": {
+					Alias:           nil,
+					Caniuse:         nil,
+					CompatFeatures:  nil,
+					Name:            "feature 3",
+					Description:     "Feature 3 description",
+					DescriptionHTML: "<html>3",
+					Status:          nil,
+					UsageStats:      nil,
+					Spec:            nil,
+				},
+			},
+			expectedUpserts:     map[string]gds.FeatureMetadata{},
+			mockClientError:     nil,
+			expectedErrorReturn: nil,
+		},
+		{
+			name:           "Upsert error",
+			featureKeyToID: map[string]string{"feature4": "id4"},
+			inputFeatureData: map[string]web_platform_dx__web_features.FeatureData{
+				"feature4": {
+					Alias:           nil,
+					Caniuse:         nil,
+					CompatFeatures:  nil,
+					Name:            "feature 4",
+					Description:     "Feature 4 description",
+					DescriptionHTML: "<html>4",
+					Status:          nil,
+					UsageStats:      nil,
+					Spec:            nil,
+				},
+			},
+			expectedUpserts:     map[string]gds.FeatureMetadata{},
+			mockClientError:     context.DeadlineExceeded,
+			expectedErrorReturn: context.DeadlineExceeded,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := &MockWebFeatureDatastoreClient{
+				UpsertedData:  make(map[string]gds.FeatureMetadata),
+				ErrorToReturn: tc.mockClientError,
+			}
+			consumer := NewWebFeaturesConsumer(mockClient)
+
+			err := consumer.InsertWebFeaturesMetadata(context.Background(), tc.featureKeyToID, tc.inputFeatureData)
+			if !errors.Is(err, tc.expectedErrorReturn) {
+				t.Errorf("Unexpected error: got %v, want %v", err, tc.expectedErrorReturn)
+			}
+
+			if !reflect.DeepEqual(mockClient.UpsertedData, tc.expectedUpserts) {
+				t.Errorf("Upserted data mismatch:\ngot:  %v\nwant: %v", mockClient.UpsertedData, tc.expectedUpserts)
+			}
+		})
+	}
+}

--- a/lib/gds/feature_metadata.go
+++ b/lib/gds/feature_metadata.go
@@ -1,0 +1,94 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gds
+
+import (
+	"cmp"
+	"context"
+
+	"cloud.google.com/go/datastore"
+)
+
+const featureMetadataKey = "FeatureMetadataKey"
+
+// FeatureMetadata contains useful metadata about the feature.
+// This information is not stored in the relational database because it is not used in complex queries for
+// the overview page.
+type FeatureMetadata struct {
+	// The ID from WebFeatures table in spanner. Not the web features key.
+	WebFeatureID string `datastore:"web_feature_id"`
+	// Non-null fields from https://github.com/web-platform-dx/web-features/blob/main/schemas/defs.schema.json
+	Description string `datastore:"description"`
+	// Nullable fields from https://github.com/web-platform-dx/web-features/blob/main/schemas/defs.schema.json
+	CanIUseIDs []string `datastore:"can_i_use_ids"`
+}
+
+// webFeaturesMetadataFilter implements Filterable to filter by web_feature_id.
+// Compatible kinds:
+// - featureMetadataKey.
+type webFeaturesMetadataFilter struct {
+	webFeatureID string
+}
+
+func (f webFeaturesMetadataFilter) FilterQuery(query *datastore.Query) *datastore.Query {
+	return query.FilterField("web_feature_id", "=", f.webFeatureID)
+}
+
+// webFeatureMetadataMerge implements Mergeable for FeatureMetadata.
+type webFeatureMetadataMerge struct{}
+
+func (m webFeatureMetadataMerge) Merge(existing *FeatureMetadata, new *FeatureMetadata) *FeatureMetadata {
+	canIUseIDs := existing.CanIUseIDs
+	if len(new.CanIUseIDs) > 0 {
+		canIUseIDs = new.CanIUseIDs
+	}
+
+	return &FeatureMetadata{
+		Description: cmp.Or[string](new.Description, existing.Description, ""),
+		CanIUseIDs:  canIUseIDs,
+		// The below fields cannot be overridden during a merge.
+		WebFeatureID: existing.WebFeatureID,
+	}
+}
+
+// UpsertFeatureMetadata inserts/updates metadata for the given web feature.
+func (c *Client) UpsertFeatureMetadata(
+	ctx context.Context,
+	data FeatureMetadata,
+) error {
+	entityClient := entityClient[FeatureMetadata]{c}
+
+	return entityClient.upsert(ctx,
+		featureMetadataKey,
+		&data,
+		webFeatureMetadataMerge{},
+		webFeaturesMetadataFilter{
+			webFeatureID: data.WebFeatureID,
+		},
+	)
+}
+
+// GetWebFeatureMetadata atttempts to get data for a given web feature.
+func (c *Client) GetWebFeatureMetadata(ctx context.Context, webFeatureID string) (*FeatureMetadata, error) {
+	entityClient := entityClient[FeatureMetadata]{c}
+	featureData, err := entityClient.get(ctx, featureMetadataKey, webFeaturesMetadataFilter{
+		webFeatureID: webFeatureID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return featureData, nil
+}

--- a/lib/gds/feature_metadata_test.go
+++ b/lib/gds/feature_metadata_test.go
@@ -1,0 +1,80 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gds
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestFeatureDataOperations(t *testing.T) {
+	ctx := context.Background()
+	client, cleanup := getTestDatabase(ctx, t)
+	defer cleanup()
+
+	// Part 0. Try to get id that does not exist yet.
+	data, err := client.GetWebFeatureMetadata(ctx, "id-1")
+	if !errors.Is(err, ErrEntityNotFound) {
+		t.Errorf("unexpected error %v", err)
+	}
+	if data != nil {
+		t.Error("expected nil data")
+	}
+
+	// Part 1. Try to insert the first version
+	version1 := &FeatureMetadata{
+		WebFeatureID: "id-1",
+		Description:  "initial-description",
+		CanIUseIDs:   nil, // not required on first try
+	}
+	err = client.UpsertFeatureMetadata(ctx, *version1)
+	if err != nil {
+		t.Errorf("failed to upsert %s", err.Error())
+	}
+	data, err = client.GetWebFeatureMetadata(ctx, "id-1")
+	if err != nil {
+		t.Errorf("failed to get feature metadata %s", err.Error())
+	}
+	if !reflect.DeepEqual(version1, data) {
+		t.Errorf("unexpected metadata %v", data)
+	}
+
+	// Part 2. Upsert the second version
+	partialVersion2 := FeatureMetadata{
+		WebFeatureID: "id-1",
+		Description:  "", // Do not override description
+		CanIUseIDs:   []string{"can-i-use-1", "can-i-use-2"},
+	}
+	err = client.UpsertFeatureMetadata(ctx, partialVersion2)
+	if err != nil {
+		t.Errorf("failed to upsert again %s", err.Error())
+	}
+
+	expectedVersion2 := &FeatureMetadata{
+		WebFeatureID: "id-1",
+		Description:  "initial-description",
+		CanIUseIDs:   []string{"can-i-use-1", "can-i-use-2"},
+	}
+
+	data, err = client.GetWebFeatureMetadata(ctx, "id-1")
+	if err != nil {
+		t.Errorf("failed to get feature metadata %s", err.Error())
+	}
+	if !reflect.DeepEqual(expectedVersion2, data) {
+		t.Errorf("unexpected metadata %v", data)
+	}
+}


### PR DESCRIPTION
This change adds the get and upsert methods for the web feature metadata.

Background:
There exists additional metadata that we always wanted to ingest for a feature. Such as a the description, html-description, CanIUse IDs.

However, putting that information in spanner doesn't make too much sense given that we do not need to do any relational joins against it. Plus, the data is likely to change shape. This makes maintenance of this data very hard.

Other changes:
Additionally, it adds the adapter for the web features workflow that will eventually use it to convert the data from web features to the datastore model.

This is part of splitting up #229

Depends on #230