### PR TITLE
Update instructions

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -37,6 +37,7 @@ instructions assume you have access to the following projects:
 cd infra
 gcloud auth login
 gcloud auth application-default login --project=web-compass-staging
+gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
 # Something 6 characters long. Could use "openssl rand -hex 3"
 ENV_ID="some-unique-string-here"
 # SAVE THAT ENV_ID
@@ -100,6 +101,7 @@ terraform workspace delete $ENV_ID
 cd infra
 gcloud auth login
 gcloud auth application-default login --project=web-compass-staging
+gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
 ENV_ID="staging"
 export TF_WORKSPACE=${ENV_ID}
 terraform init -reconfigure --var-file=.envs/staging.tfvars --backend-config=.envs/backend-staging.tfvars
@@ -117,7 +119,7 @@ export SPANNER_INSTANCE_ID=${ENV_ID}-spanner
 wrench migrate up --directory ./storage/spanner/
 ```
 
-Assumming the plan output by the terraform plan command looks fine, run:
+Assuming the plan output by the terraform plan command looks fine, run:
 
 ```sh
 terraform apply \
@@ -131,6 +133,7 @@ terraform apply \
 cd infra
 gcloud auth login
 gcloud auth application-default login --project=web-compass-prod
+gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
 ENV_ID="prod"
 export TF_WORKSPACE=${ENV_ID}
 terraform init -reconfigure --var-file=.envs/prod.tfvars --backend-config=.envs/backend-prod.tfvars
@@ -149,7 +152,7 @@ export SPANNER_INSTANCE_ID=${ENV_ID}-spanner
 wrench migrate up --directory ./storage/spanner/
 ```
 
-Assumming the plan output by the terraform plan command looks fine, run:
+Assuming the plan output by the terraform plan command looks fine, run:
 
 ```sh
 terraform apply \

--- a/README.md
+++ b/README.md
@@ -31,16 +31,18 @@ capabilities, please refer to our [Search Syntax Guide](./antlr/FeatureSearch.md
 
 ## Get the code
 
-This repository relies heavily on devcontainers to get started.
+This repository relies heavily on [devcontainers](https://code.visualstudio.com/docs/remote/create-dev-container) to get started.
 
-| Service                                                                                                  | Click The Badge                                                                                                                                                                                                                                                                             | Requirements                           |
-| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| [Visual Studio Code Remote - Containers](https://code.visualstudio.com/docs/remote/create-dev-container) | [![Open in Remote - Containers](https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/GoogleChrome/webstatus.dev) | Locally: Docker and Visual Studio Code |
-
-Otherwise, to continue setting up locally:
+To continue setting up locally:
 
 ```sh
 git clone https://github.com/GoogleChrome/webstatus.dev
+code webstatus.dev # Opens Visual Studio Code with the webstatus.dev folder.
+
+# While inside Visual Studio Code, start the devcontainer.
+# Start it by:
+# 1. Opening the Command Palette (via View -> Command Palette)
+# 2. Select the option: Dev containers: Rebuild and Reopen in Container
 ```
 
 ### Running the services locally


### PR DESCRIPTION
This will serve as a catch-all PR that updates any instructions as we do our meeting today.

Changes so far:
- Remove the devcontainer badge. The badge does not work anymore because we use volumes to help with speed. The badge does a clone into its own volume which will not work with our volumes. Instead, update the instructions to tell developers how to manually start the devcontainer.
- Add missing docker auth instructions (it's a one time thing that I forgot a long time ago)
- Fix typos