### PR TITLE
Expose feature metadata endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters"
 	"github.com/GoogleChrome/webstatus.dev/lib/gds"
+	"github.com/GoogleChrome/webstatus.dev/lib/gds/datastoreadapters"
 	"github.com/GoogleChrome/webstatus.dev/lib/httpmiddlewares"
 	"github.com/GoogleChrome/webstatus.dev/lib/rediscache"
 	"github.com/go-chi/cors"
@@ -97,7 +98,7 @@ func main() {
 
 	srv, err := httpserver.NewHTTPServer(
 		"8080",
-		fs,
+		datastoreadapters.NewBackend(fs),
 		spanneradapters.NewBackend(spannerClient),
 		[]func(http.Handler) http.Handler{
 			cors.Handler(

--- a/backend/pkg/httpserver/get_feature_metadata.go
+++ b/backend/pkg/httpserver/get_feature_metadata.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// GetFeatureMetadata implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Name generated from openapi
+func (s *Server) GetFeatureMetadata(ctx context.Context,
+	request backend.GetFeatureMetadataRequestObject) (backend.GetFeatureMetadataResponseObject, error) {
+	featureId, err := s.wptMetricsStorer.GetIDFromFeatureKey(ctx, request.FeatureId)
+	if err != nil {
+		if errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {
+			return backend.GetFeatureMetadata404JSONResponse{
+				Code:    http.StatusNotFound,
+				Message: fmt.Sprintf("feature id %s is not found", request.FeatureId),
+			}, nil
+		}
+		// Catch all for all other errors.
+		slog.Error("unable to check feature before fetching metadata", "error", err)
+
+		return backend.GetFeatureMetadata500JSONResponse{
+			Code:    500,
+			Message: "unable to get feature metadata",
+		}, nil
+	}
+
+	metadata, err := s.metadataStorer.GetFeatureMetadata(ctx, *featureId)
+	if err != nil {
+		// Catch all for all other errors.
+		slog.Error("unable to get feature metadata", "error", err)
+
+		return backend.GetFeatureMetadata500JSONResponse{
+			Code:    500,
+			Message: "unable to get feature metadata",
+		}, nil
+	}
+
+	return backend.GetFeatureMetadata200JSONResponse(*metadata), nil
+}

--- a/backend/pkg/httpserver/get_feature_metadata_test.go
+++ b/backend/pkg/httpserver/get_feature_metadata_test.go
@@ -1,0 +1,101 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestGetFeatureMetadata(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		mockGetIDConfig       MockGetIDFromFeatureKeyConfig
+		mockGetMetadataConfig MockGetFeatureMetadataConfig
+		request               backend.GetFeatureMetadataRequestObject
+		expectedResponse      backend.GetFeatureMetadataResponseObject
+		expectedError         error
+	}{
+		{
+			name: "success",
+			mockGetIDConfig: MockGetIDFromFeatureKeyConfig{
+				expectedFeatureKey: "key1",
+				result:             valuePtr("id1"),
+				err:                nil,
+			},
+			mockGetMetadataConfig: MockGetFeatureMetadataConfig{
+				expectedFeatureID: "id1",
+				result: &backend.FeatureMetadata{
+					CanIUse: &backend.CanIUseInfo{
+						Items: &[]backend.CanIUseItem{
+							{
+								Id: valuePtr("caniuse1"),
+							},
+						},
+					},
+					Description: valuePtr("desc"),
+				},
+				err: nil,
+			},
+			request: backend.GetFeatureMetadataRequestObject{
+				FeatureId: "key1",
+			},
+			expectedResponse: backend.GetFeatureMetadata200JSONResponse(
+				backend.FeatureMetadata{
+					CanIUse: &backend.CanIUseInfo{
+						Items: &[]backend.CanIUseItem{
+							{
+								Id: valuePtr("caniuse1"),
+							},
+						},
+					},
+					Description: valuePtr("desc"),
+				},
+			),
+			expectedError: nil,
+		},
+		// TODO(jcscottiii). Add more test cases later.
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// nolint: exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				getIDFromFeatureKeyConfig: tc.mockGetIDConfig,
+				t:                         t,
+			}
+			mockMetadataStorer := &MockWebFeatureMetadataStorer{
+				mockGetFeatureMetadataCfg: tc.mockGetMetadataConfig,
+				t:                         t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: mockMetadataStorer}
+
+			// Call the function under test
+			resp, err := myServer.GetFeatureMetadata(context.Background(), tc.request)
+
+			// Assertions
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tc.expectedResponse, resp) {
+				t.Errorf("Unexpected response: %v", resp)
+			}
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -27,7 +27,12 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-type WebFeatureMetadataStorer interface{}
+type WebFeatureMetadataStorer interface {
+	GetFeatureMetadata(
+		ctx context.Context,
+		featureID string,
+	) (*backend.FeatureMetadata, error)
+}
 
 type WPTMetricsStorer interface {
 	ListMetricsForFeatureIDBrowserAndChannel(
@@ -73,6 +78,10 @@ type WPTMetricsStorer interface {
 		pageSize int,
 		pageToken *string,
 	) (*backend.BrowserReleaseFeatureMetricsPage, error)
+	GetIDFromFeatureKey(
+		ctx context.Context,
+		featureID string,
+	) (*string, error)
 }
 
 type Server struct {

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -28,6 +28,28 @@ import (
 
 func valuePtr[T any](in T) *T { return &in }
 
+type MockGetFeatureMetadataConfig struct {
+	expectedFeatureID string
+	result            *backend.FeatureMetadata
+	err               error
+}
+
+type MockWebFeatureMetadataStorer struct {
+	t                         *testing.T
+	mockGetFeatureMetadataCfg MockGetFeatureMetadataConfig
+}
+
+func (s *MockWebFeatureMetadataStorer) GetFeatureMetadata(
+	_ context.Context,
+	featureID string,
+) (*backend.FeatureMetadata, error) {
+	if featureID != s.mockGetFeatureMetadataCfg.expectedFeatureID {
+		s.t.Error("unexpected feature id")
+	}
+
+	return s.mockGetFeatureMetadataCfg.result, s.mockGetFeatureMetadataCfg.err
+}
+
 type MockListMetricsForFeatureIDBrowserAndChannelConfig struct {
 	expectedFeatureID string
 	expectedBrowser   string
@@ -75,6 +97,12 @@ type MockGetFeatureByIDConfig struct {
 	err                   error
 }
 
+type MockGetIDFromFeatureKeyConfig struct {
+	expectedFeatureKey string
+	result             *string
+	err                error
+}
+
 type MockListBrowserFeatureCountMetricConfig struct {
 	expectedBrowser   string
 	expectedStartAt   time.Time
@@ -92,12 +120,24 @@ type MockWPTMetricsStorer struct {
 	featuresSearchCfg                                 MockFeaturesSearchConfig
 	listBrowserFeatureCountMetricCfg                  MockListBrowserFeatureCountMetricConfig
 	getFeatureByIDConfig                              MockGetFeatureByIDConfig
+	getIDFromFeatureKeyConfig                         MockGetIDFromFeatureKeyConfig
 	t                                                 *testing.T
 	callCountListBrowserFeatureCountMetric            int
 	callCountFeaturesSearch                           int
 	callCountListMetricsForFeatureIDBrowserAndChannel int
 	callCountListMetricsOverTimeWithAggregatedTotals  int
 	callCountGetFeature                               int
+}
+
+func (m *MockWPTMetricsStorer) GetIDFromFeatureKey(
+	_ context.Context,
+	featureID string,
+) (*string, error) {
+	if featureID != m.getIDFromFeatureKeyConfig.expectedFeatureKey {
+		m.t.Errorf("unexpected feature key %s", featureID)
+	}
+
+	return m.getIDFromFeatureKeyConfig.result, m.getIDFromFeatureKeyConfig.err
 }
 
 func (m *MockWPTMetricsStorer) ListMetricsForFeatureIDBrowserAndChannel(_ context.Context,

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -77,7 +77,7 @@ type BackendSpannerClient interface {
 	) (*gcpspanner.BrowserFeatureCountResultPage, error)
 }
 
-// Backend converts queries to spanner to useable entities for the backend
+// Backend converts queries to spanner to usable entities for the backend
 // service.
 type Backend struct {
 	client BackendSpannerClient

--- a/lib/gds/datastoreadapters/backend.go
+++ b/lib/gds/datastoreadapters/backend.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastoreadapters
+
+import (
+	"context"
+	"errors"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gds"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+type BackendDatastoreClient interface {
+	GetWebFeatureMetadata(ctx context.Context, webFeatureID string) (*gds.FeatureMetadata, error)
+}
+
+// Backend converts queries to datastore to usable entities for the backend
+// service.
+type Backend struct {
+	client BackendDatastoreClient
+}
+
+// NewBackend constructs an adapter for the backend service.
+func NewBackend(client BackendDatastoreClient) *Backend {
+	return &Backend{client: client}
+}
+
+func (d *Backend) GetFeatureMetadata(
+	ctx context.Context,
+	featureID string,
+) (*backend.FeatureMetadata, error) {
+	metadata, err := d.client.GetWebFeatureMetadata(ctx, featureID)
+	if errors.Is(err, gds.ErrEntityNotFound) {
+		// Return an empty metadata for now.
+		// The feature exists but datastore doesn't have any metadata for it.
+		// This could be because the feature's metadata has not been stored yet.
+		return &backend.FeatureMetadata{
+			CanIUse:     nil,
+			Description: nil,
+		}, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	var canIUse *backend.CanIUseInfo
+	if len(metadata.CanIUseIDs) > 0 {
+		items := make([]backend.CanIUseItem, 0, len(metadata.CanIUseIDs))
+		for idx := range metadata.CanIUseIDs {
+			items = append(items, backend.CanIUseItem{
+				Id: &metadata.CanIUseIDs[idx],
+			})
+		}
+		canIUse = &backend.CanIUseInfo{
+			Items: &items,
+		}
+	}
+
+	return &backend.FeatureMetadata{
+		CanIUse:     canIUse,
+		Description: &metadata.Description,
+	}, nil
+}

--- a/lib/gds/datastoreadapters/backend_test.go
+++ b/lib/gds/datastoreadapters/backend_test.go
@@ -1,0 +1,149 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastoreadapters
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gds"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+type mockGetFeatureMetadataConfig struct {
+	expectedFeatureID string
+	result            *gds.FeatureMetadata
+	err               error
+}
+
+type mockBackendDatastoreClient struct {
+	t                         *testing.T
+	mockGetFeatureMetadataCfg mockGetFeatureMetadataConfig
+}
+
+func (c mockBackendDatastoreClient) GetWebFeatureMetadata(
+	_ context.Context, webFeatureID string) (*gds.FeatureMetadata, error) {
+	if c.mockGetFeatureMetadataCfg.expectedFeatureID != webFeatureID {
+		c.t.Error("unexpected input to mock")
+	}
+
+	return c.mockGetFeatureMetadataCfg.result, c.mockGetFeatureMetadataCfg.err
+}
+
+var errGetMetadataTestError = errors.New("get feature metadata tests error")
+
+func TestGetFeatureMetadata(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		featureID                 string
+		mockGetFeatureMetadataCfg mockGetFeatureMetadataConfig
+		expectedMetadata          *backend.FeatureMetadata
+		expectedErr               error
+	}{
+		{
+			name:      "success - no can i use ids",
+			featureID: "id-1",
+			mockGetFeatureMetadataCfg: mockGetFeatureMetadataConfig{
+				expectedFeatureID: "id-1",
+				result: &gds.FeatureMetadata{
+					WebFeatureID: "id-1",
+					Description:  "desc",
+					CanIUseIDs:   nil,
+				},
+				err: nil,
+			},
+			expectedMetadata: &backend.FeatureMetadata{
+				Description: valuePtr("desc"),
+				CanIUse:     nil,
+			},
+			expectedErr: nil,
+		},
+		{
+			name:      "success - with can i use ids",
+			featureID: "id-1",
+			mockGetFeatureMetadataCfg: mockGetFeatureMetadataConfig{
+				expectedFeatureID: "id-1",
+				result: &gds.FeatureMetadata{
+					WebFeatureID: "id-1",
+					Description:  "desc",
+					CanIUseIDs: []string{
+						"caniuse1",
+						"caniuse2",
+					},
+				},
+				err: nil,
+			},
+			expectedMetadata: &backend.FeatureMetadata{
+				Description: valuePtr("desc"),
+				CanIUse: &backend.CanIUseInfo{
+					Items: &[]backend.CanIUseItem{
+						{
+							Id: valuePtr("caniuse1"),
+						},
+						{
+							Id: valuePtr("caniuse2"),
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:      "success - default metadata",
+			featureID: "id-1",
+			mockGetFeatureMetadataCfg: mockGetFeatureMetadataConfig{
+				expectedFeatureID: "id-1",
+				result:            nil,
+				err:               gds.ErrEntityNotFound,
+			},
+			expectedMetadata: &backend.FeatureMetadata{
+				Description: nil,
+				CanIUse:     nil,
+			},
+			expectedErr: nil,
+		},
+
+		{
+			name:      "error",
+			featureID: "id-1",
+			mockGetFeatureMetadataCfg: mockGetFeatureMetadataConfig{
+				expectedFeatureID: "id-1",
+				result:            nil,
+				err:               errGetMetadataTestError,
+			},
+			expectedMetadata: nil,
+			expectedErr:      errGetMetadataTestError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := mockBackendDatastoreClient{
+				t:                         t,
+				mockGetFeatureMetadataCfg: tc.mockGetFeatureMetadataCfg,
+			}
+			b := NewBackend(mock)
+			metadata, err := b.GetFeatureMetadata(context.Background(), tc.featureID)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Error("unexpected error")
+			}
+			if !reflect.DeepEqual(metadata, tc.expectedMetadata) {
+				t.Error("unexpected metadata")
+			}
+		})
+	}
+}

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -144,6 +144,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasicErrorModel'
+  /v1/features/{feature_id}/feature-metadata:
+    parameters:
+      - name: feature_id
+        in: path
+        description: Feature ID
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get metadata for a given feature from github.com/web-platform-dx/web-features
+      operationId: getFeatureMetadata
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureMetadata'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '429':
+          description: Rate Limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
   /v1/features/{feature_id}/stats/wpt/browsers/{browser}/channels/{channel}/{metric_view}:
     parameters:
       - name: feature_id
@@ -576,6 +618,24 @@ components:
       type: object
       properties:
         link:
+          type: string
+    FeatureMetadata:
+      type: object
+      properties:
+        can_i_use:
+          $ref: '#/components/schemas/CanIUseInfo'
+        description:
+          type: string
+    CanIUseInfo:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/CanIUseItem'
+    CanIUseItem:
+      properties:
+        id:
           type: string
     Feature:
       type: object


### PR DESCRIPTION
On the API side, a new endpoint exists /v1/features/{feature_id}/feature-metadata to expose that data. For now, it only returns Can I Use IDs. The returned object, while bulky, is structured in case we want to add any information without breaking our schema in the future.

This change also introduces the adapters which convert the database model from datastore to the expected backend model that is returned

Future changes:
- Add more tests to backend/pkg/httpserver/get_feature_metadata_test.go

This is part of splitting up #229

Depends on #232