### PR TITLE
Only show wpt.fyi link if there are stable metrics

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
@@ -27,11 +27,30 @@ describe('webstatus-feature-page', () => {
 
     await el.updateComplete;
   });
-  it('builds the WPT link correctly', async () => {
-    const link = el.buildWPTLink('declarative-shadow-dom');
+  it('builds the WPT link correctly when there are stable metrics', async () => {
+    const link = el.buildWPTLink({
+      feature_id: 'declarative-shadow-dom',
+      wpt: {stable: {}},
+    });
     expect(link).to.eq(
       'https://wpt.fyi/results?label=master&label=stable&aligned=&q=feature%3Adeclarative-shadow-dom+%21is%3Atentative'
     );
+  });
+
+  it('builds a null WPT link correctly when there are no stable metrics', async () => {
+    const noStableMetricsLink = el.buildWPTLink({
+      feature_id: 'declarative-shadow-dom',
+      wpt: {experimental: {}},
+    });
+    expect(noStableMetricsLink).to.eq(null);
+
+    const missingWPTSectionLink = el.buildWPTLink({
+      feature_id: 'declarative-shadow-dom',
+    });
+    expect(missingWPTSectionLink).to.eq(null);
+
+    const missingFeatureLink = el.buildWPTLink();
+    expect(missingFeatureLink).to.eq(null);
   });
 
   it('optionally builds a caniuse link', async () => {

--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -573,9 +573,18 @@ export class FeaturePage extends LitElement {
     `;
   }
 
-  buildWPTLink(featureId: string): string {
+  buildWPTLink(feature?: {
+    feature_id: string;
+    wpt?: {stable?: object; experimental?: object};
+  }): string | null {
+    if (
+      feature === undefined ||
+      feature.wpt === undefined ||
+      feature.wpt.stable === undefined
+    )
+      return null;
     const wptLinkURL = new URL('https://wpt.fyi/results');
-    const query = `feature:${featureId} !is:tentative`;
+    const query = `feature:${feature.feature_id} !is:tentative`;
     wptLinkURL.searchParams.append('label', 'master');
     wptLinkURL.searchParams.append('label', 'stable');
     wptLinkURL.searchParams.append('aligned', '');
@@ -595,8 +604,7 @@ export class FeaturePage extends LitElement {
   }
 
   renderNameAndOffsiteLinks(): TemplateResult {
-    const featureId = this.feature?.feature_id || this.featureId;
-    const wptLink = this.buildWPTLink(featureId);
+    const wptLink = this.buildWPTLink(this.feature);
     const wptLogo = '/public/img/wpt-logo.svg';
     const canIUseLink = this.findCanIUseLink(this.featureMetadata?.can_i_use);
 

--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -577,12 +577,7 @@ export class FeaturePage extends LitElement {
     feature_id: string;
     wpt?: {stable?: object; experimental?: object};
   }): string | null {
-    if (
-      feature === undefined ||
-      feature.wpt === undefined ||
-      feature.wpt.stable === undefined
-    )
-      return null;
+    if (feature?.wpt?.stable === undefined) return null;
     const wptLinkURL = new URL('https://wpt.fyi/results');
     const query = `feature:${feature.feature_id} !is:tentative`;
     wptLinkURL.searchParams.append('label', 'master');


### PR DESCRIPTION
We currently link to the stable wpt.fyi page in wpt.fyi everytime. Even if the feature does not have wpt.fyi stable tests.

This change hides the wpt.fyi link if there are no stable metrics for that feature.

Fixes #296

