### PR TITLE
Update DEPLOYMENT.md

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -34,6 +34,7 @@ instructions assume you have access to the following projects:
 ## Deploying your own copy
 
 ```sh
+make build
 cd infra
 gcloud auth login
 gcloud auth application-default login --project=web-compass-staging
@@ -98,6 +99,7 @@ terraform workspace delete $ENV_ID
 ## Deploy Staging
 
 ```sh
+make build
 cd infra
 gcloud auth login
 gcloud auth application-default login --project=web-compass-staging
@@ -130,6 +132,7 @@ terraform apply \
 ## Deploy Prod
 
 ```sh
+make build
 cd infra
 gcloud auth login
 gcloud auth application-default login --project=web-compass-prod


### PR DESCRIPTION
In the event, the person doing the deployment pulled in changes to anything that is auto-generated, they could have autodated generated files. This could cause the build to fail or push up autodated files. This adds a command to run to remedy that in the DEPLOYMENT readme.