### PR TITLE
Make the "Features" text an anchor

### DIFF
--- a/frontend/src/static/js/components/webstatus-sidebar-menu.ts
+++ b/frontend/src/static/js/components/webstatus-sidebar-menu.ts
@@ -85,6 +85,10 @@ export class WebstatusSidebarMenu extends LitElement {
           font-size: 24px;
           vertical-align: middle;
         }
+        .features-link {
+          color: inherit;
+          text-decoration: none;
+        }
         .bookmark-link {
           color: inherit;
           text-decoration: none;
@@ -248,7 +252,12 @@ export class WebstatusSidebarMenu extends LitElement {
           id="${NavigationItemKey.FEATURES}"
           expanded=${this.isFeaturesDropdownExpanded}
         >
-          <sl-icon name="menu-button"></sl-icon> Features
+          <sl-icon name="menu-button"></sl-icon>
+          <a
+            class="features-link"
+            href="${navigationMap[NavigationItemKey.FEATURES].path}"
+            >Features</a
+          >
           ${this.bookmarks.map((bookmark, index) =>
             this.renderBookmark(bookmark, index)
           )}


### PR DESCRIPTION
This PR merely wraps the Features text with an anchor, with style that makes it look exactly like the bookmarks-link.
This makes it so that the Features tree item is always clickable, or accessible via keyboard for that matter.