### PR TITLE
Add Spanner functionality to store and retrieve daily UMA metrics

### DIFF
--- a/lib/gcpspanner/daily_chromium_histogram_metric_capstones.go
+++ b/lib/gcpspanner/daily_chromium_histogram_metric_capstones.go
@@ -1,0 +1,122 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"cloud.google.com/go/civil"
+	"cloud.google.com/go/spanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+const dailyChromiumHistogramEnumCapstonesTable = "DailyChromiumHistogramEnumCapstones"
+
+// Implements the entityMapper interface for DailyChromiumHistogramEnumCapstone
+// and SpannerDailyChromiumHistogramEnumCapstone.
+type dailyChromiumHistogramEnumCapstonesSpannerMapper struct{}
+
+func (m dailyChromiumHistogramEnumCapstonesSpannerMapper) Table() string {
+	return dailyChromiumHistogramEnumCapstonesTable
+}
+
+type dailyChromiumHistogramEnumCapstoneKey struct {
+	ChromiumHistogramEnumID string
+	Day                     civil.Date
+}
+
+func (m dailyChromiumHistogramEnumCapstonesSpannerMapper) GetKey(
+	in spannerDailyChromiumHistogramEnumCapstone) dailyChromiumHistogramEnumCapstoneKey {
+	return dailyChromiumHistogramEnumCapstoneKey{
+		ChromiumHistogramEnumID: in.ChromiumHistogramEnumID,
+		Day:                     in.Day,
+	}
+}
+
+func (m dailyChromiumHistogramEnumCapstonesSpannerMapper) Merge(
+	_ spannerDailyChromiumHistogramEnumCapstone,
+	existing spannerDailyChromiumHistogramEnumCapstone) spannerDailyChromiumHistogramEnumCapstone {
+	return existing
+}
+
+func (m dailyChromiumHistogramEnumCapstonesSpannerMapper) SelectOne(
+	key dailyChromiumHistogramEnumCapstoneKey) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ChromiumHistogramEnumID, Day
+	FROM %s
+	WHERE ChromiumHistogramEnumID = @chromiumHistogramEnumID AND Day = @day
+	LIMIT 1`,
+		m.Table()))
+	parameters := map[string]interface{}{
+		"chromiumHistogramEnumID": key.ChromiumHistogramEnumID,
+		"day":                     key.Day,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+type DailyChromiumHistogramEnumCapstone struct {
+	Day           civil.Date
+	HistogramName metricdatatypes.HistogramName
+}
+
+type spannerDailyChromiumHistogramEnumCapstone struct {
+	Day                     civil.Date `spanner:"Day"`
+	ChromiumHistogramEnumID string     `spanner:"ChromiumHistogramEnumID"`
+}
+
+func (c *Client) HasDailyChromiumHistogramCapstone(
+	ctx context.Context, in DailyChromiumHistogramEnumCapstone) (*bool, error) {
+	chromiumHistogramEnumID, err := c.GetIDFromChromiumHistogramKey(ctx, string(in.HistogramName))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = newEntityReader[
+		dailyChromiumHistogramEnumCapstonesSpannerMapper,
+		spannerDailyChromiumHistogramEnumCapstone](c).readRowByKey(ctx, dailyChromiumHistogramEnumCapstoneKey{
+		ChromiumHistogramEnumID: *chromiumHistogramEnumID,
+		Day:                     in.Day,
+	})
+	ret := false
+	if err != nil {
+		if !errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, err
+		}
+	} else {
+		ret = true
+	}
+
+	return &ret, nil
+}
+
+func (c *Client) UpsertDailyChromiumHistogramCapstone(
+	ctx context.Context, in DailyChromiumHistogramEnumCapstone) error {
+	chromiumHistogramEnumID, err := c.GetIDFromChromiumHistogramKey(
+		ctx, string(in.HistogramName))
+	if err != nil {
+		return err
+	}
+
+	return newEntityWriter[dailyChromiumHistogramEnumCapstonesSpannerMapper](c).upsert(
+		ctx, spannerDailyChromiumHistogramEnumCapstone{
+			ChromiumHistogramEnumID: *chromiumHistogramEnumID,
+			Day:                     in.Day,
+		})
+}

--- a/lib/gcpspanner/daily_chromium_histogram_metric_capstones_test.go
+++ b/lib/gcpspanner/daily_chromium_histogram_metric_capstones_test.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+func TestUpsertDailyChromiumHistogramCapstone(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+	insertSampleChromiumHistogramEnums(ctx, t, spannerClient)
+
+	in := DailyChromiumHistogramEnumCapstone{
+		HistogramName: metricdatatypes.WebDXFeatureEnum,
+		Day: civil.Date{
+			Year:  2000,
+			Month: time.January,
+			Day:   3,
+		},
+	}
+	// Test absence
+	found, err := spannerClient.HasDailyChromiumHistogramCapstone(ctx, in)
+	if err != nil {
+		t.Errorf("unable to get capstone. error %s", err)
+	}
+
+	if *found {
+		t.Error("expected false")
+	}
+
+	// Insert capstone
+	err = spannerClient.UpsertDailyChromiumHistogramCapstone(ctx, in)
+	if err != nil {
+		t.Errorf("unable to upsert capstone. error %s", err)
+	}
+
+	// Test presence
+	found, err = spannerClient.HasDailyChromiumHistogramCapstone(ctx, in)
+	if err != nil {
+		t.Errorf("unable to get capstone. error %s", err)
+	}
+
+	if !*found {
+		t.Error("expected true")
+	}
+}

--- a/lib/gcpspanner/daily_chromium_histogram_metrics.go
+++ b/lib/gcpspanner/daily_chromium_histogram_metrics.go
@@ -1,0 +1,107 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"cloud.google.com/go/civil"
+	"cloud.google.com/go/spanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+const dailyChromiumHistogramMetricsTable = "DailyChromiumHistogramMetrics"
+
+// Implements the entityMapper interface for DailyChromiumHistogramMetric and SpannerDailyChromiumHistogramMetric.
+type dailyChromiumHistogramMetricSpannerMapper struct{}
+
+func (m dailyChromiumHistogramMetricSpannerMapper) Table() string {
+	return dailyChromiumHistogramMetricsTable
+}
+
+type dailyChromiumHistogramMetricKey struct {
+	ChromiumHistogramEnumValueID string
+	Day                          civil.Date
+}
+
+func (m dailyChromiumHistogramMetricSpannerMapper) GetKey(
+	in spannerDailyChromiumHistogramMetric) dailyChromiumHistogramMetricKey {
+	return dailyChromiumHistogramMetricKey{
+		ChromiumHistogramEnumValueID: in.ChromiumHistogramEnumValueID,
+		Day:                          in.Day,
+	}
+}
+
+func (m dailyChromiumHistogramMetricSpannerMapper) Merge(
+	in spannerDailyChromiumHistogramMetric,
+	existing spannerDailyChromiumHistogramMetric) spannerDailyChromiumHistogramMetric {
+	return spannerDailyChromiumHistogramMetric{
+		ChromiumHistogramEnumValueID: existing.ChromiumHistogramEnumValueID,
+		DailyChromiumHistogramMetric: DailyChromiumHistogramMetric{
+			Day:  existing.Day,
+			Rate: in.Rate,
+		},
+	}
+}
+
+func (m dailyChromiumHistogramMetricSpannerMapper) SelectOne(key dailyChromiumHistogramMetricKey) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ChromiumHistogramEnumValueID, Day, Rate
+	FROM %s
+	WHERE ChromiumHistogramEnumValueID = @chromiumHistogramEnumValueID AND Day = @day
+	LIMIT 1`,
+		m.Table()))
+	parameters := map[string]interface{}{
+		"chromiumHistogramEnumValueID": key.ChromiumHistogramEnumValueID,
+		"day":                          key.Day,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+type DailyChromiumHistogramMetric struct {
+	Day  civil.Date `spanner:"Day"`
+	Rate big.Rat    `spanner:"Rate"`
+}
+
+type spannerDailyChromiumHistogramMetric struct {
+	DailyChromiumHistogramMetric
+	ChromiumHistogramEnumValueID string `spanner:"ChromiumHistogramEnumValueID"`
+}
+
+func (c *Client) UpsertDailyChromiumHistogramMetric(
+	ctx context.Context,
+	histogramName metricdatatypes.HistogramName,
+	bucketID int64,
+	metric DailyChromiumHistogramMetric) error {
+	// TODO: When we have a generic way to do batch upserts, change this to accept an array of metrics.
+	chromiumHistogramEnumID, err := c.GetIDFromChromiumHistogramKey(ctx, string(histogramName))
+	if err != nil {
+		return err
+	}
+	chromiumHistogramEnumValueID, err := c.GetIDFromChromiumHistogramEnumValueKey(ctx, *chromiumHistogramEnumID, bucketID)
+	if err != nil {
+		return err
+	}
+
+	return newEntityWriter[dailyChromiumHistogramMetricSpannerMapper](c).upsert(ctx, spannerDailyChromiumHistogramMetric{
+		DailyChromiumHistogramMetric: metric,
+		ChromiumHistogramEnumValueID: *chromiumHistogramEnumValueID,
+	})
+}

--- a/lib/gcpspanner/daily_chromium_histogram_metrics_test.go
+++ b/lib/gcpspanner/daily_chromium_histogram_metrics_test.go
@@ -1,0 +1,242 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/civil"
+	"cloud.google.com/go/spanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+	"google.golang.org/api/iterator"
+)
+
+type dailyChromiumHistogramMetricToInsert struct {
+	DailyChromiumHistogramMetric
+	histogramName metricdatatypes.HistogramName
+	bucketID      int64
+}
+
+func getSampleDailyChromiumHistogramMetricsToInsert() []dailyChromiumHistogramMetricToInsert {
+	return []dailyChromiumHistogramMetricToInsert{
+		// CompressionStreams
+		{
+			histogramName: metricdatatypes.WebDXFeatureEnum,
+			bucketID:      1,
+			DailyChromiumHistogramMetric: DailyChromiumHistogramMetric{
+				Day: civil.Date{
+					Year:  2000,
+					Month: time.January,
+					Day:   1,
+				},
+				Rate: *big.NewRat(7, 100),
+			},
+		},
+		{
+			histogramName: metricdatatypes.WebDXFeatureEnum,
+			bucketID:      1,
+			DailyChromiumHistogramMetric: DailyChromiumHistogramMetric{
+				Day: civil.Date{
+					Year:  2000,
+					Month: time.January,
+					Day:   2,
+				},
+				Rate: *big.NewRat(8, 100),
+			},
+		},
+		// ViewTransitions
+		{
+			histogramName: metricdatatypes.WebDXFeatureEnum,
+			bucketID:      2,
+			DailyChromiumHistogramMetric: DailyChromiumHistogramMetric{
+				Day: civil.Date{
+					Year:  2000,
+					Month: time.January,
+					Day:   1,
+				},
+				Rate: *big.NewRat(91, 100),
+			},
+		},
+	}
+}
+
+type testSpannerDailyChromiumHistogramMetric struct {
+	ChromiumHistogramEnumValueID string     `spanner:"ChromiumHistogramEnumValueID"`
+	Day                          civil.Date `spanner:"Day"`
+	Rate                         big.Rat    `spanner:"Rate"`
+}
+
+func getSampleDailyChromiumHistogramMetricsToCheckBeforeUpdate(
+	enumValueLabelToIDMap map[string]string) []testSpannerDailyChromiumHistogramMetric {
+	return []testSpannerDailyChromiumHistogramMetric{
+		// AnotherLabel
+		{
+			ChromiumHistogramEnumValueID: enumValueLabelToIDMap["CompressionStreams"],
+			Day: civil.Date{
+				Year:  2000,
+				Month: time.January,
+				Day:   1,
+			},
+			Rate: *big.NewRat(7, 100),
+		},
+		// CompressionStreams
+		{
+			ChromiumHistogramEnumValueID: enumValueLabelToIDMap["CompressionStreams"],
+			Day: civil.Date{
+				Year:  2000,
+				Month: time.January,
+				Day:   2,
+			},
+			Rate: *big.NewRat(8, 100),
+		},
+		// ViewTransitions
+		{
+			ChromiumHistogramEnumValueID: enumValueLabelToIDMap["ViewTransitions"],
+			Day: civil.Date{
+				Year:  2000,
+				Month: time.January,
+				Day:   1,
+			},
+			Rate: *big.NewRat(91, 100),
+		},
+	}
+}
+
+func getSampleDailyChromiumHistogramMetricsToCheckAfterUpdate(
+	enumValueLabelToIDMap map[string]string) []testSpannerDailyChromiumHistogramMetric {
+	return []testSpannerDailyChromiumHistogramMetric{
+		// AnotherLabel
+		{
+			ChromiumHistogramEnumValueID: enumValueLabelToIDMap["CompressionStreams"],
+			Day: civil.Date{
+				Year:  2000,
+				Month: time.January,
+				Day:   1,
+			},
+			Rate: *big.NewRat(7, 100),
+		},
+		// CompressionStreams
+		{
+			ChromiumHistogramEnumValueID: enumValueLabelToIDMap["CompressionStreams"],
+			Day: civil.Date{
+				Year:  2000,
+				Month: time.January,
+				Day:   2,
+			},
+			Rate: *big.NewRat(8, 100),
+		},
+		// ViewTransitions
+		{
+			ChromiumHistogramEnumValueID: enumValueLabelToIDMap["ViewTransitions"],
+			Day: civil.Date{
+				Year:  2000,
+				Month: time.January,
+				Day:   1,
+			},
+			Rate: *big.NewRat(93, 100),
+		},
+	}
+}
+
+func insertSampleDailyChromiumHistogramMetrics(
+	ctx context.Context, t *testing.T, c *Client) {
+	metrics := getSampleDailyChromiumHistogramMetricsToInsert()
+	for _, metric := range metrics {
+		err := c.UpsertDailyChromiumHistogramMetric(
+			ctx, metric.histogramName, metric.bucketID, metric.DailyChromiumHistogramMetric)
+		if err != nil {
+			t.Fatalf("unable to insert metric. error %s", err)
+		}
+	}
+}
+
+// Helper method to get all the metrics in a stable order.
+func (c *Client) readAllDailyChromiumHistogramMetrics(
+	ctx context.Context) ([]testSpannerDailyChromiumHistogramMetric, error) {
+	stmt := spanner.NewStatement(
+		`SELECT
+			ChromiumHistogramEnumValueID, Day, Rate
+		FROM DailyChromiumHistogramMetrics
+		ORDER BY Rate ASC`)
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []testSpannerDailyChromiumHistogramMetric
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var metric testSpannerDailyChromiumHistogramMetric
+		if err := row.ToStruct(&metric); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		ret = append(ret, metric)
+	}
+
+	return ret, nil
+}
+
+func TestUpsertDailyChromiumHistogramMetric(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+	enumIDMap := insertSampleChromiumHistogramEnums(ctx, t, spannerClient)
+	enumValueLabelToIDMap := insertSampleChromiumHistogramEnumValues(ctx, t, spannerClient, enumIDMap)
+	insertSampleDailyChromiumHistogramMetrics(ctx, t, spannerClient)
+	metricValues, err := spannerClient.readAllDailyChromiumHistogramMetrics(ctx)
+	if err != nil {
+		t.Errorf("unexpected error during read all. %s", err.Error())
+	}
+	samples := getSampleDailyChromiumHistogramMetricsToCheckBeforeUpdate(enumValueLabelToIDMap)
+	if !slices.EqualFunc(samples, metricValues, dailyMetricEquality) {
+		t.Errorf("unequal metrics.\nexpected %+v\nreceived %+v", samples, metricValues)
+	}
+
+	// Update the rate of one of the items.
+	err = spannerClient.UpsertDailyChromiumHistogramMetric(ctx,
+		metricdatatypes.WebDXFeatureEnum, 2, DailyChromiumHistogramMetric{
+			Day: civil.Date{
+				Year:  2000,
+				Month: time.January,
+				Day:   1,
+			},
+			// Change it to 93
+			Rate: *big.NewRat(93, 100),
+		})
+	if err != nil {
+		t.Errorf("unexpected error during update. %s", err.Error())
+	}
+	metricValues, err = spannerClient.readAllDailyChromiumHistogramMetrics(ctx)
+	if err != nil {
+		t.Errorf("unexpected error during read all. %s", err.Error())
+	}
+	samples = getSampleDailyChromiumHistogramMetricsToCheckAfterUpdate(enumValueLabelToIDMap)
+	if !slices.EqualFunc(samples, metricValues, dailyMetricEquality) {
+		t.Errorf("unequal metrics.\nexpected %+v\nreceived %+v", samples, metricValues)
+	}
+}
+
+func dailyMetricEquality(left, right testSpannerDailyChromiumHistogramMetric) bool {
+	return reflect.DeepEqual(left, right)
+}


### PR DESCRIPTION
This change builds on the landed schema changes in #665.

Background:

This change adds functionality store daily metrics from UMA export server. To prevent redundant requests, we also store a capstone (similar to ChromeStatus). The capstone lets us know if we already processed data from the UMA server for a given day.

Table: DailyChromiumHistogramMetrics
- Implements the writeableEntityMapper interface
- Exposes one method:
  - UpsertDailyChromiumHistogramMetric - to upsert the metric for a given histogram enum value

Table: DailyChromiumHistogramEnumCapstones
- Implements the writeableEntityMapper interface
- Exposes two methods:
  - HasDailyChromiumHistogramCapstone - to check if the metrics for a given day have already been processed.
  - UpsertDailyChromiumHistogramCapstone - for inserting the capstone for a given day.

Part of splitting up #616