### PR TITLE
Refactor: Centralize Upsert Logic into Reusable Generic

### DIFF
--- a/lib/gcpspanner/baseline_status_test.go
+++ b/lib/gcpspanner/baseline_status_test.go
@@ -79,7 +79,7 @@ func (c *Client) ReadAllBaselineStatuses(ctx context.Context, _ *testing.T) ([]F
 		if err != nil {
 			return nil, errors.Join(ErrInternalQueryFailure, err)
 		}
-		var status SpannerFeatureBaselineStatus
+		var status spannerFeatureBaselineStatus
 		if err := row.ToStruct(&status); err != nil {
 			return nil, errors.Join(ErrInternalQueryFailure, err)
 		}

--- a/lib/gcpspanner/browser_availabilities_test.go
+++ b/lib/gcpspanner/browser_availabilities_test.go
@@ -107,7 +107,7 @@ func (c *Client) ReadAllAvailabilities(ctx context.Context, _ *testing.T) ([]Bro
 		if err != nil {
 			return nil, errors.Join(ErrInternalQueryFailure, err)
 		}
-		var availability SpannerBrowserFeatureAvailability
+		var availability spannerBrowserFeatureAvailability
 		if err := row.ToStruct(&availability); err != nil {
 			return nil, errors.Join(ErrInternalQueryFailure, err)
 		}

--- a/lib/gcpspanner/browser_releases.go
+++ b/lib/gcpspanner/browser_releases.go
@@ -16,19 +16,18 @@ package gcpspanner
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"time"
 
 	"cloud.google.com/go/spanner"
-	"google.golang.org/grpc/codes"
 )
 
 const browserReleasesTable = "BrowserReleases"
 
-// SpannerBrowserRelease is a wrapper for the browser release that is actually
+// spannerBrowserRelease is a wrapper for the browser release that is actually
 // stored in spanner. For now, it is the same. But we keep this structure to be
 // consistent to the other database models.
-type SpannerBrowserRelease struct {
+type spannerBrowserRelease struct {
 	BrowserRelease
 }
 
@@ -39,40 +38,47 @@ type BrowserRelease struct {
 	ReleaseDate    time.Time `spanner:"ReleaseDate"`
 }
 
-// InsertBrowserRelease will insert the given browser release.
-// If the release, does not exist, it will insert a new release.
-// If the release exists, it currently does nothing and keeps the existing as-is.
-// nolint: dupl // TODO. Will refactor for common patterns.
-func (c *Client) InsertBrowserRelease(ctx context.Context, release BrowserRelease) error {
-	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
-		_, err := txn.ReadRow(
-			ctx,
-			browserReleasesTable,
-			spanner.Key{release.BrowserName, release.BrowserVersion},
-			[]string{
-				"ReleaseDate",
-			})
-		if err != nil {
-			// Received an error other than not found. Return now.
-			if spanner.ErrCode(err) != codes.NotFound {
-				return errors.Join(ErrInternalQueryFailure, err)
-			}
-			m, err := spanner.InsertOrUpdateStruct(browserReleasesTable, release)
-			if err != nil {
-				return errors.Join(ErrInternalQueryFailure, err)
-			}
-			err = txn.BufferWrite([]*spanner.Mutation{m})
-			if err != nil {
-				return errors.Join(ErrInternalQueryFailure, err)
-			}
-		}
-		// For now, do not overwrite anything for releases.
-		return nil
+type browserReleaseKey struct {
+	BrowserName    string
+	BrowserVersion string
+}
 
-	})
-	if err != nil {
-		return errors.Join(ErrInternalQueryFailure, err)
+// Implements the entityMapper interface for BrowserRelease and SpannerBrowserRelease.
+type browserReleaseSpannerMapper struct{}
+
+func (m browserReleaseSpannerMapper) SelectOne(key browserReleaseKey) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		BrowserName, BrowserVersion, ReleaseDate
+	FROM %s
+	WHERE BrowserName = @browserName AND BrowserVersion = @browserVersion
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"browserName":    key.BrowserName,
+		"browserVersion": key.BrowserVersion,
 	}
+	stmt.Params = parameters
 
-	return nil
+	return stmt
+}
+
+func (m browserReleaseSpannerMapper) Merge(_ BrowserRelease, existing spannerBrowserRelease) spannerBrowserRelease {
+	// If the release exists, it currently does nothing and keeps the existing as-is.
+	return existing
+}
+
+func (m browserReleaseSpannerMapper) GetKey(in BrowserRelease) browserReleaseKey {
+	return browserReleaseKey{
+		BrowserName:    in.BrowserName,
+		BrowserVersion: in.BrowserVersion,
+	}
+}
+
+func (m browserReleaseSpannerMapper) Table() string {
+	return browserReleasesTable
+}
+
+// InsertBrowserRelease will insert the given browser release.
+func (c *Client) InsertBrowserRelease(ctx context.Context, release BrowserRelease) error {
+	return newEntityWriter[browserReleaseSpannerMapper](c).upsert(ctx, release)
 }

--- a/lib/gcpspanner/browser_releases_test.go
+++ b/lib/gcpspanner/browser_releases_test.go
@@ -77,7 +77,7 @@ func (c *Client) ReadAllBrowserReleases(ctx context.Context, _ *testing.T) ([]Br
 		if err != nil {
 			return nil, errors.Join(ErrInternalQueryFailure, err)
 		}
-		var release SpannerBrowserRelease
+		var release spannerBrowserRelease
 		if err := row.ToStruct(&release); err != nil {
 			return nil, errors.Join(ErrInternalQueryFailure, err)
 		}


### PR DESCRIPTION
In preparation for adding new tables to support feature groups and snapshots, I identified repetitive code patterns in our Spanner client logic. This was also flagged by the dupl linter.

This change introduces a more reusable and maintainable approach to handling upsert operations (insert or update) in our Spanner interactions.

Key changes

- entityMapper interface: Establishes the core mapping between external structs and their corresponding Spanner representations, along with methods for key retrieval, select queries, and table identification.
- writeableEntityMapper & writeableEntityMapperWithIDRetrieval interfaces: Extend entityMapper to handle merging data during updates and optionally retrieving entity IDs.
- entityWriter & entityWriterWithIDRetrieval structs: Implement the writeable mapper interfaces, providing concrete implementations for upsert operations.
- Refactoring of existing entities: Most entities have been updated to leverage these new structs, promoting consistency and reducing code duplication.
- unexport most spanner structs since they do not need to be exposed externally.

This refactor not only streamlines our current codebase but also lays a solid foundation for seamlessly integrating future table additions.

We can do this for readonly queries too in the future but given I am about to add more tables, there will be a lot more upserts happening. We can do readonly query refactoring in the future.