### PR TITLE
Add a space between the query terms for wpt link

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
@@ -30,7 +30,7 @@ describe('webstatus-feature-page', () => {
   it('builds the WPT link correctly', async () => {
     const link = el.buildWPTLink('declarative-shadow-dom');
     expect(link).to.eq(
-      'https://wpt.fyi/results?label=master&label=stable&aligned=&q=feature%3Adeclarative-shadow-dom%21is%3Atentative'
+      'https://wpt.fyi/results?label=master&label=stable&aligned=&q=feature%3Adeclarative-shadow-dom+%21is%3Atentative'
     );
   });
 

--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -529,7 +529,7 @@ export class FeaturePage extends LitElement {
 
   buildWPTLink(featureId: string): string {
     const wptLinkURL = new URL('https://wpt.fyi/results');
-    const query = `feature:${featureId}!is:tentative`;
+    const query = `feature:${featureId} !is:tentative`;
     wptLinkURL.searchParams.append('label', 'master');
     wptLinkURL.searchParams.append('label', 'stable');
     wptLinkURL.searchParams.append('aligned', '');


### PR DESCRIPTION
Currently, there is no space between the feature id and the !is:tentative term. While the link renders the correct results, we are probably just very lucky that it works.

