### PR TITLE
Add terraform for uma and chromium jobs

### DIFF
--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -58,6 +58,16 @@ web_features_region_schedules = {
   "europe-west1" = "0 8 * * *"  # Daily at 8:00 AM
 }
 
+chromium_region_schedules = {
+  "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
+  "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
+}
+
+uma_region_schedules = {
+  "us-central1"  = "0 22 * * *" # Daily at 10:00 PM
+  "europe-west1" = "0 10 * * *" # Daily at 10:00 AM
+}
+
 wpt_region_schedules = {
   "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
   "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -59,6 +59,16 @@ web_features_region_schedules = {
   "europe-west1" = "0 8 * * *"  # Daily at 8:00 AM
 }
 
+chromium_region_schedules = {
+  "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
+  "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
+}
+
+uma_region_schedules = {
+  "us-central1"  = "0 22 * * *" # Daily at 10:00 PM
+  "europe-west1" = "0 10 * * *" # Daily at 10:00 AM
+}
+
 wpt_region_schedules = {
   "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
   "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM

--- a/infra/ingestion/variables.tf
+++ b/infra/ingestion/variables.tf
@@ -68,6 +68,14 @@ variable "bcd_region_schedules" {
   type = map(string)
 }
 
+variable "chromium_region_schedules" {
+  type = map(string)
+}
+
+variable "uma_region_schedules" {
+  type = map(string)
+}
+
 variable "wpt_region_schedules" {
   type = map(string)
 }

--- a/infra/ingestion/workflows.tf
+++ b/infra/ingestion/workflows.tf
@@ -115,3 +115,73 @@ module "bcd_workflow" {
   ]
 }
 
+module "chromium_enum_workflow" {
+  source = "../modules/single_stage_go_workflow"
+  providers = {
+    google.internal_project = google.internal_project
+    google.public_project   = google.public_project
+  }
+  regions                       = var.regions
+  short_name                    = "chromium-enum"
+  full_name                     = "Chromium Enum Workflow"
+  deletion_protection           = var.deletion_protection
+  project_id                    = var.spanner_datails.project_id
+  timeout_seconds               = 60 * 5 # 5 minutes
+  image_name                    = "chromium_enum_consumer_image"
+  spanner_details               = var.spanner_datails
+  env_id                        = var.env_id
+  region_schedules              = var.chromium_region_schedules
+  docker_repository_url         = var.docker_repository_details.url
+  go_module_path                = "workflows/steps/services/chromium_histogram_enums"
+  does_process_write_to_spanner = true
+  env_vars = [
+    {
+      name  = "PROJECT_ID"
+      value = var.spanner_datails.project_id
+    },
+    {
+      name  = "SPANNER_DATABASE"
+      value = var.spanner_datails.database
+    },
+    {
+      name  = "SPANNER_INSTANCE"
+      value = var.spanner_datails.instance
+    }
+  ]
+}
+
+module "uma_export_workflow" {
+  source = "../modules/single_stage_go_workflow"
+  providers = {
+    google.internal_project = google.internal_project
+    google.public_project   = google.public_project
+  }
+  regions                       = var.regions
+  short_name                    = "uma-consumer"
+  full_name                     = "UMA Export Workflow"
+  deletion_protection           = var.deletion_protection
+  project_id                    = var.spanner_datails.project_id
+  timeout_seconds               = 60 * 5 # 5 minutes
+  image_name                    = "uma_export_consumer_image"
+  spanner_details               = var.spanner_datails
+  env_id                        = var.env_id
+  region_schedules              = var.uma_region_schedules
+  docker_repository_url         = var.docker_repository_details.url
+  go_module_path                = "workflows/steps/services/uma_export"
+  does_process_write_to_spanner = true
+  env_vars = [
+    {
+      name  = "PROJECT_ID"
+      value = var.spanner_datails.project_id
+    },
+    {
+      name  = "SPANNER_DATABASE"
+      value = var.spanner_datails.database
+    },
+    {
+      name  = "SPANNER_INSTANCE"
+      value = var.spanner_datails.instance
+    }
+  ]
+}
+

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -73,6 +73,8 @@ module "ingestion" {
   depends_on                    = [module.services]
   wpt_region_schedules          = var.wpt_region_schedules
   bcd_region_schedules          = var.bcd_region_schedules
+  uma_region_schedules          = var.uma_region_schedules
+  chromium_region_schedules     = var.chromium_region_schedules
   web_features_region_schedules = var.web_features_region_schedules
 }
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -130,6 +130,14 @@ variable "wpt_region_schedules" {
   type = map(string)
 }
 
+variable "uma_region_schedules" {
+  type = map(string)
+}
+
+variable "chromium_region_schedules" {
+  type = map(string)
+}
+
 variable "web_features_region_schedules" {
   type = map(string)
 }


### PR DESCRIPTION
This change adds the terraform to deploy the new jobs from the #616 split up.

Times are random but UMA should happen after the chromium job.