### PR TITLE
Display the caniuse link on feature detail page

### DIFF
--- a/frontend/src/static/js/api/client.ts
+++ b/frontend/src/static/js/api/client.ts
@@ -128,6 +128,24 @@ export class APIClient {
     return data;
   }
 
+  public async getFeatureMetadata(
+    featureId: string
+  ): Promise<components['schemas']['FeatureMetadata']> {
+    const {data, error} = await this.client.GET(
+      '/v1/features/{feature_id}/feature-metadata',
+      {
+        ...temporaryFetchOptions,
+        params: {
+          path: {feature_id: featureId},
+        },
+      }
+    );
+    if (error !== undefined) {
+      throw new Error(error?.message || error?.toString());
+    }
+    return data;
+  }
+
   // Internal client detail for constructing a FeatureResultOffsetCursor pagination token.
   // Typically, users of the /v1/features endpoint should use the provided pagination token.
   // However, this token can be used to facilitate a UI with where we have selectable page numbers.

--- a/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
@@ -33,4 +33,39 @@ describe('webstatus-feature-page', () => {
       'https://wpt.fyi/results?label=master&label=stable&aligned=&q=feature%3Adeclarative-shadow-dom%21is%3Atentative'
     );
   });
+
+  it('optionally builds a caniuse link', async () => {
+    // Single item renders a link
+    const singleItem = {
+      items: [{id: 'flexbox'}],
+    };
+    const singleItemLink = el.findCanIUseLink(singleItem);
+    expect(singleItemLink).to.eq('https://caniuse.com/flexbox');
+
+    // Multiple item renders no link
+    const multipleItems = {
+      items: [{id: 'flexbox'}, {id: 'grid'}],
+    };
+    const multipleItemsLink = el.findCanIUseLink(multipleItems);
+    expect(multipleItemsLink).to.eq(null);
+
+    // No item renders no link
+    const emptyItems = {
+      items: [],
+    };
+    const emptyItemsLink = el.findCanIUseLink(emptyItems);
+    expect(emptyItemsLink).to.eq(null);
+
+    // Undefined items renders no link
+    const undefinedItems = {
+      items: undefined,
+    };
+    const undefinedItemsLink = el.findCanIUseLink(undefinedItems);
+    expect(undefinedItemsLink).to.eq(null);
+
+    // Undefined object renders no link
+    const undefinedObjItems = undefined;
+    const undefinedObjItemsLink = el.findCanIUseLink(undefinedObjItems);
+    expect(undefinedObjItemsLink).to.eq(null);
+  });
 });


### PR DESCRIPTION
This change queries the new metadata link.
Upon analyzing the response, if it sees exactly
one caniuse id, it will render a link out for it.

Anymore than 1 or zero items or null items renders no link.

Depends on #233 