### PR TITLE
Avoid horizontal scrollbar on safari.

### DIFF
--- a/frontend/src/static/index.html
+++ b/frontend/src/static/index.html
@@ -43,6 +43,7 @@
 
       webstatus-app {
         width: 100vw;
+        max-width: 100%;
         min-height: 100vh;
       }
     </style>


### PR DESCRIPTION
This is the solution recommended here:
https://stackoverflow.com/questions/23367345/100vw-causing-horizontal-overflow-but-only-if-more-than-one