### PR TITLE
Fix opentelemetry config

### DIFF
--- a/otel/otel-collector-config.yaml
+++ b/otel/otel-collector-config.yaml
@@ -78,12 +78,12 @@ receivers:
 exporters:
   # Export logs and traces using the standard googelcloud exporter
   googlecloud:
-    project: $GOOGLE_CLOUD_PROJECT
+    project: ${env:GOOGLE_CLOUD_PROJECT}
     log:
       default_log_name: 'opentelemetry.io/collector-exported-log'
   # Export metrics to Google Managed service for Prometheus
   googlemanagedprometheus:
-    project: $GOOGLE_CLOUD_PROJECT
+    project: ${env:GOOGLE_CLOUD_PROJECT}
 
 processors:
   # Batch telemetry together to more efficiently send to GCP


### PR DESCRIPTION
Opentelemetry was recently updated in #476

I did not read the Changelog but there's an important notice there from the release [notes](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.104.0):

> Expansion of BASH-style environment variables, such as $FOO is no longer supported by default. If you depend on this syntax, disable the confmap.unifyEnvVarExpansion feature gate, but know that the feature will be removed in the future in favor of ${env:FOO}.

I started to see problems in staging when I deployed it.

![image](https://github.com/GoogleChrome/webstatus.dev/assets/7788930/d8c40c0e-da83-4d56-9233-76ee42a81ec2)


This change fixes it to be consistent with other environment variables.

