### PR TITLE
Fetch and parse histogram enum files

### DIFF
--- a/workflows/steps/services/chromium_histogram_enums/go.mod
+++ b/workflows/steps/services/chromium_histogram_enums/go.mod
@@ -5,3 +5,5 @@ go 1.23.0
 replace github.com/GoogleChrome/webstatus.dev/lib => ../../../../lib
 
 replace github.com/GoogleChrome/webstatus.dev/lib/gen => ../../../../lib/gen
+
+require github.com/GoogleChrome/webstatus.dev/lib v0.0.0-00010101000000-000000000000

--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+)
+
+func NewChromiumCodesearchEnumFetcher(httpClient *http.Client) (*ChromiumCodesearchEnumFetcher, error) {
+	u, err := url.Parse(enumURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ChromiumCodesearchEnumFetcher{
+		httpClient: httpClient,
+		enumURL:    u,
+	}, nil
+}
+
+// ChromiumCodesearchEnumFetcher fetches the enums from Chromium code search.
+// The returned data will be base64 encoded and it is up the consumer to decode
+// before reading.
+type ChromiumCodesearchEnumFetcher struct {
+	httpClient *http.Client
+	enumURL    *url.URL
+}
+
+const enumURL = "https://chromium.googlesource.com/chromium/src/+/main/tools/metrics/histograms/enums.xml?format=TEXT"
+
+func (f ChromiumCodesearchEnumFetcher) Fetch(ctx context.Context) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.enumURL.String(), nil)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to create request", "error", err)
+
+		return nil, err
+	}
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Clean up by closing since we will not be returning the body
+		resp.Body.Close()
+
+		return nil, err
+	}
+
+	return resp.Body, nil
+}

--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher_test.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher_test.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// This is more of an integration test to ensure the data is actually base64 encoded.
+func TestChromiumCodesearchEnumFetcher_Fetch_Base64Encoded(t *testing.T) {
+	ctx := context.Background()
+	httpClient := http.DefaultClient
+	fetcher, err := NewChromiumCodesearchEnumFetcher(httpClient)
+	if err != nil {
+		t.Fatalf("Failed to create fetcher: %v", err)
+	}
+
+	reader, err := fetcher.Fetch(ctx)
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+	defer reader.Close()
+
+	// Read the fetched data into a buffer
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, reader)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
+	fetchedData := buf.String()
+
+	// Attempt to decode the fetched data as base64
+	b, err := base64.StdEncoding.DecodeString(fetchedData)
+	if err != nil {
+		t.Errorf("Fetched data is not valid base64: %v\nData:\n%s", err, string(b))
+	}
+}

--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_parser.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_parser.go
@@ -101,8 +101,8 @@ func (p ChromiumCodesearchEnumParser) Parse(
 			}
 
 			enums = append(enums, metricdatatypes.HistogramEnumValue{
-				BucketID: value.Value,
-				Label:    value.Label,
+				Value: value.Value,
+				Label: value.Label,
 			})
 		}
 		m[metricdatatypes.HistogramName(histogram.Name)] = enums

--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_parser.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_parser.go
@@ -1,0 +1,122 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/xml"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+// ChromiumCodesearchEnumFetcher parses the enums from Chromium code search.
+// It expects the base64 encoded stream from ChromiumCodesearchEnumFetcher.
+type ChromiumCodesearchEnumParser struct{}
+
+type HistogramConfiguration struct {
+	XMLName xml.Name       `xml:"histogram-configuration"`
+	Enums   HistogramEnums `xml:"enums"`
+}
+
+type HistogramEnums struct {
+	XMLName    xml.Name    `xml:"enums"`
+	Histograms []Histogram `xml:"enum"`
+}
+
+type Histogram struct {
+	XMLName xml.Name `xml:"enum"`
+	Name    string   `xml:"name,attr"`
+
+	Values []HistogramInt `xml:"int"`
+}
+
+type HistogramInt struct {
+	XMLName xml.Name `xml:"int"`
+	Value   int64    `xml:"value,attr"`
+	Label   string   `xml:"label,attr"`
+}
+
+var (
+	errMissingHistogram = errors.New("unable to find histogram")
+)
+
+// Inspired by the get_template_data method on the HistogramsHandler class
+// https://github.com/GoogleChrome/chromium-dashboard/blob/main/internals/fetchmetrics.py
+func (p ChromiumCodesearchEnumParser) Parse(
+	ctx context.Context,
+	encodedData io.ReadCloser,
+	filteredHistogramEnums []metricdatatypes.HistogramName) (metricdatatypes.HistogramMapping, error) {
+	defer encodedData.Close()
+	rawDataDecoder := base64.NewDecoder(base64.StdEncoding, encodedData)
+	xmlDataDecoder := xml.NewDecoder(rawDataDecoder)
+	var config HistogramConfiguration
+	err := xmlDataDecoder.Decode(&config)
+	if err != nil {
+		slog.ErrorContext(ctx, "error decoding xml", "error", err)
+
+		return nil, err
+	}
+	m := make(metricdatatypes.HistogramMapping)
+	for _, filteredHistogramEnum := range filteredHistogramEnums {
+		m[filteredHistogramEnum] = nil
+	}
+	for _, histogram := range config.Enums.Histograms {
+
+		histogramName := metricdatatypes.HistogramName(histogram.Name)
+		_, found := m[histogramName]
+		if !found {
+			continue
+		}
+		var bucketIDToSkip *int64
+		switch histogramName {
+		case metricdatatypes.WebDXFeatureEnum:
+			bucketIDToSkip = valuePtr[int64](0)
+		}
+		enums := []metricdatatypes.HistogramEnumValue{}
+		for _, value := range histogram.Values {
+
+			if bucketIDToSkip != nil && *bucketIDToSkip == value.Value {
+				continue
+			}
+			// Skip labels with DRAFT_ prefix
+			if strings.HasPrefix(value.Label, "DRAFT_") {
+				continue
+			}
+
+			enums = append(enums, metricdatatypes.HistogramEnumValue{
+				BucketID: value.Value,
+				Label:    value.Label,
+			})
+		}
+		m[metricdatatypes.HistogramName(histogram.Name)] = enums
+	}
+
+	for key, value := range m {
+		if len(value) == 0 {
+			slog.ErrorContext(ctx, "unable to find histogram", "name", key)
+
+			return nil, errMissingHistogram
+		}
+	}
+
+	return m, nil
+}
+
+func valuePtr[T any](in T) *T { return &in }

--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_parser_test.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_parser_test.go
@@ -57,8 +57,8 @@ func TestChromiumCodesearchEnumParser_Parse(t *testing.T) {
 			filteredEnums: []metricdatatypes.HistogramName{metricdatatypes.WebDXFeatureEnum},
 			expectedOutput: metricdatatypes.HistogramMapping{
 				metricdatatypes.WebDXFeatureEnum: []metricdatatypes.HistogramEnumValue{
-					{BucketID: 1, Label: "CompressionStreams"},
-					{BucketID: 2, Label: "ViewTransitions"},
+					{Value: 1, Label: "CompressionStreams"},
+					{Value: 2, Label: "ViewTransitions"},
 				},
 			},
 			expectedError: nil,

--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_parser_test.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_parser_test.go
@@ -1,0 +1,131 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"io"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+func TestChromiumCodesearchEnumParser_Parse(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		encodedData    string
+		filteredEnums  []metricdatatypes.HistogramName
+		expectedOutput metricdatatypes.HistogramMapping
+		expectedError  error
+	}{
+		{
+			name: "Successful Parsing with Filtering",
+			encodedData: base64.StdEncoding.EncodeToString([]byte(`
+                <histogram-configuration>
+                    <enums>
+                        <enum name="WebDXFeatureObserver">
+                            <int value="0" label="PageVisits"/>
+                            <int value="1" label="CompressionStreams"/>
+                            <int value="2" label="ViewTransitions"/>
+                            <int value="3" label="DRAFT_Serial"/>
+                        </enum>
+                        <enum name="OtherEnum">
+                            <int value="10" label="SomeValue"/>
+                        </enum>
+                    </enums>
+                </histogram-configuration>
+            `)),
+			filteredEnums: []metricdatatypes.HistogramName{metricdatatypes.WebDXFeatureEnum},
+			expectedOutput: metricdatatypes.HistogramMapping{
+				metricdatatypes.WebDXFeatureEnum: []metricdatatypes.HistogramEnumValue{
+					{BucketID: 1, Label: "CompressionStreams"},
+					{BucketID: 2, Label: "ViewTransitions"},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:        "Empty Input",
+			encodedData: "",
+			filteredEnums: []metricdatatypes.HistogramName{
+				metricdatatypes.WebDXFeatureEnum,
+			},
+			expectedOutput: nil,
+			expectedError:  io.EOF,
+		},
+		{
+			name: "Missing Histogram",
+			encodedData: base64.StdEncoding.EncodeToString([]byte(`
+                <histogram-configuration>
+                    <enums>
+                        <enum name="SomeOtherEnum">
+                            <int value="5" label="SomeLabel"/>
+                        </enum>
+                    </enums>
+                </histogram-configuration>
+            `)),
+			filteredEnums: []metricdatatypes.HistogramName{
+				metricdatatypes.WebDXFeatureEnum,
+			},
+			expectedOutput: nil,
+			expectedError:  errMissingHistogram,
+		},
+		{
+			name: "Invalid XML",
+			encodedData: base64.StdEncoding.EncodeToString([]byte(`
+                <histogram-configuration>
+                    <enums>
+                        <enum name="WebDXFeatureObserver">
+                            <int value="invalid" label="PageVisits"/>
+                        </enum>
+                    </enums>
+                </histogram-configuration>
+            `)),
+			filteredEnums: []metricdatatypes.HistogramName{
+				metricdatatypes.WebDXFeatureEnum,
+			},
+			expectedOutput: nil,
+			expectedError:  strconv.ErrSyntax,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := ChromiumCodesearchEnumParser{}
+			encodedDataReader := io.NopCloser(bytes.NewReader([]byte(tt.encodedData)))
+			output, err := parser.Parse(ctx, encodedDataReader, tt.filteredEnums)
+
+			if tt.expectedError != nil {
+				if !errors.Is(err, tt.expectedError) {
+					t.Errorf("Expected error '%v', but got '%v'", tt.expectedError, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if !reflect.DeepEqual(output, tt.expectedOutput) {
+					t.Errorf("Output mismatch:\nExpected: %v\nGot: %v", tt.expectedOutput, output)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add logic to:
1. Fetch enums from the chromium codesearch
2. Parse the data into our metricdatatypes.HistogramMapping

This fetch and parse logic is inspired by
ChromeStatus's [logic](https://github.com/GoogleChrome/chromium-dashboard/blob/f367dd0690b857c85453c67f9d388f2b08797e6c/internals/fetchmetrics.py#L253-L282).

Part of split up of #616

Parent PR: #669