### PR TITLE
Fix gzip compression

### DIFF
--- a/e2e/tests/nginx-conf.spec.ts
+++ b/e2e/tests/nginx-conf.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {test, expect, Response} from '@playwright/test';
+import {gotoOverviewPageUrl} from './utils';
+
+function checkReponseForGZIPCompression(response: Response) {
+  expect(
+    response.headers()['content-encoding'],
+    `GZIP assertion failed for ${response.url()}: Asset not returning GZIP compression. Headers: ${JSON.stringify(
+      response.headers()
+    )}`
+  ).toContain('gzip');
+}
+
+test('All public assets should be served with GZIP compression', async ({
+  page,
+}) => {
+  let publicAssetFound = false;
+  let homepageFound = false;
+
+  page.on('response', response => {
+    // Intercept network requests to check for GZIP compression
+    if (response.url().startsWith('http://localhost:5555/public')) {
+      checkReponseForGZIPCompression(response);
+      publicAssetFound = true;
+    } else if (response.url() === 'http://localhost:5555/') {
+      checkReponseForGZIPCompression(response);
+      homepageFound = true;
+    }
+  });
+
+  await gotoOverviewPageUrl(page, 'http://localhost:5555');
+  expect(
+    publicAssetFound,
+    'At least one public asset must be loaded'
+  ).toBeTruthy();
+  expect(homepageFound, 'index.html must be loaded').toBeTruthy();
+});

--- a/e2e/tests/overview-page.spec.ts
+++ b/e2e/tests/overview-page.spec.ts
@@ -15,18 +15,10 @@
  */
 
 import {test, expect} from '@playwright/test';
-
-async function gotoUrl(page: any, url: string) {
-  await page.goto(url);
-
-  // Wait for the loading indicator to disappear and be replaced (with timeout):
-  await page
-    .locator('webstatus-overview-content >> text=Loading features...')
-    .waitFor({state: 'hidden', timeout: 30000});
-}
+import {gotoOverviewPageUrl} from './utils';
 
 test('matches the screenshot', async ({page}) => {
-  await gotoUrl(page, 'http://localhost:5555/');
+  await gotoOverviewPageUrl(page, 'http://localhost:5555/');
   const pageContainer = page.locator('.page-container');
   await expect(pageContainer).toHaveScreenshot();
 });
@@ -67,7 +59,7 @@ test('shows an unknown error when there is an internal error', async ({
 
 // test of hover over a baseline chip to show tooltip
 test('shows a tooltip when hovering over a baseline chip', async ({page}) => {
-  await gotoUrl(page, 'http://localhost:5555/');
+  await gotoOverviewPageUrl(page, 'http://localhost:5555/');
 
   // Find the tooltip for the first Widely available chip.
   const tooltip = page

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -51,3 +51,12 @@ export async function setupFakeNow(
     Date.now = () => __DateNow() + __DateNowOffset;
   }`);
 }
+
+export async function gotoOverviewPageUrl(page: Page, url: string) {
+  await page.goto(url);
+
+  // Wait for the loading indicator to disappear and be replaced (with timeout):
+  await page
+    .locator('webstatus-overview-content >> text=Loading features...')
+    .waitFor({state: 'hidden', timeout: 30000});
+}

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -16,6 +16,7 @@ http {
     root /usr/share/nginx/html;
     error_page 404 @404_fallback;
     index index.html;
+    gzip on;
 
     if ($host ~* ^www\.(.*)$) {
       set $non_www_host $1;
@@ -25,8 +26,7 @@ http {
     # Serve static files and handle missing files in '/public' with SPA fallback
     location /public {
       try_files $uri =404;
-      # expires modified 1y;
-      # add_header Cache-Control "public";
+      gzip_types application/javascript text/css image/png image/svg+xml;
       access_log off;
     }
 
@@ -53,8 +53,5 @@ http {
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
     add_header X-Content-Type-Options "nosniff";
     add_header X-Frame-Options "SAMEORIGIN";
-
-    gzip on;
-    gzip_types application/javascript application/json text/css;
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,6 +42,10 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://127.0.0.1:3000',
+    extraHTTPHeaders: {
+      // Must add this to simulate the headers sent by the browser.
+      'Accept-Encoding': 'gzip, deflate, br, zstd',
+    },
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',


### PR DESCRIPTION
As reported in #367, the gzip compression is not working for the static resources.

This change fixes that by enabling gzip:
- For the static resources in the public directory
- The index.html that is served

Added a test make sure Content-Encoding is indeed coming back from the NGINX server.

