### PR TITLE
Refactor: Make reusable modules for creating jobs in terraform

### DIFF
--- a/infra/modules/go_image/main.tf
+++ b/infra/modules/go_image/main.tf
@@ -1,0 +1,46 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "docker_image" "local_image" {
+  name = "${var.docker_repository_url}/${var.image_name}"
+  build {
+    context = "${path.cwd}/.."
+    build_args = {
+      service_dir : var.go_module_path
+      MAIN_BINARY : var.binary_type
+    }
+    dockerfile = "images/go_service.Dockerfile"
+  }
+  triggers = {
+    dir_sha1 = sha1(join("",
+      # Rebuild the image if anything changes in the go module itself.
+      [for f in fileset(path.cwd, "/../${var.go_module_path}/**") : filesha1(f)],
+      # Rebuild the go image if anything changes in the lib directory.
+      [for f in fileset(path.cwd, "/../lib/**") : filesha1(f)]
+    ))
+  }
+}
+
+resource "docker_registry_image" "remote_image" {
+  name          = docker_image.local_image.name
+  keep_remotely = true
+  triggers = {
+    dir_sha1 = sha1(join("",
+      # Rebuild the image if anything changes in the go module itself.
+      [for f in fileset(path.cwd, "/../${var.go_module_path}/**") : filesha1(f)],
+      # Rebuild the go image if anything changes in the lib directory.
+      [for f in fileset(path.cwd, "/../lib/**") : filesha1(f)]
+    ))
+  }
+}

--- a/infra/modules/go_image/outputs.tf
+++ b/infra/modules/go_image/outputs.tf
@@ -1,0 +1,18 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "remote_image" {
+  description = "The full image that is pushed to the remote repository"
+  value       = "${docker_image.local_image.name}@${docker_registry_image.remote_image.sha256_digest}"
+}

--- a/infra/modules/go_image/providers.tf
+++ b/infra/modules/go_image/providers.tf
@@ -1,0 +1,21 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+  }
+}

--- a/infra/modules/go_image/variables.tf
+++ b/infra/modules/go_image/variables.tf
@@ -1,0 +1,36 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "go_module_path" {
+  type        = string
+  description = "The path to go module. This path is relative to the root of the repository."
+}
+
+variable "image_name" {
+  description = "Name of the docker image"
+  type        = string
+}
+
+variable "binary_type" {
+  description = "The arg used in to tell go_service.Dockerfile whether it is a long standing 'server' or an ad-hoc 'job'"
+  type        = string
+  validation {
+    condition     = contains(["job", "server"], var.binary_type)
+    error_message = "Valid values for var: binary_type are (job, server)."
+  }
+}
+
+variable "docker_repository_url" {
+  description = "The docker repository url"
+}

--- a/infra/modules/job/main.tf
+++ b/infra/modules/job/main.tf
@@ -1,0 +1,70 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_cloud_run_v2_job" "job" {
+  provider = google.internal_project
+  count    = length(var.regions)
+  name     = "${var.env_id}-${var.regions[count.index]}-${var.short_name}"
+  location = var.regions[count.index]
+
+  template {
+    template {
+      timeout = format("%ds", var.timeout_seconds)
+      containers {
+        image = var.image
+        resources {
+          limits = {
+            cpu    = var.resource_limits.cpu
+            memory = var.resource_limits.memory
+          }
+        }
+        dynamic "env" {
+          for_each = var.env_vars
+          content {
+            name  = env.value.name
+            value = env.value.value
+          }
+        }
+      }
+      service_account = google_service_account.job_service_account.email
+    }
+  }
+
+  deletion_protection = var.deletion_protection
+}
+
+
+resource "google_service_account" "job_service_account" {
+  provider     = google.internal_project
+  account_id   = "${var.short_name}-job-${var.env_id}"
+  display_name = "${var.full_name} Job service account for ${var.env_id}"
+}
+
+resource "google_project_iam_member" "spanner_user" {
+  count    = var.does_process_write_to_spanner ? 1 : 0
+  provider = google.internal_project
+  role     = "roles/spanner.databaseUser"
+  project  = var.spanner_project_id
+  member   = google_service_account.job_service_account.member
+}
+
+resource "google_project_iam_member" "datastore_user" {
+  count    = var.does_process_write_to_datastore ? 1 : 0
+  provider = google.internal_project
+  role     = "roles/datastore.user"
+  # For now assume the spanner project also contains the datastore project.
+  project = var.spanner_project_id
+  member  = google_service_account.job_service_account.member
+}
+

--- a/infra/modules/job/outputs.tf
+++ b/infra/modules/job/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "regional_job_map" {
+  value = tomap({
+    for j in google_cloud_run_v2_job.job : j.location => {
+      project_id = j.project
+      name       = j.name
+    }
+  })
+}

--- a/infra/modules/job/providers.tf
+++ b/infra/modules/job/providers.tf
@@ -1,0 +1,25 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      configuration_aliases = [
+        google.internal_project,
+        google.public_project,
+      ]
+    }
+  }
+}

--- a/infra/modules/job/variables.tf
+++ b/infra/modules/job/variables.tf
@@ -1,0 +1,74 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "env_id" {
+  type = string
+}
+
+variable "regions" {
+  type = list(string)
+}
+
+variable "image" {
+  type = string
+}
+
+variable "timeout_seconds" {
+  type = number
+}
+
+variable "short_name" {
+  type = string
+}
+
+variable "full_name" {
+  type = string
+}
+
+variable "deletion_protection" {
+  type = bool
+}
+
+variable "env_vars" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+}
+
+variable "spanner_project_id" {
+  type = string
+}
+
+# Refer to this document for the resource limit rules.
+# By default, we use the minimum for the second generation cloud run processes.
+variable "resource_limits" {
+  type = object({
+    cpu    = string
+    memory = string
+  })
+  default = {
+    cpu    = "1"
+    memory = "512Mi"
+  }
+
+}
+
+variable "does_process_write_to_spanner" {
+  type = bool
+}
+
+variable "does_process_write_to_datastore" {
+  type = bool
+}

--- a/infra/modules/single_stage_go_workflow/main.tf
+++ b/infra/modules/single_stage_go_workflow/main.tf
@@ -1,0 +1,103 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module "image" {
+  source                = "../go_image"
+  go_module_path        = var.go_module_path
+  image_name            = var.image_name
+  binary_type           = "job"
+  docker_repository_url = var.docker_repository_url
+}
+
+module "job" {
+  source = "../job"
+  providers = {
+    google.internal_project = google.internal_project
+    google.public_project   = google.public_project
+  }
+  env_id                          = var.env_id
+  regions                         = var.regions
+  env_vars                        = var.env_vars
+  image                           = module.image.remote_image
+  deletion_protection             = var.deletion_protection
+  full_name                       = var.full_name
+  short_name                      = var.short_name
+  timeout_seconds                 = var.timeout_seconds
+  spanner_project_id              = var.spanner_details.project_id
+  does_process_write_to_datastore = var.does_process_write_to_datastore
+  does_process_write_to_spanner   = var.does_process_write_to_spanner
+}
+
+resource "google_service_account" "service_account" {
+  account_id   = "${var.short_name}-${var.env_id}"
+  provider     = google.internal_project
+  display_name = "${var.full_name} service account for ${var.env_id}"
+}
+
+resource "google_cloud_run_v2_job_iam_member" "job_invoker" {
+  for_each = module.job.regional_job_map
+  provider = google.internal_project
+  location = each.key
+  name     = each.value.name
+  role     = "roles/run.invoker"
+  member   = google_service_account.service_account.member
+}
+
+resource "google_cloud_run_v2_job_iam_member" "job_status" {
+  for_each = module.job.regional_job_map
+  provider = google.internal_project
+  location = each.key
+  name     = each.value.name
+  role     = "roles/run.viewer"
+  member   = google_service_account.service_account.member
+}
+
+resource "google_workflows_workflow" "workflow" {
+  for_each        = module.job.regional_job_map
+  provider        = google.internal_project
+  name            = "${var.env_id}-${var.short_name}-${each.key}"
+  region          = each.key
+  description     = "${var.full_name}. Env id: ${var.env_id}"
+  service_account = google_service_account.service_account.id
+  source_contents = templatefile(
+    "${path.root}/modules/single_stage_go_workflow/workflows.yaml.tftpl",
+    {
+      project_id   = each.value.project_id
+      job_name     = each.value.name
+      job_location = each.key
+    }
+  )
+}
+
+resource "google_cloud_scheduler_job" "workflow_trigger_job" {
+  for_each = google_workflows_workflow.workflow
+  provider = google.internal_project
+  name     = "${var.env_id}-${var.short_name}-trigger-job-${each.value.region}"
+  region   = each.value.region
+  schedule = var.region_schedules[each.value.region]
+  http_target {
+    uri         = "https://workflowexecutions.googleapis.com/v1/${each.value.id}/executions"
+    http_method = "POST"
+    oauth_token {
+      service_account_email = google_service_account.service_account.email
+    }
+  }
+}
+
+resource "google_project_iam_member" "invoker" {
+  provider = google.internal_project
+  role     = "roles/workflows.invoker"
+  project  = var.project_id
+  member   = google_service_account.service_account.member
+}

--- a/infra/modules/single_stage_go_workflow/providers.tf
+++ b/infra/modules/single_stage_go_workflow/providers.tf
@@ -1,0 +1,25 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      configuration_aliases = [
+        google.internal_project,
+        google.public_project,
+      ]
+    }
+  }
+}

--- a/infra/modules/single_stage_go_workflow/variables.tf
+++ b/infra/modules/single_stage_go_workflow/variables.tf
@@ -1,0 +1,99 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "go_module_path" {
+  type = string
+}
+
+variable "env_id" {
+  type = string
+}
+
+variable "regions" {
+  type = list(string)
+}
+
+variable "region_schedules" {
+  type = map(string)
+}
+
+variable "deletion_protection" {
+  type = bool
+}
+
+variable "docker_repository_url" {
+  type = string
+}
+
+variable "spanner_details" {
+  type = object({
+    instance   = string
+    database   = string
+    project_id = string
+  })
+}
+
+variable "timeout_seconds" {
+  type = number
+}
+
+
+variable "short_name" {
+  type        = string
+  description = "short name to describe resources. Typically 10 characters or less"
+}
+
+variable "full_name" {
+  type        = string
+  description = "Full name of Workflow"
+}
+
+variable "image_name" {
+  type = string
+}
+
+variable "project_id" {
+  type = string
+}
+
+variable "env_vars" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+}
+
+variable "does_process_write_to_spanner" {
+  type    = bool
+  default = false
+}
+
+variable "does_process_write_to_datastore" {
+  type    = bool
+  default = false
+}
+
+# Refer to this document for the resource limit rules.
+# By default, we use the minimum for the second generation cloud run processes.
+variable "resource_job_limits" {
+  type = object({
+    cpu    = string
+    memory = string
+  })
+  default = {
+    cpu    = "1"
+    memory = "512Mi"
+  }
+
+}

--- a/infra/modules/single_stage_go_workflow/workflows.yaml.tftpl
+++ b/infra/modules/single_stage_go_workflow/workflows.yaml.tftpl
@@ -1,0 +1,10 @@
+main:
+  steps:
+    - run_job:
+        call: googleapis.run.v1.namespaces.jobs.run
+        args:
+            name: namespaces/${project_id}/jobs/${job_name}
+            location: ${job_location}
+        result: job_execution
+    - finish:
+        return: $${job_execution}


### PR DESCRIPTION
Upon doing #616, I saw I was once again creating a lot of terraform files to deploy the jobs. And a lot of the terraform was a repeat of previous jobs with slight name tweaks.

This change introduces three new reusable modules:
- go_image - useful for any of the Go images built for the project
- job - useful for deploying an image to a cloud run job. creates the service account and adds permissions as needed
- single_stage_go_workflow - all of the workflows are single jobs (not a chain of multiple jobs.). This adds a common workflow template for one job, creates a schedule and gives it the permission to invoke the job.

After this change has landed, developers can simply make a change like the following to deploy a job (instead of creating multiple files):

```
module "bcd_workflow" {
  source = "../modules/single_stage_go_workflow"
  providers = {
    google.internal_project = google.internal_project
    google.public_project   = google.public_project
  }
  regions               = var.regions
  short_name            = "bcd-wrkflw"
  full_name             = "BCD Workflow"
  deletion_protection   = var.deletion_protection
  project_id            = var.spanner_datails.project_id
  timeout_seconds       = 60 * 5 # 5 minutes
  image_name            = "bcd_consumer_image"
  spanner_details       = var.spanner_datails
  env_id                = var.env_id
  region_schedules      = var.bcd_region_schedules
  docker_repository_url = var.docker_repository_details.url
  go_module_path        = "workflows/steps/services/bcd_consumer"
  env_vars = [
    {
      name  = "PROJECT_ID"
      value = var.spanner_datails.project_id
    },
    {
      name  = "SPANNER_DATABASE"
      value = var.spanner_datails.database
    },
    {
      name  = "SPANNER_INSTANCE"
      value = var.spanner_datails.instance
    }
  ]
}

```