### PR TITLE
Add Authentication Emulator

### DIFF
--- a/.dev/auth/Dockerfile
+++ b/.dev/auth/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM node:20.14.0-slim
+# FIREBASE_CLI_VERSION from https://github.com/firebase/firebase-tools/releases
+ARG FIREBASE_CLI_VERSION=13.14.1
+# Workaround for https://github.com/firebase/firebase-tools/issues/6931 is to install via npm
+RUN npm i firebase-tools@${FIREBASE_CLI_VERSION} -g
+# Once https://github.com/firebase/firebase-tools/issues/6931 is resolved, we can install via ADD instead of npm
+# ADD https://github.com/firebase/firebase-tools/releases/download/v${FIREBASE_CLI_VERSION}/firebase-tools-linux /usr/local/bin/firebase
+RUN chmod +x /usr/local/bin/firebase
+ADD firebase.json firebase.json
+RUN firebase setup:emulators:ui --project=local
+ENTRYPOINT [ "firebase", "emulators:start", "--project=local" ]

--- a/.dev/auth/firebase.json
+++ b/.dev/auth/firebase.json
@@ -1,0 +1,14 @@
+{
+  "emulators": {
+    "auth": {
+      "port": 9099,
+      "host": "0.0.0.0"
+    },
+    "ui": {
+      "enabled": true,
+      "port": 9100,
+      "host": "0.0.0.0"
+    },
+    "singleProjectMode": true
+  }
+}

--- a/.dev/auth/manifests/pod.yaml
+++ b/.dev/auth/manifests/pod.yaml
@@ -1,0 +1,44 @@
+# Copyright 2024 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: auth
+  labels:
+    app.kubernetes.io/name: auth
+spec:
+  containers:
+    - name: auth
+      image: auth
+      imagePullPolicy: Never # Need this for pushing directly into minikube
+      ports:
+        - containerPort: 9099
+          name: auth-port
+        - containerPort: 9100
+          name: auth-ui-port
+      startupProbe:
+        httpGet:
+          port: auth-ui-port
+          path: /health
+        # Wait 10 sec * 10 fails = 100 seconds before failing
+        failureThreshold: 10
+        periodSeconds: 10
+      resources:
+        limits:
+          cpu: 250m
+          memory: 1024Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi

--- a/.dev/auth/manifests/service.yaml
+++ b/.dev/auth/manifests/service.yaml
@@ -1,0 +1,30 @@
+# Copyright 2024 Google LLC
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     https://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth
+spec:
+  selector:
+    app.kubernetes.io/name: auth
+  ports:
+    - protocol: TCP
+      port: 9099
+      targetPort: auth-port
+      name: emulator
+    - protocol: TCP
+      port: 9100
+      targetPort: auth-ui-port
+      name: ui

--- a/.dev/auth/skaffold.yaml
+++ b/.dev/auth/skaffold.yaml
@@ -1,11 +1,11 @@
-# Copyright 2023 Google LLC
-
+# Copyright 2024 Google LLC
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
-#     https://www.apache.org/licenses/LICENSE-2.0
-
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,23 +15,13 @@
 apiVersion: skaffold/v4beta9
 kind: Config
 metadata:
-  name: backend-config
-requires:
-  - path: ../.dev/auth
-  - path: ../.dev/datastore
-  - path: ../.dev/redis
-  - path: ../.dev/spanner
+  name: auth-config
 profiles:
   - name: local
     build:
       artifacts:
-        - image: backend
-          context: ..
-          runtimeType: go
-          docker:
-            dockerfile: images/go_service.Dockerfile
-            buildArgs:
-              service_dir: backend
+        - image: auth
+          context: .
       local:
         useBuildkit: true
     manifests:
@@ -39,7 +29,3 @@ profiles:
         - manifests/*
     deploy:
       kubectl: {}
-    portForward:
-      - resourceType: pod
-        resourceName: backend
-        port: 8080

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -83,14 +83,15 @@ this command or the `make port-forward-manual` command, something may be wrong.
 
 The above skaffold command deploys multiple resources:
 
-| Resource  | Description                    | Port Forwarded Address | Internal Address                                    |
-| --------- | ------------------------------ | ---------------------- | --------------------------------------------------- |
-| backend   | Backend service in ./backend   | http://localhost:8080  | http://backend:8080                                 |
-| frontend  | Frontend service in ./frontend | http://localhost:5555  | http://frontend:5555                                |
-| datastore | Datastore Emulator             | N/A                    | http://datastore:8085                               |
-| spanner   | Spanner Emulator               | N/A                    | spanner:9010 (grpc)<br />http://spanner:9020 (rest) |
-| redis     | Redis                          | N/A                    | redis:6379                                          |
-| gcs       | Google Cloud Storage Emulator  | N/A                    | http://gcs:4443                                     |
+| Resource  | Description                    | Port Forwarded Address                                     | Internal Address                                    |
+| --------- | ------------------------------ | ---------------------------------------------------------- | --------------------------------------------------- |
+| backend   | Backend service in ./backend   | http://localhost:8080                                      | http://backend:8080                                 |
+| frontend  | Frontend service in ./frontend | http://localhost:5555                                      | http://frontend:5555                                |
+| datastore | Datastore Emulator             | N/A                                                        | http://datastore:8085                               |
+| spanner   | Spanner Emulator               | N/A                                                        | spanner:9010 (grpc)<br />http://spanner:9020 (rest) |
+| redis     | Redis                          | N/A                                                        | redis:6379                                          |
+| gcs       | Google Cloud Storage Emulator  | N/A                                                        | http://gcs:4443                                     |
+| auth      | Auth Emulator                  | http://localhost:9099<br />http://localhost:9100/auth (ui) | http://auth:9099<br />http://auth:9100/auth (ui)    |
 
 _In the event the servers are not responsive, make a temporary change to a file_
 _in a watched directory (e.g. backend). This will rebuild and expose the_

--- a/Makefile
+++ b/Makefile
@@ -52,17 +52,24 @@ port-forward-manual: port-forward-terminate
 	kubectl wait --for=condition=ready pod/frontend
 	kubectl wait --for=condition=ready pod/backend
 	kubectl wait --for=condition=ready pod/web-feature-consumer
+	kubectl wait --for=condition=ready pod/auth
 	kubectl port-forward --address 127.0.0.1 pod/frontend 5555:5555 2>&1 >/dev/null &
 	kubectl port-forward --address 127.0.0.1 pod/backend 8080:8080 2>&1 >/dev/null &
 	kubectl port-forward --address 127.0.0.1 pod/web-feature-consumer 8092:8080 2>&1 >/dev/null &
+	kubectl port-forward --address 127.0.0.1 pod/auth 9099:9099 2>&1 >/dev/null &
+	kubectl port-forward --address 127.0.0.1 pod/auth 9100:9100 2>&1 >/dev/null &
 	curl -s -o /dev/null -m 5 http://localhost:8080 || true
 	curl -s -o /dev/null -m 5 http://localhost:5555 || true
 	curl -s -o /dev/null -m 5 http://localhost:8092 || true
+	curl -s -o /dev/null -m 5 http://localhost:9099 || true
+	curl -s -o /dev/null -m 5 http://localhost:9100 || true
 
 port-forward-terminate:
 	fuser -k 5555/tcp || true
 	fuser -k 8080/tcp || true
 	fuser -k 8092/tcp || true
+	fuser -k 9099/tcp || true
+	fuser -k 9100/tcp || true
 
 # Prerequisite target to start minikube if necessary
 minikube-running:


### PR DESCRIPTION
In preparation for supporting user accounts that
bacekd by Google Cloud Identity Platform, this
change adds the authentication emulator. This will allow developers to easily test out the
authentication and authorization flows via Github
locally.

Changes:
- Add Dockerfile that installs the emulator in the image.
- Add kubernetes manifests to deploy the image locally.
- Make the authentication emulator start up before the backend
- Expose the two ports for the emulator locally (9099, 9100)
- Update the development readme



You can see in the UI you can create a test user that signs in with github locally (the button will come in a future PR)
-  ![image](https://github.com/user-attachments/assets/37b2bdd5-94ea-46c6-8353-7c444c4095aa)
- ![image](https://github.com/user-attachments/assets/e80284bc-ab7b-476f-9b5b-0b43b5746b3f)
- ![image](https://github.com/user-attachments/assets/4959fef7-df78-494e-95ad-83af4f80251b)

In a future PR, we can programatically create users and then our tests will use those accounts.