### PR TITLE
Add available_date query

### DIFF
--- a/antlr/FeatureSearch.g4
+++ b/antlr/FeatureSearch.g4
@@ -26,10 +26,13 @@ ANY_VALUE:
 available_on_term: 'available_on' COLON BROWSER_NAME;
 baseline_status_term: 'baseline_status' COLON BASELINE_STATUS;
 // In the future support other operators by doing something like (date_operator_query | date_range_query)
+available_date_term: 'available_date' COLON (date_range_query);
+// In the future support other operators by doing something like (date_operator_query | date_range_query)
 baseline_date_term: 'baseline_date' COLON (date_range_query);
 name_term: 'name' COLON ANY_VALUE;
 term:
-	available_on_term
+	available_date_term
+	| available_on_term
 	| baseline_status_term
 	| baseline_date_term
 	| name_term;

--- a/antlr/FeatureSearch.md
+++ b/antlr/FeatureSearch.md
@@ -25,6 +25,8 @@ This query language enables you to construct flexible searches to find features 
       - chrome
       - chrome,safari
 - **Terms:**
+  - `available_date`: Represents the date a feature became available
+    - Option 1: Specifies an inclusive date range (DATE1..DATE2) during which features became available.
   - `available_on`: Indicates whether a feature is available on a specific browser. Expects a browser name (BROWSER_NAME) as its value.
     - Example: `available_on:chrome`
   - `baseline_status`: Represents a feature's baseline status. Expects an enum value (BASELINE_STATUS) as its value.
@@ -45,6 +47,7 @@ This query language enables you to construct flexible searches to find features 
 
 ### Simple Term Examples
 
+- `available_date:2023-01-01..2023-12-31` - Searches for all features that became available on any browser in 2023.
 - `available_on:chrome` - Find features available on Chrome.
 - `-available_on:firefox` - Find features not available on Firefox.
 - `baseline_status:high` - Find features with a high baseline status.
@@ -53,6 +56,7 @@ This query language enables you to construct flexible searches to find features 
 
 ### Complex Queries
 
+- `available_date:2023-01-01..2023-12-31 AND available_on:chrome` - Searches for all features that became available on Chrome in 2023.
 - `available_on:chrome AND baseline_status:newly` - Find features available on Chrome and having a newly baseline status.
 - `-available_on:firefox OR name:"CSS Grid"` - Find features either not available on Firefox or named "CSS Grid".
 - `"CSS Grid" baseline_status:limited` - Find features named "CSS Grid" with a baseline status of none (implied AND).

--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -308,46 +308,29 @@ FROM WebFeatures wf
 LEFT OUTER JOIN FeatureBaselineStatus fbs ON wf.ID = fbs.WebFeatureID
 LEFT OUTER JOIN ExcludedFeatureKeys efk ON wf.FeatureKey = efk.FeatureKey
 LEFT OUTER JOIN FeatureSpecs fs ON wf.ID = fs.WebFeatureID
+LEFT OUTER JOIN (
+	SELECT
+		bfa.WebFeatureID,
+		ARRAY_AGG(
+			STRUCT(
+				bfa.BrowserName AS BrowserName,
+				bfa.BrowserVersion AS ImplementationVersion,
+				IF(br.ReleaseDate IS NULL, 'unavailable', 'available') AS ImplementationStatus,
+				br.ReleaseDate AS ImplementationDate
+			)
+		) AS BrowserInfo
+	FROM BrowserFeatureAvailabilities bfa
+	LEFT OUTER JOIN BrowserReleases br
+		ON bfa.BrowserName = br.BrowserName AND bfa.BrowserVersion = br.BrowserVersion
+	GROUP BY bfa.WebFeatureID
+) AS browser_info ON wf.ID = browser_info.WebFeatureID
 `
 	gcpFSBaseQueryTemplate   = commonFSBaseQueryTemplate
 	localFSBaseQueryTemplate = commonFSBaseQueryTemplate
 
 	// commonFSImplementationStatusRawTemplate returns an array of structs that represent the implementation status.
 	commonFSImplementationStatusRawTemplate = `
-COALESCE(
-	(
-		SELECT ARRAY_AGG(
-			STRUCT(
-				bfa.BrowserName AS BrowserName,
-				COALESCE(
-					(
-						SELECT 'available'
-						FROM BrowserFeatureAvailabilities bfa1
-						WHERE bfa.WebFeatureID = wf.ID
-							AND bfa1.BrowserName = bfa.BrowserName
-						LIMIT 1
-					),
-					'unavailable' -- Default if no match
-				) AS ImplementationStatus,
-				COALESCE(br.ReleaseDate, CAST(NULL AS TIMESTAMP)) AS ImplementationDate,
-				br.BrowserVersion AS ImplementationVersion
-			)
-		)
-		FROM BrowserFeatureAvailabilities bfa
-		LEFT JOIN BrowserReleases br
-			ON bfa.BrowserName = br.BrowserName AND bfa.BrowserVersion = br.BrowserVersion
-		WHERE bfa.WebFeatureID = wf.ID
-	),
-	(
-		SELECT ARRAY(
-	   		SELECT AS STRUCT
-				'' BrowserName,
-				'unavailable' AS ImplementationStatus,
-				CAST(NULL AS TIMESTAMP) AS ImplementationDate,
-				'' AS ImplementationVersion
-		)
-	)
-) AS ImplementationStatuses
+browser_info.BrowserInfo as ImplementationStatuses
 `
 	gcpFSImplementationStatusRawTemplate   = commonFSImplementationStatusRawTemplate
 	localFSImplementationStatusRawTemplate = commonFSImplementationStatusRawTemplate

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -562,6 +562,120 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
+			InputQuery: "available_date:2000-01-01..2000-12-31",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Keyword: KeywordAND,
+						Term:    nil,
+						Children: []*SearchNode{
+							{
+								Keyword: KeywordNone,
+								Term: &SearchTerm{
+									Identifier: IdentifierAvailableDate,
+									Value:      "2000-01-01",
+									Operator:   OperatorGtEq,
+								},
+								Children: nil,
+							},
+							{
+								Keyword: KeywordNone,
+								Term: &SearchTerm{
+									Identifier: IdentifierAvailableDate,
+									Value:      "2000-12-31",
+									Operator:   OperatorLtEq,
+								},
+								Children: nil,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			InputQuery: "-available_date:2000-01-01..2000-12-31",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Keyword: KeywordOR,
+						Term:    nil,
+						Children: []*SearchNode{
+							{
+								Keyword: KeywordNone,
+								Term: &SearchTerm{
+									Identifier: IdentifierAvailableDate,
+									Value:      "2000-01-01",
+									Operator:   OperatorLt,
+								},
+								Children: nil,
+							},
+							{
+								Keyword: KeywordNone,
+								Term: &SearchTerm{
+									Identifier: IdentifierAvailableDate,
+									Value:      "2000-12-31",
+									Operator:   OperatorGt,
+								},
+								Children: nil,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			InputQuery: `available_date:2000-01-01..2000-12-31 AND available_on:chrome`,
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Keyword: KeywordAND,
+						Term:    nil,
+						Children: []*SearchNode{
+							{
+								Keyword: KeywordAND,
+								Term:    nil,
+								Children: []*SearchNode{
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierAvailableDate,
+											Value:      "2000-01-01",
+											Operator:   OperatorGtEq,
+										},
+										Children: nil,
+									},
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierAvailableDate,
+											Value:      "2000-12-31",
+											Operator:   OperatorLtEq,
+										},
+										Children: nil,
+									},
+								},
+							},
+							{
+								Keyword:  KeywordNone,
+								Children: nil,
+								Term: &SearchTerm{
+									Identifier: IdentifierAvailableOn,
+									Value:      "chrome",
+									Operator:   OperatorEq,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			InputQuery: "-available_on:chrome OR baseline_status:widely",
 			ExpectedTree: &SearchNode{
 				Keyword: KeywordRoot,

--- a/lib/gcpspanner/searchtypes/features_search_visitor.go
+++ b/lib/gcpspanner/searchtypes/features_search_visitor.go
@@ -190,12 +190,29 @@ func (v *FeaturesSearchVisitor) VisitBaseline_status_term(ctx *parser.Baseline_s
 }
 
 // nolint: revive // Method signature is generated.
-func (v *FeaturesSearchVisitor) VisitBaseline_date_term(ctx *parser.Baseline_date_termContext) interface{} {
+func (v *FeaturesSearchVisitor) VisitAvailable_date_term(ctx *parser.Available_date_termContext) interface{} {
+	if dateRangeCtx := ctx.Date_range_query(); dateRangeCtx != nil {
+		return v.VisitDateRangeQuery(dateRangeCtx, IdentifierAvailableDate)
+	}
+
+	// Otherwise, use the default behavior of the visitor.
 	return v.VisitChildren(ctx)
 }
 
 // nolint: revive // Method signature is generated.
-func (v *FeaturesSearchVisitor) VisitDate_range_query(ctx *parser.Date_range_queryContext) interface{} {
+func (v *FeaturesSearchVisitor) VisitBaseline_date_term(ctx *parser.Baseline_date_termContext) interface{} {
+	if dateRangeCtx := ctx.Date_range_query(); dateRangeCtx != nil {
+		return v.VisitDateRangeQuery(dateRangeCtx, IdentifierBaselineDate)
+	}
+
+	// Otherwise, use the default behavior of the visitor.
+	return v.VisitChildren(ctx)
+}
+
+// VisitDateRangeQuery is not part of the generated methods. It is specialized to handle queries that
+// have a date range context. The generated VisitDate_range_query is no longer needed.
+func (v *FeaturesSearchVisitor) VisitDateRangeQuery(ctx parser.IDate_range_queryContext,
+	identifier SearchIdentifier) *SearchNode {
 	startDate := ctx.GetStartDate().GetText()
 	endDate := ctx.GetEndDate().GetText()
 
@@ -206,7 +223,7 @@ func (v *FeaturesSearchVisitor) VisitDate_range_query(ctx *parser.Date_range_que
 			{
 				Keyword: KeywordNone,
 				Term: &SearchTerm{
-					Identifier: IdentifierBaselineDate,
+					Identifier: identifier,
 					Value:      startDate,
 					Operator:   OperatorGtEq,
 				},
@@ -215,7 +232,7 @@ func (v *FeaturesSearchVisitor) VisitDate_range_query(ctx *parser.Date_range_que
 			{
 				Keyword: KeywordNone,
 				Term: &SearchTerm{
-					Identifier: IdentifierBaselineDate,
+					Identifier: identifier,
 					Value:      endDate,
 					Operator:   OperatorLtEq,
 				},

--- a/lib/gcpspanner/searchtypes/searchtypes.go
+++ b/lib/gcpspanner/searchtypes/searchtypes.go
@@ -83,6 +83,7 @@ type SearchTerm struct {
 type SearchIdentifier string
 
 const (
+	IdentifierAvailableDate  SearchIdentifier = "available_date"
 	IdentifierAvailableOn    SearchIdentifier = "available_on"
 	IdentifierBaselineDate   SearchIdentifier = "baseline_date"
 	IdentifierBaselineStatus SearchIdentifier = "baseline_status"


### PR DESCRIPTION
This PR introduces a new `available_date` query, enabling users to search for features that became available within a specified date range. This functionality is similar to the existing `baseline_date` query.

The antlr4 grammar has been expanded to accommodate this new term.

The generated Go code now uses a new custom method `VisitDateRangeQuery` that allows the generated `VisitBaseline_date_term` and `VisitAvailable_date_term` methods to pass in which identifier type to use while building the query's intermediate representation tree.

On the spanner side, a new JOIN has been added to base joins to create a browser_info alias that will allow us to do the filtering by available_date. An added benefit of this allowed us to replace existing column generation with data from browser_info.

Updated the query readme too.