### PR TITLE
Add util package to populate users automatically

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,9 +6,10 @@
 2. Project Structure
 3. Running Locally
 4. Populate Data Locally
-5. Generating Code
-6. Test Code
-7. Clean Up
+5. Populate Users Locally
+6. Generating Code
+7. Test Code
+8. Clean Up
 
 ## Requirements
 
@@ -145,6 +146,16 @@ from the latest snapshot from the web-features repo.
 | Resource | Location                                                     |
 | -------- | ------------------------------------------------------------ |
 | backend  | [openapi/backend/openapi.yaml](openapi/backend/openapi.yaml) |
+
+## Populate Users Locally
+
+After doing an initial deployment, we need to set up users in the auth emulator.
+
+```sh
+make dev_fake_users
+```
+
+The output of the command will indicate if it is successful.
 
 ## Generating Code
 

--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ license-fix:
 ################################
 # Playwright
 ################################
-fresh-env-for-playwright: playwright-install delete-local build deploy-local dev_fake_data port-forward-manual
+fresh-env-for-playwright: playwright-install delete-local build deploy-local dev_fake_data dev_fake_users port-forward-manual
 
 playwright-install:
 	npx playwright install --with-deps
@@ -371,6 +371,10 @@ wpt_workflow:
 bcd_workflow:
 	./util/run_job.sh bcd-consumer images/go_service.Dockerfile workflows/steps/services/bcd_consumer \
 		workflows/steps/services/bcd_consumer/manifests/job.yaml bcd-consumer
+dev_fake_users: build
+	fuser -k 9099/tcp || true
+	kubectl port-forward --address 127.0.0.1 pod/auth 9099:9099 2>&1 >/dev/null &
+	go run util/cmd/load_test_users/main.go -project=local
 dev_fake_data: build is_local_migration_ready
 	fuser -k 9010/tcp || true
 	kubectl port-forward --address 127.0.0.1 pod/spanner 9010:9010 2>&1 >/dev/null &

--- a/util/cmd/load_test_users/main.go
+++ b/util/cmd/load_test_users/main.go
@@ -1,0 +1,170 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// nolint:lll // WONTFIX: useful comment
+/*
+createUserClaim creates the token that will be used to create a fake user in the auth emulator.
+
+The user will be created so that it can fake a sign in with GitHub.
+
+More details about the structure of the claims can be found below.
+
+Currently the JWT ID looks like this:
+eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJuYW1lIjoiQXdlc29tZSBVc2VyIDEiLCJlbWFpbCI6ImF3ZXNvbWUudXNlci4xQGV4YW1wbGUuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF1dGhfdGltZSI6MTcyMjI2MjQ4MiwidXNlcl9pZCI6ImRuMWJlV3JOWFFGZm1XRUxjdUtkUmh1UlhnRlIiLCJmaXJlYmFzZSI6eyJpZGVudGl0aWVzIjp7ImVtYWlsIjpbImF3ZXNvbWUudXNlci4xQGV4YW1wbGUuY29tIl0sImdpdGh1Yi5jb20iOlsiNDEzMTU2OTA1NTg1NTE2MjI2MTgyNDM3NzIxOTEwOTI4MTcwMzM1NyJdfSwic2lnbl9pbl9wcm92aWRlciI6ImdpdGh1Yi5jb20ifSwiaWF0IjoxNzIyMjYyNDg1LCJleHAiOjE3MjIyNjYwODUsImF1ZCI6ImxvY2FsIiwiaXNzIjoiaHR0cHM6Ly9zZWN1cmV0b2tlbi5nb29nbGUuY29tL2xvY2FsIiwic3ViIjoiZG4xYmVXck5YUUZmbVdFTGN1S2RSaHVSWGdGUiJ9.
+Using jwt.io, that decodes to:
+
+	{
+		"name": "Awesome User 1",
+		"email": "awesome.user.1@example.com",
+		"email_verified": true,
+		"auth_time": 1722262482,
+		"user_id": "dn1beWrNXQFfmWELcuKdRhuRXgFR",
+		"firebase": {
+			"identities": {
+				"email": [
+					"awesome.user.1@example.com"
+				],
+				"github.com": [
+					"4131569055855162261824377219109281703357"
+				]
+			},
+			"sign_in_provider": "github.com"
+		},
+		"iat": 1722262485,
+		"exp": 1722266085,
+		"aud": "local",
+		"iss": "https://securetoken.google.com/local",
+		"sub": "dn1beWrNXQFfmWELcuKdRhuRXgFR"
+	}
+
+	Inspiration for createUsers comes from:
+	- https://github.com/firebase/firebase-tools/blob/1037f51ba2e07a1668b9ae334bec6ee457f02786/src/emulator/auth/idp.spec.ts#L37-L47
+	- https://github.com/mikcsabee/auth-emulator-example/blob/4ec3c0f749dddda5afb92f5ee7435527a4774583/postman_pre-request_script.js#L31-L38
+	- https://github.com/Dietarify/app-backend/blob/5c905a5c956a1542eebf28d0fbe1c7cab0ea80f4/README.md?plain=1#L70-L79
+*/
+func createUserClaim(user User, project string) jwt.MapClaims {
+	issueTime := time.Now()
+	claims := jwt.MapClaims{
+		"name":           user.Name,
+		"email":          user.Email,
+		"email_verified": user.EmailVerified,
+		"auth_time":      issueTime.Unix(),
+		"user_id":        user.UserID,
+		"firebase": map[string]interface{}{
+			"identities": map[string]interface{}{
+				"email": []string{
+					user.Email,
+				},
+				"github.com": []string{},
+			},
+			"sign_in_provider": "github.com",
+		},
+		"iat": issueTime.Unix(),
+		"exp": issueTime.Add(1 * time.Hour).Unix(),
+		"aud": project,
+		"sub": user.UserID,
+		"iss": "https://securetoken.google.com/" + project,
+	}
+
+	return claims
+}
+
+// getUsers contains the list of users to create.
+func getUsers() []User {
+	return []User{
+		{
+			Name:          "test user 1",
+			Email:         "test.user.1@example.com",
+			EmailVerified: true,
+			UserID:        "abcdedf1234567890",
+		},
+	}
+}
+
+func createUsers(project string) {
+	for _, user := range getUsers() {
+		// Step 1. Build the token
+		claim := createUserClaim(user, project)
+		token := jwt.NewWithClaims(jwt.SigningMethodNone, claim)
+		if token == nil {
+			slog.Error("missing token")
+			os.Exit(1)
+		}
+		signedString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+		if err != nil {
+			slog.Error("unable to sign token", "error", err)
+			os.Exit(1)
+		}
+
+		u := "http://localhost:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=fake"
+
+		var jsonData = []byte(fmt.Sprintf(`{
+			"postBody": "providerId=github.com&id_token=%s",
+			"requestUri": "http://localhost",
+			"returnIdpCredential": true,
+			"returnSecureToken": true
+		}`, signedString))
+
+		// Step 2. Send the request to create the account
+		req, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, u, bytes.NewBuffer(jsonData))
+		if err != nil {
+			slog.Error("unable to create request", "error", err)
+			os.Exit(1)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			slog.Error("unable to send request", "error", err)
+			os.Exit(1)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			slog.Error("unexpected status code", "status code", resp.StatusCode)
+			os.Exit(1)
+		}
+
+		slog.Info("user created", "email", user.Email)
+	}
+}
+
+type User struct {
+	Name          string
+	Email         string
+	EmailVerified bool
+	UserID        string
+}
+
+func main() {
+	var (
+		authProject = flag.String("project", "", "Google Cloud Identity Platform Project")
+	)
+	flag.Parse()
+	createUsers(*authProject)
+}

--- a/util/go.mod
+++ b/util/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/GoogleChrome/webstatus.dev/lib v0.0.0-20240708145018-355a5213f27b
 	github.com/GoogleChrome/webstatus.dev/lib/gen v0.0.0-20240708145018-355a5213f27b
 	github.com/brianvoe/gofakeit/v7 v7.0.4
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/web-platform-tests/wpt.fyi v0.0.0-20240708101548-8d306180e4ed
 	golang.org/x/text v0.16.0
 )

--- a/util/go.sum
+++ b/util/go.sum
@@ -760,6 +760,8 @@ github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncV
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=


### PR DESCRIPTION
This changes utilizes the API of the emulator to create users that will "Sign in With Github" locally.

In the future, we can associate these users in our database with certain roles.

The change makes sure it runs automatically when running playwright tests.

Depends on #534 