### PR TITLE
Add LatestWPTRunFeatureMetrics table to speed up initial look ups

### DIFF
--- a/infra/storage/spanner/migrations/000005.sql
+++ b/infra/storage/spanner/migrations/000005.sql
@@ -14,9 +14,9 @@
 
 -- LatestWPTRunFeatureMetrics contains latest snapshot of WPT metric information for a web feature.
 CREATE TABLE IF NOT EXISTS LatestWPTRunFeatureMetrics (
-    ID STRING(36) NOT NULL,
+    RunMetricID STRING(36) NOT NULL,
     WebFeatureID STRING(36) NOT NULL,
     BrowserName STRING(64) NOT NULL,
     Channel STRING(32) NOT NULL,
-    FOREIGN KEY (ID, WebFeatureID) REFERENCES WPTRunFeatureMetrics(ID, WebFeatureID) ON DELETE CASCADE
+    FOREIGN KEY (RunMetricID, WebFeatureID) REFERENCES WPTRunFeatureMetrics(ID, WebFeatureID) ON DELETE CASCADE
 ) PRIMARY KEY (WebFeatureID, BrowserName, Channel);

--- a/infra/storage/spanner/migrations/000005.sql
+++ b/infra/storage/spanner/migrations/000005.sql
@@ -1,0 +1,22 @@
+-- Copyright 2024 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- LatestWPTRunFeatureMetrics contains latest snapshot of WPT metric information for a web feature.
+CREATE TABLE IF NOT EXISTS LatestWPTRunFeatureMetrics (
+    ID STRING(36) NOT NULL,
+    WebFeatureID STRING(36) NOT NULL,
+    BrowserName STRING(64) NOT NULL,
+    Channel STRING(32) NOT NULL,
+    FOREIGN KEY (ID, WebFeatureID) REFERENCES WPTRunFeatureMetrics(ID, WebFeatureID) ON DELETE CASCADE
+) PRIMARY KEY (WebFeatureID, BrowserName, Channel);

--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -515,7 +515,7 @@ COALESCE(
 			)
 		)
 		FROM LatestWPTRunFeatureMetrics latest
-		JOIN WPTRunFeatureMetrics wpfm ON latest.ID = wpfm.ID
+		JOIN WPTRunFeatureMetrics wpfm ON latest.RunMetricID = wpfm.ID
 			AND latest.WebFeatureID = wpfm.WebFeatureID
 			AND latest.WebFeatureID = wf.ID
 		WHERE latest.Channel = @{{ $.ChannelParam }}

--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -507,55 +507,19 @@ OFFSET {{ .Offset }}
 	gcpFSMetricsSubQueryRawTemplate = `
 COALESCE(
 	(
-		SELECT ARRAY_AGG(metric_struct)
-		FROM (
-		{{- range $index, $browser := .BrowserList }}
-			{{ if $index -}}
-			UNION ALL
-			{{ end }}
-			SELECT AS STRUCT
-				"{{ $browser }}" AS BrowserName,
-				(
-					SELECT
-						IF(
-							ARRAY_LENGTH(ARRAY_AGG({{ $.PassRateColumn }})) > 0,
-							ARRAY_AGG({{ $.PassRateColumn }})[OFFSET(0)],
-							NULL
-						) AS PassRate
-					FROM WPTRunFeatureMetrics metrics
-					WHERE metrics.WebFeatureID = wf.ID
-						AND metrics.Channel = @{{ $.ChannelParam }}
-						AND metrics.BrowserName = "{{ $browser }}"
-						AND metrics.TimeStart = (
-							SELECT MAX(TimeStart)
-							FROM WPTRunFeatureMetrics metrics2
-							WHERE metrics2.WebFeatureID = wf.ID
-								AND metrics2.Channel = @{{ $.ChannelParam }}
-								AND metrics2.BrowserName = "{{ $browser }}"
-						)
-				) AS PassRate,
-				(
-					SELECT
-						IF(
-							ARRAY_LENGTH(ARRAY_AGG(FeatureRunDetails)) > 0,
-							ARRAY_AGG(FeatureRunDetails)[OFFSET(0)],
-							NULL
-						) AS FeatureRunDetails
-					FROM WPTRunFeatureMetrics metrics
-					WHERE metrics.WebFeatureID = wf.ID
-						AND metrics.Channel = @{{ $.ChannelParam }}
-						AND metrics.BrowserName = "{{ $browser }}"
-						AND metrics.TimeStart = (
-							SELECT MAX(TimeStart)
-							FROM WPTRunFeatureMetrics metrics2
-							WHERE metrics2.WebFeatureID = wf.ID
-								AND metrics2.Channel = @{{ $.ChannelParam }}
-								AND metrics2.BrowserName = "{{ $browser }}"
-						)
-				) AS FeatureRunDetails
-			{{- end }}
-		) metric_struct
-		WHERE metric_struct.PassRate IS NOT NULL
+		SELECT ARRAY_AGG(
+			STRUCT(
+				latest.BrowserName AS BrowserName,
+				wpfm.{{ $.PassRateColumn }} AS PassRate,
+				wpfm.FeatureRunDetails AS FeatureRunDetails
+			)
+		)
+		FROM LatestWPTRunFeatureMetrics latest
+		JOIN WPTRunFeatureMetrics wpfm ON latest.ID = wpfm.ID
+			AND latest.WebFeatureID = wpfm.WebFeatureID
+			AND latest.WebFeatureID = wf.ID
+		WHERE latest.Channel = @{{ $.ChannelParam }}
+			AND latest.BrowserName IN UNNEST(@browserNames)
 	),
 	(
 		SELECT ARRAY(
@@ -616,6 +580,8 @@ func (f GCPFeatureSearchBaseQuery) Query(args FeatureSearchQueryArgs) (
 	params[stableParamName] = "stable"
 	experimentalParamName := "experimentalChannelParam"
 	params[experimentalParamName] = "experimental"
+
+	params["browserNames"] = args.Browsers
 
 	stableMetricsData := GCPFSMetricsTemplateData{
 		Channel:        "Stable",

--- a/lib/gcpspanner/wpt_run_feature_metric.go
+++ b/lib/gcpspanner/wpt_run_feature_metric.go
@@ -121,7 +121,7 @@ type WPTRunFeatureMetric struct {
 
 // SpannerLatestWPTRunFeatureMetric represents a pointer to an entry in WPTRunFeatureMetrics.
 type SpannerLatestWPTRunFeatureMetric struct {
-	ID           string `spanner:"ID"`
+	RunMetricID  string `spanner:"RunMetricID"`
 	WebFeatureID string `spanner:"WebFeatureID"`
 	BrowserName  string `spanner:"BrowserName"`
 	Channel      string `spanner:"Channel"`
@@ -195,7 +195,7 @@ func getLatestWPTRunFeatureMetricTimeStart(
 	stmt := spanner.NewStatement(`
         SELECT wpfm.TimeStart
         FROM LatestWPTRunFeatureMetrics l
-        JOIN WPTRunFeatureMetrics wpfm ON l.ID = wpfm.ID
+        JOIN WPTRunFeatureMetrics wpfm ON l.RunMetricID = wpfm.ID
         WHERE l.WebFeatureID = @featureID
         AND l.BrowserName = @browserName
         AND l.Channel = @channel`)
@@ -356,7 +356,7 @@ func (c *Client) UpsertWPTRunFeatureMetrics(
 			// Update LatestWPTRunFeatureMetrics if newer
 			if shouldUpsertLatestMetric(existingTimeStart, metric.TimeStart) {
 				m1, err := spanner.InsertOrUpdateStruct(LatestWPTRunFeatureMetricsTable, SpannerLatestWPTRunFeatureMetric{
-					ID:           metric.ID,
+					RunMetricID:  metric.ID,
 					WebFeatureID: metric.WebFeatureID,
 					BrowserName:  metric.BrowserName,
 					Channel:      metric.Channel,

--- a/lib/gcpspanner/wpt_run_feature_metric_test.go
+++ b/lib/gcpspanner/wpt_run_feature_metric_test.go
@@ -85,7 +85,7 @@ func (c *Client) GetLatestMetricByFeatureKeyBrowserChannel(
         SELECT
 			wpfm.TotalTests, wpfm.TestPass, wpfm.TotalSubtests, wpfm.SubtestPass
         FROM LatestWPTRunFeatureMetrics l
-        JOIN WPTRunFeatureMetrics wpfm ON l.ID = wpfm.ID AND l.WebFeatureID = wpfm.WebFeatureID
+        JOIN WPTRunFeatureMetrics wpfm ON l.RunMetricID = wpfm.ID AND l.WebFeatureID = wpfm.WebFeatureID
         JOIN WebFeatures wf ON wf.ID = l.WebFeatureID
         WHERE wf.FeatureKey = @featureKey AND l.BrowserName = @browserName AND l.Channel = @channel`)
 


### PR DESCRIPTION
Finding the latest metric before an arbitrary timestamp is complex because Spanner does not currently support SQL window functions like RANK or ROW_NUMBER. These would be ideal for directly identifying the latest metric for a given timestamp within a query. To compensate for that, there are multiple subqueries to:
1. find the latest wpt metric for a feature given a certain browser name + channel combo and
2. build the struct.

This initial design allowed for flexible time-based filtering to retrieve data at arbitrary timestamps but we don't need that functionality. (Tradeoff: This would have allowed users to share the view of what one user saw exactly at a given timestamp)

Fixes #382

Other things tried:
- I tried to get rid of the emulator specific queries but they didn't seem to get faster with this new table. So I kept them. But this does improve performance on GCP.

