### PR TITLE
Add the cron schedule for the ingestion pipelines

### DIFF
--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -48,3 +48,18 @@ spanner_region_override = "nam-eur-asia1"
 cache_duration = "5m"
 
 backend_cors_allowed_origin = "https://*"
+
+bcd_region_schedules = {
+  "us-central1"  = "0 19 * * *" # Daily at 7:00 PM
+  "europe-west1" = "0 7 * * *"  # Daily at 7:00 AM
+}
+
+web_features_region_schedules = {
+  "us-central1"  = "0 20 * * *" # Daily at 8:00 PM
+  "europe-west1" = "0 8 * * *"  # Daily at 8:00 AM
+}
+
+wpt_region_schedules = {
+  "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
+  "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
+}

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -49,3 +49,18 @@ cache_duration = "5m"
 
 # Needed for UbP.
 backend_cors_allowed_origin = "https://website-webstatus-dev.corp.goog"
+
+bcd_region_schedules = {
+  "us-central1"  = "0 19 * * *" # Daily at 7:00 PM
+  "europe-west1" = "0 7 * * *"  # Daily at 7:00 AM
+}
+
+web_features_region_schedules = {
+  "us-central1"  = "0 20 * * *" # Daily at 8:00 PM
+  "europe-west1" = "0 8 * * *"  # Daily at 8:00 AM
+}
+
+wpt_region_schedules = {
+  "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
+  "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
+}

--- a/infra/ingestion/variables.tf
+++ b/infra/ingestion/variables.tf
@@ -63,3 +63,15 @@ variable "spanner_datails" {
     database   = string
   })
 }
+
+variable "bcd_region_schedules" {
+  type = map(string)
+}
+
+variable "wpt_region_schedules" {
+  type = map(string)
+}
+
+variable "web_features_region_schedules" {
+  type = map(string)
+}

--- a/infra/ingestion/workflows.tf
+++ b/infra/ingestion/workflows.tf
@@ -26,6 +26,7 @@ module "web_features_repo_workflow" {
   spanner_datails                              = var.spanner_datails
   repo_bucket                                  = var.buckets.repo_download_bucket
   docker_repository_details                    = var.docker_repository_details
+  region_schedules                             = var.web_features_region_schedules
 }
 
 module "wpt_workflow" {
@@ -40,6 +41,7 @@ module "wpt_workflow" {
   datastore_info            = var.datastore_info
   spanner_datails           = var.spanner_datails
   docker_repository_details = var.docker_repository_details
+  region_schedules          = var.wpt_region_schedules
 }
 
 module "bcd_workflow" {
@@ -53,4 +55,5 @@ module "bcd_workflow" {
   env_id                    = var.env_id
   spanner_datails           = var.spanner_datails
   docker_repository_details = var.docker_repository_details
+  region_schedules          = var.bcd_region_schedules
 }

--- a/infra/ingestion/workflows/bcd/main.tf
+++ b/infra/ingestion/workflows/bcd/main.tf
@@ -34,3 +34,25 @@ resource "google_workflows_workflow" "workflow" {
     }
   )
 }
+
+resource "google_cloud_scheduler_job" "workflow_trigger_job" {
+  count    = length(var.regions)
+  provider = google.internal_project
+  name     = "${var.env_id}-bcd-trigger-job-${var.regions[count.index]}"
+  region   = var.regions[count.index]
+  schedule = var.region_schedules[var.regions[count.index]]
+  http_target {
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.workflow[count.index].id}/executions"
+    http_method = "POST"
+    oauth_token {
+      service_account_email = google_service_account.service_account.email
+    }
+  }
+}
+
+resource "google_project_iam_member" "invoker" {
+  provider = google.internal_project
+  role     = "roles/workflows.invoker"
+  project  = var.spanner_datails.project_id
+  member   = google_service_account.service_account.member
+}

--- a/infra/ingestion/workflows/bcd/variables.tf
+++ b/infra/ingestion/workflows/bcd/variables.tf
@@ -45,3 +45,7 @@ variable "docker_repository_details" {
     name     = string
   })
 }
+
+variable "region_schedules" {
+  type = map(string)
+}

--- a/infra/ingestion/workflows/web_features_repo/variables.tf
+++ b/infra/ingestion/workflows/web_features_repo/variables.tf
@@ -60,3 +60,7 @@ variable "docker_repository_details" {
     name     = string
   })
 }
+
+variable "region_schedules" {
+  type = map(string)
+}

--- a/infra/ingestion/workflows/wpt/main.tf
+++ b/infra/ingestion/workflows/wpt/main.tf
@@ -35,3 +35,25 @@ resource "google_workflows_workflow" "workflow" {
     }
   )
 }
+
+resource "google_cloud_scheduler_job" "workflow_trigger_job" {
+  count    = length(var.regions)
+  provider = google.internal_project
+  name     = "${var.env_id}-wpt-trigger-job-${var.regions[count.index]}"
+  region   = var.regions[count.index]
+  schedule = var.region_schedules[var.regions[count.index]]
+  http_target {
+    uri         = "https://workflowexecutions.googleapis.com/v1/${google_workflows_workflow.workflow[count.index].id}/executions"
+    http_method = "POST"
+    oauth_token {
+      service_account_email = google_service_account.service_account.email
+    }
+  }
+}
+
+resource "google_project_iam_member" "invoker" {
+  provider = google.internal_project
+  role     = "roles/workflows.invoker"
+  project  = var.spanner_datails.project_id
+  member   = google_service_account.service_account.member
+}

--- a/infra/ingestion/workflows/wpt/variables.tf
+++ b/infra/ingestion/workflows/wpt/variables.tf
@@ -59,3 +59,7 @@ variable "docker_repository_details" {
     name     = string
   })
 }
+
+variable "region_schedules" {
+  type = map(string)
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -61,15 +61,18 @@ module "ingestion" {
     google.public_project   = google.public_project
   }
 
-  env_id                    = var.env_id
-  docker_repository_details = module.storage.docker_repository_details
-  regions                   = keys(var.region_information)
-  buckets                   = module.storage.buckets
-  secret_ids                = var.secret_ids
-  datastore_info            = module.storage.datastore_info
-  spanner_datails           = module.storage.spanner_info
-  projects                  = var.projects
-  depends_on                = [module.services]
+  env_id                        = var.env_id
+  docker_repository_details     = module.storage.docker_repository_details
+  regions                       = keys(var.region_information)
+  buckets                       = module.storage.buckets
+  secret_ids                    = var.secret_ids
+  datastore_info                = module.storage.datastore_info
+  spanner_datails               = module.storage.spanner_info
+  projects                      = var.projects
+  depends_on                    = [module.services]
+  wpt_region_schedules          = var.wpt_region_schedules
+  bcd_region_schedules          = var.bcd_region_schedules
+  web_features_region_schedules = var.web_features_region_schedules
 }
 
 module "backend" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -125,3 +125,15 @@ variable "cache_duration" {
 variable "backend_cors_allowed_origin" {
   type = string
 }
+
+variable "bcd_region_schedules" {
+  type = map(string)
+}
+
+variable "wpt_region_schedules" {
+  type = map(string)
+}
+
+variable "web_features_region_schedules" {
+  type = map(string)
+}


### PR DESCRIPTION
Previously, I ran the workflows myself whenever needed. But we should not rely on that long term.

This change puts a cron schedule on the various workflows.

We run them in order
- bcd (contains the browser info)
- web features (features info that uses some of the browser info from bcd)
- wpt (scores that maps to web features)

The workflows are deployed many regions so we just add a cron for each of those regions.

