### PR TITLE
Fetch and parse UMA export server responses

### DIFF
--- a/workflows/steps/services/uma_export/go.mod
+++ b/workflows/steps/services/uma_export/go.mod
@@ -5,3 +5,5 @@ go 1.23.0
 replace github.com/GoogleChrome/webstatus.dev/lib => ../../../../lib
 
 replace github.com/GoogleChrome/webstatus.dev/lib/gen => ../../../../lib/gen
+
+require github.com/GoogleChrome/webstatus.dev/lib v0.0.0-00010101000000-000000000000

--- a/workflows/steps/services/uma_export/workflow/http_metrics_fetcher.go
+++ b/workflows/steps/services/uma_export/workflow/http_metrics_fetcher.go
@@ -1,0 +1,107 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+const umaQueryServer = "https://uma-export.appspot.com/webstatus/"
+
+var errGeneratingToken = errors.New("token generation error")
+var errMissingBody = errors.New("missing response body")
+var errUnexpectedStatusCode = errors.New("unexpected status code")
+
+type tokenGenerator interface {
+	Generate(ctx context.Context, url string) (*string, error)
+}
+
+func NewHTTPMetricsFetcher(tokenGen tokenGenerator) (*HTTPMetricsFetcher, error) {
+	baseURL, err := url.Parse(umaQueryServer)
+	if err != nil {
+		return nil, err
+	}
+
+	client := http.DefaultClient
+	// Use the same timeout as
+	// https://github.com/GoogleChrome/chromium-dashboard/blob/main/internals/fetchmetrics.py
+	client.Timeout = 120 * time.Second
+
+	return &HTTPMetricsFetcher{
+		baseURL:  baseURL,
+		tokenGen: tokenGen,
+
+		httpClient: client,
+	}, nil
+}
+
+type HTTPMetricsFetcher struct {
+	baseURL    *url.URL
+	tokenGen   tokenGenerator
+	httpClient *http.Client
+}
+
+func (f HTTPMetricsFetcher) Fetch(ctx context.Context,
+	queryName metricdatatypes.UMAExportQuery) (io.ReadCloser, error) {
+	queryURL := f.queryURL(queryName)
+
+	token, err := f.tokenGen.Generate(ctx, queryURL)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to generate token", "error", err)
+
+		return nil, errors.Join(err, errGeneratingToken)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, queryURL, nil)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to create request", "error", err)
+
+		return nil, err
+	}
+
+	req.Header.Add("Authorization", "Bearer "+*token)
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Clean up by closing since we will not be returning the body
+		if resp.Body != nil {
+			resp.Body.Close()
+		}
+
+		return nil, errUnexpectedStatusCode
+	}
+
+	if resp.Body == nil {
+		return nil, errMissingBody
+	}
+
+	return resp.Body, nil
+}
+
+func (f HTTPMetricsFetcher) queryURL(queryName metricdatatypes.UMAExportQuery) string {
+	return f.baseURL.JoinPath(string(queryName)).String()
+}

--- a/workflows/steps/services/uma_export/workflow/http_metrics_fetcher_test.go
+++ b/workflows/steps/services/uma_export/workflow/http_metrics_fetcher_test.go
@@ -1,0 +1,163 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+func TestHTTPMetricsFetcher_Fetch(t *testing.T) {
+	tests := []struct {
+		name         string
+		queryName    metricdatatypes.UMAExportQuery
+		expectedURL  string
+		token        string
+		tokenErr     error
+		httpStatus   int
+		responseBody string
+		want         string
+		err          error
+	}{
+		{
+			name:       "success",
+			queryName:  metricdatatypes.WebDXFeaturesQuery,
+			token:      "test-token",
+			httpStatus: http.StatusOK,
+			responseBody: `{
+				"queryName": "WebFeatureObserverDailyMetrics",
+				"rows": []
+			}`,
+			want: `{
+				"queryName": "WebFeatureObserverDailyMetrics",
+				"rows": []
+			}`,
+			expectedURL: "https://uma-export.appspot.com/webstatus/usecounter.webdxfeatures",
+			err:         nil,
+			tokenErr:    nil,
+		},
+		{
+			name:        "error generating token",
+			queryName:   metricdatatypes.WebDXFeaturesQuery,
+			tokenErr:    errors.New("some error"),
+			httpStatus:  http.StatusOK,
+			expectedURL: "",
+			err:         errGeneratingToken,
+			// Empty values that won't be checked
+			want:         "",
+			responseBody: "",
+			token:        "",
+		},
+		{
+			name:        "error unexpected status code",
+			queryName:   metricdatatypes.WebDXFeaturesQuery,
+			token:       "test-token",
+			httpStatus:  http.StatusInternalServerError,
+			expectedURL: "",
+			err:         errUnexpectedStatusCode,
+			// Empty values that won't be checked
+			want:         "",
+			responseBody: "",
+			tokenErr:     nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a mock RoundTripper
+			mockTransport := &mockRoundTripper{
+				// nolint:exhaustruct // WONTFIX - external struct.
+				response: &http.Response{
+					StatusCode: tc.httpStatus,
+					Body:       io.NopCloser(strings.NewReader(tc.responseBody)),
+				},
+			}
+
+			// Create a mock token generator
+			mockTokenGen := &mockTokenGenerator{
+				lastURL: "",
+				token:   &tc.token,
+				err:     tc.tokenErr,
+			}
+
+			// Create the HTTP metrics fetcher with the mock transport
+			fetcher, err := NewHTTPMetricsFetcher(mockTokenGen)
+			if err != nil {
+				t.Fatalf("unable to create fetcher. err %s", err)
+			}
+
+			// nolint:exhaustruct // WONTFIX - external struct.
+			fetcher.httpClient = &http.Client{
+				Transport: mockTransport,
+			}
+
+			got, err := fetcher.Fetch(context.Background(), tc.queryName)
+			if !errors.Is(err, tc.err) {
+				t.Errorf("Fetch() error = %s, expected %s", err, tc.err)
+
+				return
+			}
+
+			if err == nil {
+				body, err := io.ReadAll(got)
+				if err != nil {
+					t.Errorf("Failed to read response body: %v", err)
+
+					return
+				}
+				got.Close()
+
+				if strings.TrimSpace(string(body)) != tc.want {
+					t.Errorf("Fetch() got = %v, want %v", string(body), tc.want)
+				}
+
+				// Assert that the request URL is correct
+				if !strings.HasPrefix(mockTokenGen.lastURL, umaQueryServer) {
+					t.Errorf("Fetch() used incorrect URL prefix, got = %v, want prefix %v", mockTokenGen.lastURL, umaQueryServer)
+				}
+
+				if mockTokenGen.lastURL != tc.expectedURL {
+					t.Errorf("Fetch() used incorrect URL, got = %v, want %v", mockTokenGen.lastURL, tc.expectedURL)
+				}
+			}
+		})
+	}
+}
+
+// mockRoundTripper is a mock implementation of http.RoundTripper.
+type mockRoundTripper struct {
+	response *http.Response
+}
+
+func (m *mockRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return m.response, nil
+}
+
+type mockTokenGenerator struct {
+	token   *string
+	err     error
+	lastURL string
+}
+
+func (m *mockTokenGenerator) Generate(_ context.Context, url string) (*string, error) {
+	m.lastURL = url
+
+	return m.token, m.err
+}

--- a/workflows/steps/services/uma_export/workflow/xssi_metrics_parser.go
+++ b/workflows/steps/services/uma_export/workflow/xssi_metrics_parser.go
@@ -1,0 +1,102 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"strconv"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+var (
+	errMissingXSSIPrefix  = errors.New("missing xssi prefix")
+	errUnexpectedBucketID = errors.New("unable to parse bucket id")
+	errInvalidJSON        = errors.New("unable to decode json payload")
+)
+
+type XSSIMetricsParser struct{}
+
+func removeXSSIPrefix(body io.ReadCloser) (io.ReadCloser, error) {
+	var buf bytes.Buffer
+
+	// Read and discard until newline
+	_, err := buf.ReadFrom(body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the remaining data from the buffer
+	remainingData := buf.Bytes()
+
+	// Find the index of the first newline
+	newlineIndex := bytes.IndexByte(remainingData, '\n')
+	if newlineIndex == -1 {
+		return nil, errMissingXSSIPrefix
+	}
+
+	// Discard up to and including the newline
+	remainingData = remainingData[newlineIndex+1:]
+
+	// Create a new ReadCloser from the remaining data
+	newBody := io.NopCloser(bytes.NewReader(remainingData))
+
+	return newBody, nil
+}
+
+type RField map[string]metricdatatypes.BucketDataMetric
+type JSONPayload struct {
+	R RField `json:"r,omitempty"`
+}
+
+func (p XSSIMetricsParser) Parse(ctx context.Context, data io.ReadCloser) (metricdatatypes.BucketDataMetrics, error) {
+	defer data.Close()
+
+	jsonBody, err := removeXSSIPrefix(data)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to detect and remove xssi prefix", "error", err)
+
+		return nil, err
+	}
+	defer jsonBody.Close()
+
+	jsonDecoder := json.NewDecoder(jsonBody)
+
+	var parsedData JSONPayload
+	err = jsonDecoder.Decode(&parsedData)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to decode json payload", "error", err)
+
+		return nil, errors.Join(err, errInvalidJSON)
+	}
+
+	ret := make(metricdatatypes.BucketDataMetrics, len(parsedData.R))
+	for keyStr, data := range parsedData.R {
+		keyInt, err := strconv.ParseInt(keyStr, 10, 64)
+		if err != nil {
+			slog.ErrorContext(ctx, "unable to parse bucket id", "error", err, "bucket", keyStr)
+
+			return nil, errors.Join(errUnexpectedBucketID, err)
+		}
+		ret[keyInt] = data
+	}
+
+	return ret, nil
+}

--- a/workflows/steps/services/uma_export/workflow/xssi_metrics_parser_test.go
+++ b/workflows/steps/services/uma_export/workflow/xssi_metrics_parser_test.go
@@ -1,0 +1,122 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workflow
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+func TestXSSIMetricsParser_Parse(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputData   string
+		expected    metricdatatypes.BucketDataMetrics
+		expectedErr error
+	}{
+		{
+			name: "Valid JSON with XSSI prefix",
+			inputData: `)]}\
+{
+	"r": {
+		"123":
+			{
+				"rate": 0.5,
+				"milestone": "89",
+				"low_volume": true
+			},
+		"456":
+			{
+				"rate": 0.2,
+				"milestone": "99",
+				"low_volume": false
+			}
+	}
+}`,
+			expected: metricdatatypes.BucketDataMetrics{
+				123: {Rate: 0.5, Milestone: "89", LowVolume: true},
+				456: {Rate: 0.2, Milestone: "99", LowVolume: false},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "Invalid JSON",
+			inputData: `)]}\
+{"invalid": }`,
+			expected:    nil,
+			expectedErr: errInvalidJSON,
+		},
+		{
+			name: "Non-numeric bucket ID",
+			inputData: `)]}\
+{
+	"r": {
+		"abc":
+			{
+				"rate": 0.5,
+				"milestone": "89",
+				"low_volume": true
+			},
+		"456":
+			{
+				"rate": 0.2,
+				"milestone": "99",
+				"low_volume": false
+			}
+	}
+}`,
+			expected:    nil,
+			expectedErr: errUnexpectedBucketID,
+		},
+		{
+			name:        "Empty input",
+			inputData:   "",
+			expected:    nil,
+			expectedErr: errMissingXSSIPrefix,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := XSSIMetricsParser{}
+			ctx := context.Background()
+
+			data := io.NopCloser(bytes.NewReader([]byte(tt.inputData)))
+			got, err := parser.Parse(ctx, data)
+
+			if tt.expectedErr != nil {
+				if err == nil {
+					t.Errorf("Expected error, but got nil")
+				} else if !errors.Is(err, tt.expectedErr) {
+					t.Errorf("Expected error '%v', but got '%v'", tt.expectedErr, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			} else if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("Expected %v, but got %v", tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add logic to:
1. Make a request to the UMA Export server
2. Remove the XSSI prefix
3. Parse the JSON response into our metricdatatypes.BucketDataMetrics

This fetch and parse logic is inspired by
ChromeStatus's [uma export logic](https://github.com/GoogleChrome/chromium-dashboard/blob/f367dd0690b857c85453c67f9d388f2b08797e6c/internals/fetchmetrics.py#L104-L116).

Part of split up of #616

Parent PR: #669