### PR TITLE
[3/4] Add Support for Group-Based Feature Search

### DIFF
--- a/antlr/FeatureSearch.g4
+++ b/antlr/FeatureSearch.g4
@@ -31,11 +31,13 @@ available_date_term:
 // In the future support other operators by doing something like (date_operator_query | date_range_query)
 baseline_date_term: 'baseline_date' COLON (date_range_query);
 name_term: 'name' COLON ANY_VALUE;
+group_term: 'group' COLON ANY_VALUE;
 term:
 	available_date_term
 	| available_on_term
 	| baseline_status_term
 	| baseline_date_term
+	| group_term
 	| name_term;
 
 date_range_query: startDate = DATE '..' endDate = DATE;

--- a/antlr/FeatureSearch.md
+++ b/antlr/FeatureSearch.md
@@ -37,6 +37,7 @@ This query language enables you to construct flexible searches to find features 
       - `name:"CSS Grid"`
   - `baseline_date`: Represents the date a feature reached baseline.
     - Option 1: Searches for an inclusive date range (DATE..DATE) where features reached baseline.
+  - `group`: Searches for features that belong to a group defined in the web-features [repository](https://github.com/web-platform-dx/web-features/tree/main/groups).
 - **Negation:** Prepend a term with a minus sign (-) to indicate negation (search for features not matching that criterion).
 - **Keywords:** These are reserved words used in the grammar, such as `AND`, `OR`
   - `AND`: Combine terms with the AND keyword for explicit logical AND, or use a space between terms for implied AND.
@@ -53,6 +54,7 @@ This query language enables you to construct flexible searches to find features 
 - `baseline_status:high` - Find features with a high baseline status.
 - `name:"Dark Mode"` - Find features named "Dark Mode" (including spaces).
 - `baseline_date:2023-01-01..2023-12-31` - Searches for all features that reached baseline in 2023.
+- `group:css` - Searches for features that belong to the `css` group and any groups that are descendants of that group.
 
 ### Complex Queries
 

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -603,6 +603,72 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
+			InputQuery: "group:css",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Children: nil,
+						Term: &SearchTerm{
+							Identifier: IdentifierGroup,
+							Value:      "css",
+							Operator:   OperatorEq,
+						},
+						Keyword: KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: `baseline_date:2000-01-01..2000-12-31 OR group:css`,
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Keyword: KeywordOR,
+						Term:    nil,
+						Children: []*SearchNode{
+							{
+								Keyword: KeywordAND,
+								Term:    nil,
+								Children: []*SearchNode{
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierBaselineDate,
+											Value:      "2000-01-01",
+											Operator:   OperatorGtEq,
+										},
+										Children: nil,
+									},
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierBaselineDate,
+											Value:      "2000-12-31",
+											Operator:   OperatorLtEq,
+										},
+										Children: nil,
+									},
+								},
+							},
+							{
+								Keyword:  KeywordNone,
+								Children: nil,
+								Term: &SearchTerm{
+									Identifier: IdentifierGroup,
+									Value:      "css",
+									Operator:   OperatorEq,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			// Should remove the quotes
 			InputQuery: `name:"CSS Grid"`,
 			ExpectedTree: &SearchNode{

--- a/lib/gcpspanner/searchtypes/features_search_visitor.go
+++ b/lib/gcpspanner/searchtypes/features_search_visitor.go
@@ -128,16 +128,27 @@ func (v *FeaturesSearchVisitor) aggregateNodesImplicitAND(nodes []*SearchNode) *
 	return rootNode
 }
 
+func (v *FeaturesSearchVisitor) createGroupNode(group string) *SearchNode {
+	return v.createSimpleNode(group, IdentifierGroup, OperatorEq)
+}
+
 func (v *FeaturesSearchVisitor) createNameNode(name string) *SearchNode {
-	name = strings.Trim(name, `"`)
+	return v.createSimpleNode(name, IdentifierName, OperatorEq)
+}
+
+func (v *FeaturesSearchVisitor) createSimpleNode(
+	value string,
+	identifier SearchIdentifier,
+	operator SearchOperator) *SearchNode {
+	value = strings.Trim(value, `"`)
 
 	return &SearchNode{
 		Keyword:  KeywordNone,
 		Children: nil,
 		Term: &SearchTerm{
-			Identifier: IdentifierName,
-			Value:      name,
-			Operator:   OperatorEq,
+			Identifier: identifier,
+			Value:      value,
+			Operator:   operator,
 		},
 	}
 }
@@ -371,6 +382,8 @@ func (v *FeaturesSearchVisitor) Visit(tree antlr.ParseTree) any {
 		return v.VisitDate_range_query(tree)
 	case *parser.Generic_search_termContext:
 		return v.VisitGeneric_search_term(tree)
+	case *parser.Group_termContext:
+		return v.VisitGroup_term(tree)
 	case *parser.Name_termContext:
 		return v.VisitName_term(tree)
 	case *parser.OperatorContext:
@@ -424,6 +437,11 @@ func (v *FeaturesSearchVisitor) VisitCombined_search_criteria(ctx *parser.Combin
 	root = current
 
 	return root
+}
+
+// nolint: revive // Method signature is generated.
+func (v *FeaturesSearchVisitor) VisitGroup_term(ctx *parser.Group_termContext) interface{} {
+	return v.createGroupNode(ctx.ANY_VALUE().GetText())
 }
 
 // nolint: revive // Method signature is generated.

--- a/lib/gcpspanner/searchtypes/searchtypes.go
+++ b/lib/gcpspanner/searchtypes/searchtypes.go
@@ -92,4 +92,5 @@ const (
 	IdentifierBaselineDate         SearchIdentifier = "baseline_date"
 	IdentifierBaselineStatus       SearchIdentifier = "baseline_status"
 	IdentifierName                 SearchIdentifier = "name"
+	IdentifierGroup                SearchIdentifier = "group"
 )


### PR DESCRIPTION
Depends on #595 

This PR enhances the feature search functionality by introducing a new `group` query term.  Users can now search for features belonging to a specific group and any of its descendant groups in the web-features repository hierarchy. 

**New Query Functionality**

* Query: `group:css`
* Interpretation: Retrieves features belonging to the "css" group *and* any of its child or descendant groups (e.g., "grid").

**Implementation Details**

* **Grammar Expansion:** The ANTLR4 grammar has been extended to include the `group` query term.
* **Visitor Method:** A new `VisitGroup_term` method has been implemented to handle the parsing and generation of the intermediate representation for group queries.

**Future Considerations**

* While the current implementation includes descendant groups by default, future enhancements could allow users to optionally exclude descendants from the search results.

**Benefits**

* **Enhanced Search Capabilities:** Users can now perform more targeted searches based on the hierarchical organization of features within groups.
* **Improved User Experience:** The new query term provides a more intuitive way to discover features related to a specific domain or area of interest.
