### PR TITLE
Make CORS settings a variable, nginx redirect www

### DIFF
--- a/backend/manifests/pod.yaml
+++ b/backend/manifests/pod.yaml
@@ -39,7 +39,7 @@ spec:
         - name: DATASTORE_EMULATOR_HOST
           value: 'datastore:8085'
         - name: CORS_ALLOWED_ORIGIN
-          value: 'http://localhost:5555'
+          value: 'http://*'
         - name: REDISHOST
           value: redis
         - name: REDISPORT

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -17,6 +17,11 @@ http {
     error_page 404 @404_fallback;
     index index.html;
 
+    if ($host ~* ^www\.(.*)$) {
+      set $non_www_host $1;
+      return 301 $scheme://$non_www_host$request_uri;
+    }
+
     # Serve static files and handle missing files in '/public' with SPA fallback
     location /public {
       try_files $uri =404;

--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -46,3 +46,5 @@ ssl_certificates                              = []
 spanner_region_override = "nam-eur-asia1"
 
 cache_duration = "5m"
+
+backend_cors_allowed_origin = "https://*"

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -42,7 +42,10 @@ frontend_docker_build_target = "static"
 backend_domains_for_gcp_managed_certificates  = []
 frontend_domains_for_gcp_managed_certificates = []
 
-# Temporary for UB.
+# Temporary for UbP.
 ssl_certificates = ["ub-self-sign"]
 
 cache_duration = "5m"
+
+# Needed for UbP.
+backend_cors_allowed_origin = "https://website-webstatus-dev.corp.goog"

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -82,7 +82,7 @@ resource "google_cloud_run_v2_service" "service" {
       }
       env {
         name  = "CORS_ALLOWED_ORIGIN"
-        value = "https://website-webstatus-dev.corp.goog"
+        value = var.cors_allowed_origin
       }
       env {
         name  = "REDISHOST"

--- a/infra/backend/variables.tf
+++ b/infra/backend/variables.tf
@@ -78,3 +78,7 @@ variable "redis_env_vars" {
 variable "cache_duration" {
   type = string
 }
+
+variable "cors_allowed_origin" {
+  type = string
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -90,6 +90,7 @@ module "backend" {
   projects                             = var.projects
   cache_duration                       = var.cache_duration
   redis_env_vars                       = module.storage.redis_env_vars
+  cors_allowed_origin                  = var.backend_cors_allowed_origin
 }
 
 module "frontend" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -121,3 +121,7 @@ variable "cache_duration" {
   type        = string
   description = "TTL for entries that are cached"
 }
+
+variable "backend_cors_allowed_origin" {
+  type = string
+}


### PR DESCRIPTION
Previously CORS was set to the staging deployment's URL even for prod.

Now, CORS is set to https://* for prod. (We can eventually make it * after some code changes and moving off of UberProxy)

Also, redirect www. to non www domain in nginx. We can probably do that in DNS but rolling those changes take awhile.

This will help with going from www.webstatus.dev to webstatus.dev

