### PR TITLE
[1/4] Add support for WebDX Groups, Feature-Group Mappings &  Group Descendants

### DIFF
--- a/infra/storage/spanner/migrations/000006.sql
+++ b/infra/storage/spanner/migrations/000006.sql
@@ -1,0 +1,48 @@
+-- Copyright 2024 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- WebDXGroups contains basic metadata about groups from the webdx web features repository.
+-- Named WebDXGroups because Groups is a reserved word.
+CREATE TABLE IF NOT EXISTS WebDXGroups (
+    ID STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
+    GroupKey STRING(64) NOT NULL,
+    Name STRING(64) NOT NULL,
+
+    -- Additional lowercase columns for case-insensitive search
+    GroupKey_Lowercase STRING(64) AS (LOWER(GroupKey)) STORED,
+    Name_Lowercase STRING(64) AS (LOWER(Name)) STORED
+) PRIMARY KEY (ID);
+
+-- Maps web features to groups.
+CREATE TABLE IF NOT EXISTS WebFeatureGroups (
+    WebFeatureID STRING(36) NOT NULL,
+    -- Stores an array of Group IDs associated with this web feature.
+    -- Each feature does not belong to many groups. For now, keep them here.
+    GroupIDs ARRAY<STRING(36)>,
+    FOREIGN KEY (WebFeatureID) REFERENCES WebFeatures(ID)  ON DELETE CASCADE
+) PRIMARY KEY (WebFeatureID);
+
+-- Stores descendant group IDs for each group.
+-- This separate table allows efficient retrieval of features associated with a group and its descendants.
+-- It also simplifies updates to the group hierarchy compared to storing descendant IDs directly within the WebDXGroups
+-- table.
+CREATE TABLE IF NOT EXISTS WebDXGroupDescendants (
+    GroupID STRING(36) NOT NULL,
+    -- Stores IDs of all descendant groups to optimize
+    -- queries for features associated with a group and its children.
+    -- TODO: Consider a separate GroupChildren table if the group hierarchy
+    -- becomes deeply nested.
+    DescendantGroupIDs ARRAY<STRING(36)>,
+    FOREIGN KEY (GroupID) REFERENCES WebDXGroups(ID)  ON DELETE CASCADE
+) PRIMARY KEY (GroupID);

--- a/lib/gcpspanner/group_descendants.go
+++ b/lib/gcpspanner/group_descendants.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+)
+
+const groupDescendantsTable = "WebDXGroupDescendants"
+
+// Implements the entityMapper interface for GroupDescendantInfo and SpannerGroupDescendantInfo.
+type groupDescendantInfoMapper struct{}
+
+func (m groupDescendantInfoMapper) Merge(
+	in spannerGroupDescendantInfo, existing spannerGroupDescendantInfo) spannerGroupDescendantInfo {
+	return spannerGroupDescendantInfo{
+		ID: existing.ID,
+		GroupDescendantInfo: GroupDescendantInfo{
+			DescendantGroupIDs: in.DescendantGroupIDs,
+		},
+	}
+}
+
+func (m groupDescendantInfoMapper) GetKey(in spannerGroupDescendantInfo) string {
+	return in.ID
+}
+
+func (m groupDescendantInfoMapper) Table() string {
+	return groupDescendantsTable
+}
+
+func (m groupDescendantInfoMapper) SelectOne(id string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		GroupID, DescendantGroupIDs
+	FROM %s
+	WHERE GroupID = @id
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"id": id,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+type GroupDescendantInfo struct {
+	DescendantGroupIDs []string `spanner:"DescendantGroupIDs"`
+}
+
+type spannerGroupDescendantInfo struct {
+	ID string `spanner:"GroupID"`
+	GroupDescendantInfo
+}
+
+func (c *Client) UpsertGroupDescendantInfo(
+	ctx context.Context, groupKey string, descendantInfo GroupDescendantInfo) error {
+	id, err := c.GetGroupIDFromGroupKey(ctx, groupKey)
+	if err != nil {
+		return err
+	}
+	info := spannerGroupDescendantInfo{
+		ID:                  *id,
+		GroupDescendantInfo: descendantInfo,
+	}
+
+	return newEntityWriter[groupDescendantInfoMapper](c).upsert(ctx, info)
+}

--- a/lib/gcpspanner/group_descendants_test.go
+++ b/lib/gcpspanner/group_descendants_test.go
@@ -1,0 +1,195 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func (c *Client) readAllGroupDescendantInfo(ctx context.Context, _ *testing.T) ([]spannerGroupDescendantInfo, error) {
+	stmt := spanner.NewStatement(
+		`SELECT
+			GroupID, DescendantGroupIDs
+		FROM WebDXGroupDescendants`)
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []spannerGroupDescendantInfo
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var info spannerGroupDescendantInfo
+		if err := row.ToStruct(&info); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		ret = append(ret, info)
+	}
+
+	return ret, nil
+}
+
+func (c *Client) createSampleGroupDescendantInfo(
+	ctx context.Context, t *testing.T, groupKeyToIDMapping map[string]string) {
+	infoArr := []struct {
+		groupKey string
+		info     GroupDescendantInfo
+	}{
+		{
+			groupKey: "child1",
+			info: GroupDescendantInfo{
+				DescendantGroupIDs: []string{
+					groupKeyToIDMapping["grandchild1"],
+					groupKeyToIDMapping["grandchild2"],
+				},
+			},
+		},
+		{
+			groupKey: "parent1",
+			info: GroupDescendantInfo{
+				DescendantGroupIDs: []string{
+					groupKeyToIDMapping["child1"],
+					groupKeyToIDMapping["grandchild1"],
+					groupKeyToIDMapping["grandchild2"],
+				},
+			},
+		},
+		{
+			groupKey: "parent2",
+			info: GroupDescendantInfo{
+				DescendantGroupIDs: []string{
+					groupKeyToIDMapping["child2"],
+				},
+			},
+		},
+	}
+	for _, info := range infoArr {
+		err := c.UpsertGroupDescendantInfo(ctx, info.groupKey, info.info)
+		if err != nil {
+			t.Fatalf("unable to insert group descendant info err %s", err)
+		}
+	}
+}
+
+func TestUpsertGroupDescendantInfo(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+	idMapping := spannerClient.createSampleGroups(ctx, t)
+	spannerClient.createSampleGroupDescendantInfo(ctx, t, idMapping)
+
+	expectedInfoArr := []spannerGroupDescendantInfo{
+		{
+			ID: idMapping["child1"],
+			GroupDescendantInfo: GroupDescendantInfo{
+				DescendantGroupIDs: []string{
+					idMapping["grandchild1"],
+					idMapping["grandchild2"],
+				},
+			},
+		},
+		{
+			ID: idMapping["parent1"],
+			GroupDescendantInfo: GroupDescendantInfo{
+				DescendantGroupIDs: []string{
+					idMapping["child1"],
+					idMapping["grandchild1"],
+					idMapping["grandchild2"],
+				},
+			},
+		},
+		{
+			ID: idMapping["parent2"],
+			GroupDescendantInfo: GroupDescendantInfo{
+				DescendantGroupIDs: []string{
+					idMapping["child2"],
+				},
+			},
+		},
+	}
+	infoArr, err := spannerClient.readAllGroupDescendantInfo(ctx, t)
+	if err != nil {
+		t.Fatalf("unable to get all groups info err: %s", err)
+	}
+	slices.SortFunc(expectedInfoArr, sortGroupDescendantInfo)
+	slices.SortFunc(infoArr, sortGroupDescendantInfo)
+	if !slices.EqualFunc(expectedInfoArr, infoArr, groupDescendantInfoEquality) {
+		t.Errorf("unequal groups.\nexpected %+v\nreceived %+v", expectedInfoArr, infoArr)
+	}
+
+	// Reset the descendants on parent2
+	err = spannerClient.UpsertGroupDescendantInfo(ctx, "parent2", GroupDescendantInfo{
+		DescendantGroupIDs: nil,
+	})
+	if err != nil {
+		t.Errorf("unable to edit the group descendant info %s", err)
+	}
+
+	expectedInfoArr = []spannerGroupDescendantInfo{
+		{
+			ID: idMapping["child1"],
+			GroupDescendantInfo: GroupDescendantInfo{
+				DescendantGroupIDs: []string{
+					idMapping["grandchild1"],
+					idMapping["grandchild2"],
+				},
+			},
+		},
+		{
+			ID: idMapping["parent1"],
+			GroupDescendantInfo: GroupDescendantInfo{
+				DescendantGroupIDs: []string{
+					idMapping["child1"],
+					idMapping["grandchild1"],
+					idMapping["grandchild2"],
+				},
+			},
+		},
+		{
+			ID: idMapping["parent2"],
+			GroupDescendantInfo: GroupDescendantInfo{
+				DescendantGroupIDs: nil,
+			},
+		},
+	}
+	infoArr, err = spannerClient.readAllGroupDescendantInfo(ctx, t)
+	if err != nil {
+		t.Fatalf("unable to get all groups info err: %s", err)
+	}
+	slices.SortFunc(expectedInfoArr, sortGroupDescendantInfo)
+	slices.SortFunc(infoArr, sortGroupDescendantInfo)
+	if !slices.EqualFunc(expectedInfoArr, infoArr, groupDescendantInfoEquality) {
+		t.Errorf("unequal groups.\nexpected %+v\nreceived %+v", expectedInfoArr, infoArr)
+	}
+}
+
+func groupDescendantInfoEquality(left, right spannerGroupDescendantInfo) bool {
+	return left.ID == right.ID &&
+		slices.Equal(left.DescendantGroupIDs, right.DescendantGroupIDs)
+}
+
+func sortGroupDescendantInfo(left, right spannerGroupDescendantInfo) int {
+	return cmp.Compare(left.ID, right.ID)
+}

--- a/lib/gcpspanner/groups.go
+++ b/lib/gcpspanner/groups.go
@@ -1,0 +1,101 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+)
+
+const groupsTable = "WebDXGroups"
+
+// Implements the entityMapper interface for Group and SpannerGroup.
+type groupSpannerMapper struct{}
+
+func (m groupSpannerMapper) Merge(in Group, existing spannerGroup) spannerGroup {
+	return spannerGroup{
+		ID: existing.ID,
+		Group: Group{
+			Name:     cmp.Or[string](in.Name, existing.Name),
+			GroupKey: existing.GroupKey,
+		},
+	}
+}
+
+func (m groupSpannerMapper) GetKey(in Group) string {
+	return in.GroupKey
+}
+
+func (m groupSpannerMapper) SelectOne(key string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ID, GroupKey, Name
+	FROM %s
+	WHERE GroupKey = @groupKey
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"groupKey": key,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (m groupSpannerMapper) Table() string {
+	return groupsTable
+}
+
+func (m groupSpannerMapper) GetID(key string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ID
+	FROM %s
+	WHERE GroupKey = @groupKey
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"groupKey": key,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+// Group contains common metadata for a group from the WebDX web-feature
+// repository.
+// Columns come from the ../../infra/storage/spanner/migrations/*.sql files.
+type Group struct {
+	GroupKey string `spanner:"GroupKey"`
+	Name     string `spanner:"Name"`
+}
+
+// spannerGroup is a wrapper for the group that is actually
+// stored in spanner. This is useful because the spanner id is not useful to
+// return to the end user since it is only used to decouple the primary keys
+// between this system and web features repo.
+type spannerGroup struct {
+	ID string `spanner:"ID"`
+	Group
+}
+
+func (c *Client) UpsertGroup(ctx context.Context, group Group) (*string, error) {
+	return newEntityWriterWithIDRetrieval[groupSpannerMapper, string](c).upsertAndGetID(ctx, group)
+}
+
+func (c *Client) GetGroupIDFromGroupKey(ctx context.Context, groupKey string) (*string, error) {
+	return newEntityWriterWithIDRetrieval[groupSpannerMapper, string](c).getIDByKey(ctx, groupKey)
+}

--- a/lib/gcpspanner/groups_test.go
+++ b/lib/gcpspanner/groups_test.go
@@ -1,0 +1,205 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func (c *Client) createSampleGroups(ctx context.Context, t *testing.T) map[string]string {
+	grandChild1 := Group{
+		GroupKey: "grandchild1",
+		Name:     "Grand Child 1",
+	}
+	grandChild2 := Group{
+		GroupKey: "grandchild2",
+		Name:     "Grand Child 2",
+	}
+	grandChild1ID, err := c.UpsertGroup(ctx, grandChild1)
+	if err != nil {
+		t.Fatalf("failed to insert group. err: %s group: %v\n", err, grandChild1)
+	}
+	grandChild2ID, err := c.UpsertGroup(ctx, grandChild2)
+	if err != nil {
+		t.Fatalf("failed to insert group. err: %s group: %v\n", err, grandChild2)
+	}
+	child1 := Group{
+		GroupKey: "child1",
+		Name:     "Child 1",
+	}
+	child2 := Group{
+		GroupKey: "child2",
+		Name:     "Child 2",
+	}
+	child1ID, err := c.UpsertGroup(ctx, child1)
+	if err != nil {
+		t.Fatalf("failed to insert group. err: %s group: %v\n", err, child1)
+	}
+	child2ID, err := c.UpsertGroup(ctx, child2)
+	if err != nil {
+		t.Fatalf("failed to insert group. err: %s group: %v\n", err, child2)
+	}
+	parent1 := Group{
+		GroupKey: "parent1",
+		Name:     "Parent 1",
+	}
+	parent2 := Group{
+		GroupKey: "parent2",
+		Name:     "Parent 2",
+	}
+	parent1ID, err := c.UpsertGroup(ctx, parent1)
+	if err != nil {
+		t.Fatalf("failed to insert group. err: %s group: %v\n", err, parent1)
+	}
+	parent2ID, err := c.UpsertGroup(ctx, parent2)
+	if err != nil {
+		t.Fatalf("failed to insert group. err: %s group: %v\n", err, parent2)
+	}
+
+	return map[string]string{
+		grandChild1.GroupKey: *grandChild1ID,
+		grandChild2.GroupKey: *grandChild2ID,
+		child1.GroupKey:      *child1ID,
+		child2.GroupKey:      *child2ID,
+		parent1.GroupKey:     *parent1ID,
+		parent2.GroupKey:     *parent2ID,
+	}
+}
+
+func (c *Client) ReadAllGroups(ctx context.Context, _ *testing.T) ([]Group, error) {
+	stmt := spanner.NewStatement(
+		`SELECT
+			ID, GroupKey, Name
+		FROM WebDXGroups ORDER BY GroupKey ASC`)
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []Group
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var group spannerGroup
+		if err := row.ToStruct(&group); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		ret = append(ret, group.Group)
+	}
+
+	return ret, nil
+}
+
+func TestUpsertGroup(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+	_ = spannerClient.createSampleGroups(ctx, t)
+
+	groups, err := spannerClient.ReadAllGroups(ctx, t)
+	if err != nil {
+		t.Fatalf("unable to get all groups err: %s", err)
+	}
+
+	expectedGroups := []Group{
+		{
+			GroupKey: "child1",
+			Name:     "Child 1",
+		},
+		{
+			GroupKey: "child2",
+			Name:     "Child 2",
+		},
+		{
+			GroupKey: "grandchild1",
+			Name:     "Grand Child 1",
+		},
+		{
+			GroupKey: "grandchild2",
+			Name:     "Grand Child 2",
+		},
+		{
+			GroupKey: "parent1",
+			Name:     "Parent 1",
+		},
+		{
+			GroupKey: "parent2",
+			Name:     "Parent 2",
+		},
+	}
+
+	if !slices.EqualFunc(expectedGroups, groups, groupEquality) {
+		t.Errorf("unequal groups.\nexpected %+v\nreceived %+v", expectedGroups, groups)
+	}
+
+	// Change one of the groups
+	_, err = spannerClient.UpsertGroup(ctx, Group{
+		GroupKey: "parent2",
+		// Change the name
+		Name: "Parent 2 edit",
+	})
+	if err != nil {
+		t.Errorf("unable to edit the group %s", err)
+	}
+
+	expectedGroups = []Group{
+		{
+			GroupKey: "child1",
+			Name:     "Child 1",
+		},
+		{
+			GroupKey: "child2",
+			Name:     "Child 2",
+		},
+		{
+			GroupKey: "grandchild1",
+			Name:     "Grand Child 1",
+		},
+		{
+			GroupKey: "grandchild2",
+			Name:     "Grand Child 2",
+		},
+		{
+			GroupKey: "parent1",
+			Name:     "Parent 1",
+		},
+		{
+			GroupKey: "parent2",
+			Name:     "Parent 2 edit",
+		},
+	}
+
+	groups, err = spannerClient.ReadAllGroups(ctx, t)
+	if err != nil {
+		t.Fatalf("unable to get all groups err: %s", err)
+	}
+
+	if !slices.EqualFunc(expectedGroups, groups, groupEquality) {
+		t.Errorf("unequal groups.\nexpected %+v\nreceived %+v", expectedGroups, groups)
+	}
+}
+
+func groupEquality(left, right Group) bool {
+	return left.Name == right.Name &&
+		left.GroupKey == right.GroupKey
+}

--- a/lib/gcpspanner/web_feature_groups.go
+++ b/lib/gcpspanner/web_feature_groups.go
@@ -1,0 +1,82 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+)
+
+const webFeatureGroupsTable = "WebFeatureGroups"
+
+// WebFeatureGroup contains the mapping between WebDXGroups and WebFeatures.
+// Columns come from the ../../infra/storage/spanner/migrations/*.sql files.
+type WebFeatureGroup struct {
+	WebFeatureID string   `spanner:"WebFeatureID"`
+	GroupIDs     []string `spanner:"GroupIDs"`
+}
+
+// Implements the Mapping interface for WebFeatureGroup and SpannerWebFeatureGroup.
+type webFeaturesGroupSpannerMapper struct{}
+
+func (m webFeaturesGroupSpannerMapper) GetKey(in WebFeatureGroup) string { return in.WebFeatureID }
+
+func (m webFeaturesGroupSpannerMapper) Merge(
+	in WebFeatureGroup, existing spannerWebFeatureGroup) spannerWebFeatureGroup {
+	var groupIDs []string
+	if in.GroupIDs != nil {
+		groupIDs = in.GroupIDs
+	} else {
+		groupIDs = existing.GroupIDs
+	}
+
+	return spannerWebFeatureGroup{
+		WebFeatureGroup: WebFeatureGroup{
+			WebFeatureID: existing.WebFeatureID,
+			GroupIDs:     groupIDs,
+		},
+	}
+}
+
+func (m webFeaturesGroupSpannerMapper) SelectOne(id string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		WebFeatureID, GroupIDs
+	FROM %s
+	WHERE WebFeatureID = @webFeatureID
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"webFeatureID": id,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (m webFeaturesGroupSpannerMapper) Table() string {
+	return webFeatureGroupsTable
+}
+
+// SpannerGroup is a wrapper for the WebFeatureGroup that is actually
+// stored in spanner.
+type spannerWebFeatureGroup struct {
+	WebFeatureGroup
+}
+
+func (c *Client) UpsertWebFeatureGroup(ctx context.Context, group WebFeatureGroup) error {
+	return newEntityWriter[webFeaturesGroupSpannerMapper](c).upsert(ctx, group)
+}

--- a/lib/gcpspanner/web_feature_groups_test.go
+++ b/lib/gcpspanner/web_feature_groups_test.go
@@ -1,0 +1,172 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func setupRequiredTablesForWebFeatureGroup(
+	ctx context.Context,
+	t *testing.T,
+) map[string]string {
+	ret := map[string]string{}
+	sampleFeatures := getSampleFeatures()
+	for _, feature := range sampleFeatures {
+		id, err := spannerClient.UpsertWebFeature(ctx, feature)
+		if err != nil {
+			t.Errorf("unexpected error during insert. %s", err.Error())
+
+			continue
+		}
+		ret[feature.FeatureKey] = *id
+	}
+
+	return ret
+}
+
+func (c *Client) createSampleWebFeatureGroups(
+	ctx context.Context, t *testing.T, idMap map[string]string) {
+	err := c.UpsertWebFeatureGroup(ctx, WebFeatureGroup{
+		WebFeatureID: idMap["feature1"],
+		GroupIDs: []string{
+			"group1",
+			"group2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to insert group. err: %s group\n", err)
+	}
+	err = c.UpsertWebFeatureGroup(ctx, WebFeatureGroup{
+		WebFeatureID: idMap["feature2"],
+		GroupIDs:     nil,
+	})
+	if err != nil {
+		t.Fatalf("failed to insert group. err: %s group\n", err)
+	}
+}
+
+func (c *Client) ReadAllWebFeatureGroups(ctx context.Context, _ *testing.T) ([]WebFeatureGroup, error) {
+	stmt := spanner.NewStatement(
+		`SELECT
+			WebFeatureID, GroupIDs
+		FROM WebFeatureGroups`)
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []WebFeatureGroup
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var group spannerWebFeatureGroup
+		if err := row.ToStruct(&group); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		ret = append(ret, group.WebFeatureGroup)
+	}
+
+	return ret, nil
+}
+
+func sortWebFeatureGroups(left, right WebFeatureGroup) int {
+	return cmp.Compare(left.WebFeatureID, right.WebFeatureID)
+}
+
+func webFeatureGroupEquality(left, right WebFeatureGroup) bool {
+	return left.WebFeatureID == right.WebFeatureID &&
+		slices.Equal(left.GroupIDs, right.GroupIDs)
+}
+
+func TestUpsertWebFeatureGroup(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+	idMap := setupRequiredTablesForWebFeatureGroup(ctx, t)
+	spannerClient.createSampleWebFeatureGroups(ctx, t, idMap)
+
+	expected := []WebFeatureGroup{
+		{
+			WebFeatureID: idMap["feature1"],
+			GroupIDs: []string{
+				"group1",
+				"group2",
+			},
+		},
+		{
+			WebFeatureID: idMap["feature2"],
+			GroupIDs:     nil,
+		},
+	}
+	slices.SortFunc(expected, sortWebFeatureGroups)
+
+	groups, err := spannerClient.ReadAllWebFeatureGroups(ctx, t)
+	if err != nil {
+		t.Fatalf("unable to get all groups err: %s", err)
+	}
+	slices.SortFunc(groups, sortWebFeatureGroups)
+
+	if !slices.EqualFunc(expected, groups, webFeatureGroupEquality) {
+		t.Errorf("unequal groups.\nexpected %+v\nreceived %+v", expected, groups)
+	}
+
+	// Upsert group
+	err = spannerClient.UpsertWebFeatureGroup(ctx, WebFeatureGroup{
+		WebFeatureID: idMap["feature2"],
+		GroupIDs: []string{
+			"group3",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unable to update group err: %s", err)
+	}
+
+	expected = []WebFeatureGroup{
+		{
+			WebFeatureID: idMap["feature1"],
+			GroupIDs: []string{
+				"group1",
+				"group2",
+			},
+		},
+		{
+			WebFeatureID: idMap["feature2"],
+			GroupIDs: []string{
+				"group3",
+			},
+		},
+	}
+	slices.SortFunc(expected, sortWebFeatureGroups)
+
+	groups, err = spannerClient.ReadAllWebFeatureGroups(ctx, t)
+	if err != nil {
+		t.Fatalf("unable to get all groups err: %s", err)
+	}
+	slices.SortFunc(groups, sortWebFeatureGroups)
+
+	if !slices.EqualFunc(expected, groups, webFeatureGroupEquality) {
+		t.Errorf("unequal groups.\nexpected %+v\nreceived %+v", expected, groups)
+	}
+}


### PR DESCRIPTION
Depends on #593 

**Description:**

This PR introduces the foundational schema and data access layer for managing WebDX Groups and their associations with Web Features in Spanner. This is the beginning of #299 to support only the groups storage and filtering. (Snapshot schema will come separately)

**Key Changes**

* **Schema:**
   * Created the `WebDXGroups` table to store group metadata.
   * Created the `WebFeatureGroups` table to map web features to their associated groups.
   * Created the `WebDXGroupDescendants` to include the descendant group IDs for efficient querying

* **Data Access Layer:**
   * Implemented `UpsertGroup` and `GetGroupIDFromGroupKey` methods in the `Client` struct to interact with the `WebDXGroups` table.
   * Implemented `UpsertWebFeatureGroup` to manage feature-group mappings in the `WebFeatureGroups` table.
   * Implemeneted `UpsertGroupDescendantInfo` to manage mappings of groups to all descendant groups.
   * Introduced helper structs and mappers (`WebFeatureGroup`, `groupSpannerMapper`, etc.) to facilitate data mapping and persistence.

**Purpose**

* Enables storing and retrieving information about WebDX Groups and their relationships with Web Features.
* Lays the groundwork for future features that rely on group-based organization and filtering.
* Optimizes queries for features associated with a group and its descendants by pre-calculating and storing descendant group IDs.
  * This is useful because if a user queries for a group, it should return the features belonging to children groups too.