### PR TITLE
Bug fixes for UMA job_process

### DIFF
--- a/lib/gcpspanner/spanneradapters/uma_metric_consumer.go
+++ b/lib/gcpspanner/spanneradapters/uma_metric_consumer.go
@@ -89,7 +89,7 @@ func (c *UMAMetricConsumer) SaveMetrics(
 				Rate: *rate,
 			})
 		if err != nil {
-			return errors.Join(ErrMetricsSaveFailed)
+			return errors.Join(ErrMetricsSaveFailed, err)
 		}
 	}
 

--- a/workflows/steps/services/uma_export/workflow/job_processor.go
+++ b/workflows/steps/services/uma_export/workflow/job_processor.go
@@ -105,6 +105,12 @@ func (p UMAExportJobProcessor) Process(ctx context.Context, job JobArguments) er
 		return err
 	}
 
+	if len(data) == 0 {
+		slog.WarnContext(ctx, "no data found for date. will return early", "date", job.day)
+
+		return nil
+	}
+
 	// Step 4. Save the data.
 	err = p.metricStorer.SaveMetrics(ctx, job.day, data)
 	if err != nil {

--- a/workflows/steps/services/uma_export/workflow/job_processor_test.go
+++ b/workflows/steps/services/uma_export/workflow/job_processor_test.go
@@ -51,6 +51,7 @@ func TestUMAExportJobProcessor_Process(t *testing.T) {
 		hasCapstone     bool
 		hasCapstoneErr  error
 		fetchErr        error
+		parseRet        metricdatatypes.BucketDataMetrics
 		parseErr        error
 		saveMetricsErr  error
 		saveCapstoneErr error
@@ -62,6 +63,7 @@ func TestUMAExportJobProcessor_Process(t *testing.T) {
 			hasCapstone: true,
 			want:        nil,
 			// Values that don't matter
+			parseRet:        nil,
 			parseErr:        nil,
 			saveMetricsErr:  nil,
 			saveCapstoneErr: nil,
@@ -74,6 +76,7 @@ func TestUMAExportJobProcessor_Process(t *testing.T) {
 			hasCapstoneErr: errHasCapstone,
 			want:           errHasCapstone,
 			// Values that don't matter
+			parseRet:        nil,
 			parseErr:        nil,
 			saveMetricsErr:  nil,
 			saveCapstoneErr: nil,
@@ -86,6 +89,7 @@ func TestUMAExportJobProcessor_Process(t *testing.T) {
 			fetchErr: errFetchMetrics,
 			want:     errFetchMetrics,
 			// Values that don't matter
+			parseRet:        nil,
 			parseErr:        nil,
 			saveMetricsErr:  nil,
 			saveCapstoneErr: nil,
@@ -98,6 +102,7 @@ func TestUMAExportJobProcessor_Process(t *testing.T) {
 			parseErr: errParseMetrics,
 			want:     errParseMetrics,
 			// Values that don't matter
+			parseRet:        nil,
 			saveMetricsErr:  nil,
 			saveCapstoneErr: nil,
 			fetchErr:        nil,
@@ -109,6 +114,7 @@ func TestUMAExportJobProcessor_Process(t *testing.T) {
 			job:            NewJobArguments(sampleQuery, sampleDate, sampleHistogram),
 			saveMetricsErr: errSaveMetrics,
 			want:           errSaveMetrics,
+			parseRet:       sampleMetrics,
 			// Values that don't matter
 			parseErr:        nil,
 			saveCapstoneErr: nil,
@@ -121,6 +127,7 @@ func TestUMAExportJobProcessor_Process(t *testing.T) {
 			job:             NewJobArguments(sampleQuery, sampleDate, sampleHistogram),
 			saveCapstoneErr: errSaveCapstone,
 			want:            errSaveCapstone,
+			parseRet:        sampleMetrics,
 			// Values that don't matter
 			parseErr:       nil,
 			saveMetricsErr: nil,
@@ -129,9 +136,23 @@ func TestUMAExportJobProcessor_Process(t *testing.T) {
 			hasCapstoneErr: nil,
 		},
 		{
-			name: "success",
-			job:  NewJobArguments(sampleQuery, sampleDate, sampleHistogram),
-			want: nil, // No error on successful processing
+			name:     "success",
+			job:      NewJobArguments(sampleQuery, sampleDate, sampleHistogram),
+			parseRet: sampleMetrics,
+			want:     nil, // No error on successful processing
+			// Values that don't matter
+			parseErr:        nil,
+			saveMetricsErr:  nil,
+			saveCapstoneErr: nil,
+			fetchErr:        nil,
+			hasCapstone:     false,
+			hasCapstoneErr:  nil,
+		},
+		{
+			name:     "success no data",
+			job:      NewJobArguments(sampleQuery, sampleDate, sampleHistogram),
+			parseRet: nil,
+			want:     nil, // No error on successful processing
 			// Values that don't matter
 			parseErr:        nil,
 			saveMetricsErr:  nil,
@@ -173,7 +194,7 @@ func TestUMAExportJobProcessor_Process(t *testing.T) {
 						return nil, tt.parseErr
 					}
 
-					return sampleMetrics, nil
+					return tt.parseRet, nil
 				},
 			}
 


### PR DESCRIPTION
1. Check if the data from UMA export has actual data in 200 response.
  - Over the weekend, the process received a 200 response but no data. Then we marked the capstone even though there was no data. This makes sure there's data first. If no data, return early for that day.
2. Handle missing draft histograms. Currently, we don't store draft enums. So when we get data from uma export server for that enum bucket id, we won't find it. This skips those.
3. Fix wrapping an error SaveMetrics. Previously, we stopped returning the internal error. But this fixes the error wrap in errors.Join.