### PR TITLE
Typing slash focuses on searchbox.

### DIFF
--- a/e2e/tests/overview-page.spec.ts
+++ b/e2e/tests/overview-page.spec.ts
@@ -225,3 +225,15 @@ test('Export to CSV button fails to download file and shows toast', async ({
   const toast = page.locator('.toast');
   await toast.waitFor({state: 'visible'});
 });
+
+test('Typing slash focuses on searchbox', async ({page}) => {
+  await gotoOverviewPageUrl(page, 'http://localhost:5555/');
+  const searchbox = page.locator('#inputfield');
+  await expect(searchbox).toBeVisible();
+  await expect(searchbox).toHaveAttribute('value', '');
+  await page.keyboard.type('abc/def/ghi');
+  // Characters before the first slash go to the page.
+  // The slash focuses on the searchbox.
+  // Later characters, including slashes, go in the searchbox.
+  await expect(searchbox).toHaveAttribute('value', 'def/ghi');
+});

--- a/frontend/src/static/js/components/webstatus-overview-filters.ts
+++ b/frontend/src/static/js/components/webstatus-overview-filters.ts
@@ -141,23 +141,27 @@ export class WebstatusOverviewFilters extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
-    document.addEventListener('keyup', this.handleDocumentKeyUp)
+    document.addEventListener('keyup', this.handleDocumentKeyUp);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-      document.removeEventListener('keyup', this.handleDocumentKeyUp);
+    document.removeEventListener('keyup', this.handleDocumentKeyUp);
   }
 
   handleDocumentKeyUp = (e: KeyboardEvent) => {
-      const inInputContext = e.composedPath().some((el) =>
-          ['INPUT', 'TEXTAREA', 'SL-POPUP', 'SL-DIALOG'].includes(
-              (el as HTMLElement).tagName));
-      if (e.key === '/' && !inInputContext) {
-          e.preventDefault();
-          e.stopPropagation();
-          (this.typeaheadRef?.value as WebstatusTypeahead).focus();
-      }
+    const inInputContext = e
+      .composedPath()
+      .some(el =>
+        ['INPUT', 'TEXTAREA', 'SL-POPUP', 'SL-DIALOG'].includes(
+          (el as HTMLElement).tagName
+        )
+      );
+    if (e.key === '/' && !inInputContext) {
+      e.preventDefault();
+      e.stopPropagation();
+      (this.typeaheadRef?.value as WebstatusTypeahead).focus();
+    }
   };
 
   gotoFilterQueryString(): void {

--- a/frontend/src/static/js/components/webstatus-overview-filters.ts
+++ b/frontend/src/static/js/components/webstatus-overview-filters.ts
@@ -139,6 +139,27 @@ export class WebstatusOverviewFilters extends LitElement {
     ];
   }
 
+  connectedCallback(): void {
+    super.connectedCallback();
+    document.addEventListener('keyup', this.handleDocumentKeyUp)
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+      document.removeEventListener('keyup', this.handleDocumentKeyUp);
+  }
+
+  handleDocumentKeyUp = (e: KeyboardEvent) => {
+      const inInputContext = e.composedPath().some((el) =>
+          ['INPUT', 'TEXTAREA', 'SL-POPUP', 'SL-DIALOG'].includes(
+              (el as HTMLElement).tagName));
+      if (e.key === '/' && !inInputContext) {
+          e.preventDefault();
+          e.stopPropagation();
+          (this.typeaheadRef?.value as WebstatusTypeahead).focus();
+      }
+  };
+
   gotoFilterQueryString(): void {
     const newUrl = formatOverviewPageUrl(this.location, {
       q: (this.typeaheadRef.value as WebstatusTypeahead).value,

--- a/frontend/src/static/js/components/webstatus-typeahead.ts
+++ b/frontend/src/static/js/components/webstatus-typeahead.ts
@@ -134,6 +134,16 @@ export class WebstatusTypeahead extends LitElement {
     (this.slDropdownRef.value as SlDropdown).show();
   }
 
+  focus() {
+    const slInput: SlInput = this.slInputRef.value as SlInput;
+    slInput?.focus();
+  }
+
+  blur() {
+    const slInput: SlInput = this.slInputRef.value as SlInput;
+    slInput?.blur();
+  }
+
   findPrefix() {
     const inputEl = (this.slInputRef.value as SlInput).input;
     const wholeStr = inputEl!.value;


### PR DESCRIPTION
This should resolve #261.  The webstatus-overview-filters element now adds a document keyup listener that looks for a `/` key pressed while the user is not in a dialog, menu, input, or textarea.  