### PR TITLE
[3/3] Clean up Google Sign In references

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -132,7 +132,7 @@ in `apiUrl` settings property value in the `webstatus-app` component of
 
 ```html
 <webstatus-app
-  settings='{"apiUrl": "https://api.webstatus.dev", "gsiClientId": "$GSI_CLIENT_ID"}'
+  settings='{"apiUrl": "https://api.webstatus.dev" ...}'
 ></webstatus-app>
 ```
 

--- a/frontend/manifests/pod.yaml
+++ b/frontend/manifests/pod.yaml
@@ -32,8 +32,6 @@ spec:
       env:
         - name: API_URL
           value: http://localhost:8080
-        - name: GSI_CLIENT_ID
-          value: 367048339992-5os99v0p6chosv28dpo9863h9sjeno36.apps.googleusercontent.com
         - name: GOOGLE_ANALYTICS_ID
           value: G-EPZE5TL134
         - name: FIREBASE_AUTH_EMULATOR_URL

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,6 @@
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-terser": "^0.4.4",
     "@types/chai": "^4.3.11",
-    "@types/google.accounts": "^0.0.14",
     "@types/mocha": "^10.0.7",
     "@types/node": "^20.14.10",
     "@types/webstatus.dev-backend": "file:../lib/gen/openapi/ts-webstatus.dev-backend-types",

--- a/frontend/src/common/app-settings.ts
+++ b/frontend/src/common/app-settings.ts
@@ -17,7 +17,6 @@
 // AppSettings contains non sensitive settings that can be passed to the client.
 export interface AppSettings {
   apiUrl: string;
-  gsiClientId: string;
   firebase: FirebaseSettings;
 }
 

--- a/frontend/src/static/index.html
+++ b/frontend/src/static/index.html
@@ -75,7 +75,6 @@
     <webstatus-app
       settings='{
         "apiUrl": "$API_URL",
-        "gsiClientId": "$GSI_CLIENT_ID",
         "firebase": {
           "app": {
             "apiKey": "$FIREBASE_APP_API_KEY",

--- a/frontend/src/static/js/components/test/webstatus-app.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-app.test.ts
@@ -23,7 +23,6 @@ describe('webstatus-app', () => {
   it('can be added to the page with the settings', async () => {
     const settings: AppSettings = {
       apiUrl: 'http://localhost',
-      gsiClientId: 'testclientid',
       firebase: {
         app: {
           apiKey: 'testapikey',

--- a/frontend/src/static/js/components/test/webstatus-services-container.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-services-container.test.ts
@@ -24,7 +24,6 @@ import {ServiceElement} from '../../services/service-element.js';
 describe('WebstatusServiceContainer', () => {
   const settings: AppSettings = {
     apiUrl: 'http://localhost',
-    gsiClientId: 'testclientid',
     firebase: {
       app: {
         apiKey: 'testapikey',

--- a/frontend/src/static/js/services/test/webstatus-app-settings-service.test.ts
+++ b/frontend/src/static/js/services/test/webstatus-app-settings-service.test.ts
@@ -29,7 +29,6 @@ import {type WebstatusAppSettingsService} from '../webstatus-app-settings-servic
 describe('webstatus-app-settings-service', () => {
   const settings: AppSettings = {
     apiUrl: 'http://localhost',
-    gsiClientId: 'testclientid',
     firebase: {
       app: {
         apiKey: 'testapikey',

--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -33,7 +33,6 @@ region_information = {
   },
 }
 backend_api_url = "https://api.webstatus.dev"
-gsi_client_id   = "367048339992-5os99v0p6chosv28dpo9863h9sjeno36.apps.googleusercontent.com"
 
 google_analytics_id = "G-CZ6STBPSB2"
 

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -33,7 +33,6 @@ region_information = {
   },
 }
 backend_api_url = "https://api-webstatus-dev.corp.goog"
-gsi_client_id   = "367048339992-5os99v0p6chosv28dpo9863h9sjeno36.apps.googleusercontent.com"
 
 google_analytics_id = "G-EPZE5TL134"
 

--- a/infra/frontend/service.tf
+++ b/infra/frontend/service.tf
@@ -72,10 +72,6 @@ resource "google_cloud_run_v2_service" "service" {
         value = var.backend_api_host
       }
       env {
-        name  = "GSI_CLIENT_ID"
-        value = var.gsi_client_id
-      }
-      env {
         name  = "GOOGLE_ANALYTICS_ID"
         value = var.google_analytics_id
       }

--- a/infra/frontend/variables.tf
+++ b/infra/frontend/variables.tf
@@ -39,9 +39,6 @@ variable "docker_repository_details" {
 variable "backend_api_host" {
   type = string
 }
-variable "gsi_client_id" {
-  type = string
-}
 
 variable "google_analytics_id" {
   type = string

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -106,7 +106,6 @@ module "frontend" {
   env_id                               = var.env_id
   docker_repository_details            = module.storage.docker_repository_details
   backend_api_host                     = var.backend_api_url
-  gsi_client_id                        = var.gsi_client_id
   google_analytics_id                  = var.google_analytics_id
   region_to_subnet_info_map            = module.network.region_to_subnet_info_map
   vpc_name                             = module.network.vpc_name

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -88,10 +88,6 @@ variable "backend_api_url" {
   type = string
 }
 
-variable "gsi_client_id" {
-  type = string
-}
-
 variable "google_analytics_id" {
   type = string
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
         "@rollup/plugin-node-resolve": "^15.2.1",
         "@rollup/plugin-terser": "^0.4.4",
         "@types/chai": "^4.3.11",
-        "@types/google.accounts": "^0.0.14",
         "@types/mocha": "^10.0.7",
         "@types/node": "^20.14.10",
         "@types/webstatus.dev-backend": "file:../lib/gen/openapi/ts-webstatus.dev-backend-types",
@@ -2207,12 +2206,6 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/google.accounts": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@types/google.accounts/-/google.accounts-0.0.14.tgz",
-      "integrity": "sha512-HqIVkVzpiLWhlajhQQd4rIV7czanFvXblJI2J1fSrL+VKQuQwwZ63m35D/mI0flsqKE6p/hNrAG0Yn4FD6JvNA==",
-      "dev": true
     },
     "node_modules/@types/google.visualization": {
       "version": "0.0.74",


### PR DESCRIPTION
We are moving from Google Sign In to Google Cloud Identity Platform.

This change deletes all references to Google Sign In configuration.