### PR TITLE
Make firebase settings optional when deploying

### DIFF
--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -73,9 +73,10 @@ wpt_region_schedules = {
   "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
 }
 
-firebase_api_key_location = "prod-firebase-app-api-key"
+firebase_api_key_location = ""
+# firebase_api_key_location = "prod-firebase-app-api-key"
 
 auth_github_config_locations = {
-  client_id     = "prod-github-client-id"
-  client_secret = "prod-github-client-secret"
+  # client_id     = "prod-github-client-id"
+  # client_secret = "prod-github-client-secret"
 }

--- a/infra/auth/main.tf
+++ b/infra/auth/main.tf
@@ -13,16 +13,18 @@
 # limitations under the License.
 
 locals {
-  gh_client_id     = sensitive(data.google_secret_manager_secret_version_access.gh_client_id.secret_data)
-  gh_client_secret = sensitive(data.google_secret_manager_secret_version_access.gh_client_secret.secret_data)
+  gh_client_id     = sensitive(try(data.google_secret_manager_secret_version_access.gh_client_id[0].secret_data, ""))
+  gh_client_secret = sensitive(try(data.google_secret_manager_secret_version_access.gh_client_secret[0].secret_data, ""))
 }
 
 data "google_secret_manager_secret_version_access" "gh_client_id" {
+  count    = var.github_config_locations.client_id != null ? 1 : 0
   provider = google.internal_project
   secret   = var.github_config_locations.client_id
 }
 
 data "google_secret_manager_secret_version_access" "gh_client_secret" {
+  count    = var.github_config_locations.client_secret != null ? 1 : 0
   provider = google.internal_project
   secret   = var.github_config_locations.client_secret
 }
@@ -35,6 +37,7 @@ resource "google_identity_platform_tenant" "tenant" {
 }
 
 resource "google_identity_platform_tenant_default_supported_idp_config" "github_idp_config" {
+  count         = local.gh_client_secret != "" ? 1 : 0
   provider      = google.internal_project
   enabled       = true
   tenant        = google_identity_platform_tenant.tenant.name

--- a/infra/auth/variables.tf
+++ b/infra/auth/variables.tf
@@ -19,7 +19,7 @@ variable "env_id" {
 variable "github_config_locations" {
   description = "Location of the github configuration in secret manager"
   type = object({
-    client_id     = string
-    client_secret = string
+    client_id     = optional(string)
+    client_secret = optional(string)
   })
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 locals {
-  firebase_api_key = sensitive(data.google_secret_manager_secret_version_access.firebase_api_key.secret_data)
+  firebase_api_key = sensitive(try(data.google_secret_manager_secret_version_access.firebase_api_key[0].secret_data, ""))
 }
 
 data "google_secret_manager_secret_version_access" "firebase_api_key" {
+  count    = var.firebase_api_key_location != "" ? 1 : 0
   provider = google.internal_project
   secret   = var.firebase_api_key_location
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -151,7 +151,7 @@ variable "firebase_api_key_location" {
 variable "auth_github_config_locations" {
   description = "Location of the github configuration in secret manager"
   type = object({
-    client_id     = string
-    client_secret = string
+    client_id     = optional(string)
+    client_secret = optional(string)
   })
 }


### PR DESCRIPTION
While waiting on getting the GitHub app setup, we don't want prod to show a login button. This makes those fields optional. Then we change the prod configuration to temporarily remove those fields.

Without this, a login button will appear in prod but it won't function (since the prod GitHub app is not setup).