### PR TITLE
Add Spanner functionality to store and retrieve Chromium Histogram Enums and EnumValues

### DIFF
--- a/lib/gcpspanner/chromium_histogram_enum_values.go
+++ b/lib/gcpspanner/chromium_histogram_enum_values.go
@@ -1,0 +1,106 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+)
+
+const (
+	chromiumHistogramEnumValuesTable = "ChromiumHistogramEnumValues"
+)
+
+type chromiumHistogramEnumValuesMapper struct{}
+
+func (m chromiumHistogramEnumValuesMapper) Table() string {
+	return chromiumHistogramEnumValuesTable
+}
+
+func (m chromiumHistogramEnumValuesMapper) SelectOne(key spannerChromiumHistogramEnumValueKey) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ID, ChromiumHistogramEnumID, BucketID, Label
+	FROM %s
+	WHERE ChromiumHistogramEnumID = @chromiumHistogramEnumID AND BucketID = @bucketID
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"chromiumHistogramEnumID": key.ChromiumHistogramEnumID,
+		"bucketID":                key.BucketID,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (m chromiumHistogramEnumValuesMapper) GetKey(in ChromiumHistogramEnumValue) spannerChromiumHistogramEnumValueKey {
+	return spannerChromiumHistogramEnumValueKey{
+		ChromiumHistogramEnumID: in.ChromiumHistogramEnumID,
+		BucketID:                in.BucketID,
+	}
+}
+
+func (m chromiumHistogramEnumValuesMapper) Merge(
+	_ ChromiumHistogramEnumValue, existing spannerChromiumHistogramEnumValue) spannerChromiumHistogramEnumValue {
+	// If the histogram exists, it currently does nothing and keeps the existing as-is.
+	return existing
+}
+
+func (m chromiumHistogramEnumValuesMapper) GetID(in spannerChromiumHistogramEnumValueKey) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ID
+	FROM %s
+	WHERE ChromiumHistogramEnumID = @chromiumHistogramEnumID AND BucketID = @bucketID
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"chromiumHistogramEnumID": in.ChromiumHistogramEnumID,
+		"bucketID":                in.BucketID,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+type ChromiumHistogramEnumValue struct {
+	ChromiumHistogramEnumID string `spanner:"ChromiumHistogramEnumID"`
+	BucketID                int64  `spanner:"BucketID"`
+	Label                   string `spanner:"Label"`
+}
+
+type spannerChromiumHistogramEnumValue struct {
+	ID string `spanner:"ID"`
+	ChromiumHistogramEnumValue
+}
+
+type spannerChromiumHistogramEnumValueKey struct {
+	ChromiumHistogramEnumID string
+	BucketID                int64
+}
+
+func (c *Client) UpsertChromiumHistogramEnumValue(ctx context.Context, in ChromiumHistogramEnumValue) (*string, error) {
+	return newEntityWriterWithIDRetrieval[chromiumHistogramEnumValuesMapper, string](c).upsertAndGetID(ctx, in)
+}
+
+func (c *Client) GetIDFromChromiumHistogramEnumValueKey(
+	ctx context.Context, chromiumHistogramEnumID string, bucketID int64) (*string, error) {
+	return newEntityWriterWithIDRetrieval[chromiumHistogramEnumValuesMapper, string](c).
+		getIDByKey(ctx, spannerChromiumHistogramEnumValueKey{
+			ChromiumHistogramEnumID: chromiumHistogramEnumID,
+			BucketID:                bucketID,
+		})
+}

--- a/lib/gcpspanner/chromium_histogram_enum_values_test.go
+++ b/lib/gcpspanner/chromium_histogram_enum_values_test.go
@@ -1,0 +1,135 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func getSampleChromiumHistogramEnumValues(histogramIDMap map[string]string) []ChromiumHistogramEnumValue {
+	return []ChromiumHistogramEnumValue{
+		{
+			ChromiumHistogramEnumID: histogramIDMap["AnotherHistogram"],
+			BucketID:                1,
+			Label:                   "AnotherLabel",
+		},
+		{
+			ChromiumHistogramEnumID: histogramIDMap["WebDXFeatureObserver"],
+			BucketID:                1,
+			Label:                   "CompressionStreams",
+		},
+		{
+			ChromiumHistogramEnumID: histogramIDMap["WebDXFeatureObserver"],
+			BucketID:                2,
+			Label:                   "ViewTransitions",
+		},
+	}
+}
+
+func insertSampleChromiumHistogramEnumValues(
+	ctx context.Context, t *testing.T, c *Client, enumIDMap map[string]string) map[string]string {
+	enumValues := getSampleChromiumHistogramEnumValues(enumIDMap)
+	m := make(map[string]string, len(enumValues))
+	for _, enumValue := range enumValues {
+		enumValueID, err := c.UpsertChromiumHistogramEnumValue(ctx, enumValue)
+		if err != nil {
+			t.Fatalf("unable to insert sample enum value. error %s", err)
+		}
+		m[enumValue.Label] = *enumValueID
+	}
+
+	return m
+}
+
+// Helper method to get all the enum values in a stable order.
+func (c *Client) ReadAllChromiumHistogramEnumValues(
+	ctx context.Context, t *testing.T) ([]ChromiumHistogramEnumValue, error) {
+	stmt := spanner.NewStatement(
+		`SELECT
+			ChromiumHistogramEnumID, BucketID, Label
+		FROM ChromiumHistogramEnumValues
+		ORDER BY BucketID ASC`)
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []ChromiumHistogramEnumValue
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var enum spannerChromiumHistogramEnumValue
+		if err := row.ToStruct(&enum); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		if enum.ChromiumHistogramEnumID == "" {
+			t.Error("retrieved enum ID is empty")
+		}
+		ret = append(ret, enum.ChromiumHistogramEnumValue)
+	}
+
+	return ret, nil
+}
+
+func TestUpsertChromiumHistogramEnumValue(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+	enumIDMap := insertSampleChromiumHistogramEnums(ctx, t, spannerClient)
+	insertSampleChromiumHistogramEnumValues(ctx, t, spannerClient, enumIDMap)
+	enumValues, err := spannerClient.ReadAllChromiumHistogramEnumValues(ctx, t)
+	if err != nil {
+		t.Errorf("unexpected error during read all. %s", err.Error())
+	}
+	sampleHistogramsEnumValues := getSampleChromiumHistogramEnumValues(enumIDMap)
+	slices.SortFunc(enumValues, sortChromiumHistogramEnumValues)
+	if !slices.Equal[[]ChromiumHistogramEnumValue](sampleHistogramsEnumValues, enumValues) {
+		t.Errorf("unequal enums. expected %+v actual %+v", sampleHistogramsEnumValues, enumValues)
+	}
+
+	_, err = spannerClient.UpsertChromiumHistogramEnumValue(ctx, ChromiumHistogramEnumValue{
+		ChromiumHistogramEnumID: enumIDMap["WebDXFeatureObserver"],
+		BucketID:                1,
+		// Should not update
+		Label: "CompressionStreamssssssss",
+	})
+	if err != nil {
+		t.Errorf("unexpected error during update. %s", err.Error())
+	}
+
+	enumValues, err = spannerClient.ReadAllChromiumHistogramEnumValues(ctx, t)
+	if err != nil {
+		t.Errorf("unexpected error during read all. %s", err.Error())
+	}
+	slices.SortFunc(enumValues, sortChromiumHistogramEnumValues)
+
+	// Should be the same. No updates should happen.
+	if !slices.Equal[[]ChromiumHistogramEnumValue](sampleHistogramsEnumValues, enumValues) {
+		t.Errorf("unequal enum values after update. expected %+v actual %+v", sampleHistogramsEnumValues, enumValues)
+	}
+}
+
+func sortChromiumHistogramEnumValues(left, right ChromiumHistogramEnumValue) int {
+	return cmp.Compare(left.Label, right.Label)
+}

--- a/lib/gcpspanner/chromium_histogram_enums.go
+++ b/lib/gcpspanner/chromium_histogram_enums.go
@@ -1,0 +1,91 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+)
+
+const (
+	chromiumHistogramEnumsTable = "ChromiumHistogramEnums"
+)
+
+type chromiumHistogramEnumsMapper struct{}
+
+func (m chromiumHistogramEnumsMapper) Table() string {
+	return chromiumHistogramEnumsTable
+}
+
+func (m chromiumHistogramEnumsMapper) SelectOne(histogramName string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ID, HistogramName
+	FROM %s
+	WHERE HistogramName = @histogramName
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"histogramName": histogramName,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (m chromiumHistogramEnumsMapper) GetKey(in ChromiumHistogramEnum) string {
+	return in.HistogramName
+}
+
+func (m chromiumHistogramEnumsMapper) Merge(
+	_ ChromiumHistogramEnum, existing spannerChromiumHistogramEnum) spannerChromiumHistogramEnum {
+	// If the histogram exists, it currently does nothing and keeps the existing as-is.
+	return existing
+}
+
+type ChromiumHistogramEnum struct {
+	HistogramName string `spanner:"HistogramName"`
+}
+
+type spannerChromiumHistogramEnum struct {
+	ID string `spanner:"ID"`
+	ChromiumHistogramEnum
+}
+
+func (m chromiumHistogramEnumsMapper) GetID(histogramName string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ID
+	FROM %s
+	WHERE HistogramName = @histogramName
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"histogramName": histogramName,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (c *Client) UpsertChromiumHistogramEnum(ctx context.Context, in ChromiumHistogramEnum) (*string, error) {
+	return newEntityWriterWithIDRetrieval[chromiumHistogramEnumsMapper, string](c).upsertAndGetID(ctx, in)
+}
+
+func (c *Client) GetIDFromChromiumHistogramKey(
+	ctx context.Context, histogramName string) (*string, error) {
+	return newEntityWriterWithIDRetrieval[chromiumHistogramEnumsMapper, string](c).
+		getIDByKey(ctx, histogramName)
+}

--- a/lib/gcpspanner/chromium_histogram_enums_test.go
+++ b/lib/gcpspanner/chromium_histogram_enums_test.go
@@ -1,0 +1,104 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func getSampleChromiumHistogramEnums() []ChromiumHistogramEnum {
+	return []ChromiumHistogramEnum{
+		{
+			HistogramName: "AnotherHistogram",
+		},
+		{
+			HistogramName: "WebDXFeatureObserver",
+		},
+	}
+}
+
+func insertSampleChromiumHistogramEnums(ctx context.Context, t *testing.T, c *Client) map[string]string {
+	enums := getSampleChromiumHistogramEnums()
+	m := make(map[string]string, len(enums))
+	for _, enum := range enums {
+		id, err := c.UpsertChromiumHistogramEnum(ctx, enum)
+		if err != nil {
+			t.Fatalf("unable to insert sample histogram enums. error %s", err)
+		}
+		m[enum.HistogramName] = *id
+	}
+
+	return m
+}
+
+// Helper method to get all the enums in a stable order.
+func (c *Client) ReadAllChromiumHistogramEnums(ctx context.Context, t *testing.T) ([]ChromiumHistogramEnum, error) {
+	stmt := spanner.NewStatement(
+		`SELECT
+			ID, HistogramName
+		FROM ChromiumHistogramEnums
+		ORDER BY HistogramName ASC`)
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []ChromiumHistogramEnum
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var enum spannerChromiumHistogramEnum
+		if err := row.ToStruct(&enum); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		if enum.ID == "" {
+			t.Error("retrieved enum ID is empty")
+		}
+		ret = append(ret, enum.ChromiumHistogramEnum)
+	}
+
+	return ret, nil
+}
+
+func TestUpsertChromiumHistogramEnum(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+	insertSampleChromiumHistogramEnums(ctx, t, spannerClient)
+	enums, err := spannerClient.ReadAllChromiumHistogramEnums(ctx, t)
+	if err != nil {
+		t.Errorf("unexpected error during read all. %s", err.Error())
+	}
+	sampleHistogramsEnums := getSampleChromiumHistogramEnums()
+	if !slices.Equal[[]ChromiumHistogramEnum](getSampleChromiumHistogramEnums(), enums) {
+		t.Errorf("unequal enums. expected %+v actual %+v", sampleHistogramsEnums, enums)
+	}
+
+	_, err = spannerClient.UpsertChromiumHistogramEnum(ctx, ChromiumHistogramEnum{
+		HistogramName: "WebDXFeatureObserver",
+	})
+	if err != nil {
+		t.Errorf("unexpected error during update. %s", err.Error())
+	}
+	// TODO: Try to upsert with the generated UUID.
+}


### PR DESCRIPTION
This change builds on the landed schema changes in #665.

Background:
- This change adds functionality to store and retrieve Chromium Histogram Enums and their values in Spanner. This data will be used in future changes to associate enum values with feature keys and store daily metrics.

This is the first part of the background where we are only storing the enum and enum values from the enums.xml file.

Table: ChromiumHistogramEnums
- It implements the writeableEntityMapperWithIDRetrieval [interface](https://github.com/GoogleChrome/webstatus.dev/blob/976ac09c7431204205970a566ef94db42b8e4456/lib/gcpspanner/client.go#L202-L205)
- Expose two methods:
  - UpsertChromiumHistogramEnum - for upserting values
  - GetIDFromChromiumHistogramKey - for getting the internal ID since we will be using the ID as the foreign key ChromiumHistogramEnumID in the tables ChromiumHistogramEnumValues and DailyChromiumHistogramEnumCapstones.

Table: ChromiumHistogramEnumValues
- It implements the writeableEntityMapperWithIDRetrieval [interface](https://github.com/GoogleChrome/webstatus.dev/blob/976ac09c7431204205970a566ef94db42b8e4456/lib/gcpspanner/client.go#L202-L205)
- Expose two methods:
  - UpsertChromiumHistogramEnumValue - for upserting values
  - GetIDFromChromiumHistogramEnumValueKey - for getting the internal ID since we will be using the ID as the foreign key ChromiumHistogramEnumValueID in the tables WebFeatureChromiumHistogramEnumValues and DailyChromiumHistogramMetrics.

Part of splitting up #616