### PR TITLE
Add available_on to autocomplete

### DIFF
--- a/frontend/src/static/js/components/webstatus-overview-filters.ts
+++ b/frontend/src/static/js/components/webstatus-overview-filters.ts
@@ -28,6 +28,10 @@ import {TaskStatus} from '@lit/task';
 
 const VOCABULARY = [
   {
+    name: 'available_date:2023-01-01..2024-01-01',
+    doc: 'Became available between the given dates',
+  },
+  {
     name: 'available_on:chrome',
     doc: 'Features available on Chrome',
   },


### PR DESCRIPTION
This should resolve #570.  It adds an `available_on` term to the autocomplete vocabulary.

This depends on #568.