### PR TITLE
Upload playwright report, helper scripts to download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,9 @@ jobs:
           cacheFrom: ghcr.io/${{ github.repository_owner }}/webstatus-dev-devcontainer
           push: never
           runCmd: CI=true make playwright-test
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -104,3 +104,9 @@ jobs:
           cacheFrom: ghcr.io/${{ github.repository_owner }}/webstatus-dev-devcontainer
           push: never
           runCmd: CI=true make playwright-test
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,7 +7,8 @@
 3. Running Locally
 4. Populate Data Locally
 5. Generating Code
-6. Clean Up
+6. Test Code
+7. Clean Up
 
 ## Requirements
 
@@ -202,6 +203,10 @@ Run `make antlr-gen`
 #### TypeScript & ANTLR
 
 TODO
+
+## Test Code
+
+To learn more about testing and linting the code, refer to the testing [document](./docs/testing.md).
 
 ## Clean Up
 

--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ license-fix: download-addlicense
 ################################
 # Playwright
 ################################
-fresh-env-for-playwright: playwright-install delete-local deploy-local dev_fake_data port-forward-manual
+fresh-env-for-playwright: playwright-install delete-local build deploy-local dev_fake_data port-forward-manual
 
 playwright-install:
 	npx playwright install --with-deps
@@ -288,6 +288,12 @@ playwright-test: fresh-env-for-playwright
 
 playwright-ui: fresh-env-for-playwright
 	npx playwright test --ui --ui-port=8123
+
+playwright-open-report:
+	npx playwright show-report playwright-report --host 0.0.0.0
+
+playwright-show-traces:
+	find playwright-report/data -name *.zip -printf "%p %TY-%Tm-%Td %TH:%TM:%TS %Tz\n"
 
 ################################
 # Go Misc
@@ -368,8 +374,7 @@ check-gh-login:
 print-gh-runs: check-gh-login
 	gh run ls -R $(GH_REPO) -u $$(gh api user | jq -r '.login')
 
-playwright-report-from-run-%: check-gh-login
+download-playwright-report-from-run-%: check-gh-login
 	rm -rf playwright-report
 	mkdir -p playwright-report
 	gh run download -R $(GH_REPO) $* -n playwright-report --dir playwright-report
-	npx playwright show-report playwright-report --host 0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -364,5 +364,12 @@ check-gh-login:
 	@if ! gh auth status 2>/dev/null; then \
 		echo "Not logged into GitHub CLI. Please run 'gh auth login'." && exit 1; \
 	fi
+
 print-gh-runs: check-gh-login
 	gh run ls -R $(GH_REPO) -u $$(gh api user | jq -r '.login')
+
+playwright-report-from-run-%: check-gh-login
+	rm -rf playwright-report
+	mkdir -p playwright-report
+	gh run download -R $(GH_REPO) $* -n playwright-report --dir playwright-report
+	npx playwright show-report playwright-report --host 0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ playwright-open-report:
 	npx playwright show-report playwright-report --host 0.0.0.0
 
 playwright-show-traces:
-	find playwright-report/data -name *.zip -printf "%p %TY-%Tm-%Td %TH:%TM:%TS %Tz\n"
+	find playwright-report/data -name *.zip -printf "%TY-%Tm-%Td %TH:%TM:%TS %Tz %p\n"
 
 ################################
 # Go Misc

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
 NPROCS := $(shell nproc)
+GH_REPO := "GoogleChrome/webstatus.dev"
 
 .PHONY: all \
 		antlr-gen \
@@ -355,3 +356,13 @@ spanner_er_diagram: spanner_port_forward
 	go install github.com/k1LoW/tbls@v1.73.2
 	SPANNER_EMULATOR_HOST=localhost:9010 tbls doc --rm-dist
 	make spanner_port_forward_terminate
+
+################################
+# GitHub
+################################
+check-gh-login:
+	@if ! gh auth status 2>/dev/null; then \
+		echo "Not logged into GitHub CLI. Please run 'gh auth login'." && exit 1; \
+	fi
+print-gh-runs: check-gh-login
+	gh run ls -R $(GH_REPO) -u $$(gh api user | jq -r '.login')

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,16 +2,104 @@
 
 _This doucument assumes you are using the devcontainer._
 
-## Go Tests
+## Table Of Contents
 
-TODO
+1. Run Precommit Suite
 
-## Integration Tests
+   - Go Tests
+   - TypeScript Tests
+   - License Check
+     - License Fix
+   - Linting
+     - Attempt Automatic Lint Error Fixing
 
-Consider using the [testcontainers](https://golang.testcontainers.org/) library.
+1. Run Playwright Tests
 
-## Playwright
+   - Update Screenshots
+   - Download GitHub Playwright Test Results
+   - Analyze Playwright Test Results
+     - Show Playwright Test Report
+     - Show Playwright Test Trace
 
-If you do not see the Playwright button on the left side of the IDE, go to
-extensions button and search for "Playwright". A reload may be required for that
-extension.
+## Run Precommit Suite
+
+The `precommit` command is a wrapper command that includes many tools (tests minus Playwright tests, license check,
+linting, etc).
+
+Run the following command to run the precommit suite: `make precommit`.
+
+Below describes some of the commands from the `precommit` command that a developer can run.
+
+### Go Tests
+
+To run only the Go tests, run: `make go-test`.
+
+### TypeScript Tests
+
+To run only the TypeScript tests (excluding Playwright tests), run: `make node-test`.
+
+### License Check
+
+Run the following command to lint all the code: `make license-check`.
+
+#### License Fix
+
+Run the following command to automatically fix the license errors: `make license-fix`.
+
+### Linting
+
+Run the following command to lint all the code: `make lint`.
+
+#### Attempt Automatic Lint Error Fixing
+
+Some lint errors can be fixed automatically. This command will try to fix all the lint errors: `make lint-fix`.
+
+Developers may still need to inspect and manually fix the error.
+
+## Run Playwright Tests
+
+Run the following command to run the Playwright tests: `make playwright-test`.
+
+### Update Screenshots
+
+There are some tests that check screenshots. That means, your changes may impact the existing screenshots. Run the
+following command to update the screenshots: `make playwright-update-snapshots`.
+
+### Download GitHub Playwright Test Results
+
+Sometimes the Playwright tests fail in GitHub and you will want to download the results and analyze them.
+
+1. Find the GitHub Action ID by running: `make print-gh-runs`
+   - Example output:
+   ```
+   STATUS  TITLE     WORKFLOW  BRANCH             EVENT        ID          ELAPSED  AGE
+   ✓       PR title  build     jcscottiii/branch  pull_request 9551121552  12m49s   about 2 hours ago
+   X       PR title  build     jcscottiii/branch  pull_request 9551110554  16m28s   about 2 hours ago
+   ```
+   In this example, we will use ID `9551110554`
+2. Download the report: `make download-playwright-report-from-run-$RUNID`
+   - In this example, you would run: `make download-playwright-report-from-run-9551110554`
+
+### Analyze Playwright Test Results
+
+This section describes how to analyze the Playwright tests. The following sections expect there is a `playwright-report`
+directory that is present by:
+
+- running the Playwright tests locally, or
+- downloading the report from GitHub.
+
+#### Show Playwright Test Report
+
+Given the `playwright-report` directory exists, run the following command: `make playwright-open-report` to open the [report](https://playwright.dev/docs/trace-viewer-intro#opening-the-html-report).
+
+#### Show Playwright Test Trace
+
+1. Given there are failures, there should be traces. You can list each failure trace by running: `make playwright-show-traces`
+   - Example:
+   ```
+   playwright-report/data/9bd87f9fe48efeb348ad4c6f05d01743b15501b8.zip
+   playwright-report/data/4dc5b7341597474f7fb1abedf1b2017e3b271eef.zip
+   playwright-report/data/0baeb6be37c91cd90156df684dc28a7b51970df3.zip
+   ```
+2. Open the [trace](https://playwright.dev/docs/trace-viewer#opening-the-trace): `npx playwright show-trace path/to/trace.zip`
+   - Example: `npx playwright show-trace playwright-report/data/9bd87f9fe48efeb348ad4c6f05d01743b15501b8.zip`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,7 +40,7 @@ To run only the TypeScript tests (excluding Playwright tests), run: `make node-t
 
 ### License Check
 
-Run the following command to lint all the code: `make license-check`.
+Run the following command to check the license headers for all code: `make license-check`.
 
 #### License Fix
 

--- a/e2e/tests/overview-page.spec.ts
+++ b/e2e/tests/overview-page.spec.ts
@@ -72,7 +72,7 @@ test('shows a tooltip when hovering over a baseline chip', async ({page}) => {
   // Find the tooltip for the first Widely available chip.
   const tooltip = page
     .locator('sl-tooltip')
-    .filter({hasText: 'Widely availables'})
+    .filter({hasText: 'Widely available'})
     .first();
   const baselineText = 'Baseline since 2035-05-06';
   await expect(tooltip.getByText(baselineText)).toBeHidden();

--- a/e2e/tests/overview-page.spec.ts
+++ b/e2e/tests/overview-page.spec.ts
@@ -72,7 +72,7 @@ test('shows a tooltip when hovering over a baseline chip', async ({page}) => {
   // Find the tooltip for the first Widely available chip.
   const tooltip = page
     .locator('sl-tooltip')
-    .filter({hasText: 'Widely available'})
+    .filter({hasText: 'Widely availables'})
     .first();
   const baselineText = 'Baseline since 2035-05-06';
   await expect(tooltip.getByText(baselineText)).toBeHidden();


### PR DESCRIPTION
Following https://playwright.dev/docs/ci-intro#viewing-the-trace

Add a command to list the github runs
- ![image](https://github.com/GoogleChrome/webstatus.dev/assets/7788930/73b463cc-a6ae-465d-9a95-cb3c6b42ab9b)


Add a command to download the playwright report from a given GitHub run


Add instructions on opening report
- ![image](https://github.com/GoogleChrome/webstatus.dev/assets/7788930/672ff6b3-6316-4461-b30b-9e3db035eedb)

Add instructions on opening a playwright trace
- ![image](https://github.com/GoogleChrome/webstatus.dev/assets/7788930/c9036ba9-521a-4997-9633-915c633406d3)

Other changes:
- Call `make build` before running the playwright tests
- Start to fill in documentation for testing