### PR TITLE
[1/5] Add support for WebDX Snapshot & Feature-Snapshot Mappings

### DIFF
--- a/infra/storage/spanner/migrations/000007.sql
+++ b/infra/storage/spanner/migrations/000007.sql
@@ -1,0 +1,32 @@
+-- Copyright 2024 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Snapshots contains basic metadata about snapshots from the WebDX web features repository.
+CREATE TABLE IF NOT EXISTS WebDXSnapshots (
+    ID STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
+    SnapshotKey STRING(64) NOT NULL,
+    Name STRING(64) NOT NULL,
+    -- Additional lowercase columns for case-insensitive search
+    SnapshotKey_Lowercase STRING(64) AS (LOWER(SnapshotKey)) STORED,
+    Name_Lowercase STRING(64) AS (LOWER(Name)) STORED,
+) PRIMARY KEY (ID);
+
+-- Maps web features to snapshots.
+CREATE TABLE IF NOT EXISTS WebFeatureSnapshots (
+    WebFeatureID STRING(36) NOT NULL,
+    -- Stores an array of Snapshot IDs associated with this web feature.
+    -- Each feature does not belong to many snapshots. For now, keep them here.
+    SnapshotIDs ARRAY<STRING(36)>,
+    FOREIGN KEY (WebFeatureID) REFERENCES WebFeatures(ID)  ON DELETE CASCADE
+) PRIMARY KEY (WebFeatureID);

--- a/lib/gcpspanner/snapshots.go
+++ b/lib/gcpspanner/snapshots.go
@@ -1,0 +1,101 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+)
+
+const snapshotsTable = "WebDXSnapshots"
+
+// Snapshot contains common metadata for a snapshot from the WebDX web-feature
+// repository.
+// Columns come from the ../../infra/storage/spanner/migrations/*.sql files.
+type Snapshot struct {
+	SnapshotKey string `spanner:"SnapshotKey"`
+	Name        string `spanner:"Name"`
+}
+
+// spannerSnapshot is a wrapper for the Snapshot that is actually
+// stored in spanner. This is useful because the spanner id is not useful to
+// return to the end user since it is only used to decouple the primary keys
+// between this system and web features repo.
+type spannerSnapshot struct {
+	ID string `spanner:"ID"`
+	Snapshot
+}
+
+// Implements the entityMapper interface for Snapshot and SpannerSnapshot.
+type snapshotSpannerMapper struct{}
+
+func (m snapshotSpannerMapper) Merge(in Snapshot, existing spannerSnapshot) spannerSnapshot {
+	return spannerSnapshot{
+		ID: existing.ID,
+		Snapshot: Snapshot{
+			Name:        cmp.Or(in.Name, existing.Name),
+			SnapshotKey: existing.SnapshotKey,
+		},
+	}
+}
+
+func (m snapshotSpannerMapper) GetKey(in Snapshot) string {
+	return in.SnapshotKey
+}
+
+func (m snapshotSpannerMapper) SelectOne(key string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ID, SnapshotKey, Name
+	FROM %s
+	WHERE SnapshotKey = @snapshotKey
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"snapshotKey": key,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (m snapshotSpannerMapper) Table() string {
+	return snapshotsTable
+}
+
+func (m snapshotSpannerMapper) GetID(key string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ID
+	FROM %s
+	WHERE SnapshotKey = @snapshotKey
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"snapshotKey": key,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (c *Client) UpsertSnapshot(ctx context.Context, snapshot Snapshot) (*string, error) {
+	return newEntityWriterWithIDRetrieval[snapshotSpannerMapper, string](c).upsertAndGetID(ctx, snapshot)
+}
+
+func (c *Client) GetSnapshotIDFromSnapshotKey(ctx context.Context, snapshotKey string) (*string, error) {
+	return newEntityWriterWithIDRetrieval[snapshotSpannerMapper, string](c).getIDByKey(ctx, snapshotKey)
+}

--- a/lib/gcpspanner/snapshots_test.go
+++ b/lib/gcpspanner/snapshots_test.go
@@ -1,0 +1,137 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func (c *Client) createSampleSnapshots(ctx context.Context, t *testing.T) map[string]string {
+	snapshot1 := Snapshot{
+		SnapshotKey: "snapshot1",
+		Name:        "Snapshot 1",
+	}
+	snapshot2 := Snapshot{
+		SnapshotKey: "snapshot2",
+		Name:        "Snapshot 2",
+	}
+	snapshot1ID, err := c.UpsertSnapshot(ctx, snapshot1)
+	if err != nil {
+		t.Fatalf("failed to insert snapshot. err: %s snapshot: %v\n", err, snapshot1)
+	}
+	snapshot2ID, err := c.UpsertSnapshot(ctx, snapshot2)
+	if err != nil {
+		t.Fatalf("failed to insert snapshot. err: %s snapshot: %v\n", err, snapshot2)
+	}
+
+	return map[string]string{
+		snapshot1.SnapshotKey: *snapshot1ID,
+		snapshot2.SnapshotKey: *snapshot2ID,
+	}
+}
+
+func (c *Client) ReadAllSnapshots(ctx context.Context, _ *testing.T) ([]Snapshot, error) {
+	stmt := spanner.NewStatement(
+		`SELECT
+			ID, SnapshotKey, Name
+		FROM WebDXSnapshots ORDER BY SnapshotKey ASC`)
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []Snapshot
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var snapshot spannerSnapshot
+		if err := row.ToStruct(&snapshot); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		ret = append(ret, snapshot.Snapshot)
+	}
+
+	return ret, nil
+}
+
+func TestUpsertSnapshot(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+	_ = spannerClient.createSampleSnapshots(ctx, t)
+
+	snapshots, err := spannerClient.ReadAllSnapshots(ctx, t)
+	if err != nil {
+		t.Fatalf("unable to get all snapshots err: %s", err)
+	}
+
+	expectedSnapshots := []Snapshot{
+		{
+			SnapshotKey: "snapshot1",
+			Name:        "Snapshot 1",
+		},
+		{
+			SnapshotKey: "snapshot2",
+			Name:        "Snapshot 2",
+		},
+	}
+
+	if !slices.EqualFunc(expectedSnapshots, snapshots, snapshotEquality) {
+		t.Errorf("unequal snapshots.\nexpected %+v\nreceived %+v", expectedSnapshots, snapshots)
+	}
+
+	// Change one of the snapshots
+	_, err = spannerClient.UpsertSnapshot(ctx, Snapshot{
+		SnapshotKey: "snapshot2",
+		// Change the name
+		Name: "Snapshot 2 edit",
+	})
+	if err != nil {
+		t.Errorf("unable to edit the snapshot %s", err)
+	}
+
+	expectedSnapshots = []Snapshot{
+		{
+			SnapshotKey: "snapshot1",
+			Name:        "Snapshot 1",
+		},
+		{
+			SnapshotKey: "snapshot2",
+			Name:        "Snapshot 2 edit",
+		},
+	}
+
+	snapshots, err = spannerClient.ReadAllSnapshots(ctx, t)
+	if err != nil {
+		t.Fatalf("unable to get all snapshots err: %s", err)
+	}
+
+	if !slices.EqualFunc(expectedSnapshots, snapshots, snapshotEquality) {
+		t.Errorf("unequal snapshots.\nexpected %+v\nreceived %+v", expectedSnapshots, snapshots)
+	}
+}
+
+func snapshotEquality(left, right Snapshot) bool {
+	return left.Name == right.Name &&
+		left.SnapshotKey == right.SnapshotKey
+}

--- a/lib/gcpspanner/web_feature_groups_test.go
+++ b/lib/gcpspanner/web_feature_groups_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint:dupl // WONTFIX
 package gcpspanner
 
 import (

--- a/lib/gcpspanner/web_feature_snapshots.go
+++ b/lib/gcpspanner/web_feature_snapshots.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+)
+
+const webFeatureSnapshotsTable = "WebFeatureSnapshots"
+
+// WebFeatureSnapshot contains the mapping between WebDXSnapshots and WebFeatures.
+// Columns come from the ../../infra/storage/spanner/migrations/*.sql files.
+type WebFeatureSnapshot struct {
+	WebFeatureID string   `spanner:"WebFeatureID"`
+	SnapshotIDs  []string `spanner:"SnapshotIDs"`
+}
+
+// SpannerWebFeatureSnapshot is a wrapper for the WebFeatureSnapshot that is actually
+// stored in spanner.
+type spannerWebFeatureSnapshot struct {
+	WebFeatureSnapshot
+}
+
+// Implements the Mapping interface for WebFeatureSnapshot and SpannerWebFeatureSnapshot.
+type webFeaturesSnapshotSpannerMapper struct{}
+
+func (m webFeaturesSnapshotSpannerMapper) GetKey(in WebFeatureSnapshot) string {
+	return in.WebFeatureID
+}
+
+func (m webFeaturesSnapshotSpannerMapper) Table() string {
+	return webFeatureSnapshotsTable
+}
+
+func (m webFeaturesSnapshotSpannerMapper) Merge(
+	in WebFeatureSnapshot, existing spannerWebFeatureSnapshot) spannerWebFeatureSnapshot {
+	var snapshotIDs []string
+	if in.SnapshotIDs != nil {
+		snapshotIDs = in.SnapshotIDs
+	} else {
+		snapshotIDs = existing.SnapshotIDs
+	}
+
+	return spannerWebFeatureSnapshot{
+		WebFeatureSnapshot: WebFeatureSnapshot{
+			WebFeatureID: existing.WebFeatureID,
+			SnapshotIDs:  snapshotIDs,
+		},
+	}
+}
+
+func (m webFeaturesSnapshotSpannerMapper) SelectOne(id string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		WebFeatureID, SnapshotIDs
+	FROM %s
+	WHERE WebFeatureID = @webFeatureID
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"webFeatureID": id,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (c *Client) UpsertWebFeatureSnapshot(ctx context.Context, snapshot WebFeatureSnapshot) error {
+	return newEntityWriter[webFeaturesSnapshotSpannerMapper](c).upsert(ctx, snapshot)
+}

--- a/lib/gcpspanner/web_feature_snapshots_test.go
+++ b/lib/gcpspanner/web_feature_snapshots_test.go
@@ -1,0 +1,173 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint:dupl // WONTFIX
+package gcpspanner
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func setupRequiredTablesForWebFeatureSnapshot(
+	ctx context.Context,
+	t *testing.T,
+) map[string]string {
+	ret := map[string]string{}
+	sampleFeatures := getSampleFeatures()
+	for _, feature := range sampleFeatures {
+		id, err := spannerClient.UpsertWebFeature(ctx, feature)
+		if err != nil {
+			t.Errorf("unexpected error during insert. %s", err.Error())
+
+			continue
+		}
+		ret[feature.FeatureKey] = *id
+	}
+
+	return ret
+}
+
+func (c *Client) createSampleWebFeatureSnapshots(
+	ctx context.Context, t *testing.T, idMap map[string]string) {
+	err := c.UpsertWebFeatureSnapshot(ctx, WebFeatureSnapshot{
+		WebFeatureID: idMap["feature1"],
+		SnapshotIDs: []string{
+			"snapshot1",
+			"snapshot2",
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to insert snapshot. err: %s snapshot\n", err)
+	}
+	err = c.UpsertWebFeatureSnapshot(ctx, WebFeatureSnapshot{
+		WebFeatureID: idMap["feature2"],
+		SnapshotIDs:  nil,
+	})
+	if err != nil {
+		t.Fatalf("failed to insert snapshot. err: %s snapshot\n", err)
+	}
+}
+
+func (c *Client) ReadAllWebFeatureSnapshots(ctx context.Context, _ *testing.T) ([]WebFeatureSnapshot, error) {
+	stmt := spanner.NewStatement(
+		`SELECT
+			WebFeatureID, SnapshotIDs
+		FROM WebFeatureSnapshots`)
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []WebFeatureSnapshot
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var snapshot spannerWebFeatureSnapshot
+		if err := row.ToStruct(&snapshot); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		ret = append(ret, snapshot.WebFeatureSnapshot)
+	}
+
+	return ret, nil
+}
+
+func sortWebFeatureSnapshots(left, right WebFeatureSnapshot) int {
+	return cmp.Compare(left.WebFeatureID, right.WebFeatureID)
+}
+
+func webFeatureSnapshotEquality(left, right WebFeatureSnapshot) bool {
+	return left.WebFeatureID == right.WebFeatureID &&
+		slices.Equal(left.SnapshotIDs, right.SnapshotIDs)
+}
+
+func TestUpsertWebFeatureSnapshot(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+	idMap := setupRequiredTablesForWebFeatureSnapshot(ctx, t)
+	spannerClient.createSampleWebFeatureSnapshots(ctx, t, idMap)
+
+	expected := []WebFeatureSnapshot{
+		{
+			WebFeatureID: idMap["feature1"],
+			SnapshotIDs: []string{
+				"snapshot1",
+				"snapshot2",
+			},
+		},
+		{
+			WebFeatureID: idMap["feature2"],
+			SnapshotIDs:  nil,
+		},
+	}
+	slices.SortFunc(expected, sortWebFeatureSnapshots)
+
+	snapshots, err := spannerClient.ReadAllWebFeatureSnapshots(ctx, t)
+	if err != nil {
+		t.Fatalf("unable to get all snapshots err: %s", err)
+	}
+	slices.SortFunc(snapshots, sortWebFeatureSnapshots)
+
+	if !slices.EqualFunc(expected, snapshots, webFeatureSnapshotEquality) {
+		t.Errorf("unequal snapshots.\nexpected %+v\nreceived %+v", expected, snapshots)
+	}
+
+	// Upsert snapshot
+	err = spannerClient.UpsertWebFeatureSnapshot(ctx, WebFeatureSnapshot{
+		WebFeatureID: idMap["feature2"],
+		SnapshotIDs: []string{
+			"snapshot3",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unable to update snapshot err: %s", err)
+	}
+
+	expected = []WebFeatureSnapshot{
+		{
+			WebFeatureID: idMap["feature1"],
+			SnapshotIDs: []string{
+				"snapshot1",
+				"snapshot2",
+			},
+		},
+		{
+			WebFeatureID: idMap["feature2"],
+			SnapshotIDs: []string{
+				"snapshot3",
+			},
+		},
+	}
+	slices.SortFunc(expected, sortWebFeatureSnapshots)
+
+	snapshots, err = spannerClient.ReadAllWebFeatureSnapshots(ctx, t)
+	if err != nil {
+		t.Fatalf("unable to get all snapshots err: %s", err)
+	}
+	slices.SortFunc(snapshots, sortWebFeatureSnapshots)
+
+	if !slices.EqualFunc(expected, snapshots, webFeatureSnapshotEquality) {
+		t.Errorf("unequal snapshots.\nexpected %+v\nreceived %+v", expected, snapshots)
+	}
+}


### PR DESCRIPTION
**Description:**

This PR introduces the foundational schema and data access layer for managing WebDX Snapshots and their associations with Web Features in Spanner. This is the second half of #299 to support only the snapshot storage and filtering.

**Note**: Unlike groups, snapshots do not have any hierarchy. So it is a little simpler.

**Key Changes**

* **Schema:**
   * Created the `WebDXSnapshots` table to store snapshot metadata.
   * Created the `WebFeatureSnapshots` table to map web features to their associated snapshots.

* **Data Access Layer:**
   * Implemented `UpsertSnapshot` and `GetSnapshotIDFromSnapshotKey` methods in the `Client` struct to interact with the `WebDXSnapshots` table.
   * Implemented `UpsertWebFeatureSnapshot` to manage feature-snapshot mappings in the `WebFeatureSnapshots` table.
   * Introduced helper structs and mappers (`WebFeatureSnapshot`, `snapshotSpannerMapper`, etc.) to facilitate data mapping and persistence.

**Purpose**

* Enables storing and retrieving information about WebDX Snapshots and their relationships with Web Features.
* Lays the groundwork for future features that rely on snapshot-based storage and filtering.