### PR TITLE
Fix gzip compression in GCP

### DIFF
--- a/e2e/tests/nginx-conf.spec.ts
+++ b/e2e/tests/nginx-conf.spec.ts
@@ -32,6 +32,16 @@ test('All public assets should be served with GZIP compression', async ({
   let publicAssetFound = false;
   let homepageFound = false;
 
+  page.on('request', async request => {
+    await page.route('**/*', async route => {
+      const headers = route.request().headers();
+      // Add the "Via" header to simulate Cloud Run environment
+      // https://cloud.google.com/load-balancing/docs/https/troubleshooting-ext-https-lbs#compression-not-working
+      headers['Via'] = 'test google'; // Simulate a Via header from Google Cloud Load Balancer;
+      await route.continue({headers});
+    });
+  });
+
   page.on('response', response => {
     // Intercept network requests to check for GZIP compression
     if (response.url().startsWith('http://localhost:5555/public')) {

--- a/e2e/tests/nginx-conf.spec.ts
+++ b/e2e/tests/nginx-conf.spec.ts
@@ -37,7 +37,7 @@ test('All public assets should be served with GZIP compression', async ({
       const headers = route.request().headers();
       // Add the "Via" header to simulate Cloud Run environment
       // https://cloud.google.com/load-balancing/docs/https/troubleshooting-ext-https-lbs#compression-not-working
-      headers['Via'] = 'test google'; // Simulate a Via header from Google Cloud Load Balancer;
+      headers['Via'] = '1.1 google'; // Simulate a Via header from Google Cloud Load Balancer;
       await route.continue({headers});
     });
   });

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -17,6 +17,10 @@ http {
     error_page 404 @404_fallback;
     index index.html;
     gzip on;
+    # Recommended GZIP settings from GCP documentation.
+    # https://cloud.google.com/load-balancing/docs/https/troubleshooting-ext-https-lbs#compression-not-working
+    gzip_vary on;
+    gzip_proxied any;
 
     if ($host ~* ^www\.(.*)$) {
       set $non_www_host $1;


### PR DESCRIPTION
I fixed GZIP compression. However, when I deployed it to GCP, it still did not work. Turns out that nginx turns off gzip compression when there's a Via header sent. (which is what GCP load balancers do) [1]

This change follows the recommendations from the GCP docs [1] and modifies the test to use a Via header to simulate being in a GCP environment to be close to what is used live.

![image](https://github.com/user-attachments/assets/81333a21-7d8b-4cc4-ad05-1f7272de23a3)


[1] https://cloud.google.com/load-balancing/docs/https/troubleshooting-ext-https-lbs#compression-not-working


Via value seen in browser
![image](https://github.com/user-attachments/assets/4e4b821a-4cb3-408e-b449-607acad875ca)


