### PR TITLE
Fix new lint error and warning

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,7 +33,7 @@ linters:
     - errorlint
     - exhaustive
     - exhaustruct
-    - exportloopref
+    - copyloopvar
     - gochecknoglobals
     - gocognit
     - goconst

--- a/workflows/steps/services/common/repo_downloader/pkg/targz/archive.go
+++ b/workflows/steps/services/common/repo_downloader/pkg/targz/archive.go
@@ -17,21 +17,23 @@ package targz
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"io"
+	"math"
 	"path/filepath"
 	"strings"
 )
 
 const (
-	defaultStripComponents uint = 1
-	minStripComonents      int  = 0
-	maxStripComonents      int  = 1
+	defaultStripComponents uint32 = 1
+	minStripComonents      int    = 0
+	maxStripComonents      int    = 1
 )
 
 type ArchiveIteartor struct {
 	gzipReader      *gzip.Reader
 	tarReader       *tar.Reader
-	stripComponents uint
+	stripComponents uint32
 }
 
 type ArchiveFile struct {
@@ -85,7 +87,11 @@ func NewTarGzArchiveIterator(reader io.ReadCloser, stripComponentsInput *int) (*
 	if stripComponentsInput != nil &&
 		(*stripComponentsInput >= minStripComonents &&
 			*stripComponentsInput <= maxStripComonents) {
-		stripComponents = uint(*stripComponentsInput)
+		value := *stripComponentsInput
+		if value < 0 || value > math.MaxUint32 {
+			return nil, errors.New("overflow")
+		}
+		stripComponents = uint32(value)
 	}
 	tarReader := tar.NewReader(gzip)
 


### PR DESCRIPTION
golangci-lint recently updated. It flags one error and one warning.

The error is an overflow error. You can see examples of how to fix it in the linter itself [1]. This change adds the bounds check which satisfies the linter.

The warning was to let us know that linter was deprecated and to switch to another. This change does that.

[1] https://github.com/securego/gosec/pull/1194/files#diff-f7279b9a692123f375cfadc43e1cd48a2b1679b908b90a84a9d6b151a854b745