### PR TITLE
Move the multi-selection option to gchart, and disable.

### DIFF
--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -425,11 +425,6 @@ export class FeaturePage extends LitElement {
       colors: seriesColors,
       chartArea: {left: 100, right: 16, top: 40, bottom: 40},
 
-      // Multiple selection of points will be summarized in one tooltip.
-      tooltip: {trigger: 'selection'},
-      selectionMode: 'multiple',
-      aggregationTarget: 'category',
-
       // Enable explorer mode
       explorer: {
         actions: ['dragToZoom', 'rightClickToReset'],

--- a/frontend/src/static/js/components/webstatus-gchart.ts
+++ b/frontend/src/static/js/components/webstatus-gchart.ts
@@ -112,10 +112,9 @@ export class WebstatusGChart extends LitElement {
   augmentOptions(
     options: google.visualization.ComboChartOptions
   ): google.visualization.ComboChartOptions {
-
     options = {
       ...options,
-      tooltip: { trigger: 'selection' },
+      tooltip: {trigger: 'selection'},
       aggregationTarget: 'category',
       // The following enables multiple selection of points, in one tooltip.
       // selectionMode: 'multiple',

--- a/frontend/src/static/js/components/webstatus-gchart.ts
+++ b/frontend/src/static/js/components/webstatus-gchart.ts
@@ -108,9 +108,19 @@ export class WebstatusGChart extends LitElement {
     return dataTable;
   }
 
+  // Augment the options with options that apply for all charts.
   augmentOptions(
     options: google.visualization.ComboChartOptions
   ): google.visualization.ComboChartOptions {
+
+    options = {
+      ...options,
+      tooltip: { trigger: 'selection' },
+      aggregationTarget: 'category',
+      // The following enables multiple selection of points, in one tooltip.
+      // selectionMode: 'multiple',
+    };
+
     const numColumns = this.dataTable!.getNumberOfColumns();
     // The number of series is the number of columns with role 'data'.
     let numSeries = 0;

--- a/frontend/src/static/js/components/webstatus-gchart.ts
+++ b/frontend/src/static/js/components/webstatus-gchart.ts
@@ -115,9 +115,6 @@ export class WebstatusGChart extends LitElement {
     options = {
       ...options,
       tooltip: {trigger: 'selection'},
-      aggregationTarget: 'category',
-      // The following enables multiple selection of points, in one tooltip.
-      // selectionMode: 'multiple',
     };
 
     const numColumns = this.dataTable!.getNumberOfColumns();


### PR DESCRIPTION
Disabling the multi-selection mode fixes the problem of accumulating data points in the tooltip without an easy way of clearing the selection, in #309.

Google Charts has no support for control-click, which would be the appropriate way to allow multi-selection as a modifier of normal clicking.   A fairly complex workaround would involve handling mouse events at the chart container level outside the chart, and converting those event into modifications of the selection in the chart by determining what data point was selected.  Alternatively, we could support clicking in the chart area but not on any data point in order to clear the selection.