### PR TITLE
Make web features workflow store the metadata

### DIFF
--- a/workflows/steps/services/web_feature_consumer/cmd/server/main.go
+++ b/workflows/steps/services/web_feature_consumer/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters"
 	"github.com/GoogleChrome/webstatus.dev/lib/gds"
+	"github.com/GoogleChrome/webstatus.dev/lib/gds/datastoreadapters"
 	"github.com/GoogleChrome/webstatus.dev/lib/gh"
 	"github.com/GoogleChrome/webstatus.dev/workflows/steps/services/web_feature_consumer/pkg/httpserver"
 )
@@ -35,7 +36,6 @@ func main() {
 		slog.Error("failed to create datastore client", "error", err.Error())
 		os.Exit(1)
 	}
-	_ = fs
 
 	projectID := os.Getenv("PROJECT_ID")
 	spannerDB := os.Getenv("SPANNER_DATABASE")
@@ -53,6 +53,7 @@ func main() {
 		"8080",
 		gh.NewClient(token),
 		spanneradapters.NewWebFeaturesConsumer(spannerClient),
+		datastoreadapters.NewWebFeaturesConsumer(fs),
 		"data.json",
 		"web-platform-dx",
 		"web-features",

--- a/workflows/steps/services/web_feature_consumer/pkg/httpserver/server.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/httpserver/server.go
@@ -50,9 +50,19 @@ type WebFeatureStorer interface {
 		data map[string]web_platform_dx__web_features.FeatureData) (map[string]string, error)
 }
 
+// WebFeatureMetadataStorer describes the logic to insert the non-relation metadata about web features that
+// were returned by the AssetParser.
+type WebFeatureMetadataStorer interface {
+	InsertWebFeaturesMetadata(
+		ctx context.Context,
+		featureKeyToID map[string]string,
+		data map[string]web_platform_dx__web_features.FeatureData) error
+}
+
 type Server struct {
 	assetGetter           AssetGetter
 	storer                WebFeatureStorer
+	metadataStorer        WebFeatureMetadataStorer
 	webFeaturesDataParser AssetParser
 	defaultAssetName      string
 	defaultRepoOwner      string
@@ -90,14 +100,23 @@ func (s *Server) PostV1WebFeatures(
 		}, nil
 	}
 
-	// TODO use the mapping in the future for storing metadata
-	_, err = s.storer.InsertWebFeatures(ctx, data)
+	mapping, err := s.storer.InsertWebFeatures(ctx, data)
 	if err != nil {
 		slog.Error("unable to store data", "error", err)
 
 		return web_feature_consumer.PostV1WebFeatures500JSONResponse{
 			Code:    500,
 			Message: "unable to store data",
+		}, nil
+	}
+
+	err = s.metadataStorer.InsertWebFeaturesMetadata(ctx, mapping, data)
+	if err != nil {
+		slog.Error("unable to store metadata", "error", err)
+
+		return web_feature_consumer.PostV1WebFeatures500JSONResponse{
+			Code:    500,
+			Message: "unable to store metadata",
 		}, nil
 	}
 
@@ -108,6 +127,7 @@ func NewHTTPServer(
 	port string,
 	assetGetter AssetGetter,
 	storer WebFeatureStorer,
+	metadataStorer WebFeatureMetadataStorer,
 	defaultAssetName string,
 	defaultRepoOwner string,
 	defaultRepoName string,
@@ -121,6 +141,7 @@ func NewHTTPServer(
 	srv := &Server{
 		assetGetter:           assetGetter,
 		storer:                storer,
+		metadataStorer:        metadataStorer,
 		webFeaturesDataParser: data.Parser{},
 		defaultAssetName:      defaultAssetName,
 		defaultRepoOwner:      defaultRepoOwner,


### PR DESCRIPTION
Now that we the ability to
1. store metadata and translate the web feature data to the datastore model (#231),
2. get the internal spanner id that maps to the feature key in bulk (#230)

This change hooks up the workflow to actually start using that functionality to store the web feature metadata.

This is part of splitting up #229

Depends on #231

