### PR TITLE
Enable Google Cloud Identity Platform for staging and production

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -90,7 +90,7 @@ go run ./util/cmd/load_fake_data/main.go -spanner_project=${SPANNER_PROJECT_ID} 
 
 Setup auth:
 
-Add your domain to the allow-list of domains in the [console](https://pantheon.corp.google.com/customer-identity/settings?project=webstatus-dev-internal-staging).
+Add your domain to the allow-list of domains in the [console](https://console.cloud.google.com/customer-identity/settings?project=webstatus-dev-internal-staging).
 
 When you are done with your own copy
 
@@ -105,7 +105,7 @@ terraform workspace select default
 terraform workspace delete $ENV_ID
 ```
 
-Also, remove your domain from the allow-list of domains in the [console](https://pantheon.corp.google.com/customer-identity/settings?project=webstatus-dev-internal-staging).
+Also, remove your domain from the allow-list of domains in the [console](https://console.cloud.google.com/customer-identity/settings?project=webstatus-dev-internal-staging).
 
 ## Deploy Staging
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -27,9 +27,14 @@ instructions assume you have access to the following projects:
   - webstatus-dev-internal-staging
   - webstatus-dev-public-staging
 - production
-  - web-compass-staging
+  - web-compass-prod
   - webstatus-dev-internal-prod
   - webstatus-dev-public-prod
+
+Google Cloud Identity Platform:
+
+- [Enable](https://console.cloud.google.com/marketplace/details/google-cloud-platform/customer-identity) Cloud Identity Platform for the internal project.
+- [Enable](https://cloud.google.com/identity-platform/docs/multi-tenancy-quickstart) multi-tenancy in the Google Cloud Console.
 
 ## Deploying your own copy
 
@@ -83,6 +88,10 @@ Or you could populate with fake data by running.
 go run ./util/cmd/load_fake_data/main.go -spanner_project=${SPANNER_PROJECT_ID} -spanner_instance=${SPANNER_INSTANCE_ID} -spanner_database=${SPANNER_DATABASE_ID} -datastore_project=${DATASTORE_PROJECT_ID} -datastore_database=${DATASTORE_DATABASE}
 ```
 
+Setup auth:
+
+Add your domain to the allow-list of domains in the [console](https://pantheon.corp.google.com/customer-identity/settings?project=webstatus-dev-internal-staging).
+
 When you are done with your own copy
 
 ```sh
@@ -95,6 +104,8 @@ terraform destroy \
 terraform workspace select default
 terraform workspace delete $ENV_ID
 ```
+
+Also, remove your domain from the allow-list of domains in the [console](https://pantheon.corp.google.com/customer-identity/settings?project=webstatus-dev-internal-staging).
 
 ## Deploy Staging
 

--- a/frontend/src/common/app-settings.ts
+++ b/frontend/src/common/app-settings.ts
@@ -27,6 +27,7 @@ interface FirebaseAppSettings {
 
 interface FirebaseAuthSettings {
   emulatorURL: string;
+  tenantID: string;
 }
 
 interface FirebaseSettings {

--- a/frontend/src/static/index.html
+++ b/frontend/src/static/index.html
@@ -81,7 +81,8 @@
             "authDomain": "$FIREBASE_APP_AUTH_DOMAIN"
           },
           "auth": {
-            "emulatorURL": "$FIREBASE_AUTH_EMULATOR_URL"
+            "emulatorURL": "$FIREBASE_AUTH_EMULATOR_URL",
+            "tenantID": "$FIREBASE_AUTH_TENANT_ID"
           }
         }
       }'

--- a/frontend/src/static/js/components/test/webstatus-app.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-app.test.ts
@@ -30,6 +30,7 @@ describe('webstatus-app', () => {
         },
         auth: {
           emulatorURL: 'http://localhost:9099',
+          tenantID: 'tenantID',
         },
       },
     };

--- a/frontend/src/static/js/components/test/webstatus-services-container.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-services-container.test.ts
@@ -31,6 +31,7 @@ describe('WebstatusServiceContainer', () => {
       },
       auth: {
         emulatorURL: 'http://localhost:9099',
+        tenantID: 'tenantID',
       },
     },
   };

--- a/frontend/src/static/js/services/test/webstatus-app-settings-service.test.ts
+++ b/frontend/src/static/js/services/test/webstatus-app-settings-service.test.ts
@@ -36,6 +36,7 @@ describe('webstatus-app-settings-service', () => {
       },
       auth: {
         emulatorURL: 'http://localhost:9099',
+        tenantID: 'tenantID',
       },
     },
   };

--- a/frontend/src/static/js/services/test/webstatus-firebase-auth-service.test.ts
+++ b/frontend/src/static/js/services/test/webstatus-firebase-auth-service.test.ts
@@ -53,6 +53,7 @@ class FakeParentElement extends LitElement {
 describe('webstatus-firebase-auth-service', () => {
   const settings = {
     emulatorURL: '',
+    tenantID: 'tenantID',
   };
   it('can be added to the page with the settings', async () => {
     const component = await fixture<WebstatusFirebaseAuthService>(
@@ -144,6 +145,11 @@ describe('webstatus-firebase-auth-service', () => {
       'github',
       'icon should be github'
     );
+    assert.equal(
+      component.firebaseAuthConfig?.auth.tenantId,
+      'tenantID',
+      'unexpected tenantID'
+    );
     // Ensure it gets it via context.
     assert.equal(
       component.firebaseAuthConfig,
@@ -193,6 +199,7 @@ describe('webstatus-firebase-auth-service', () => {
     const testSettings = {
       // Set emulator URL
       emulatorURL: 'http://localhost:9099',
+      tenantID: '',
     };
     const root = document.createElement('div');
     document.body.appendChild(root);
@@ -228,6 +235,10 @@ describe('webstatus-firebase-auth-service', () => {
     await component.updateComplete;
 
     assert.isTrue(emulatorConnectorStub.calledOnce);
+    assert.notExists(
+      component.firebaseAuthConfig?.auth.tenantId,
+      'unexpected tenantID'
+    );
     expect(emulatorConnectorStub).to.have.been.calledWith(
       authStub,
       'http://localhost:9099'

--- a/frontend/src/static/js/services/webstatus-firebase-auth-service.ts
+++ b/frontend/src/static/js/services/webstatus-firebase-auth-service.ts
@@ -36,6 +36,7 @@ import {ServiceElement} from './service-element.js';
 
 interface FirebaseAuthSettings {
   emulatorURL: string;
+  tenantID: string;
 }
 
 @customElement('webstatus-firebase-auth-service')
@@ -62,6 +63,10 @@ export class WebstatusFirebaseAuthService extends ServiceElement {
   initFirebaseAuth() {
     if (this.firebaseApp) {
       const auth = this.authInitializer(this.firebaseApp);
+      // Local environment will not have a tenantID.
+      if (this.settings.tenantID !== '') {
+        auth.tenantId = this.settings.tenantID;
+      }
       const provider = new GithubAuthProvider();
       this.firebaseAuthConfig = {
         auth: auth,

--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -72,3 +72,10 @@ wpt_region_schedules = {
   "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
   "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
 }
+
+firebase_api_key_location = "prod-firebase-app-api-key"
+
+auth_github_config_locations = {
+  client_id     = "prod-github-client-id"
+  client_secret = "prod-github-client-secret"
+}

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -73,3 +73,10 @@ wpt_region_schedules = {
   "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
   "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
 }
+
+firebase_api_key_location = "staging-firebase-app-api-key"
+
+auth_github_config_locations = {
+  client_id     = "staging-github-client-id"
+  client_secret = "staging-github-client-secret"
+}

--- a/infra/auth/main.tf
+++ b/infra/auth/main.tf
@@ -1,0 +1,44 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  gh_client_id     = sensitive(data.google_secret_manager_secret_version_access.gh_client_id.secret_data)
+  gh_client_secret = sensitive(data.google_secret_manager_secret_version_access.gh_client_secret.secret_data)
+}
+
+data "google_secret_manager_secret_version_access" "gh_client_id" {
+  provider = google.internal_project
+  secret   = var.github_config_locations.client_id
+}
+
+data "google_secret_manager_secret_version_access" "gh_client_secret" {
+  provider = google.internal_project
+  secret   = var.github_config_locations.client_secret
+}
+
+resource "google_identity_platform_tenant" "tenant" {
+  provider                 = google.internal_project
+  display_name             = var.env_id
+  allow_password_signup    = false
+  enable_email_link_signin = false
+}
+
+resource "google_identity_platform_tenant_default_supported_idp_config" "github_idp_config" {
+  provider      = google.internal_project
+  enabled       = true
+  tenant        = google_identity_platform_tenant.tenant.name
+  idp_id        = "github.com"
+  client_id     = local.gh_client_id
+  client_secret = local.gh_client_secret
+}

--- a/infra/auth/outputs.tf
+++ b/infra/auth/outputs.tf
@@ -1,0 +1,18 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+output "tenant_id" {
+  value = google_identity_platform_tenant.tenant.name
+}

--- a/infra/auth/providers.tf
+++ b/infra/auth/providers.tf
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      configuration_aliases = [
+        google.internal_project,
+      ]
+    }
+  }
+}

--- a/infra/auth/variables.tf
+++ b/infra/auth/variables.tf
@@ -1,0 +1,25 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "env_id" {
+  type = string
+}
+
+variable "github_config_locations" {
+  description = "Location of the github configuration in secret manager"
+  type = object({
+    client_id     = string
+    client_secret = string
+  })
+}

--- a/infra/frontend/service.tf
+++ b/infra/frontend/service.tf
@@ -79,6 +79,18 @@ resource "google_cloud_run_v2_service" "service" {
         name  = "PROJECT_ID"
         value = data.google_project.datastore_project.number
       }
+      env {
+        name  = "FIREBASE_APP_AUTH_DOMAIN"
+        value = var.firebase_settings.auth_domain
+      }
+      env {
+        name  = "FIREBASE_APP_API_KEY"
+        value = var.firebase_settings.api_key
+      }
+      env {
+        name  = "FIREBASE_AUTH_TENANT_ID"
+        value = var.firebase_settings.tenant_id
+      }
     }
     vpc_access {
       network_interfaces {

--- a/infra/frontend/variables.tf
+++ b/infra/frontend/variables.tf
@@ -67,3 +67,11 @@ variable "projects" {
 variable "deletion_protection" {
   type = bool
 }
+
+variable "firebase_settings" {
+  type = object({
+    auth_domain = string
+    api_key     = string
+    tenant_id   = string
+  })
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -33,6 +33,9 @@ provider "google" {
 provider "google" {
   alias   = "internal_project"
   project = var.projects.internal
+  # Need user_project_override=true for identity platform
+  # https://stackoverflow.com/a/78203631
+  user_project_override = true
 }
 
 provider "google" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -141,3 +141,17 @@ variable "chromium_region_schedules" {
 variable "web_features_region_schedules" {
   type = map(string)
 }
+
+
+variable "firebase_api_key_location" {
+  description = "Location of the firebase api key in secret manager"
+  type        = string
+}
+
+variable "auth_github_config_locations" {
+  description = "Location of the github configuration in secret manager"
+  type = object({
+    client_id     = string
+    client_secret = string
+  })
+}


### PR DESCRIPTION
This change configures Google Cloud Identity Platform (GCIP) for staging and production environments, enabling developers to deploy full-stack applications with GCIP to GCP.

Key changes include:

- Setting up a new GCIP tenant with a GitHub Provider for authentication.
- Modifying the frontend infrastructure module to utilize the new tenant and enable GitHub login.
- Updating frontend code to handle optional tenant IDs, allowing seamless transition between local and cloud environments.

This addresses the previous limitation of having GCIP configured only locally with the emulator.