### PR TITLE
Helper to get credentials while on GCP infra

### DIFF
--- a/lib/auth/gcp_token_generator.go
+++ b/lib/auth/gcp_token_generator.go
@@ -1,0 +1,52 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/idtoken"
+	"google.golang.org/api/option"
+)
+
+// GCPTokenGenerator generates an authentication token for processes running inside GCP.
+type GCPTokenGenerator struct{}
+
+// Taken from https://cloud.google.com/docs/authentication/get-id-token#metadata-server
+func (g GCPTokenGenerator) Generate(ctx context.Context, url string) (*string, error) {
+	// Construct the GoogleCredentials object which obtains the default configuration from your
+	// working environment.
+	credentials, err := google.FindDefaultCredentials(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate default credentials: %w", err)
+	}
+
+	ts, err := idtoken.NewTokenSource(ctx, url, option.WithCredentials(credentials))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create NewTokenSource: %w", err)
+	}
+
+	// Get the ID token.
+	// Once you've obtained the ID token, you can use it to make an authenticated call
+	// to the target audience.
+	token, err := ts.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to receive token: %w", err)
+	}
+
+	return &token.AccessToken, nil
+}

--- a/lib/auth/gcp_token_generator_test.go
+++ b/lib/auth/gcp_token_generator_test.go
@@ -1,0 +1,35 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+// An optional integration test to show that the library can get a token for a particular GCP resource.
+func TestGCPTokenGenerator_Generate(t *testing.T) {
+	// According to the docs, this will not work locally. Has to be run on GCP infrastructure.
+	// https://cloud.google.com/docs/authentication/get-id-token#metadata-server
+	t.Skip("need to be logged in with GCP to run this test. Skip by default")
+	generator := GCPTokenGenerator{}
+	token, err := generator.Generate(context.Background(), "https://uma-export.appspot.com/webstatus/")
+	if err != nil {
+		t.Errorf("unable to get token, err %s", err)
+	}
+	if token == nil {
+		t.Error("expected non nil token")
+	}
+}

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -140,7 +140,7 @@ require (
 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
-	golang.org/x/oauth2 v0.22.0 // indirect
+	golang.org/x/oauth2 v0.22.0
 	golang.org/x/sync v0.8.0 // indirect
 	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/text v0.17.0 // indirect


### PR DESCRIPTION
This helper code is taken directly from
https://cloud.google.com/docs/authentication/get-id-token#metadata-server

It will be needed by the uma export service that will come in a future PR (you can see it in action in #616). This is similar to the fetch_id_token that happens on [ChromeStatus](https://github.com/GoogleChrome/chromium-dashboard/blob/8fd512af666290e13173176268b9a4e28bbc9c63/internals/fetchmetrics.py#L53)

FindCredentials is a method to get credentials from the metadata-server (found only when on GCP infra). As a result, there is a skipped test that will need to be run directly on GCP infra. (helpful if we move to GCP Cloud Build)