### PR TITLE
Show zero subtests instead of null

### DIFF
--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -555,6 +555,7 @@ COALESCE(
 				) AS FeatureRunDetails
 			{{- end }}
 		) metric_struct
+		WHERE metric_struct.PassRate IS NOT NULL
 	),
 	(
 		SELECT ARRAY(

--- a/lib/gcpspanner/feature_search.go
+++ b/lib/gcpspanner/feature_search.go
@@ -279,9 +279,9 @@ func findDefaultPlaceHolder(in *SpannerFeatureResultMetric) bool {
 		return false
 	}
 
-	return in.BrowserName == "" ||
-		(in.PassRate == nil || (in.PassRate != nil && in.PassRate.Cmp(zeroPassRatePlaceholder) == 0)) &&
-			!in.FeatureRunDetails.Valid
+	return in.BrowserName == "" &&
+		(in.PassRate != nil && in.PassRate.Cmp(zeroPassRatePlaceholder) == 0) &&
+		!in.FeatureRunDetails.Valid
 }
 
 // The base query has a solution that works on both GCP Spanner and Emulator that if it finds


### PR DESCRIPTION
Fixes #253

The placeholder removal logic accidentally removed the row. As a result, it never was returned and caused it show null.


