### PR TITLE
Browser names case insensitive, remove missing_in_one

### DIFF
--- a/antlr/FeatureSearch.g4
+++ b/antlr/FeatureSearch.g4
@@ -12,10 +12,12 @@ COLON: ':';
 WS: [ \t\r\n]+ -> skip;
 
 // Identifiers
+BROWSER_NAME options {
+	caseInsensitive = true;
+}: 'chrome' | 'firefox' | 'edge' | 'safari';
 BASELINE_STATUS: 'limited' | 'newly' | 'widely';
-BROWSER_NAME: 'chrome' | 'firefox' | 'edge' | 'safari';
-BROWSER_LIST: BROWSER_NAME (',' BROWSER_NAME)*;
-DATE: [2][0-9][0-9][0-9]'-'[01][0-9]'-'[0-3][0-9]; // YYYY-MM-DD (starting from 2000)
+DATE:
+	[2][0-9][0-9][0-9]'-' [01][0-9]'-' [0-3][0-9]; // YYYY-MM-DD (starting from 2000)
 ANY_VALUE:
 	'"' [a-zA-Z][a-zA-Z0-9_ -]* '"' // Words with spaces.
 	| [a-zA-Z][a-zA-Z0-9_-]*; // Single words
@@ -26,20 +28,20 @@ baseline_status_term: 'baseline_status' COLON BASELINE_STATUS;
 // In the future support other operators by doing something like (date_operator_query | date_range_query)
 baseline_date_term: 'baseline_date' COLON (date_range_query);
 name_term: 'name' COLON ANY_VALUE;
-term: available_on_term | baseline_status_term | baseline_date_term | name_term;
+term:
+	available_on_term
+	| baseline_status_term
+	| baseline_date_term
+	| name_term;
 
-date_range_query: startDate=DATE '..' endDate=DATE;
+date_range_query: startDate = DATE '..' endDate = DATE;
 
 generic_search_term: (NOT)? term;
 
 // Search criteria
 search_criteria:
 	generic_search_term
-	| missing_in_one_of
 	| ANY_VALUE; // Default to ANY_VALUE search without "name:" prefix.
-
-// Missing in one of
-missing_in_one_of: 'missing_in_one_of' '(' BROWSER_LIST ')';
 
 // Combined search criteria
 combined_search_criteria:

--- a/antlr/FeatureSearch.md
+++ b/antlr/FeatureSearch.md
@@ -35,12 +35,6 @@ This query language enables you to construct flexible searches to find features 
       - `name:"CSS Grid"`
   - `baseline_date`: Represents the date a feature reached baseline.
     - Option 1: Searches for an inclusive date range (DATE..DATE) where features reached baseline.
-  - `missing_in_one_of`: Searches for features that are almost universally supported, meaning they are available on all
-    browsers **except one**. Expects a browser list (BROWSER_LIST) as its value. Not compatible with the `-` negation prefix.
-    - Example:
-      - missing_in_one_of(chrome, edge, firefox)
-        - Explanation: Look at all the features supported among the 4 specified browsers. Find the features that are
-          supported in N-1 browsers.
 - **Negation:** Prepend a term with a minus sign (-) to indicate negation (search for features not matching that criterion).
 - **Keywords:** These are reserved words used in the grammar, such as `AND`, `OR`
   - `AND`: Combine terms with the AND keyword for explicit logical AND, or use a space between terms for implied AND.
@@ -61,5 +55,4 @@ This query language enables you to construct flexible searches to find features 
 
 - `available_on:chrome AND baseline_status:newly` - Find features available on Chrome and having a newly baseline status.
 - `-available_on:firefox OR name:"CSS Grid"` - Find features either not available on Firefox or named "CSS Grid".
-- `missing_in_one_of(chrome,firefox,safari)` - Find features missing from at least one of the listed browsers.
 - `"CSS Grid" baseline_status:limited` - Find features named "CSS Grid" with a baseline status of none (implied AND).

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -46,6 +46,42 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
+			InputQuery: "available_on:Chrome",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Term: &SearchTerm{
+							Identifier: IdentifierAvailableOn,
+							Value:      "chrome",
+							Operator:   OperatorEq,
+						},
+						Children: nil,
+						Keyword:  KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: "available_on:CHROME",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Term: &SearchTerm{
+							Identifier: IdentifierAvailableOn,
+							Value:      "chrome",
+							Operator:   OperatorEq,
+						},
+						Children: nil,
+						Keyword:  KeywordNone,
+					},
+				},
+			},
+		},
+		{
 			InputQuery: "-available_on:chrome",
 			ExpectedTree: &SearchNode{
 				Keyword: KeywordRoot,
@@ -635,16 +671,20 @@ func TestParseQueryBadInput(t *testing.T) {
 		{
 			input: "baseline_status:none",
 		},
+		{
+			input: "available_on:chrome,edge",
+		},
 	}
 	for _, tc := range testCases {
-		parser := FeaturesSearchQueryParser{}
-		resultTree, err := parser.Parse(tc.input)
-		if resultTree != nil {
-			t.Error("expected nil node")
-		}
-		if errors.Is(err, nil) {
-			t.Error("expected non nil error")
-		}
-
+		t.Run(tc.input, func(t *testing.T) {
+			parser := FeaturesSearchQueryParser{}
+			resultTree, err := parser.Parse(tc.input)
+			if resultTree != nil {
+				t.Error("expected nil node")
+			}
+			if errors.Is(err, nil) {
+				t.Error("expected non nil error")
+			}
+		})
 	}
 }

--- a/lib/gcpspanner/searchtypes/features_search_visitor.go
+++ b/lib/gcpspanner/searchtypes/features_search_visitor.go
@@ -161,7 +161,7 @@ func (v *FeaturesSearchVisitor) VisitQuery(ctx *parser.QueryContext) interface{}
 
 // nolint: revive // Method signature is generated.
 func (v *FeaturesSearchVisitor) VisitAvailable_on_term(ctx *parser.Available_on_termContext) interface{} {
-	browserName := ctx.BROWSER_NAME().GetText()
+	browserName := strings.ToLower(ctx.BROWSER_NAME().GetText())
 
 	return &SearchNode{
 		Keyword: KeywordNone,
@@ -274,8 +274,6 @@ func (v *FeaturesSearchVisitor) Visit(tree antlr.ParseTree) any {
 		return v.VisitDate_range_query(tree)
 	case *parser.Generic_search_termContext:
 		return v.VisitGeneric_search_term(tree)
-	case *parser.Missing_in_one_ofContext:
-		return v.VisitMissing_in_one_of(tree)
 	case *parser.Name_termContext:
 		return v.VisitName_term(tree)
 	case *parser.OperatorContext:
@@ -370,11 +368,6 @@ func (v *FeaturesSearchVisitor) VisitSearch_criteria(ctx *parser.Search_criteria
 		return v.createNameNode(node.GetText())
 	}
 
-	return v.VisitChildren(ctx)
-}
-
-// nolint: revive // Method signature is generated.
-func (v *FeaturesSearchVisitor) VisitMissing_in_one_of(ctx *parser.Missing_in_one_ofContext) interface{} {
 	return v.VisitChildren(ctx)
 }
 


### PR DESCRIPTION
Fixes #236

Fixes #238

For the browser1,browser2 bug, the BROWSER_LIST rule was causing that issue.

Given, we don't use missing_in_one yet, let's remove it for now and BROWSER_LIST rule. Add a test case to assert that it returns an error now.

Also, make the browsers case insensitive. On the backend, we lower case everything to keep it standard.

