### PR TITLE
Provide UI feedback during export to CSV

### DIFF
--- a/frontend/src/static/js/components/webstatus-overview-filters.ts
+++ b/frontend/src/static/js/components/webstatus-overview-filters.ts
@@ -84,8 +84,7 @@ export class WebstatusOverviewFilters extends LitElement {
   @state()
   location!: {search: string}; // Set by parent.
 
-  // Whether the export button is enabled.
-  // false unless waiting for export to finish.
+  // Whether the export button should be enabled based on export status.
   @state()
   exportDataStatus: TaskStatus = TaskStatus.INITIAL;
 

--- a/frontend/src/static/js/components/webstatus-overview-filters.ts
+++ b/frontend/src/static/js/components/webstatus-overview-filters.ts
@@ -24,6 +24,7 @@ import {SHARED_STYLES} from '../css/shared-css.js';
 import './webstatus-typeahead.js';
 import {type WebstatusTypeahead} from './webstatus-typeahead.js';
 import './webstatus-overview-table.js';
+import {TaskStatus} from '@lit/task';
 
 const VOCABULARY = [
   {
@@ -86,7 +87,7 @@ export class WebstatusOverviewFilters extends LitElement {
   // Whether the export button is enabled.
   // false unless waiting for export to finish.
   @state()
-  exportingData: boolean = false;
+  exportDataStatus: TaskStatus = TaskStatus.INITIAL;
 
   static get styles(): CSSResultGroup {
     return [
@@ -133,14 +134,6 @@ export class WebstatusOverviewFilters extends LitElement {
         }
       `,
     ];
-  }
-
-  constructor() {
-    super();
-    // Setup listener for exportToCSVDone
-    this.addEventListener('exportToCSVDone', () => {
-      this.exportingData = false;
-    });
   }
 
   gotoFilterQueryString(): void {
@@ -197,7 +190,7 @@ export class WebstatusOverviewFilters extends LitElement {
 
   renderExportButton(): TemplateResult {
     const exportToCSV = () => {
-      this.exportingData = true;
+      this.exportDataStatus = TaskStatus.PENDING;
 
       // dispatch an event via CustomEvent
       const event = new CustomEvent('exportToCSV', {
@@ -206,7 +199,7 @@ export class WebstatusOverviewFilters extends LitElement {
         cancelable: true,
         detail: {
           callback: () => {
-            this.exportingData = false;
+            this.exportDataStatus = TaskStatus.COMPLETE;
           },
         },
       });
@@ -216,8 +209,8 @@ export class WebstatusOverviewFilters extends LitElement {
     return html`
       <sl-button
         @click=${exportToCSV}
-        ?loading=${this.exportingData}
-        ?disabled=${this.exportingData}
+        ?loading=${this.exportDataStatus === TaskStatus.PENDING}
+        ?disabled=${this.exportDataStatus === TaskStatus.PENDING}
       >
         <sl-icon slot="prefix" name="download"></sl-icon>
         Export to CSV

--- a/frontend/src/static/js/components/webstatus-overview-page.ts
+++ b/frontend/src/static/js/components/webstatus-overview-page.ts
@@ -19,7 +19,7 @@ import {Task, TaskStatus} from '@lit/task';
 import {LitElement, type TemplateResult, html} from 'lit';
 import {customElement, state} from 'lit/decorators.js';
 import {type components} from 'webstatus.dev-backend';
-import {convertToCSV} from '../utils/csv.js';
+import {downloadCSV} from '../utils/csv.js';
 
 import {
   getColumnsSpec,
@@ -41,6 +41,7 @@ import {TaskTracker} from '../utils/task-tracker.js';
 import {ApiError, UnknownError} from '../api/errors.js';
 import {CELL_DEFS} from './webstatus-overview-cells.js';
 import {ColumnKey, parseColumnsSpec} from './webstatus-overview-cells.js';
+import {toast} from '../utils/toast.js';
 
 @customElement('webstatus-overview-page')
 export class OverviewPage extends LitElement {
@@ -60,8 +61,7 @@ export class OverviewPage extends LitElement {
   location!: {search: string}; // Set by router.
 
   @state()
-  // allFeaturesFetcher is either undefined or a function that returns
-  // an array of all features via apiClient.getAllFeatures
+  // A function that returns an array of all features via apiClient.getAllFeatures
   allFeaturesFetcher:
     | undefined
     | (() => Promise<components['schemas']['Feature'][]>) = undefined;
@@ -98,6 +98,7 @@ export class OverviewPage extends LitElement {
             error: error,
             data: null,
           };
+          toast(`${error.message}`, 'danger', 'exclamation-triangle');
         } else {
           // Should never reach here but let's handle it.
           this.taskTracker = {
@@ -164,16 +165,7 @@ export class OverviewPage extends LitElement {
       return row;
     });
 
-    const csv = convertToCSV(columns, rows);
-
-    // Create blob to download the csv.
-    const blob = new Blob([csv], {type: 'text/csv'});
-    const url = window.URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'webstatus-feature-overview.csv';
-    link.click();
-
+    downloadCSV(columns, rows);
     if (resolved) resolved();
   }
 

--- a/frontend/src/static/js/components/webstatus-overview-page.ts
+++ b/frontend/src/static/js/components/webstatus-overview-page.ts
@@ -110,12 +110,15 @@ export class OverviewPage extends LitElement {
     });
 
     // Set up listener of 'exportToCSV' event from webstatus-overview-filters.
-    this.addEventListener('exportToCSV', () => {
-      this.exportToCSV();
+    this.addEventListener('exportToCSV', event => {
+      const {detail} = event as CustomEvent<{
+        callback: (() => void) | undefined;
+      }>;
+      this.exportToCSV(detail.callback);
     });
   }
 
-  async exportToCSV(): Promise<void> {
+  async exportToCSV(resolved: (() => void) | undefined): Promise<void> {
     if (!this.allFeaturesFetcher) {
       return;
     }
@@ -170,6 +173,8 @@ export class OverviewPage extends LitElement {
     link.href = url;
     link.download = 'webstatus-feature-overview.csv';
     link.click();
+
+    if (resolved) resolved();
   }
 
   async _fetchFeatures(

--- a/frontend/src/static/js/index.ts
+++ b/frontend/src/static/js/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import '@shoelace-style/shoelace/dist/components/alert/alert.js';
 import '@shoelace-style/shoelace/dist/components/button/button.js';
 import '@shoelace-style/shoelace/dist/components/card/card.js';
 import '@shoelace-style/shoelace/dist/components/checkbox/checkbox.js';

--- a/frontend/src/static/js/utils/csv.ts
+++ b/frontend/src/static/js/utils/csv.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {toast} from './toast.js';
 
 /**
  * Returns a string in CSV format given header strings and rows.
@@ -49,7 +48,11 @@ export function convertToCSV(header: string[], rows: string[][]): string {
   return csv;
 }
 
-export function downloadCSV(columns: string[], rows: string[][]) {
+export function downloadCSV(
+  columns: string[],
+  rows: string[][],
+  filename: string
+): Promise<void> {
   // Create the CSV string.
   const csv = convertToCSV(columns, rows);
 
@@ -74,12 +77,11 @@ export function downloadCSV(columns: string[], rows: string[][]) {
         document.body.appendChild(link);
         link.click();
         link.parentElement!.removeChild(link);
-      })
-      // handle request error
-      .catch(err => {
-        // console.log(err);
-        toast(err);
       });
+  // // handle request error
+  // .catch(err => {
+  //   throw new Error(`Download of CSV resulted in ${err}`);
+  // });
 
-  request(url, 'webstatus-feature-overview.csv');
+  return request(url, filename);
 }

--- a/frontend/src/static/js/utils/csv.ts
+++ b/frontend/src/static/js/utils/csv.ts
@@ -77,10 +77,6 @@ export function downloadCSV(
         link.click();
         link.parentElement!.removeChild(link);
       });
-  // // handle request error
-  // .catch(err => {
-  //   throw new Error(`Download of CSV resulted in ${err}`);
-  // });
 
   return request(url, filename);
 }

--- a/frontend/src/static/js/utils/csv.ts
+++ b/frontend/src/static/js/utils/csv.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 /**
  * Returns a string in CSV format given header strings and rows.
  */

--- a/frontend/src/static/js/utils/csv.ts
+++ b/frontend/src/static/js/utils/csv.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {toast} from './toast.js';
+
 /**
  * Returns a string in CSV format given header strings and rows.
  */
@@ -45,4 +47,39 @@ export function convertToCSV(header: string[], rows: string[][]): string {
     csv += '\n' + csvRows.join('\n');
   }
   return csv;
+}
+
+export function downloadCSV(columns: string[], rows: string[][]) {
+  // Create the CSV string.
+  const csv = convertToCSV(columns, rows);
+
+  // Create blob to download the csv.
+  const blob = new Blob([csv], {type: 'text/csv'});
+  const url = window.URL.createObjectURL(blob);
+
+  // Use fetch to download the csv.
+  const request = (path: string, filename?: string) =>
+    fetch(path)
+      .then(response => response.blob())
+      .then(blob => {
+        if (!filename) {
+          const blobType = blob.type.split('/').pop();
+          const type = blobType === 'plain' ? 'txt' : blobType;
+          filename = 'file-' + new Date().getTime() + '.' + type;
+        }
+        const link = document.createElement('a');
+        link.className = 'download';
+        link.download = filename;
+        link.href = URL.createObjectURL(blob);
+        document.body.appendChild(link);
+        link.click();
+        link.parentElement!.removeChild(link);
+      })
+      // handle request error
+      .catch(err => {
+        // console.log(err);
+        toast(err);
+      });
+
+  request(url, 'webstatus-feature-overview.csv');
 }

--- a/frontend/src/static/js/utils/toast.ts
+++ b/frontend/src/static/js/utils/toast.ts
@@ -35,7 +35,7 @@ export function toast(
     closable: true,
     duration: duration,
     innerHTML: `
-      <sl-icon name="${icon}" slot="icon"></sl-icon>
+      <sl-icon name="${icon}" class="toast" slot="icon"></sl-icon>
       ${escapeHtml(message)}
     `,
   });

--- a/frontend/src/static/js/utils/toast.ts
+++ b/frontend/src/static/js/utils/toast.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {type SlAlert} from '@shoelace-style/shoelace';
+
 // Escape HTML for text arguments
 export function escapeHtml(html: string) {
   const div = document.createElement('div');
@@ -24,8 +26,8 @@ export function escapeHtml(html: string) {
 // Custom function to emit toast notifications
 export function toast(
   message: string,
-  variant = 'primary',
-  icon = 'info-circle',
+  variant: SlAlert['variant'] = 'primary',
+  icon: 'info-circle' | 'exclamation-triangle' = 'info-circle',
   duration = 3000
 ) {
   const alert = Object.assign(document.createElement('sl-alert'), {

--- a/frontend/src/static/js/utils/toast.ts
+++ b/frontend/src/static/js/utils/toast.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Escape HTML for text arguments
+export function escapeHtml(html: string) {
+  const div = document.createElement('div');
+  div.textContent = html;
+  return div.innerHTML;
+}
+
+// Custom function to emit toast notifications
+export function toast(
+  message: string,
+  variant = 'primary',
+  icon = 'info-circle',
+  duration = 3000
+) {
+  const alert = Object.assign(document.createElement('sl-alert'), {
+    variant,
+    closable: true,
+    duration: duration,
+    innerHTML: `
+      <sl-icon name="${icon}" slot="icon"></sl-icon>
+      ${escapeHtml(message)}
+    `,
+  });
+
+  document.body.append(alert);
+  return alert.toast();
+}


### PR DESCRIPTION
This PR provides feedback to the user while handling the export to CSV functionality, as requested by #511.

* When the "Export to CSV" button is clicked, it is disabled and changed to 'loading' state, and restored when done.
* If an error occurs during loading of the data or saving of the file, a toast alert will be displayed.
* Successful download results in the browser displaying the list of recent downloads, so no further confirmation is required.

This PR fixes #511

