### PR TITLE
Return browser version for feature implementation

### DIFF
--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -59,8 +59,9 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 					},
 					BrowserImplementations: &map[string]backend.BrowserImplementation{
 						"chrome": {
-							Status: valuePtr(backend.Available),
-							Date:   &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+							Status:  valuePtr(backend.Available),
+							Date:    &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+							Version: valuePtr("100"),
 						},
 					},
 					FeatureId: "feature1",
@@ -84,8 +85,9 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 				},
 				BrowserImplementations: &map[string]backend.BrowserImplementation{
 					"chrome": {
-						Status: valuePtr(backend.Available),
-						Date:   &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+						Status:  valuePtr(backend.Available),
+						Date:    &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+						Version: valuePtr("100"),
 					},
 				},
 				FeatureId: "feature1",
@@ -126,8 +128,9 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 					},
 					BrowserImplementations: &map[string]backend.BrowserImplementation{
 						"chrome": {
-							Status: valuePtr(backend.Available),
-							Date:   &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+							Status:  valuePtr(backend.Available),
+							Date:    &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+							Version: valuePtr("100"),
 						},
 					},
 					FeatureId: "feature1",
@@ -151,8 +154,9 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 				},
 				BrowserImplementations: &map[string]backend.BrowserImplementation{
 					"chrome": {
-						Status: valuePtr(backend.Available),
-						Date:   &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+						Status:  valuePtr(backend.Available),
+						Date:    &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+						Version: valuePtr("100"),
 					},
 				},
 				FeatureId: "feature1",

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -73,8 +73,9 @@ func TestGetV1Features(t *testing.T) {
 							Wpt:       nil,
 							BrowserImplementations: &map[string]backend.BrowserImplementation{
 								"browser1": {
-									Status: valuePtr(backend.Available),
-									Date:   nil,
+									Status:  valuePtr(backend.Available),
+									Date:    nil,
+									Version: valuePtr("101"),
 								},
 							},
 						},
@@ -102,8 +103,9 @@ func TestGetV1Features(t *testing.T) {
 						Wpt:       nil,
 						BrowserImplementations: &map[string]backend.BrowserImplementation{
 							"browser1": {
-								Status: valuePtr(backend.Available),
-								Date:   nil,
+								Status:  valuePtr(backend.Available),
+								Date:    nil,
+								Version: valuePtr("101"),
 							},
 						},
 					},
@@ -193,6 +195,7 @@ func TestGetV1Features(t *testing.T) {
 									Status: valuePtr(backend.Available),
 									Date: &openapi_types.Date{
 										Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+									Version: valuePtr("101"),
 								},
 							},
 						},
@@ -223,6 +226,7 @@ func TestGetV1Features(t *testing.T) {
 								Status: valuePtr(backend.Available),
 								Date: &openapi_types.Date{
 									Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+								Version: valuePtr("101"),
 							},
 						},
 					},

--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -329,7 +329,8 @@ COALESCE(
 					),
 					'unavailable' -- Default if no match
 				) AS ImplementationStatus,
-				COALESCE(br.ReleaseDate, CAST(NULL AS TIMESTAMP)) AS ImplementationDate
+				COALESCE(br.ReleaseDate, CAST(NULL AS TIMESTAMP)) AS ImplementationDate,
+				br.BrowserVersion AS ImplementationVersion
 			)
 		)
 		FROM BrowserFeatureAvailabilities bfa
@@ -342,7 +343,8 @@ COALESCE(
 	   		SELECT AS STRUCT
 				'' BrowserName,
 				'unavailable' AS ImplementationStatus,
-				CAST(NULL AS TIMESTAMP) AS ImplementationDate
+				CAST(NULL AS TIMESTAMP) AS ImplementationDate,
+				'' AS ImplementationVersion
 		)
 	)
 ) AS ImplementationStatuses

--- a/lib/gcpspanner/feature_search.go
+++ b/lib/gcpspanner/feature_search.go
@@ -54,9 +54,10 @@ const (
 
 // ImplementationStatus contains the implementation status information for a given browser.
 type ImplementationStatus struct {
-	BrowserName          string                      `spanner:"BrowserName"`
-	ImplementationStatus BrowserImplementationStatus `spanner:"ImplementationStatus"`
-	ImplementationDate   *time.Time                  `spanner:"ImplementationDate"`
+	BrowserName           string                      `spanner:"BrowserName"`
+	ImplementationStatus  BrowserImplementationStatus `spanner:"ImplementationStatus"`
+	ImplementationDate    *time.Time                  `spanner:"ImplementationDate"`
+	ImplementationVersion *string                     `spanner:"ImplementationVersion"`
 }
 
 // FeatureResultMetric contains metric information for a feature result query.
@@ -291,5 +292,9 @@ func findImplementationStatusDefaultPlaceHolder(in *ImplementationStatus) bool {
 		return false
 	}
 
-	return in.BrowserName == "" && in.ImplementationStatus == Unavailable && in.ImplementationDate == nil
+	return in.BrowserName == "" &&
+		in.ImplementationStatus == Unavailable &&
+		in.ImplementationDate == nil &&
+		in.ImplementationVersion != nil &&
+		*in.ImplementationVersion == ""
 }

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -603,14 +603,16 @@ func getFeatureSearchTestFeature(testFeatureID FeatureSearchTestFeatureID) Featu
 			},
 			ImplementationStatuses: []*ImplementationStatus{
 				{
-					BrowserName:          "barBrowser",
-					ImplementationStatus: Available,
-					ImplementationDate:   valuePtr(time.Date(2000, time.February, 2, 0, 0, 0, 0, time.UTC)),
+					BrowserName:           "barBrowser",
+					ImplementationStatus:  Available,
+					ImplementationDate:    valuePtr(time.Date(2000, time.February, 2, 0, 0, 0, 0, time.UTC)),
+					ImplementationVersion: valuePtr("1.0.0"),
 				},
 				{
-					BrowserName:          "fooBrowser",
-					ImplementationStatus: Available,
-					ImplementationDate:   valuePtr(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)),
+					BrowserName:           "fooBrowser",
+					ImplementationStatus:  Available,
+					ImplementationDate:    valuePtr(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)),
+					ImplementationVersion: valuePtr("0.0.0"),
 				},
 			},
 			SpecLinks: []string{
@@ -659,9 +661,10 @@ func getFeatureSearchTestFeature(testFeatureID FeatureSearchTestFeatureID) Featu
 			},
 			ImplementationStatuses: []*ImplementationStatus{
 				{
-					BrowserName:          "barBrowser",
-					ImplementationStatus: Available,
-					ImplementationDate:   valuePtr(time.Date(2000, time.March, 2, 0, 0, 0, 0, time.UTC)),
+					BrowserName:           "barBrowser",
+					ImplementationStatus:  Available,
+					ImplementationDate:    valuePtr(time.Date(2000, time.March, 2, 0, 0, 0, 0, time.UTC)),
+					ImplementationVersion: valuePtr("2.0.0"),
 				},
 			},
 			SpecLinks: nil,
@@ -685,9 +688,10 @@ func getFeatureSearchTestFeature(testFeatureID FeatureSearchTestFeatureID) Featu
 			ExperimentalMetrics: nil,
 			ImplementationStatuses: []*ImplementationStatus{
 				{
-					BrowserName:          "fooBrowser",
-					ImplementationStatus: Available,
-					ImplementationDate:   valuePtr(time.Date(2000, time.February, 1, 0, 0, 0, 0, time.UTC)),
+					BrowserName:           "fooBrowser",
+					ImplementationStatus:  Available,
+					ImplementationDate:    valuePtr(time.Date(2000, time.February, 1, 0, 0, 0, 0, time.UTC)),
+					ImplementationVersion: valuePtr("1.0.0"),
 				},
 			},
 			SpecLinks: []string{
@@ -1712,7 +1716,12 @@ func AreImplementationStatusesEqual(a, b []*ImplementationStatus) bool {
 				b.ImplementationDate == nil) ||
 				(a.ImplementationDate != nil &&
 					b.ImplementationDate != nil &&
-					(*a.ImplementationDate).Equal(*b.ImplementationDate)))
+					(*a.ImplementationDate).Equal(*b.ImplementationDate))) &&
+			((a.ImplementationVersion == nil &&
+				b.ImplementationVersion == nil) ||
+				(a.ImplementationVersion != nil &&
+					b.ImplementationVersion != nil &&
+					(*a.ImplementationVersion) == (*b.ImplementationVersion)))
 	})
 }
 
@@ -1771,7 +1780,8 @@ func PrettyPrintImplementationStatus(status *ImplementationStatus) string {
 	}
 	fmt.Fprintf(&builder, "\t\tBrowserName: %s\n", status.BrowserName)
 	fmt.Fprintf(&builder, "\t\tStatus: %s\n", status.ImplementationStatus)
-	fmt.Fprintf(&builder, "\t\tStatus: %s\n", status.ImplementationDate)
+	fmt.Fprintf(&builder, "\t\tDate: %s\n", PrintNullableField(status.ImplementationDate))
+	fmt.Fprintf(&builder, "\t\tVersion: %s\n", PrintNullableField(status.ImplementationVersion))
 
 	return builder.String()
 }

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -341,8 +341,9 @@ func (s *Backend) convertFeatureResult(featureResult *gcpspanner.FeatureResult) 
 				date = &openapi_types.Date{Time: *status.ImplementationDate}
 			}
 			implementationMap[status.BrowserName] = backend.BrowserImplementation{
-				Status: &backendStatus,
-				Date:   date,
+				Status:  &backendStatus,
+				Date:    date,
+				Version: status.ImplementationVersion,
 			}
 		}
 		ret.BrowserImplementations = &implementationMap

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -634,6 +634,7 @@ func TestFeaturesSearch(t *testing.T) {
 									ImplementationStatus: gcpspanner.Available,
 									ImplementationDate: valuePtr(
 										time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)),
+									ImplementationVersion: valuePtr("103"),
 								},
 							},
 							SpecLinks: nil,
@@ -676,12 +677,14 @@ func TestFeaturesSearch(t *testing.T) {
 									ImplementationStatus: gcpspanner.Available,
 									ImplementationDate: valuePtr(
 										time.Date(1998, time.January, 1, 0, 0, 0, 0, time.UTC)),
+									ImplementationVersion: valuePtr("101"),
 								},
 								{
 									BrowserName:          "browser2",
 									ImplementationStatus: gcpspanner.Available,
 									ImplementationDate: valuePtr(
 										time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)),
+									ImplementationVersion: valuePtr("102"),
 								},
 							},
 							SpecLinks: []string{
@@ -744,6 +747,7 @@ func TestFeaturesSearch(t *testing.T) {
 								Status: valuePtr(backend.Available),
 								Date: &openapi_types.Date{
 									Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+								Version: valuePtr("103"),
 							},
 						},
 					},
@@ -799,11 +803,13 @@ func TestFeaturesSearch(t *testing.T) {
 								Status: valuePtr(backend.Available),
 								Date: &openapi_types.Date{
 									Time: time.Date(1998, time.January, 1, 0, 0, 0, 0, time.UTC)},
+								Version: valuePtr("101"),
 							},
 							"browser2": {
 								Status: valuePtr(backend.Available),
 								Date: &openapi_types.Date{
 									Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
+								Version: valuePtr("102"),
 							},
 						},
 					},

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -551,6 +551,9 @@ components:
           type: string
           format: date
           description: The date on which the feature was implemented in a browser. (RFC 3339, section 5.6, for example, 2017-07-21)
+        version:
+          type: string
+          description: The browser version in which the feature became available.
     PageMetadata:
       type: object
       properties:


### PR DESCRIPTION
This change adds a new optional string field to the BrowserImplementation component for the browser version that the feature became available.

The change also modifies the database query to return this data too

This completes the backend part of #306.

There still needs to be a frontend implementation to complete that issue.

---
<details>
<summary>Example payload that shows the browser version</summary>
<br>

```json
{
  "data": [
    {
      "baseline": {
        "low_date": "2024-07-09",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2023-03-07",
          "status": "available",
          "version": "111"
        },
        "edge": {
          "date": "2023-03-13",
          "status": "available",
          "version": "111"
        },
        "firefox": {
          "date": "2024-07-09",
          "status": "available",
          "version": "128"
        },
        "safari": {
          "date": "2023-03-27",
          "status": "available",
          "version": "16.4"
        }
      },
      "feature_id": "growable-sharedarraybuffer",
      "name": "Growable SharedArrayBuffer",
      "spec": {
        "links": [
          {
            "link": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-sharedarraybuffer.prototype.growable"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2024-07-09",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2024-04-16",
          "status": "available",
          "version": "124"
        },
        "edge": {
          "date": "2024-04-18",
          "status": "available",
          "version": "124"
        },
        "firefox": {
          "date": "2024-07-09",
          "status": "available",
          "version": "128"
        },
        "safari": {
          "date": "2024-03-05",
          "status": "available",
          "version": "17.4"
        }
      },
      "feature_id": "parse-html-unsafe",
      "name": "Unsanitized HTML parsing methods",
      "spec": {
        "links": [
          {
            "link": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#unsafe-html-parsing-methods"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2024-07-09",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2020-08-25",
          "status": "available",
          "version": "85"
        },
        "edge": {
          "date": "2020-08-27",
          "status": "available",
          "version": "85"
        },
        "firefox": {
          "date": "2024-07-09",
          "status": "available",
          "version": "128"
        },
        "safari": {
          "date": "2023-03-27",
          "status": "available",
          "version": "16.4"
        }
      },
      "feature_id": "registered-custom-properties",
      "name": "Registered custom properties",
      "spec": {
        "links": [
          {
            "link": "https://drafts.css-houdini.org/css-properties-values-api-1/"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2024-07-09",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2023-10-31",
          "status": "available",
          "version": "119"
        },
        "edge": {
          "date": "2023-11-02",
          "status": "available",
          "version": "119"
        },
        "firefox": {
          "date": "2024-07-09",
          "status": "available",
          "version": "128"
        },
        "safari": {
          "date": "2023-03-27",
          "status": "available",
          "version": "16.4"
        }
      },
      "feature_id": "relative-color",
      "name": "Relative colors",
      "spec": {
        "links": [
          {
            "link": "https://drafts.csswg.org/css-color-5/#relative-colors"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2024-07-09",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2023-03-07",
          "status": "available",
          "version": "111"
        },
        "edge": {
          "date": "2023-03-13",
          "status": "available",
          "version": "111"
        },
        "firefox": {
          "date": "2024-07-09",
          "status": "available",
          "version": "128"
        },
        "safari": {
          "date": "2023-03-27",
          "status": "available",
          "version": "16.4"
        }
      },
      "feature_id": "resizable-arraybuffer",
      "name": "Resizable ArrayBuffer",
      "spec": {
        "links": [
          {
            "link": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-arraybuffer.prototype.resizable"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2024-06-11",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2018-04-17",
          "status": "available",
          "version": "66"
        },
        "edge": {
          "date": "2020-01-15",
          "status": "available",
          "version": "79"
        },
        "firefox": {
          "date": "2024-06-11",
          "status": "available",
          "version": "127"
        },
        "safari": {
          "date": "2020-03-24",
          "status": "available",
          "version": "13.1"
        }
      },
      "feature_id": "async-clipboard",
      "name": "Async clipboard",
      "spec": {
        "links": [
          {
            "link": "https://w3c.github.io/clipboard-apis/#async-clipboard-api"
          }
        ]
      },
      "wpt": {
        "experimental": {
          "chrome": {
            "score": 0.93220339
          },
          "edge": {
            "score": 0.93220339
          }
        },
        "stable": {
          "chrome": {
            "score": 0.93220339
          },
          "edge": {
            "score": 0.93220339
          },
          "firefox": {
            "score": 0.915254237
          },
          "safari": {
            "metadata": {
              "status": "C"
            }
          }
        }
      }
    },
    {
      "baseline": {
        "low_date": "2024-06-11",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2024-02-20",
          "status": "available",
          "version": "122"
        },
        "edge": {
          "date": "2024-02-23",
          "status": "available",
          "version": "122"
        },
        "firefox": {
          "date": "2024-06-11",
          "status": "available",
          "version": "127"
        },
        "safari": {
          "date": "2023-09-18",
          "status": "available",
          "version": "17"
        }
      },
      "feature_id": "set-methods",
      "name": "Set methods",
      "spec": {
        "links": [
          {
            "link": "https://tc39.es/proposal-set-methods/"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2024-05-17",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2024-05-14",
          "status": "available",
          "version": "125"
        },
        "edge": {
          "date": "2024-05-17",
          "status": "available",
          "version": "125"
        },
        "firefox": {
          "date": "2023-09-26",
          "status": "available",
          "version": "118"
        },
        "safari": {
          "date": "2022-03-14",
          "status": "available",
          "version": "15.4"
        }
      },
      "feature_id": "round-mod-rem",
      "name": "round(), mod(), and rem()",
      "spec": {
        "links": [
          {
            "link": "https://drafts.csswg.org/css-values-4/#round-func"
          }
        ]
      },
      "wpt": {
        "experimental": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 1
          }
        },
        "stable": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 1
          },
          "firefox": {
            "score": 1
          },
          "safari": {
            "score": 0.980036298
          }
        }
      }
    },
    {
      "baseline": {
        "low_date": "2024-05-17",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2024-05-14",
          "status": "available",
          "version": "125"
        },
        "edge": {
          "date": "2024-05-17",
          "status": "available",
          "version": "125"
        },
        "firefox": {
          "date": "2024-05-14",
          "status": "available",
          "version": "126"
        },
        "safari": {
          "date": "2024-03-05",
          "status": "available",
          "version": "17.4"
        }
      },
      "feature_id": "state",
      "name": ":state()",
      "spec": {
        "links": [
          {
            "link": "https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2024-05-14",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2008-12-11",
          "status": "available",
          "version": "1"
        },
        "edge": {
          "date": "2015-07-29",
          "status": "available",
          "version": "12"
        },
        "firefox": {
          "date": "2024-05-14",
          "status": "available",
          "version": "126"
        },
        "safari": {
          "date": "2008-03-18",
          "status": "available",
          "version": "3.1"
        }
      },
      "feature_id": "zoom",
      "name": "zoom",
      "spec": {
        "links": [
          {
            "link": "https://drafts.csswg.org/css-viewport/#zoom-property"
          }
        ]
      },
      "wpt": {
        "experimental": {
          "chrome": {
            "score": 0.982142857
          },
          "edge": {
            "score": 0.982142857
          }
        },
        "stable": {
          "chrome": {
            "score": 0.678571429
          },
          "edge": {
            "score": 0.678571429
          },
          "firefox": {
            "score": 0.785714286
          },
          "safari": {
            "score": 0.642857143
          }
        }
      }
    },
    {
      "baseline": {
        "low_date": "2024-05-13",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2024-03-19",
          "status": "available",
          "version": "123"
        },
        "edge": {
          "date": "2024-03-22",
          "status": "available",
          "version": "123"
        },
        "firefox": {
          "date": "2023-11-21",
          "status": "available",
          "version": "120"
        },
        "safari": {
          "date": "2024-05-13",
          "status": "available",
          "version": "17.5"
        }
      },
      "feature_id": "light-dark",
      "name": "light-dark()",
      "spec": {
        "links": [
          {
            "link": "https://drafts.csswg.org/css-color-5/#light-dark"
          }
        ]
      },
      "wpt": {
        "experimental": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 1
          }
        },
        "stable": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 1
          },
          "firefox": {
            "score": 1
          },
          "safari": {
            "score": 1
          }
        }
      }
    },
    {
      "baseline": {
        "low_date": "2024-05-13",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2023-05-30",
          "status": "available",
          "version": "114"
        },
        "edge": {
          "date": "2023-06-02",
          "status": "available",
          "version": "114"
        },
        "firefox": {
          "date": "2023-12-19",
          "status": "available",
          "version": "121"
        },
        "safari": {
          "date": "2024-05-13",
          "status": "available",
          "version": "17.5"
        }
      },
      "feature_id": "text-wrap-balance",
      "name": "text-wrap: balance",
      "spec": {
        "links": [
          {
            "link": "https://drafts.csswg.org/css-text-4/#valdef-text-wrap-style-balance"
          }
        ]
      },
      "wpt": {
        "experimental": {
          "chrome": {
            "score": 0.846153846
          },
          "edge": {
            "score": 0.846153846
          }
        },
        "stable": {
          "chrome": {
            "score": 0.846153846
          },
          "edge": {
            "score": 0.846153846
          },
          "firefox": {
            "score": 0.961538462
          },
          "safari": {
            "score": 0.807692308
          }
        }
      }
    },
    {
      "baseline": {
        "low_date": "2024-04-16",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2020-11-17",
          "status": "available",
          "version": "87"
        },
        "edge": {
          "date": "2020-11-19",
          "status": "available",
          "version": "87"
        },
        "firefox": {
          "date": "2024-04-16",
          "status": "available",
          "version": "125"
        },
        "safari": {
          "date": "2021-04-26",
          "status": "available",
          "version": "14.1"
        }
      },
      "feature_id": "intl-segmenter",
      "name": "Intl.Segmenter",
      "spec": {
        "links": [
          {
            "link": "https://tc39.es/ecma402/#segmenter-objects"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2024-04-16",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2023-05-30",
          "status": "available",
          "version": "114"
        },
        "edge": {
          "date": "2023-06-02",
          "status": "available",
          "version": "114"
        },
        "firefox": {
          "date": "2024-04-16",
          "status": "available",
          "version": "125"
        },
        "safari": {
          "date": "2023-09-18",
          "status": "available",
          "version": "17"
        }
      },
      "feature_id": "popover",
      "name": "Popover",
      "spec": {
        "links": [
          {
            "link": "https://html.spec.whatwg.org/multipage/popover.html"
          }
        ]
      },
      "wpt": {
        "experimental": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 0.997576345
          }
        },
        "stable": {
          "chrome": {
            "score": 0.99845679
          },
          "edge": {
            "score": 0.995884774
          },
          "firefox": {
            "score": 0.997942387
          },
          "safari": {
            "score": 0.986625514
          }
        }
      }
    },
    {
      "baseline": {
        "low_date": "2024-03-19",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2023-08-15",
          "status": "available",
          "version": "116"
        },
        "edge": {
          "date": "2023-08-21",
          "status": "available",
          "version": "116"
        },
        "firefox": {
          "date": "2024-03-19",
          "status": "available",
          "version": "124"
        },
        "safari": {
          "date": "2024-03-05",
          "status": "available",
          "version": "17.4"
        }
      },
      "feature_id": "abortsignal-any",
      "name": "AbortSignal.any()",
      "spec": {
        "links": [
          {
            "link": "https://dom.spec.whatwg.org/#dom-abortsignal-any"
          }
        ]
      },
      "wpt": {
        "experimental": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 1
          }
        },
        "stable": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 1
          },
          "firefox": {
            "score": 1
          },
          "safari": {
            "score": 1
          }
        }
      }
    },
    {
      "baseline": {
        "low_date": "2024-03-19",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2023-05-30",
          "status": "available",
          "version": "114"
        },
        "edge": {
          "date": "2023-06-02",
          "status": "available",
          "version": "114"
        },
        "firefox": {
          "date": "2024-03-19",
          "status": "available",
          "version": "124"
        },
        "safari": {
          "date": "2024-03-05",
          "status": "available",
          "version": "17.4"
        }
      },
      "feature_id": "text-wrap-nowrap",
      "name": "text-wrap: nowrap",
      "spec": {
        "links": [
          {
            "link": "https://drafts.csswg.org/css-text-4/#valdef-text-wrap-mode-nowrap"
          }
        ]
      },
      "wpt": {
        "experimental": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 1
          }
        },
        "stable": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 1
          },
          "firefox": {
            "score": 1
          },
          "safari": {
            "score": 1
          }
        }
      }
    },
    {
      "baseline": {
        "low_date": "2024-03-05",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2023-09-12",
          "status": "available",
          "version": "117"
        },
        "edge": {
          "date": "2023-09-15",
          "status": "available",
          "version": "117"
        },
        "firefox": {
          "date": "2023-10-24",
          "status": "available",
          "version": "119"
        },
        "safari": {
          "date": "2024-03-05",
          "status": "available",
          "version": "17.4"
        }
      },
      "feature_id": "array-group",
      "name": "Array grouping",
      "spec": {
        "links": [
          {
            "link": "https://tc39.es/proposal-array-grouping/"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2024-03-05",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2022-09-02",
          "status": "available",
          "version": "105"
        },
        "edge": {
          "date": "2022-09-01",
          "status": "available",
          "version": "105"
        },
        "firefox": {
          "date": "2022-10-18",
          "status": "available",
          "version": "106"
        },
        "safari": {
          "date": "2024-03-05",
          "status": "available",
          "version": "17.4"
        }
      },
      "feature_id": "check-visibility",
      "name": "checkVisibility()",
      "spec": {
        "links": [
          {
            "link": "https://drafts.csswg.org/cssom-view-1/#dom-element-checkvisibility"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2024-03-05",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2023-10-31",
          "status": "available",
          "version": "119"
        },
        "edge": {
          "date": "2023-11-02",
          "status": "available",
          "version": "119"
        },
        "firefox": {
          "date": "2023-12-19",
          "status": "available",
          "version": "121"
        },
        "safari": {
          "date": "2024-03-05",
          "status": "available",
          "version": "17.4"
        }
      },
      "feature_id": "promise-withresolvers",
      "name": "Promise.withResolvers()",
      "spec": {
        "links": [
          {
            "link": "https://tc39.es/proposal-promise-with-resolvers/#sec-promise.withResolvers"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2024-03-05",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2023-05-30",
          "status": "available",
          "version": "114"
        },
        "edge": {
          "date": "2023-06-02",
          "status": "available",
          "version": "114"
        },
        "firefox": {
          "date": "2024-01-23",
          "status": "available",
          "version": "122"
        },
        "safari": {
          "date": "2024-03-05",
          "status": "available",
          "version": "17.4"
        }
      },
      "feature_id": "transferable-arraybuffer",
      "name": "Transferable ArrayBuffer",
      "spec": {
        "links": [
          {
            "link": "https://tc39.es/proposal-arraybuffer-transfer/#sec-arraybuffer.prototype.transfer"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2024-02-20",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2023-03-07",
          "status": "available",
          "version": "111"
        },
        "edge": {
          "date": "2023-03-13",
          "status": "available",
          "version": "111"
        },
        "firefox": {
          "date": "2024-02-20",
          "status": "available",
          "version": "123"
        },
        "safari": {
          "date": "2023-03-27",
          "status": "available",
          "version": "16.4"
        }
      },
      "feature_id": "declarative-shadow-dom",
      "name": "Declarative shadow DOM",
      "spec": {
        "links": [
          {
            "link": "https://html.spec.whatwg.org/multipage/scripting.html#attr-template-shadowrootmode"
          }
        ]
      },
      "wpt": {
        "experimental": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 1
          }
        },
        "stable": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 0.999870265
          },
          "firefox": {
            "score": 1
          },
          "safari": {
            "score": 0.103296133
          }
        }
      }
    },
    {
      "baseline": {
        "low_date": "2024-01-26",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2020-08-25",
          "status": "available",
          "version": "85"
        },
        "edge": {
          "date": "2024-01-25",
          "status": "available",
          "version": "121"
        },
        "firefox": {
          "date": "2021-10-05",
          "status": "available",
          "version": "93"
        },
        "safari": {
          "date": "2022-09-12",
          "status": "available",
          "version": "16"
        }
      },
      "feature_id": "avif",
      "name": "AVIF",
      "spec": {
        "links": [
          {
            "link": "https://aomediacodec.github.io/av1-avif/"
          }
        ]
      },
      "wpt": {
        "experimental": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 1
          }
        },
        "stable": {
          "chrome": {
            "score": 1
          },
          "edge": {
            "score": 1
          },
          "firefox": {
            "score": 0
          },
          "safari": {
            "score": 1
          }
        }
      }
    },
    {
      "baseline": {
        "low_date": "2024-01-25",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2024-01-23",
          "status": "available",
          "version": "121"
        },
        "edge": {
          "date": "2024-01-25",
          "status": "available",
          "version": "121"
        },
        "firefox": {
          "date": "2023-07-04",
          "status": "available",
          "version": "115"
        },
        "safari": {
          "date": "2023-03-27",
          "status": "available",
          "version": "16.4"
        }
      },
      "feature_id": "array-fromasync",
      "name": "Array.fromAsync()",
      "spec": {
        "links": [
          {
            "link": "https://tc39.es/proposal-array-from-async/#sec-array.fromAsync"
          }
        ]
      }
    },
    {
      "baseline": {
        "low_date": "2023-12-19",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2022-09-02",
          "status": "available",
          "version": "105"
        },
        "edge": {
          "date": "2022-09-01",
          "status": "available",
          "version": "105"
        },
        "firefox": {
          "date": "2023-12-19",
          "status": "available",
          "version": "121"
        },
        "safari": {
          "date": "2022-03-14",
          "status": "available",
          "version": "15.4"
        }
      },
      "feature_id": "has",
      "name": ":has()",
      "spec": {
        "links": [
          {
            "link": "https://drafts.csswg.org/selectors-4/#relational"
          }
        ]
      },
      "wpt": {
        "experimental": {
          "chrome": {
            "metadata": {
              "status": "C"
            }
          },
          "edge": {
            "metadata": {
              "status": "C"
            }
          }
        },
        "stable": {
          "chrome": {
            "metadata": {
              "status": "C"
            }
          },
          "edge": {
            "metadata": {
              "status": "C"
            }
          },
          "firefox": {
            "score": 0.997435897
          },
          "safari": {
            "score": 0.991575092
          }
        }
      }
    },
    {
      "baseline": {
        "low_date": "2023-12-19",
        "status": "newly"
      },
      "browser_implementations": {
        "chrome": {
          "date": "2019-09-10",
          "status": "available",
          "version": "77"
        },
        "edge": {
          "date": "2020-01-15",
          "status": "available",
          "version": "79"
        },
        "firefox": {
          "date": "2023-12-19",
          "status": "available",
          "version": "121"
        },
        "safari": {
          "date": "2023-03-27",
          "status": "available",
          "version": "16.4"
        }
      },
      "feature_id": "loading-lazy",
      "name": "Lazy-loading images and iframes",
      "spec": {
        "links": [
          {
            "link": "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes"
          }
        ]
      },
      "wpt": {
        "experimental": {
          "chrome": {
            "score": 0.762376238
          },
          "edge": {
            "score": 0.881188119
          }
        },
        "stable": {
          "chrome": {
            "score": 0.772277228
          },
          "edge": {
            "score": 0.861386139
          },
          "firefox": {
            "score": 0.702970297
          },
          "safari": {
            "score": 0.702970297
          }
        }
      }
    }
  ],
  "metadata": {
    "next_page_token": "eyJvZmZzZXQiOjI1fQ",
    "total": 341
  }
}
```
</details>
