### PR TITLE
Set imagePullPolicy to never for locally built images

### DIFF
--- a/.dev/datastore/manifests/pod.yaml
+++ b/.dev/datastore/manifests/pod.yaml
@@ -22,6 +22,7 @@ spec:
   containers:
     - name: datastore
       image: datastore
+      imagePullPolicy: Never # Need this for pushing directly into minikube
       ports:
         - containerPort: 8085
           name: datastore-port

--- a/.dev/gcs/manifests/pod.yaml
+++ b/.dev/gcs/manifests/pod.yaml
@@ -22,6 +22,7 @@ spec:
   containers:
     - name: gcs
       image: gcs
+      imagePullPolicy: Never # Need this for pushing directly into minikube
       ports:
         - containerPort: 4443
           name: gcs-port

--- a/.dev/redis/manifests/pod.yaml
+++ b/.dev/redis/manifests/pod.yaml
@@ -22,6 +22,7 @@ spec:
   containers:
     - name: redis
       image: redis
+      imagePullPolicy: Never # Need this for pushing directly into minikube
       ports:
         - containerPort: 6379
           name: redis-port

--- a/.dev/spanner/manifests/pod.yaml
+++ b/.dev/spanner/manifests/pod.yaml
@@ -22,6 +22,7 @@ spec:
   containers:
     - name: spanner
       image: spanner
+      imagePullPolicy: Never # Need this for pushing directly into minikube
       ports:
         - containerPort: 9010
           name: grpc-port

--- a/backend/manifests/pod.yaml
+++ b/backend/manifests/pod.yaml
@@ -22,6 +22,7 @@ spec:
   containers:
     - name: backend
       image: backend
+      imagePullPolicy: Never # Need this for pushing directly into minikube
       ports:
         - containerPort: 8080
           name: http-backend

--- a/frontend/manifests/pod.yaml
+++ b/frontend/manifests/pod.yaml
@@ -25,6 +25,7 @@ spec:
   containers:
     - name: frontend
       image: frontend
+      imagePullPolicy: Never # Need this for pushing directly into minikube
       ports:
         - containerPort: 5555
           name: http-frontend

--- a/workflows/steps/services/common/repo_downloader/manifests/pod.yaml
+++ b/workflows/steps/services/common/repo_downloader/manifests/pod.yaml
@@ -22,6 +22,7 @@ spec:
   containers:
     - name: repo-downloader
       image: repo-downloader
+      imagePullPolicy: Never # Need this for pushing directly into minikube
       ports:
         - containerPort: 8080
           name: http-svc

--- a/workflows/steps/services/web_feature_consumer/manifests/pod.yaml
+++ b/workflows/steps/services/web_feature_consumer/manifests/pod.yaml
@@ -22,6 +22,7 @@ spec:
   containers:
     - name: web-feature-consumer
       image: web-feature-consumer
+      imagePullPolicy: Never # Need this for pushing directly into minikube
       ports:
         - containerPort: 8080
           name: http-svc


### PR DESCRIPTION
Sometimes, a developer can run into issues like this:

```
Watching for changes...
Error response from daemon: pull access denied for web-feature-consumer, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
Back-off pulling image "web-feature-consumer:121b121c17ed07dc780afd3f7152621a8cba2bfaaf2e008f9d97a4d2f176adc3"
```

This is because minikube is trying to pull the image from docker hub. In reality, this should never happen because the image is built locally.

By setting [imagePullPolicy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) to never, we are forcing the cluster to look locally for the image.

This was done for some resources but not all. This change should fix all the outstanding services.

