### PR TITLE
Adjust liveness probe for opentelemetry

### DIFF
--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -119,6 +119,8 @@ resource "google_cloud_run_v2_service" "service" {
         }
         initial_delay_seconds = 3
         period_seconds        = 10
+        failure_threshold     = 10
+        timeout_seconds       = 10
       }
     }
     annotations = {


### PR DESCRIPTION
This should hopefully address #269

The default number of retries is 3. This has been adjusted to 10.

The default number of seconds it waits before timing out is 1 second. That has been adjusted to 10 seconds.
