### PR TITLE
Use Target Architecture Argument for docker build

### DIFF
--- a/.dev/spanner/Dockerfile
+++ b/.dev/spanner/Dockerfile
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 FROM google/cloud-sdk:495.0.0-emulators
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+# https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope
+ARG TARGETARCH
 
 ENV SPANNER_PROJECT_ID=local
 ENV SPANNER_INSTANCE_ID=local
@@ -20,10 +23,11 @@ ENV SPANNER_DATABASE_ID=local
 ENV SPANNER_EMULATOR_HOST=0.0.0.0:9010
 
 # Install Wrench - https://github.com/cloudspannerecosystem/wrench
-ENV WRENCH_VERSION="1.7.0"
+ENV WRENCH_VERSION="1.10.1"
+RUN echo "Downloading for version ${WRENCH_VERSION} for architecture ${TARGETARCH}"
 RUN curl \
     -L -o wrench.tar.gz \
-    "https://github.com/cloudspannerecosystem/wrench/releases/download/v${WRENCH_VERSION}/wrench-${WRENCH_VERSION}-linux-amd64.tar.gz" && \
+    "https://github.com/cloudspannerecosystem/wrench/releases/download/v${WRENCH_VERSION}/wrench-${WRENCH_VERSION}-linux-${TARGETARCH}.tar.gz" && \
     tar -xf wrench.tar.gz && mv wrench /bin/
 
 RUN gcloud config set auth/disable_credentials true && \

--- a/lib/gcpspanner/client_test.go
+++ b/lib/gcpspanner/client_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -64,10 +65,13 @@ func createDatabaseContainer() error {
 	if err != nil {
 		return err
 	}
+
+	goarch := runtime.GOARCH
 	req := testcontainers.ContainerRequest{
 		FromDockerfile: testcontainers.FromDockerfile{
 			Dockerfile: filepath.Join(".dev", "spanner", "Dockerfile"),
 			Context:    repoRoot,
+			BuildArgs:  map[string]*string{"TARGETARCH": &goarch},
 		},
 		ExposedPorts: []string{"9010/tcp"},
 		WaitingFor:   wait.ForLog("Spanner setup for webstatus.dev finished"),


### PR DESCRIPTION
In the spanner emulator, a version of wrench is downloaded. But it is hardcoded to amd64.

This change uses the auto populated TARGETARCH argument.

Now, we know which architecture to use when downloading the wrench CLI. Should fix the problem for those running the repo on a Macbook.

See: https://github.com/GoogleChrome/webstatus.dev/issues/720#issuecomment-2394365939