### PR TITLE
Use custom tooltips for each browser

### DIFF
--- a/frontend/src/static/js/components/webstatus-stats-page.ts
+++ b/frontend/src/static/js/components/webstatus-stats-page.ts
@@ -202,11 +202,11 @@ export class StatsPage extends LitElement {
     const channel = 'stable';
 
     const dataObj: WebStatusDataObj = {cols: [], rows: []};
-    dataObj.cols.push({type: 'date', label: 'Date'});
+    dataObj.cols.push({type: 'date', label: 'Date', role: 'domain'});
     for (const browser of browsers) {
-      dataObj.cols.push({type: 'number', label: browser});
+      dataObj.cols.push({type: 'number', label: browser, role: 'data'});
     }
-    dataObj.cols.push({type: 'number', label: 'Total'});
+    dataObj.cols.push({type: 'number', label: 'Total', role: 'data'});
 
     // Map from date to an object with counts for each browser
     const dateToBrowserDataMap = new Map<number, {[key: string]: number}>();


### PR DESCRIPTION
This PR adds custom tooltips for each browser point in order to show the total associated with the number of tests passed. E.g. Chrome: 7 of 9

This also enables the multi-select mode, with aggregation by "category" so that all selected data points will be included in the one tooltip, and they are grouped by date (the category).  One downside to this multi-select aggregation tooltip is that it can get large and cover up the data that it is about.

![image](https://github.com/GoogleChrome/webstatus.dev/assets/570125/ba02aac5-f3a2-4e1c-8444-58263a5536e7)
