### PR TITLE
Keep typeahead closed after selection

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-typeahead.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-typeahead.test.ts
@@ -84,9 +84,9 @@ describe('webstatus-typeahead', () => {
     assert.equal('', component.prefix);
 
     slInput.value = 'term1 term2 -term3=2024-06-28..2025-02-03';
-      await slInput.updateComplete;
+    await slInput.updateComplete;
 
-      // Caret is at the start of the input field.
+    // Caret is at the start of the input field.
     slInput.input.selectionStart = 0;
     slInput.input.selectionEnd = 0;
     component.findPrefix();
@@ -94,7 +94,7 @@ describe('webstatus-typeahead', () => {
     assert.equal(5, component.chunkEnd);
     assert.equal('', component.prefix);
 
-      // User has selected a range.
+    // User has selected a range.
     slInput.input.selectionStart = 0;
     slInput.input.selectionEnd = 3; // A range
     component.findPrefix();

--- a/frontend/src/static/js/components/test/webstatus-typeahead.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-typeahead.test.ts
@@ -83,8 +83,10 @@ describe('webstatus-typeahead', () => {
     assert.equal(0, component.chunkEnd);
     assert.equal('', component.prefix);
 
-    slInput.value = 'term1 term2 term3';
-    await slInput.updateComplete;
+    slInput.value = 'term1 term2 -term3=2024-06-28..2025-02-03';
+      await slInput.updateComplete;
+
+      // Caret is at the start of the input field.
     slInput.input.selectionStart = 0;
     slInput.input.selectionEnd = 0;
     component.findPrefix();
@@ -92,24 +94,35 @@ describe('webstatus-typeahead', () => {
     assert.equal(5, component.chunkEnd);
     assert.equal('', component.prefix);
 
+      // User has selected a range.
     slInput.input.selectionStart = 0;
     slInput.input.selectionEnd = 3; // A range
     component.findPrefix();
     assert.equal(null, component.prefix);
 
-    slInput.input.selectionStart = 14;
-    slInput.input.selectionEnd = 14;
+    // Caret is in middle of term2.
+    slInput.input.selectionStart = 8;
+    slInput.input.selectionEnd = 8;
     component.findPrefix();
-    assert.equal(12, component.chunkStart);
-    assert.equal(17, component.chunkEnd);
+    assert.equal(6, component.chunkStart);
+    assert.equal(11, component.chunkEnd);
     assert.equal('te', component.prefix);
 
-    slInput.input.selectionStart = 17;
-    slInput.input.selectionEnd = 17;
+    // Caret is after the negation operator, at start of term3.
+    slInput.input.selectionStart = 13;
+    slInput.input.selectionEnd = 13;
     component.findPrefix();
-    assert.equal(12, component.chunkStart);
-    assert.equal(17, component.chunkEnd);
-    assert.equal('term3', component.prefix);
+    assert.equal(13, component.chunkStart);
+    assert.equal(41, component.chunkEnd);
+    assert.equal('', component.prefix);
+
+    // Caret is near the end of -term3=2024-06-28..2025-02-03.
+    slInput.input.selectionStart = 40;
+    slInput.input.selectionEnd = 40;
+    component.findPrefix();
+    assert.equal(13, component.chunkStart);
+    assert.equal(41, component.chunkEnd);
+    assert.equal('term3=2024-06-28..2025-02-0', component.prefix);
   });
 
   it('determines whether a candidate should be shown', async () => {

--- a/frontend/src/static/js/components/webstatus-typeahead.ts
+++ b/frontend/src/static/js/components/webstatus-typeahead.ts
@@ -80,7 +80,7 @@ export class WebstatusTypeahead extends LitElement {
   chunkEnd: number;
 
   wasDismissed: boolean;
-    termWasCompleted: boolean;
+  termWasCompleted: boolean;
 
   constructor() {
     super();
@@ -93,9 +93,9 @@ export class WebstatusTypeahead extends LitElement {
     this.chunkEnd = 0;
     // If the user hits Escape, keep the menu closed until they use up or down.
     this.wasDismissed = false;
-      // If the user completes an entire term, don't offer the menu again
-      // until they type something.
-      this.termWasCompleted = false;
+    // If the user completes an entire term, don't offer the menu again
+    // until they type something.
+    this.termWasCompleted = false;
   }
 
   static get styles(): CSSResultGroup {
@@ -143,10 +143,10 @@ export class WebstatusTypeahead extends LitElement {
       this.prefix = null;
       return;
     }
-      this.chunkStart = wholeStr.lastIndexOf(' ', caret - 1) + 1;
-      if (wholeStr.substring(this.chunkStart, this.chunkStart + 1) === '-') {
-          this.chunkStart += 1;
-      }
+    this.chunkStart = wholeStr.lastIndexOf(' ', caret - 1) + 1;
+    if (wholeStr.substring(this.chunkStart, this.chunkStart + 1) === '-') {
+      this.chunkStart += 1;
+    }
     this.chunkEnd = wholeStr.indexOf(' ', caret);
     if (this.chunkEnd === -1) this.chunkEnd = wholeStr.length;
     this.prefix = wholeStr.substring(this.chunkStart, caret);
@@ -171,8 +171,8 @@ export class WebstatusTypeahead extends LitElement {
   async handleCandidateSelected(e: {detail: {item: SlMenuItem}}) {
     const candidateValue = e.detail!.item!.value;
     const inputEl = (this.slInputRef.value as SlInput).input;
-      const wholeStr = inputEl.value;
-      // Don't add a space after the completed value: let the user type it.
+    const wholeStr = inputEl.value;
+    // Don't add a space after the completed value: let the user type it.
     const newWholeStr =
       wholeStr.substring(0, this.chunkStart) +
       candidateValue +
@@ -187,11 +187,11 @@ export class WebstatusTypeahead extends LitElement {
     this.chunkEnd = this.chunkStart;
     inputEl.selectionStart = this.chunkStart;
     inputEl.selectionEnd = this.chunkEnd;
-      // TODO(jrobbins): Don't set termWasCompleted if we offer a value.
-      if (candidateValue !== '-') {
-          this.termWasCompleted = true;
-      }
-      this.calcCandidates();
+    // TODO(jrobbins): Don't set termWasCompleted if we offer a value.
+    if (candidateValue !== '-') {
+      this.termWasCompleted = true;
+    }
+    this.calcCandidates();
     // The user may have clicked a menu item, causing the sl-input to lose
     // keyboard focus.  So, focus on the sl-input again.
     inputEl.focus();
@@ -221,8 +221,8 @@ export class WebstatusTypeahead extends LitElement {
       this.wasDismissed = false;
       return;
     }
-      this.termWasCompleted = false;
-      this.calcCandidates();
+    this.termWasCompleted = false;
+    this.calcCandidates();
   }
 
   calcCandidates(event?: Event) {
@@ -234,11 +234,11 @@ export class WebstatusTypeahead extends LitElement {
       this.shouldShowCandidate(c, this.prefix)
     );
     const slDropdown = this.slDropdownRef.value as SlDropdown;
-      if (
-       this.candidates.length > 0 &&
-       !this.wasDismissed &&
-       !this.termWasCompleted
-     ) {
+    if (
+      this.candidates.length > 0 &&
+      !this.wasDismissed &&
+      !this.termWasCompleted
+    ) {
       slDropdown.show();
     } else {
       slDropdown.hide();

--- a/frontend/src/static/js/components/webstatus-typeahead.ts
+++ b/frontend/src/static/js/components/webstatus-typeahead.ts
@@ -80,6 +80,7 @@ export class WebstatusTypeahead extends LitElement {
   chunkEnd: number;
 
   wasDismissed: boolean;
+    termWasCompleted: boolean;
 
   constructor() {
     super();
@@ -92,6 +93,9 @@ export class WebstatusTypeahead extends LitElement {
     this.chunkEnd = 0;
     // If the user hits Escape, keep the menu closed until they use up or down.
     this.wasDismissed = false;
+      // If the user completes an entire term, don't offer the menu again
+      // until they type something.
+      this.termWasCompleted = false;
   }
 
   static get styles(): CSSResultGroup {
@@ -139,10 +143,10 @@ export class WebstatusTypeahead extends LitElement {
       this.prefix = null;
       return;
     }
-    this.chunkStart = Math.max(
-      wholeStr.lastIndexOf(' ', caret - 1) + 1,
-      wholeStr.lastIndexOf('-', caret - 1) + 1
-    );
+      this.chunkStart = wholeStr.lastIndexOf(' ', caret - 1) + 1;
+      if (wholeStr.substring(this.chunkStart, this.chunkStart + 1) === '-') {
+          this.chunkStart += 1;
+      }
     this.chunkEnd = wholeStr.indexOf(' ', caret);
     if (this.chunkEnd === -1) this.chunkEnd = wholeStr.length;
     this.prefix = wholeStr.substring(this.chunkStart, caret);
@@ -167,17 +171,11 @@ export class WebstatusTypeahead extends LitElement {
   async handleCandidateSelected(e: {detail: {item: SlMenuItem}}) {
     const candidateValue = e.detail!.item!.value;
     const inputEl = (this.slInputRef.value as SlInput).input;
-    const wholeStr = inputEl.value;
-    const maybeAddSpace =
-      !candidateValue.endsWith(':') &&
-      !candidateValue.endsWith('-') &&
-      wholeStr[this.chunkEnd] !== ' '
-        ? ' '
-        : '';
+      const wholeStr = inputEl.value;
+      // Don't add a space after the completed value: let the user type it.
     const newWholeStr =
       wholeStr.substring(0, this.chunkStart) +
       candidateValue +
-      maybeAddSpace +
       wholeStr.substring(this.chunkEnd, wholeStr.length);
     (this.slInputRef.value as SlInput).value = newWholeStr;
     this.reflectValue();
@@ -185,12 +183,15 @@ export class WebstatusTypeahead extends LitElement {
     // setting or accessing the text selection.
     await this.updateComplete;
 
-    this.chunkStart =
-      this.chunkStart + candidateValue.length + maybeAddSpace.length;
+    this.chunkStart = this.chunkStart + candidateValue.length;
     this.chunkEnd = this.chunkStart;
     inputEl.selectionStart = this.chunkStart;
     inputEl.selectionEnd = this.chunkEnd;
-    this.calcCandidates();
+      // TODO(jrobbins): Don't set termWasCompleted if we offer a value.
+      if (candidateValue !== '-') {
+          this.termWasCompleted = true;
+      }
+      this.calcCandidates();
     // The user may have clicked a menu item, causing the sl-input to lose
     // keyboard focus.  So, focus on the sl-input again.
     inputEl.focus();
@@ -220,7 +221,8 @@ export class WebstatusTypeahead extends LitElement {
       this.wasDismissed = false;
       return;
     }
-    this.calcCandidates();
+      this.termWasCompleted = false;
+      this.calcCandidates();
   }
 
   calcCandidates(event?: Event) {
@@ -232,7 +234,11 @@ export class WebstatusTypeahead extends LitElement {
       this.shouldShowCandidate(c, this.prefix)
     );
     const slDropdown = this.slDropdownRef.value as SlDropdown;
-    if (this.candidates.length > 0 && !this.wasDismissed) {
+      if (
+       this.candidates.length > 0 &&
+       !this.wasDismissed &&
+       !this.termWasCompleted
+     ) {
       slDropdown.show();
     } else {
       slDropdown.hide();


### PR DESCRIPTION
This should resolve #260.  Now, `webstatus-typeahead` keeps track of whether the last action was selecting a completion, and in that case the menu is not shown.

Also, since we added support for dates that are formatted like `2024-06-28`, I made `findPrefix()` smarter about dashes used as negation operators vs. dashes that occur within a term.