### PR TITLE
Create reusable base devcontainer images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Run precommit target for CI
         uses: devcontainers/ci@v0.3
         with:
+          cacheFrom: ghcr.io/${{ github.repository_owner }}/webstatus-dev-devcontainer-ci-precommit
+          push: never
           runCmd: make precommit
   playwright:
     runs-on: ubuntu-latest
@@ -41,7 +43,6 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
           remove-codeql: 'true'
-          remove-docker-images: 'true'
       - name: Restart docker
         run: sudo service docker restart
       - name: Checkout (GitHub)
@@ -49,4 +50,6 @@ jobs:
       - name: Run playwright-test target for CI
         uses: devcontainers/ci@v0.3
         with:
+          cacheFrom: ghcr.io/${{ github.repository_owner }}/webstatus-dev-devcontainer-ci-playwright
+          push: never
           runCmd: CI=true make playwright-test

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,89 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Dev Container Image Build
+on:
+  workflow_dispatch: # Allows manual triggering
+  schedule:
+    - cron: '0 0 * * 2' # Runs every Tuesday at midnight UTC
+jobs:
+  build-base-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pre-build dev container base image
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/${{ github.repository_owner }}/webstatus-dev-devcontainer
+          cacheFrom: ghcr.io/${{ github.repository_owner }}/webstatus-dev-devcontainer
+          push: always
+  # Build two GitHub Action specific images: precommit and playwright
+  # They cannot exist in the same image together because the image would be
+  # too large to fit on the GitHub Runner.
+  build-precommit-image: # Job for precommit image
+    runs-on: ubuntu-latest
+    needs: build-base-image # Ensure base image is built first
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build CI Precommit Image
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/${{ github.repository_owner }}/webstatus-dev-devcontainer-ci-precommit
+          cacheFrom: ghcr.io/${{ github.repository_owner }}/webstatus-dev-devcontainer
+          push: always
+          runCmd: make precommit
+
+  build-playwright-image: # Job for playwright image
+    runs-on: ubuntu-latest
+    needs: build-base-image # Ensure base image is built first
+    steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c
+        with:
+          build-mount-path: /var/lib/docker/
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+      - name: Restart docker
+        run: sudo service docker restart
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build CI Playwright Image
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/${{ github.repository_owner }}/webstatus-dev-devcontainer-ci-playwright
+          cacheFrom: ghcr.io/${{ github.repository_owner }}/webstatus-dev-devcontainer
+          push: always
+          runCmd: make skaffold-build

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,13 @@ precommit: license-check lint test
 # Local Environment
 ################################
 SKAFFOLD_FLAGS = -p local
-SKAFFOLD_RUN_FLAGS = $(SKAFFOLD_FLAGS) --build-concurrency=$(NPROCS) --no-prune=false --cache-artifacts=false --port-forward=off
+SKAFFOLD_BUILD_FLAGS = $(SKAFFOLD_FLAGS) --build-concurrency=$(NPROCS)
+SKAFFOLD_RUN_FLAGS = $(SKAFFOLD_FLAGS) --build-concurrency=$(NPROCS) --port-forward=off
 start-local: configure-skaffold gen
 	skaffold dev $(SKAFFOLD_RUN_FLAGS)
+
+skaffold-build: configure-skaffold gen
+	skaffold build $(SKAFFOLD_BUILD_FLAGS)
 
 debug-local: configure-skaffold gen
 	skaffold debug $(SKAFFOLD_RUN_FLAGS)


### PR DESCRIPTION
This is the beginning of the work described in https://github.com/GoogleChrome/webstatus.dev/issues/329

It will cover the first two check boxes on that issue.

This change creates a new GitHub CI workflow that will refresh the images:
- Every tuesday (the dependabot notices will be configured for Monday)
- Ad-hoc runs that can be triggered on the Actions page

Two of the images are now used in the existing build GitHub action.

We have to split them up because the GitHub runner runs out of space. We could clean up more and try to fit it all into one image but that can come in the future.

For now, this should reduce the time spent in Github Action machine hours.

The playwright image is not caching the docker images built in `skaffold-build` but we can fix that in the future too.