### PR TITLE
Allow resetting of baseline status

### DIFF
--- a/lib/gcpspanner/baseline_status.go
+++ b/lib/gcpspanner/baseline_status.go
@@ -15,7 +15,6 @@
 package gcpspanner
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"time"
@@ -71,10 +70,10 @@ func (m baselineStatusMapper) Merge(in spannerFeatureBaselineStatus,
 	// Only allow overriding of the status, low date and high date.
 	return spannerFeatureBaselineStatus{
 		WebFeatureID:   existing.WebFeatureID,
-		InternalStatus: cmp.Or[*string]((*string)(in.Status), existing.InternalStatus),
+		InternalStatus: in.InternalStatus,
 		FeatureBaselineStatus: FeatureBaselineStatus{
-			LowDate:  cmp.Or[*time.Time](in.LowDate, existing.LowDate),
-			HighDate: cmp.Or[*time.Time](in.HighDate, existing.HighDate),
+			LowDate:  in.LowDate,
+			HighDate: in.HighDate,
 			// Status does not need to be set.
 			Status: nil,
 		},


### PR DESCRIPTION
The initial implementation cautiously override each field of the row. While that is good for other tables, we can trust that the incoming data won't be incomplete/partial.

We need this because sometimes a feature that was previously thought to be baseline can actually not be baseline. And we need to revert that.

Addresses part of #515