### PR TITLE
Fixes various nginx issues

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -26,7 +26,16 @@ http {
     }
 
     # Serve SPA
-    location / {
+    # Matches /features/featureId, but not /features/featureId/something
+    location ~ ^/features/[^/]+$ {
+      try_files $uri $uri/ /index.html;
+    }
+
+    location = /stats {
+      try_files $uri $uri/ /index.html;
+    }
+
+    location = / {
       try_files $uri $uri/ =404;
     }
 
@@ -41,6 +50,6 @@ http {
     add_header X-Frame-Options "SAMEORIGIN";
 
     gzip on;
-    gzip_types text/html application/javascript application/json text/css;
+    gzip_types application/javascript application/json text/css;
   }
 }

--- a/frontend/src/static/js/api/client.ts
+++ b/frontend/src/static/js/api/client.ts
@@ -123,7 +123,7 @@ export class APIClient {
       },
     });
     if (error !== undefined) {
-      throw new Error(error?.message || error?.toString());
+      throw createError(error);
     }
     return data;
   }
@@ -240,5 +240,94 @@ export class APIClient {
     } while (nextPageToken !== undefined);
 
     return allData;
+  }
+}
+
+function createError(error: unknown): ApiError {
+  let message = 'Unknown error';
+  let code = 500; // Default to Internal Server Error
+
+  if (error instanceof Error) {
+    message = error.message;
+
+    // Check if error object has a code property (could be ApiError or other custom error)
+    if ('code' in error && typeof error.code === 'number') {
+      code = error.code;
+    }
+  }
+
+  switch (code) {
+    case 400:
+      return new BadRequestError(message);
+    case 401:
+      return new UnauthorizedError(message);
+    case 403:
+      return new ForbiddenError(message);
+    case 404:
+      return new NotFoundError(message);
+    case 429:
+      return new RateLimitExceededError(message);
+    case 500:
+      return new InternalServerError(message);
+    default:
+      return new UnknownError(message);
+  }
+}
+
+class ApiError extends Error {
+  code: number;
+  constructor(message: string, code: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.code = code;
+  }
+}
+
+export class BadRequestError extends ApiError {
+  constructor(message: string) {
+    super(message, 400);
+    this.name = 'BadRequestError';
+  }
+}
+
+export class UnauthorizedError extends ApiError {
+  constructor(message: string) {
+    super(message, 401);
+    this.name = 'UnauthorizedError';
+  }
+}
+
+export class ForbiddenError extends ApiError {
+  constructor(message: string) {
+    super(message, 403);
+    this.name = 'ForbiddenError';
+  }
+}
+
+export class RateLimitExceededError extends ApiError {
+  constructor(message: string) {
+    super(message, 429);
+    this.name = 'RateLimitExceededError';
+  }
+}
+
+export class InternalServerError extends ApiError {
+  constructor(message: string) {
+    super(message, 500);
+    this.name = 'InternalServerError';
+  }
+}
+
+export class NotFoundError extends ApiError {
+  constructor(message: string) {
+    super(message, 404);
+    this.name = 'NotFoundError';
+  }
+}
+
+export class UnknownError extends ApiError {
+  constructor(message: string) {
+    super(message, 0);
+    this.name = 'UnknownError';
   }
 }

--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -40,6 +40,7 @@ import {
   type BrowsersParameter,
   type ChannelsParameter,
   type WPTRunMetric,
+  NotFoundError,
 } from '../api/client.js';
 import {
   formatFeaturePageUrl,
@@ -424,7 +425,16 @@ export class FeaturePage extends LitElement {
   render(): TemplateResult | undefined {
     return this._loadingTask.render({
       complete: () => this.renderWhenComplete(),
-      error: () => this.renderWhenError(),
+      error: error => {
+        if (error instanceof NotFoundError) {
+          // TODO: cannot use navigateToUrl because it creates a
+          // circular dependency.
+          // For now use the window href and revisit when navigateToUrl
+          // is move to another location.
+          window.location.href = '/errors-404/feature-not-found';
+        }
+        return this.renderWhenError();
+      },
       initial: () => this.renderWhenInitial(),
       pending: () => this.renderWhenPending(),
     });


### PR DESCRIPTION
Fixes #235 and should not break the existing 404 e2e tests

Additionally, add the errors from openapi into the client. Then use it for the feature detail page.

Previously, the feature detail page shows this message for any error (including 404):
- Error when loading feature <featureKey>.

But given we have a not found page, a first step would be to leverage that by forcing the browser to navigate to a bad 404 route with the `errors-404` path prefix.

In the future, we can add separate path prefixes in the nginx config for different status codes, for example /errors-500/ would make the page render with a 500 status code and have a 500 page (similar to the existing 404 page)


Other changes:
- Also fix the warning on start up stating there is a duplicate MIME config.
