### PR TITLE
Pre-install VS Code Live share

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -62,7 +62,8 @@
         "esbenp.prettier-vscode",
         "ms-playwright.playwright",
         "figma.figma-vscode-extension",
-        "mike-lischke.vscode-antlr4"
+        "mike-lischke.vscode-antlr4",
+        "ms-vsliveshare.vsliveshare"
       ]
     }
   },


### PR DESCRIPTION
During a recent session, Dan and I used Live Share instead of sharing screens.

This allowed us to type directly into another's vs code and try things.

To learn more, check out the docs for Live Share: https://code.visualstudio.com/learn/collaboration/live-share

Marketplace link: https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare

This change allows it to be installed by default in the devcontainer.

