### PR TITLE
[3/5] Add Support for Snapshot-Based Feature Search

### DIFF
--- a/antlr/FeatureSearch.g4
+++ b/antlr/FeatureSearch.g4
@@ -32,12 +32,14 @@ available_date_term:
 baseline_date_term: 'baseline_date' COLON (date_range_query);
 name_term: 'name' COLON ANY_VALUE;
 group_term: 'group' COLON ANY_VALUE;
+snapshot_term: 'snapshot' COLON ANY_VALUE;
 term:
 	available_date_term
 	| available_on_term
 	| baseline_status_term
 	| baseline_date_term
 	| group_term
+	| snapshot_term
 	| name_term;
 
 date_range_query: startDate = DATE '..' endDate = DATE;

--- a/antlr/FeatureSearch.md
+++ b/antlr/FeatureSearch.md
@@ -38,6 +38,7 @@ This query language enables you to construct flexible searches to find features 
   - `baseline_date`: Represents the date a feature reached baseline.
     - Option 1: Searches for an inclusive date range (DATE..DATE) where features reached baseline.
   - `group`: Searches for features that belong to a group defined in the web-features [repository](https://github.com/web-platform-dx/web-features/tree/main/groups).
+  - `snapshot`: Searches for features that belong to a snapshot defined in the web-features [repository](https://github.com/web-platform-dx/web-features/tree/main/snapshots).
 - **Negation:** Prepend a term with a minus sign (-) to indicate negation (search for features not matching that criterion).
 - **Keywords:** These are reserved words used in the grammar, such as `AND`, `OR`
   - `AND`: Combine terms with the AND keyword for explicit logical AND, or use a space between terms for implied AND.
@@ -55,6 +56,7 @@ This query language enables you to construct flexible searches to find features 
 - `name:"Dark Mode"` - Find features named "Dark Mode" (including spaces).
 - `baseline_date:2023-01-01..2023-12-31` - Searches for all features that reached baseline in 2023.
 - `group:css` - Searches for features that belong to the `css` group and any groups that are descendants of that group.
+- `snapshot:ecmascript-5` - Searches for features that belong to the `ecmascript-5` snapshot.
 
 ### Complex Queries
 

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -669,6 +669,72 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
+			InputQuery: "snapshot:ecmascript-5",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Children: nil,
+						Term: &SearchTerm{
+							Identifier: IdentifierSnapshot,
+							Value:      "ecmascript-5",
+							Operator:   OperatorEq,
+						},
+						Keyword: KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: `baseline_date:2000-01-01..2000-12-31 OR snapshot:ecmascript-5`,
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Keyword: KeywordOR,
+						Term:    nil,
+						Children: []*SearchNode{
+							{
+								Keyword: KeywordAND,
+								Term:    nil,
+								Children: []*SearchNode{
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierBaselineDate,
+											Value:      "2000-01-01",
+											Operator:   OperatorGtEq,
+										},
+										Children: nil,
+									},
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierBaselineDate,
+											Value:      "2000-12-31",
+											Operator:   OperatorLtEq,
+										},
+										Children: nil,
+									},
+								},
+							},
+							{
+								Keyword:  KeywordNone,
+								Children: nil,
+								Term: &SearchTerm{
+									Identifier: IdentifierSnapshot,
+									Value:      "ecmascript-5",
+									Operator:   OperatorEq,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			// Should remove the quotes
 			InputQuery: `name:"CSS Grid"`,
 			ExpectedTree: &SearchNode{

--- a/lib/gcpspanner/searchtypes/features_search_visitor.go
+++ b/lib/gcpspanner/searchtypes/features_search_visitor.go
@@ -128,6 +128,10 @@ func (v *FeaturesSearchVisitor) aggregateNodesImplicitAND(nodes []*SearchNode) *
 	return rootNode
 }
 
+func (v *FeaturesSearchVisitor) createSnapshotNode(snapshot string) *SearchNode {
+	return v.createSimpleNode(snapshot, IdentifierSnapshot, OperatorEq)
+}
+
 func (v *FeaturesSearchVisitor) createGroupNode(group string) *SearchNode {
 	return v.createSimpleNode(group, IdentifierGroup, OperatorEq)
 }
@@ -437,6 +441,11 @@ func (v *FeaturesSearchVisitor) VisitCombined_search_criteria(ctx *parser.Combin
 	root = current
 
 	return root
+}
+
+// nolint: revive // Method signature is generated.
+func (v *FeaturesSearchVisitor) VisitSnapshot_term(ctx *parser.Snapshot_termContext) interface{} {
+	return v.createSnapshotNode(ctx.ANY_VALUE().GetText())
 }
 
 // nolint: revive // Method signature is generated.

--- a/lib/gcpspanner/searchtypes/searchtypes.go
+++ b/lib/gcpspanner/searchtypes/searchtypes.go
@@ -93,4 +93,5 @@ const (
 	IdentifierBaselineStatus       SearchIdentifier = "baseline_status"
 	IdentifierName                 SearchIdentifier = "name"
 	IdentifierGroup                SearchIdentifier = "group"
+	IdentifierSnapshot             SearchIdentifier = "snapshot"
 )


### PR DESCRIPTION
Depends on #600 

This PR enhances the feature search functionality by introducing a new `snapshot` query term.  Users can now search for features belonging to a specific snapshot in the web-features repository hierarchy.

**New Query Functionality**

* Query: `snapshot:ecmascript-5`
* Interpretation: Retrieves features belonging to the "ecmascript-5" snapshot.

**Implementation Details**

* **Grammar Expansion:** The ANTLR4 grammar has been extended to include the `snapshot` query term.
* **Visitor Method:** A new `VisitSnapshot_term` method has been implemented to handle the parsing and generation of the intermediate representation for snapshot queries.