### PR TITLE
Infrastructure fixups

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -36,7 +36,7 @@ instructions assume you have access to the following projects:
 ```sh
 cd infra
 gcloud auth login
-gcloud auth application-default login --project=web-compass-staging --no-browser
+gcloud auth application-default login --project=web-compass-staging
 # Something 6 characters long. Could use "openssl rand -hex 3"
 ENV_ID="some-unique-string-here"
 # SAVE THAT ENV_ID
@@ -99,20 +99,19 @@ terraform workspace delete $ENV_ID
 ```sh
 cd infra
 gcloud auth login
-gcloud auth application-default login --project=web-compass-staging --no-browser
+gcloud auth application-default login --project=web-compass-staging
 ENV_ID="staging"
+export TF_WORKSPACE=${ENV_ID}
 terraform init -reconfigure --var-file=.envs/staging.tfvars --backend-config=.envs/backend-staging.tfvars
-terraform workspace select $ENV_ID
 terraform plan \
     -var-file=".envs/staging.tfvars" \
     -var "env_id=${ENV_ID}"
 ```
 
-Migrate the tables if any schemas changed:
+Migrate the tables if any schemas changed (assuming you already authenticated with `gcloud auth application-default login`):
 
 ```sh
 export SPANNER_PROJECT_ID=webstatus-dev-internal-staging
-gcloud auth application-default login --project=${SPANNER_PROJECT_ID} --no-browser
 export SPANNER_DATABASE_ID=${ENV_ID}-database
 export SPANNER_INSTANCE_ID=${ENV_ID}-spanner
 wrench migrate up --directory ./storage/spanner/
@@ -131,21 +130,20 @@ terraform apply \
 ```sh
 cd infra
 gcloud auth login
-gcloud auth application-default login --project=web-compass-prod --no-browser
+gcloud auth application-default login --project=web-compass-prod
 ENV_ID="prod"
+export TF_WORKSPACE=${ENV_ID}
 terraform init -reconfigure --var-file=.envs/prod.tfvars --backend-config=.envs/backend-prod.tfvars
-terraform workspace select $ENV_ID
 
 terraform plan \
     -var-file=".envs/prod.tfvars" \
     -var "env_id=${ENV_ID}"
 ```
 
-Migrate the tables if any schemas changed:
+Migrate the tables if any schemas changed (assuming you already authenticated with `gcloud auth application-default login`):
 
 ```sh
 export SPANNER_PROJECT_ID=webstatus-dev-internal-prod
-gcloud auth application-default login --project=${SPANNER_PROJECT_ID} --no-browser
 export SPANNER_DATABASE_ID=${ENV_ID}-database
 export SPANNER_INSTANCE_ID=${ENV_ID}-spanner
 wrench migrate up --directory ./storage/spanner/

--- a/infra/frontend/service.tf
+++ b/infra/frontend/service.tf
@@ -55,12 +55,11 @@ data "google_project" "datastore_project" {
 
 
 resource "google_cloud_run_v2_service" "service" {
-  for_each     = var.region_to_subnet_info_map
-  provider     = google.public_project
-  launch_stage = "BETA"
-  name         = "${var.env_id}-${each.key}-webstatus-frontend"
-  location     = each.key
-  ingress      = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  for_each = var.region_to_subnet_info_map
+  provider = google.public_project
+  name     = "${var.env_id}-${each.key}-webstatus-frontend"
+  location = each.key
+  ingress  = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
 
   template {
     containers {
@@ -93,6 +92,11 @@ resource "google_cloud_run_v2_service" "service" {
       egress = "ALL_TRAFFIC"
     }
     service_account = google_service_account.frontend.email
+  }
+
+  traffic {
+    percent = 100
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
   }
 }
 

--- a/infra/ingestion/common_workflow_steps/repo_downloader/main.tf
+++ b/infra/ingestion/common_workflow_steps/repo_downloader/main.tf
@@ -86,6 +86,12 @@ resource "google_cloud_run_v2_service" "service" {
     }
     service_account = google_service_account.service_account.email
   }
+
+  traffic {
+    percent = 100
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+  }
+
   depends_on = [
     google_storage_bucket_iam_member.iam_member,
     google_secret_manager_secret_iam_member.iam_member,

--- a/infra/ingestion/workflows/web_features_repo/web_feature_service.tf
+++ b/infra/ingestion/workflows/web_features_repo/web_feature_service.tf
@@ -94,6 +94,12 @@ resource "google_cloud_run_v2_service" "web_feature_service" {
     timeout         = format("%ds", var.timeout_seconds)
     service_account = google_service_account.web_feature_consumer_service_account.email
   }
+
+  traffic {
+    percent = 100
+    type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
+  }
+
   depends_on = [
     google_storage_bucket_iam_member.web_feature_consumer,
   ]

--- a/otel/otel-collector-config.yaml
+++ b/otel/otel-collector-config.yaml
@@ -17,7 +17,7 @@ receivers:
   otlp:
     protocols:
       http:
-        endpoint: localhost:4318
+        endpoint: 0.0.0.0:4318
   # Use the filelog receiver to read our log from its log file.
   filelog:
     start_at: beginning
@@ -101,6 +101,7 @@ processors:
 
 extensions:
   health_check:
+    endpoint: 0.0.0.0:4319
 
 service:
   extensions: [health_check]


### PR DESCRIPTION
This change does the following:
- Update the deployment document to 1) use TF_WORKSPACE to reduce the number of interactive prompts, 2) remove unneeded flags and commands
- Force all cloud run services to send traffic to the latest revision. If a developer manually touched a service, the next revision would deploy but no traffic would go to it. Leaving an older revision serving traffic (which could make debugging weird)
- Remove the BETA flags from the services in favor of the default GA value. Terraform kept trying to change it to BETA so something kept switching it. We don't need that field anymore
- Fix the health check for open telemetry. The latest version forces us to expose on 0.0.0.0. Otherwise, Cloud Run health check cannot access it. So it kept shutting down. Now it is fixed. Additiionally, changed the health check port from the default of 13133 to 4319.

