### PR TITLE
Add spanner adapters for uma and chromium enums

### DIFF
--- a/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer.go
+++ b/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer.go
@@ -1,0 +1,121 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"unicode"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+// ChromiumHistogramEnumConsumer handles the conversion of histogram between the workflow/API input
+// format and the format used by the GCP Spanner client.
+type ChromiumHistogramEnumConsumer struct {
+	client ChromiumHistogramEnumsClient
+}
+
+// NewChromiumHistogramEnumConsumer constructs an adapter for the chromium histogram enum consumer service.
+func NewChromiumHistogramEnumConsumer(client ChromiumHistogramEnumsClient) *ChromiumHistogramEnumConsumer {
+	return &ChromiumHistogramEnumConsumer{client: client}
+}
+
+// ChromiumHistogramEnumsClient expects a subset of the functionality from lib/gcpspanner that only apply to
+// Chromium Histograms.
+type ChromiumHistogramEnumsClient interface {
+	UpsertChromiumHistogramEnum(context.Context, gcpspanner.ChromiumHistogramEnum) (*string, error)
+	UpsertChromiumHistogramEnumValue(context.Context, gcpspanner.ChromiumHistogramEnumValue) (*string, error)
+	UpsertWebFeatureChromiumHistogramEnumValue(context.Context, gcpspanner.WebFeatureChromiumHistogramEnumValue) error
+	GetIDFromFeatureKey(context.Context, *gcpspanner.FeatureIDFilter) (*string, error)
+}
+
+func (c *ChromiumHistogramEnumConsumer) SaveHistogramEnums(
+	ctx context.Context, data metricdatatypes.HistogramMapping) error {
+	for histogram, enums := range data {
+		enumID, err := c.client.UpsertChromiumHistogramEnum(ctx, gcpspanner.ChromiumHistogramEnum{
+			HistogramName: string(histogram),
+		})
+		if err != nil {
+			return errors.Join(ErrFailedToStoreEnum, err)
+		}
+		for _, enum := range enums {
+			enumValueID, err := c.client.UpsertChromiumHistogramEnumValue(ctx, gcpspanner.ChromiumHistogramEnumValue{
+				ChromiumHistogramEnumID: *enumID,
+				BucketID:                enum.Value,
+				Label:                   enum.Label,
+			})
+			if err != nil {
+				return errors.Join(ErrFailedToStoreEnumValue, err)
+			}
+			featureKey := enumLabelToFeatureKey(enum.Label)
+			featureID, err := c.client.GetIDFromFeatureKey(
+				ctx, gcpspanner.NewFeatureKeyFilter(featureKey))
+			if err != nil {
+				slog.WarnContext(ctx,
+					"unable to find feature ID. skipping mapping",
+					"error", err,
+					"featureKey", featureKey,
+					"label", enum.Label)
+
+				continue
+			}
+			err = c.client.UpsertWebFeatureChromiumHistogramEnumValue(ctx, gcpspanner.WebFeatureChromiumHistogramEnumValue{
+				WebFeatureID:                 *featureID,
+				ChromiumHistogramEnumValueID: *enumValueID,
+			})
+			if err != nil {
+				return errors.Join(ErrFailedToStoreEnumValueWebFeatureMapping, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+var (
+	// ErrFailedToStoreEnum indicates the storage layer failed to store chromium enum.
+	ErrFailedToStoreEnum = errors.New("failed to store chromium enum")
+	// ErrFailedToStoreEnumValue indicates the storage layer failed to store chromium enum value.
+	ErrFailedToStoreEnumValue = errors.New("failed to store chromium enum value")
+	// ErrFailedToStoreEnumValueWebFeatureMapping indicates the storage layer failed to store
+	// the mapping between enum value and web feature.
+	ErrFailedToStoreEnumValueWebFeatureMapping = errors.New(
+		"failed to store web feature to chromium enum value mapping")
+)
+
+func enumLabelToFeatureKey(label string) string {
+	b := strings.Builder{}
+	for idx, c := range label {
+		// First character just return the lower case version of it.
+		if idx == 0 {
+			b.WriteRune(unicode.ToLower(c))
+
+			continue
+		}
+		if unicode.IsUpper(c) {
+			b.WriteRune('-')
+			b.WriteRune(unicode.ToLower(c))
+
+			continue
+		}
+		b.WriteRune(c)
+	}
+
+	return b.String()
+}

--- a/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer_test.go
@@ -1,0 +1,227 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+type mockChromiumHistogramEnumsClient struct {
+	upsertChromiumHistogramEnum func(context.Context,
+		gcpspanner.ChromiumHistogramEnum) (*string, error)
+	upsertChromiumHistogramEnumValue func(context.Context,
+		gcpspanner.ChromiumHistogramEnumValue) (*string, error)
+	upsertWebFeatureChromiumHistogramEnumValue func(context.Context,
+		gcpspanner.WebFeatureChromiumHistogramEnumValue) error
+	getIDFromFeatureKey func(context.Context, *gcpspanner.FeatureIDFilter) (*string, error)
+}
+
+func (m *mockChromiumHistogramEnumsClient) UpsertChromiumHistogramEnum(ctx context.Context,
+	in gcpspanner.ChromiumHistogramEnum) (*string, error) {
+	return m.upsertChromiumHistogramEnum(ctx, in)
+}
+
+func (m *mockChromiumHistogramEnumsClient) UpsertChromiumHistogramEnumValue(ctx context.Context,
+	in gcpspanner.ChromiumHistogramEnumValue) (*string, error) {
+	return m.upsertChromiumHistogramEnumValue(ctx, in)
+}
+
+func (m *mockChromiumHistogramEnumsClient) UpsertWebFeatureChromiumHistogramEnumValue(ctx context.Context,
+	in gcpspanner.WebFeatureChromiumHistogramEnumValue) error {
+	return m.upsertWebFeatureChromiumHistogramEnumValue(ctx, in)
+}
+
+func (m *mockChromiumHistogramEnumsClient) GetIDFromFeatureKey(ctx context.Context,
+	in *gcpspanner.FeatureIDFilter) (*string, error) {
+	return m.getIDFromFeatureKey(ctx, in)
+}
+
+func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
+	tests := []struct {
+		name        string
+		client      *mockChromiumHistogramEnumsClient
+		data        metricdatatypes.HistogramMapping
+		expectedErr error
+	}{
+		{
+			name: "Success",
+			client: &mockChromiumHistogramEnumsClient{
+				upsertChromiumHistogramEnum: func(_ context.Context,
+					_ gcpspanner.ChromiumHistogramEnum) (*string, error) {
+					return valuePtr("enumID"), nil
+				},
+				upsertChromiumHistogramEnumValue: func(_ context.Context,
+					_ gcpspanner.ChromiumHistogramEnumValue) (*string, error) {
+					return valuePtr("enumValueID"), nil
+				},
+				getIDFromFeatureKey: func(_ context.Context,
+					_ *gcpspanner.FeatureIDFilter) (*string, error) {
+					return valuePtr("featureID"), nil
+				},
+				upsertWebFeatureChromiumHistogramEnumValue: func(_ context.Context,
+					_ gcpspanner.WebFeatureChromiumHistogramEnumValue) error {
+					return nil
+				},
+			},
+			data: metricdatatypes.HistogramMapping{
+				"histogram": []metricdatatypes.HistogramEnumValue{
+					{Value: 1, Label: "EnumLabel"},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "UpsertChromiumHistogramEnum returns error",
+			client: &mockChromiumHistogramEnumsClient{
+				upsertChromiumHistogramEnum: func(_ context.Context,
+					_ gcpspanner.ChromiumHistogramEnum) (*string, error) {
+					return nil, errors.New("test error")
+				},
+				upsertChromiumHistogramEnumValue:           nil,
+				upsertWebFeatureChromiumHistogramEnumValue: nil,
+				getIDFromFeatureKey:                        nil,
+			},
+			data: metricdatatypes.HistogramMapping{
+				"histogram": []metricdatatypes.HistogramEnumValue{
+					{Value: 1, Label: "EnumLabel"},
+				},
+			},
+			expectedErr: ErrFailedToStoreEnum,
+		},
+		{
+			name: "UpsertChromiumHistogramEnumValue returns error",
+			client: &mockChromiumHistogramEnumsClient{
+				upsertChromiumHistogramEnum: func(_ context.Context,
+					_ gcpspanner.ChromiumHistogramEnum) (*string, error) {
+					return valuePtr("enumID"), nil
+				},
+				upsertChromiumHistogramEnumValue: func(_ context.Context,
+					_ gcpspanner.ChromiumHistogramEnumValue) (*string, error) {
+					return nil, errors.New("test error")
+				},
+				upsertWebFeatureChromiumHistogramEnumValue: nil,
+				getIDFromFeatureKey:                        nil,
+			},
+			data: metricdatatypes.HistogramMapping{
+				"histogram": []metricdatatypes.HistogramEnumValue{
+					{Value: 1, Label: "EnumLabel"},
+				},
+			},
+			expectedErr: ErrFailedToStoreEnumValue,
+		},
+		{
+			name: "GetIDFromFeatureKey returns error",
+			client: &mockChromiumHistogramEnumsClient{
+				upsertChromiumHistogramEnum: func(_ context.Context,
+					_ gcpspanner.ChromiumHistogramEnum) (*string, error) {
+					return valuePtr("enumID"), nil
+				},
+				upsertChromiumHistogramEnumValue: func(_ context.Context,
+					_ gcpspanner.ChromiumHistogramEnumValue) (*string, error) {
+					return valuePtr("enumValueID"), nil
+				},
+				getIDFromFeatureKey: func(_ context.Context,
+					_ *gcpspanner.FeatureIDFilter) (*string, error) {
+					return nil, errors.New("test error")
+				},
+				upsertWebFeatureChromiumHistogramEnumValue: nil,
+			},
+			data: metricdatatypes.HistogramMapping{
+				"histogram": []metricdatatypes.HistogramEnumValue{
+					{Value: 1, Label: "EnumLabel"},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "UpsertWebFeatureChromiumHistogramEnumValue returns error",
+			client: &mockChromiumHistogramEnumsClient{
+				upsertChromiumHistogramEnum: func(_ context.Context,
+					_ gcpspanner.ChromiumHistogramEnum) (*string, error) {
+					return valuePtr("enumID"), nil
+				},
+				upsertChromiumHistogramEnumValue: func(_ context.Context,
+					_ gcpspanner.ChromiumHistogramEnumValue) (*string, error) {
+					return valuePtr("enumValueID"), nil
+				},
+				getIDFromFeatureKey: func(_ context.Context,
+					_ *gcpspanner.FeatureIDFilter) (*string, error) {
+					return valuePtr("featureID"), nil
+				},
+				upsertWebFeatureChromiumHistogramEnumValue: func(_ context.Context,
+					_ gcpspanner.WebFeatureChromiumHistogramEnumValue) error {
+					return errors.New("test error")
+				},
+			},
+			data: metricdatatypes.HistogramMapping{
+				"histogram": []metricdatatypes.HistogramEnumValue{
+					{Value: 1, Label: "EnumLabel"},
+				},
+			},
+			expectedErr: ErrFailedToStoreEnumValueWebFeatureMapping,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &ChromiumHistogramEnumConsumer{
+				client: tc.client,
+			}
+			err := c.SaveHistogramEnums(context.Background(), tc.data)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf(
+					"ChromiumHistogramEnumConsumer.SaveHistogramEnums() error = %v, expectedErr %v",
+					err, tc.expectedErr)
+
+				return
+			}
+		})
+	}
+}
+
+func TestEnumLabelToFeatureKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		label string
+		want  string
+	}{
+		{
+			name:  "Simple lowercase",
+			label: "simple",
+			want:  "simple",
+		},
+		{
+			name:  "typical",
+			label: "TypicalCase",
+			want:  "typical-case",
+		},
+		{
+			name:  "With numbers",
+			label: "With123Numbers",
+			want:  "with123-numbers",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := enumLabelToFeatureKey(tc.label); got != tc.want {
+				t.Errorf("enumLabelToFeatureKey() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/lib/gcpspanner/spanneradapters/uma_metric_consumer.go
+++ b/lib/gcpspanner/spanneradapters/uma_metric_consumer.go
@@ -1,0 +1,111 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"errors"
+	"math/big"
+
+	"cloud.google.com/go/civil"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+// UMAMetricConsumer handles the conversion of histogram between the workflow/API input
+// format and the format used by the GCP Spanner client.
+type UMAMetricConsumer struct {
+	client UMAMetricsClient
+}
+
+// NewUMAMetricConsumer constructs an adapter for the uma metric export service.
+func NewUMAMetricConsumer(client UMAMetricsClient) *UMAMetricConsumer {
+	return &UMAMetricConsumer{client: client}
+}
+
+// UMAMetricsClient expects a subset of the functionality from lib/gcpspanner that only apply to
+// Chromium Histograms.
+type UMAMetricsClient interface {
+	HasDailyChromiumHistogramCapstone(context.Context, gcpspanner.DailyChromiumHistogramEnumCapstone) (*bool, error)
+	UpsertDailyChromiumHistogramCapstone(context.Context, gcpspanner.DailyChromiumHistogramEnumCapstone) error
+	UpsertDailyChromiumHistogramMetric(context.Context, metricdatatypes.HistogramName,
+		int64, gcpspanner.DailyChromiumHistogramMetric) error
+}
+
+func (c *UMAMetricConsumer) HasCapstone(
+	ctx context.Context,
+	day civil.Date,
+	histogramName metricdatatypes.HistogramName) (bool, error) {
+	found, err := c.client.HasDailyChromiumHistogramCapstone(ctx, gcpspanner.DailyChromiumHistogramEnumCapstone{
+		HistogramName: histogramName,
+		Day:           day,
+	})
+	if err != nil {
+		return false, errors.Join(ErrCapstoneLookupFailed, err)
+	}
+
+	return *found, nil
+}
+
+func (c *UMAMetricConsumer) SaveCapstone(
+	ctx context.Context,
+	day civil.Date,
+	histogramName metricdatatypes.HistogramName) error {
+	err := c.client.UpsertDailyChromiumHistogramCapstone(ctx, gcpspanner.DailyChromiumHistogramEnumCapstone{
+		HistogramName: histogramName,
+		Day:           day,
+	})
+	if err != nil {
+		return errors.Join(ErrCapstoneSaveFailed, err)
+	}
+
+	return nil
+}
+
+func (c *UMAMetricConsumer) SaveMetrics(
+	ctx context.Context,
+	day civil.Date,
+	data metricdatatypes.BucketDataMetrics) error {
+	for id, bucketData := range data {
+		rate := new(big.Rat).SetFloat64(bucketData.Rate)
+		if rate == nil {
+			return ErrInvalidRate
+		}
+		err := c.client.UpsertDailyChromiumHistogramMetric(ctx, metricdatatypes.WebDXFeatureEnum, id,
+			gcpspanner.DailyChromiumHistogramMetric{
+				Day:  day,
+				Rate: *rate,
+			})
+		if err != nil {
+			return errors.Join(ErrMetricsSaveFailed)
+		}
+	}
+
+	return nil
+}
+
+var (
+	// ErrCapstoneLookupFailed indicates an internal error trying to find the capstone.
+	ErrCapstoneLookupFailed = errors.New("failed to look up capstone")
+
+	// ErrCapstoneSaveFailed indicates an internal error trying to save the capstone.
+	ErrCapstoneSaveFailed = errors.New("failed to save capstone")
+
+	// ErrMetricsSaveFailed indicates an internal error trying to save the metrics.
+	ErrMetricsSaveFailed = errors.New("failed to save metrics")
+
+	// ErrInvalidRate indicates an internal error when parsing the rate.
+	ErrInvalidRate = errors.New("invalid rate")
+)

--- a/lib/gcpspanner/spanneradapters/uma_metric_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/uma_metric_consumer_test.go
@@ -1,0 +1,229 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/civil"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
+)
+
+type mockUMAMetricsClient struct {
+	hasDailyChromiumHistogramCapstone func(context.Context,
+		gcpspanner.DailyChromiumHistogramEnumCapstone) (*bool, error)
+	upsertDailyChromiumHistogramCapstone func(context.Context,
+		gcpspanner.DailyChromiumHistogramEnumCapstone) error
+	upsertDailyChromiumHistogramMetric func(context.Context,
+		metricdatatypes.HistogramName, int64, gcpspanner.DailyChromiumHistogramMetric) error
+}
+
+func (m *mockUMAMetricsClient) HasDailyChromiumHistogramCapstone(ctx context.Context,
+	in gcpspanner.DailyChromiumHistogramEnumCapstone) (*bool, error) {
+	return m.hasDailyChromiumHistogramCapstone(ctx, in)
+}
+
+func (m *mockUMAMetricsClient) UpsertDailyChromiumHistogramCapstone(ctx context.Context,
+	in gcpspanner.DailyChromiumHistogramEnumCapstone) error {
+	return m.upsertDailyChromiumHistogramCapstone(ctx, in)
+}
+
+func (m *mockUMAMetricsClient) UpsertDailyChromiumHistogramMetric(ctx context.Context,
+	histogramName metricdatatypes.HistogramName, id int64, in gcpspanner.DailyChromiumHistogramMetric) error {
+	return m.upsertDailyChromiumHistogramMetric(ctx, histogramName, id, in)
+}
+
+func TestUMAMetricConsumer_HasCapstone(t *testing.T) {
+	tests := []struct {
+		name        string
+		client      *mockUMAMetricsClient
+		day         civil.Date
+		histogram   metricdatatypes.HistogramName
+		want        bool
+		expectedErr error
+	}{
+		{
+			name: "HasDailyChromiumHistogramCapstone returns true",
+			client: &mockUMAMetricsClient{
+				hasDailyChromiumHistogramCapstone: func(_ context.Context,
+					_ gcpspanner.DailyChromiumHistogramEnumCapstone) (*bool, error) {
+					result := true
+
+					return &result, nil
+				},
+				upsertDailyChromiumHistogramCapstone: nil,
+				upsertDailyChromiumHistogramMetric:   nil,
+			},
+			day:         civil.Date{Year: 2024, Month: 1, Day: 1},
+			histogram:   metricdatatypes.HistogramName("test"),
+			want:        true,
+			expectedErr: nil,
+		},
+		{
+			name: "HasDailyChromiumHistogramCapstone returns false",
+			client: &mockUMAMetricsClient{
+				hasDailyChromiumHistogramCapstone: func(_ context.Context,
+					_ gcpspanner.DailyChromiumHistogramEnumCapstone) (*bool, error) {
+					result := false
+
+					return &result, nil
+				},
+				upsertDailyChromiumHistogramCapstone: nil,
+				upsertDailyChromiumHistogramMetric:   nil,
+			},
+			day:         civil.Date{Year: 2024, Month: 1, Day: 1},
+			histogram:   metricdatatypes.HistogramName("test"),
+			want:        false,
+			expectedErr: nil,
+		},
+		{
+			name: "HasDailyChromiumHistogramCapstone returns error",
+			client: &mockUMAMetricsClient{
+				upsertDailyChromiumHistogramCapstone: nil,
+				upsertDailyChromiumHistogramMetric:   nil,
+				hasDailyChromiumHistogramCapstone: func(_ context.Context,
+					_ gcpspanner.DailyChromiumHistogramEnumCapstone) (*bool, error) {
+					return nil, errors.New("test error")
+				},
+			},
+			day:         civil.Date{Year: 2024, Month: 1, Day: 1},
+			histogram:   metricdatatypes.HistogramName("test"),
+			want:        false,
+			expectedErr: ErrCapstoneLookupFailed,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &UMAMetricConsumer{
+				client: tc.client,
+			}
+			got, err := c.HasCapstone(context.Background(), tc.day, tc.histogram)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("UMAMetricConsumer.HasCapstone() error = %v, expectedErr %v", err, tc.expectedErr)
+			}
+			if got != tc.want {
+				t.Errorf("UMAMetricConsumer.HasCapstone() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUMAMetricConsumer_SaveCapstone(t *testing.T) {
+	tests := []struct {
+		name        string
+		client      *mockUMAMetricsClient
+		day         civil.Date
+		histogram   metricdatatypes.HistogramName
+		expectedErr error
+	}{
+		{
+			name: "UpsertDailyChromiumHistogramCapstone returns nil",
+			client: &mockUMAMetricsClient{
+				upsertDailyChromiumHistogramCapstone: func(_ context.Context,
+					_ gcpspanner.DailyChromiumHistogramEnumCapstone) error {
+					return nil
+				},
+				upsertDailyChromiumHistogramMetric: nil,
+				hasDailyChromiumHistogramCapstone:  nil,
+			},
+			day:         civil.Date{Year: 2024, Month: 1, Day: 1},
+			histogram:   metricdatatypes.HistogramName("test"),
+			expectedErr: nil,
+		},
+		{
+			name: "UpsertDailyChromiumHistogramCapstone returns error",
+			client: &mockUMAMetricsClient{
+				upsertDailyChromiumHistogramMetric: nil,
+				hasDailyChromiumHistogramCapstone:  nil,
+				upsertDailyChromiumHistogramCapstone: func(_ context.Context,
+					_ gcpspanner.DailyChromiumHistogramEnumCapstone) error {
+					return errors.New("test error")
+				},
+			},
+			day:         civil.Date{Year: 2024, Month: 1, Day: 1},
+			histogram:   metricdatatypes.HistogramName("test"),
+			expectedErr: ErrCapstoneSaveFailed,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &UMAMetricConsumer{
+				client: tt.client,
+			}
+			err := c.SaveCapstone(context.Background(), tt.day, tt.histogram)
+			if !errors.Is(err, tt.expectedErr) {
+				t.Errorf("UMAMetricConsumer.SaveCapstone() error = %v, expectedErr %v", err, tt.expectedErr)
+			}
+		})
+	}
+}
+
+func TestUMAMetricConsumer_SaveMetrics(t *testing.T) {
+	tests := []struct {
+		name        string
+		client      *mockUMAMetricsClient
+		day         civil.Date
+		data        metricdatatypes.BucketDataMetrics
+		expectedErr error
+	}{
+		{
+			name: "UpsertDailyChromiumHistogramMetric returns nil",
+			client: &mockUMAMetricsClient{
+				upsertDailyChromiumHistogramMetric: func(_ context.Context, _ metricdatatypes.HistogramName,
+					_ int64, _ gcpspanner.DailyChromiumHistogramMetric) error {
+					return nil
+				},
+				hasDailyChromiumHistogramCapstone:    nil,
+				upsertDailyChromiumHistogramCapstone: nil,
+			},
+			day: civil.Date{Year: 2024, Month: 1, Day: 1},
+			data: metricdatatypes.BucketDataMetrics{
+				1: {Rate: 0.5, LowVolume: false, Milestone: ""},
+				2: {Rate: 0.75, LowVolume: false, Milestone: ""},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "UpsertDailyChromiumHistogramMetric returns error",
+			client: &mockUMAMetricsClient{
+				hasDailyChromiumHistogramCapstone:    nil,
+				upsertDailyChromiumHistogramCapstone: nil,
+				upsertDailyChromiumHistogramMetric: func(_ context.Context, _ metricdatatypes.HistogramName,
+					_ int64, _ gcpspanner.DailyChromiumHistogramMetric) error {
+					return errors.New("test error")
+				},
+			},
+			day: civil.Date{Year: 2024, Month: 1, Day: 1},
+			data: metricdatatypes.BucketDataMetrics{
+				1: {Rate: 0.5, LowVolume: false, Milestone: ""},
+			},
+			expectedErr: ErrMetricsSaveFailed,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &UMAMetricConsumer{
+				client: tc.client,
+			}
+			err := c.SaveMetrics(context.Background(), tc.day, tc.data)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("UMAMetricConsumer.SaveMetrics() error = %v, expectedErr %v", err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -46,7 +46,7 @@ require (
 )
 
 require (
-	cloud.google.com/go v0.115.0 // indirect
+	cloud.google.com/go v0.115.0
 	cloud.google.com/go/cloudtasks v1.12.13 // indirect
 	cloud.google.com/go/compute/metadata v0.5.0 // indirect
 	cloud.google.com/go/iam v1.1.13 // indirect


### PR DESCRIPTION
Add two new spanner adapters. One for the uma export job and one for the chromium enum job.

Reminder: These adapters translate commands from the services/jobs to the storage layer. If there is any necessary conversion, it would happen here.

This part of the split up of #616