### PR TITLE
Fix available_date query to support browser-specific filtering

### DIFF
--- a/antlr/FeatureSearch.g4
+++ b/antlr/FeatureSearch.g4
@@ -26,7 +26,8 @@ ANY_VALUE:
 available_on_term: 'available_on' COLON BROWSER_NAME;
 baseline_status_term: 'baseline_status' COLON BASELINE_STATUS;
 // In the future support other operators by doing something like (date_operator_query | date_range_query)
-available_date_term: 'available_date' COLON (date_range_query);
+available_date_term:
+	'available_date' COLON BROWSER_NAME COLON (date_range_query);
 // In the future support other operators by doing something like (date_operator_query | date_range_query)
 baseline_date_term: 'baseline_date' COLON (date_range_query);
 name_term: 'name' COLON ANY_VALUE;

--- a/antlr/FeatureSearch.md
+++ b/antlr/FeatureSearch.md
@@ -47,7 +47,7 @@ This query language enables you to construct flexible searches to find features 
 
 ### Simple Term Examples
 
-- `available_date:2023-01-01..2023-12-31` - Searches for all features that became available on any browser in 2023.
+- `available_date:chrome:2023-01-01..2023-12-31` - Searches for all features that became available on Chrome in 2023.
 - `available_on:chrome` - Find features available on Chrome.
 - `-available_on:firefox` - Find features not available on Firefox.
 - `baseline_status:high` - Find features with a high baseline status.
@@ -56,7 +56,6 @@ This query language enables you to construct flexible searches to find features 
 
 ### Complex Queries
 
-- `available_date:2023-01-01..2023-12-31 AND available_on:chrome` - Searches for all features that became available on Chrome in 2023.
 - `available_on:chrome AND baseline_status:newly` - Find features available on Chrome and having a newly baseline status.
 - `-available_on:firefox OR name:"CSS Grid"` - Find features either not available on Firefox or named "CSS Grid".
 - `"CSS Grid" baseline_status:limited` - Find features named "CSS Grid" with a baseline status of none (implied AND).

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -798,7 +798,7 @@ func testFeatureSearchFilters(ctx context.Context, t *testing.T, client *Client)
 	testFeatureNameFilters(ctx, t, client)
 	testFeatureBaselineStatusFilters(ctx, t, client)
 	testFeatureBaselineStatusDateFilters(ctx, t, client)
-	testFeatureAvailableDateFilters(ctx, t, client)
+	testFeatureAvailableBrowserDateFilters(ctx, t, client)
 }
 
 func testFeatureCommonFilterCombos(ctx context.Context, t *testing.T, client *Client) {
@@ -1109,14 +1109,14 @@ func testFeatureNameFilters(ctx context.Context, t *testing.T, client *Client) {
 	)
 }
 
-func testFeatureAvailableDateFilters(ctx context.Context, t *testing.T, client *Client) {
-	// Available Date 2000-01-01..2000-02-02
+func testFeatureAvailableBrowserDateFilters(ctx context.Context, t *testing.T, client *Client) {
+	// available_date:barBrowser:2000-01-01..2000-02-02
+	// Only Feature 1 is available on barBrowser during that same time window.
 	expectedResults := []FeatureResult{
 		getFeatureSearchTestFeature(FeatureSearchTestFId1),
-		getFeatureSearchTestFeature(FeatureSearchTestFId3),
 	}
 	expectedPage := FeatureResultPage{
-		Total:         2,
+		Total:         1,
 		NextPageToken: nil,
 		Features:      expectedResults,
 	}
@@ -1128,67 +1128,48 @@ func testFeatureAvailableDateFilters(ctx context.Context, t *testing.T, client *
 				Keyword: searchtypes.KeywordAND,
 				Term:    nil,
 				Children: []*searchtypes.SearchNode{
-					{
+					{ // startDateNode
 						Keyword: searchtypes.KeywordNone,
 						Term: &searchtypes.SearchTerm{
-							Identifier: searchtypes.IdentifierAvailableDate,
-							Value:      "2000-01-01",
-							Operator:   searchtypes.OperatorGtEq,
+							Identifier: searchtypes.IdentifierAvailableBrowserDate,
+							Operator:   searchtypes.OperatorNone,
+							Value:      "",
 						},
-						Children: nil,
-					},
-					{
-						Keyword: searchtypes.KeywordNone,
-						Term: &searchtypes.SearchTerm{
-							Identifier: searchtypes.IdentifierAvailableDate,
-							Value:      "2000-02-02",
-							Operator:   searchtypes.OperatorLtEq,
-						},
-						Children: nil,
-					},
-				},
-			},
-		},
-	}
-
-	assertFeatureSearch(ctx, t, client,
-		featureSearchArgs{
-			pageToken: nil,
-			pageSize:  100,
-			node:      node,
-			sort:      defaultSorting(),
-		},
-		&expectedPage,
-	)
-
-	// Available Date = 2000-01-01..2000-02-02 AND available on = barBrowser
-	// Only Feature 1 is available on barBrowser during that same time window.
-	expectedResults = []FeatureResult{
-		getFeatureSearchTestFeature(FeatureSearchTestFId1),
-	}
-	expectedPage = FeatureResultPage{
-		Total:         1,
-		NextPageToken: nil,
-		Features:      expectedResults,
-	}
-	node = &searchtypes.SearchNode{
-		Keyword: searchtypes.KeywordRoot,
-		Term:    nil,
-		Children: []*searchtypes.SearchNode{
-			{
-				Keyword: searchtypes.KeywordAND,
-				Term:    nil,
-				Children: []*searchtypes.SearchNode{
-					{
-						Keyword: searchtypes.KeywordAND,
-						Term:    nil,
 						Children: []*searchtypes.SearchNode{
+							{
+								Keyword: searchtypes.KeywordNone,
+								Term: &searchtypes.SearchTerm{
+									Identifier: searchtypes.IdentifierAvailableOn,
+									Value:      "barBrowser",
+									Operator:   searchtypes.OperatorEq,
+								},
+								Children: nil,
+							},
 							{
 								Keyword: searchtypes.KeywordNone,
 								Term: &searchtypes.SearchTerm{
 									Identifier: searchtypes.IdentifierAvailableDate,
 									Value:      "2000-01-01",
 									Operator:   searchtypes.OperatorGtEq,
+								},
+								Children: nil,
+							},
+						},
+					},
+					{ // endDateNode
+						Keyword: searchtypes.KeywordNone,
+						Term: &searchtypes.SearchTerm{
+							Identifier: searchtypes.IdentifierAvailableBrowserDate,
+							Operator:   searchtypes.OperatorNone,
+							Value:      "",
+						},
+						Children: []*searchtypes.SearchNode{
+							{
+								Keyword: searchtypes.KeywordNone,
+								Term: &searchtypes.SearchTerm{
+									Identifier: searchtypes.IdentifierAvailableOn,
+									Value:      "barBrowser",
+									Operator:   searchtypes.OperatorEq,
 								},
 								Children: nil,
 							},
@@ -1201,15 +1182,6 @@ func testFeatureAvailableDateFilters(ctx context.Context, t *testing.T, client *
 								},
 								Children: nil,
 							},
-						},
-					},
-					{
-						Keyword:  searchtypes.KeywordNone,
-						Children: nil,
-						Term: &searchtypes.SearchTerm{
-							Identifier: searchtypes.IdentifierAvailableOn,
-							Value:      "barBrowser",
-							Operator:   searchtypes.OperatorEq,
 						},
 					},
 				},

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -100,6 +100,216 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
+			InputQuery: "available_date:chrome:2000-01-01..2000-12-31",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Keyword: KeywordAND,
+						Term:    nil,
+						Children: []*SearchNode{
+							{ // startDateNode
+								Keyword: KeywordNone,
+								Term: &SearchTerm{
+									Identifier: IdentifierAvailableBrowserDate,
+									Operator:   OperatorNone,
+									Value:      "",
+								},
+								Children: []*SearchNode{
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierAvailableOn,
+											Value:      "chrome",
+											Operator:   OperatorEq,
+										},
+										Children: nil,
+									},
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierAvailableDate,
+											Value:      "2000-01-01",
+											Operator:   OperatorGtEq,
+										},
+										Children: nil,
+									},
+								},
+							},
+							{ // endDateNode
+								Keyword: KeywordNone,
+								Term: &SearchTerm{
+									Identifier: IdentifierAvailableBrowserDate,
+									Operator:   OperatorNone,
+									Value:      "",
+								},
+								Children: []*SearchNode{
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierAvailableOn,
+											Value:      "chrome",
+											Operator:   OperatorEq,
+										},
+										Children: nil,
+									},
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierAvailableDate,
+											Value:      "2000-12-31",
+											Operator:   OperatorLtEq,
+										},
+										Children: nil,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			InputQuery: "available_date:chrome:2000-01-01..2000-12-31 OR available_date:firefox:2000-01-01..2000-12-31",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Keyword: KeywordOR,
+						Term:    nil,
+						Children: []*SearchNode{
+							{
+								Keyword: KeywordAND,
+								Term:    nil,
+								Children: []*SearchNode{
+									{ // startDateNode
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierAvailableBrowserDate,
+											Operator:   OperatorNone,
+											Value:      "",
+										},
+										Children: []*SearchNode{
+											{
+												Keyword: KeywordNone,
+												Term: &SearchTerm{
+													Identifier: IdentifierAvailableOn,
+													Value:      "chrome",
+													Operator:   OperatorEq,
+												},
+												Children: nil,
+											},
+											{
+												Keyword: KeywordNone,
+												Term: &SearchTerm{
+													Identifier: IdentifierAvailableDate,
+													Value:      "2000-01-01",
+													Operator:   OperatorGtEq,
+												},
+												Children: nil,
+											},
+										},
+									},
+									{ // endDateNode
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierAvailableBrowserDate,
+											Operator:   OperatorNone,
+											Value:      "",
+										},
+										Children: []*SearchNode{
+											{
+												Keyword: KeywordNone,
+												Term: &SearchTerm{
+													Identifier: IdentifierAvailableOn,
+													Value:      "chrome",
+													Operator:   OperatorEq,
+												},
+												Children: nil,
+											},
+											{
+												Keyword: KeywordNone,
+												Term: &SearchTerm{
+													Identifier: IdentifierAvailableDate,
+													Value:      "2000-12-31",
+													Operator:   OperatorLtEq,
+												},
+												Children: nil,
+											},
+										},
+									},
+								},
+							},
+							{
+								Keyword: KeywordAND,
+								Term:    nil,
+								Children: []*SearchNode{
+									{ // startDateNode
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierAvailableBrowserDate,
+											Operator:   OperatorNone,
+											Value:      "",
+										},
+										Children: []*SearchNode{
+											{
+												Keyword: KeywordNone,
+												Term: &SearchTerm{
+													Identifier: IdentifierAvailableOn,
+													Value:      "firefox",
+													Operator:   OperatorEq,
+												},
+												Children: nil,
+											},
+											{
+												Keyword: KeywordNone,
+												Term: &SearchTerm{
+													Identifier: IdentifierAvailableDate,
+													Value:      "2000-01-01",
+													Operator:   OperatorGtEq,
+												},
+												Children: nil,
+											},
+										},
+									},
+									{ // endDateNode
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierAvailableBrowserDate,
+											Operator:   OperatorNone,
+											Value:      "",
+										},
+										Children: []*SearchNode{
+											{
+												Keyword: KeywordNone,
+												Term: &SearchTerm{
+													Identifier: IdentifierAvailableOn,
+													Value:      "firefox",
+													Operator:   OperatorEq,
+												},
+												Children: nil,
+											},
+											{
+												Keyword: KeywordNone,
+												Term: &SearchTerm{
+													Identifier: IdentifierAvailableDate,
+													Value:      "2000-12-31",
+													Operator:   OperatorLtEq,
+												},
+												Children: nil,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			InputQuery: "available_on:chrome AND baseline_status:widely",
 			ExpectedTree: &SearchNode{
 				Keyword: KeywordRoot,
@@ -562,120 +772,6 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
-			InputQuery: "available_date:2000-01-01..2000-12-31",
-			ExpectedTree: &SearchNode{
-				Keyword: KeywordRoot,
-				Term:    nil,
-				Children: []*SearchNode{
-					{
-						Keyword: KeywordAND,
-						Term:    nil,
-						Children: []*SearchNode{
-							{
-								Keyword: KeywordNone,
-								Term: &SearchTerm{
-									Identifier: IdentifierAvailableDate,
-									Value:      "2000-01-01",
-									Operator:   OperatorGtEq,
-								},
-								Children: nil,
-							},
-							{
-								Keyword: KeywordNone,
-								Term: &SearchTerm{
-									Identifier: IdentifierAvailableDate,
-									Value:      "2000-12-31",
-									Operator:   OperatorLtEq,
-								},
-								Children: nil,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			InputQuery: "-available_date:2000-01-01..2000-12-31",
-			ExpectedTree: &SearchNode{
-				Keyword: KeywordRoot,
-				Term:    nil,
-				Children: []*SearchNode{
-					{
-						Keyword: KeywordOR,
-						Term:    nil,
-						Children: []*SearchNode{
-							{
-								Keyword: KeywordNone,
-								Term: &SearchTerm{
-									Identifier: IdentifierAvailableDate,
-									Value:      "2000-01-01",
-									Operator:   OperatorLt,
-								},
-								Children: nil,
-							},
-							{
-								Keyword: KeywordNone,
-								Term: &SearchTerm{
-									Identifier: IdentifierAvailableDate,
-									Value:      "2000-12-31",
-									Operator:   OperatorGt,
-								},
-								Children: nil,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			InputQuery: `available_date:2000-01-01..2000-12-31 AND available_on:chrome`,
-			ExpectedTree: &SearchNode{
-				Keyword: KeywordRoot,
-				Term:    nil,
-				Children: []*SearchNode{
-					{
-						Keyword: KeywordAND,
-						Term:    nil,
-						Children: []*SearchNode{
-							{
-								Keyword: KeywordAND,
-								Term:    nil,
-								Children: []*SearchNode{
-									{
-										Keyword: KeywordNone,
-										Term: &SearchTerm{
-											Identifier: IdentifierAvailableDate,
-											Value:      "2000-01-01",
-											Operator:   OperatorGtEq,
-										},
-										Children: nil,
-									},
-									{
-										Keyword: KeywordNone,
-										Term: &SearchTerm{
-											Identifier: IdentifierAvailableDate,
-											Value:      "2000-12-31",
-											Operator:   OperatorLtEq,
-										},
-										Children: nil,
-									},
-								},
-							},
-							{
-								Keyword:  KeywordNone,
-								Children: nil,
-								Term: &SearchTerm{
-									Identifier: IdentifierAvailableOn,
-									Value:      "chrome",
-									Operator:   OperatorEq,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			InputQuery: "-available_on:chrome OR baseline_status:widely",
 			ExpectedTree: &SearchNode{
 				Keyword: KeywordRoot,
@@ -787,6 +883,12 @@ func TestParseQueryBadInput(t *testing.T) {
 		},
 		{
 			input: "available_on:chrome,edge",
+		},
+		{
+			input: "available_date:chrome",
+		},
+		{
+			input: "available_date:2000-01-01..2000-12-31",
 		},
 	}
 	for _, tc := range testCases {

--- a/lib/gcpspanner/searchtypes/searchtypes.go
+++ b/lib/gcpspanner/searchtypes/searchtypes.go
@@ -45,6 +45,7 @@ const (
 	OperatorLt   SearchOperator = "LT"
 	OperatorEq   SearchOperator = "EQ"
 	OperatorNeq  SearchOperator = "NEQ"
+	OperatorNone SearchOperator = "NONE"
 )
 
 func (o *SearchOperator) Invert() {
@@ -61,6 +62,8 @@ func (o *SearchOperator) Invert() {
 		*o = OperatorGt
 	case OperatorNeq:
 		*o = OperatorEq
+	case OperatorNone:
+		break
 	}
 }
 
@@ -83,9 +86,10 @@ type SearchTerm struct {
 type SearchIdentifier string
 
 const (
-	IdentifierAvailableDate  SearchIdentifier = "available_date"
-	IdentifierAvailableOn    SearchIdentifier = "available_on"
-	IdentifierBaselineDate   SearchIdentifier = "baseline_date"
-	IdentifierBaselineStatus SearchIdentifier = "baseline_status"
-	IdentifierName           SearchIdentifier = "name"
+	IdentifierAvailableBrowserDate SearchIdentifier = "available_browser_date"
+	IdentifierAvailableDate        SearchIdentifier = "available_date"
+	IdentifierAvailableOn          SearchIdentifier = "available_on"
+	IdentifierBaselineDate         SearchIdentifier = "baseline_date"
+	IdentifierBaselineStatus       SearchIdentifier = "baseline_status"
+	IdentifierName                 SearchIdentifier = "name"
 )


### PR DESCRIPTION
This commit introduces a more precise way to filter features based on their availability date in a specific browser.  The existing `available_date` query is enhanced to optionally accept a browser prefix, enabling queries like `available_date:chrome:2023-01-01..2024-01-01` to find features that became available specifically in Chrome within the given date range.

This addresses a potential inaccuracy in the previous behavior where `available_date` combined with `available_on` could include features that were initially released in other browsers. The new syntax provides clarity and flexibility for users to express their search intent more accurately.

Additionally, the ANTLR grammar and visitor code have been updated to handle the new syntax, and the `availableDateFilter` function has been modified to incorporate the browser-specific filtering logic.

Other changes:
- Added a new `None` Operator to represent placeholder operators in cases where the children nodes contain a multi-value IR tree. This improves the clarity and flexibility of the intermediate representation.
- `available_date:DATE_RANGE` will no longer work after this. And it will be considered invalid. A test case has been added to make sure the parser interprets as invalid.

Fixes #578