### PR TITLE
Clear out any search parameters that may have been set by the bookmarks

### DIFF
--- a/frontend/src/static/js/components/webstatus-sidebar-menu.ts
+++ b/frontend/src/static/js/components/webstatus-sidebar-menu.ts
@@ -203,6 +203,8 @@ export class WebstatusSidebarMenu extends LitElement {
       }
       const currentUrl = new URL(this.getLocation().href);
       currentUrl.pathname = navigationItem.path;
+      // Clear out any search parameters that may have been set by the bookmarks.
+      currentUrl.search = '';
 
       if (currentUrl.href !== this.getLocation().href) {
         this.navigate(currentUrl.href);


### PR DESCRIPTION
This allows the page to navigate between bookmarks and the main feature.

Note: This event handler does not impact the bookmarks. Only the high level links in the tree. The selection event does not propagate the event to nested tree structure for the bookmarks.

