### PR TITLE
Restrict Traffic to Allowed Hostnames for Cloud Run w/ Load Balancer

### DIFF
--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -38,9 +38,10 @@ google_analytics_id = "G-CZ6STBPSB2"
 
 frontend_docker_build_target = "static"
 
-backend_domains_for_gcp_managed_certificates  = ["api.webstatus.dev"]
-frontend_domains_for_gcp_managed_certificates = ["webstatus.dev", "www.webstatus.dev"]
-ssl_certificates                              = []
+backend_domains                      = ["api.webstatus.dev"]
+frontend_domains                     = ["webstatus.dev", "www.webstatus.dev"]
+custom_ssl_certificates_for_frontend = []
+custom_ssl_certificates_for_backend  = []
 
 spanner_region_override = "nam-eur-asia1"
 

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -38,11 +38,12 @@ google_analytics_id = "G-EPZE5TL134"
 
 frontend_docker_build_target = "static"
 
-backend_domains_for_gcp_managed_certificates  = []
-frontend_domains_for_gcp_managed_certificates = []
+backend_domains  = ["api-webstatus-dev.corp.goog"]
+frontend_domains = ["website-webstatus-dev.corp.goog"]
 
 # Temporary for UbP.
-ssl_certificates = ["ub-self-sign"]
+custom_ssl_certificates_for_frontend = ["ub-self-sign"]
+custom_ssl_certificates_for_backend  = ["ub-self-sign"]
 
 cache_duration = "5m"
 

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -217,7 +217,21 @@ resource "google_compute_url_map" "url_map" {
   provider = google.public_project
   name     = "${var.env_id}-backend-url-map"
 
-  default_service = google_compute_backend_service.lb_backend.id
+  host_rule {
+    hosts        = var.domains
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_backend_service.lb_backend.id
+  }
+  default_url_redirect {
+    host_redirect  = "github.com"
+    https_redirect = true
+    path_redirect  = "/GoogleChrome/webstatus.dev"
+    strip_query    = true
+  }
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
@@ -252,7 +266,7 @@ resource "google_compute_target_https_proxy" "lb_https_proxy" {
   provider         = google.public_project
   name             = "${var.env_id}-backend-https-proxy"
   url_map          = google_compute_url_map.url_map.id
-  ssl_certificates = length(google_compute_managed_ssl_certificate.lb_default) > 0 ? [google_compute_managed_ssl_certificate.lb_default[0].id] : var.ssl_certificates
+  ssl_certificates = length(google_compute_managed_ssl_certificate.lb_default) > 0 ? [google_compute_managed_ssl_certificate.lb_default[0].id] : var.custom_ssl_certificates
   depends_on = [
     google_compute_managed_ssl_certificate.lb_default
   ]
@@ -261,9 +275,9 @@ resource "google_compute_target_https_proxy" "lb_https_proxy" {
 resource "google_compute_managed_ssl_certificate" "lb_default" {
   provider = google.public_project
   name     = "${var.env_id}-backend-ssl-cert"
-  count    = length(var.domains_for_gcp_managed_certificates) > 0 ? 1 : 0
+  count    = length(var.custom_ssl_certificates) > 0 ? 0 : 1
   project  = var.projects.public
   managed {
-    domains = var.domains_for_gcp_managed_certificates
+    domains = var.domains
   }
 }

--- a/infra/backend/variables.tf
+++ b/infra/backend/variables.tf
@@ -51,11 +51,11 @@ variable "docker_repository_details" {
   })
 }
 
-variable "ssl_certificates" {
+variable "custom_ssl_certificates" {
   type = list(string)
 }
 
-variable "domains_for_gcp_managed_certificates" {
+variable "domains" {
   type = list(string)
 }
 

--- a/infra/frontend/service.tf
+++ b/infra/frontend/service.tf
@@ -153,7 +153,21 @@ resource "google_compute_url_map" "url_map" {
   provider = google.public_project
   name     = "${var.env_id}-frontend-url-map"
 
-  default_service = google_compute_backend_service.lb_backend.id
+  host_rule {
+    hosts        = var.domains
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_backend_service.lb_backend.id
+  }
+  default_url_redirect {
+    host_redirect  = "github.com"
+    https_redirect = true
+    path_redirect  = "/GoogleChrome/webstatus.dev"
+    strip_query    = true
+  }
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
@@ -188,7 +202,7 @@ resource "google_compute_target_https_proxy" "lb_https_proxy" {
   provider         = google.public_project
   name             = "${var.env_id}-frontend-https-proxy"
   url_map          = google_compute_url_map.url_map.id
-  ssl_certificates = length(google_compute_managed_ssl_certificate.lb_default) > 0 ? [google_compute_managed_ssl_certificate.lb_default[0].id] : var.ssl_certificates
+  ssl_certificates = length(google_compute_managed_ssl_certificate.lb_default) > 0 ? [google_compute_managed_ssl_certificate.lb_default[0].id] : var.custom_ssl_certificates
   depends_on = [
     google_compute_managed_ssl_certificate.lb_default
   ]
@@ -197,9 +211,9 @@ resource "google_compute_target_https_proxy" "lb_https_proxy" {
 resource "google_compute_managed_ssl_certificate" "lb_default" {
   provider = google.public_project
   name     = "${var.env_id}-frontend-ssl-cert"
-  count    = length(var.domains_for_gcp_managed_certificates) > 0 ? 1 : 0
+  count    = length(var.custom_ssl_certificates) > 0 ? 0 : 1
   project  = var.projects.public
   managed {
-    domains = var.domains_for_gcp_managed_certificates
+    domains = var.domains
   }
 }

--- a/infra/frontend/variables.tf
+++ b/infra/frontend/variables.tf
@@ -44,7 +44,7 @@ variable "google_analytics_id" {
   type = string
 }
 
-variable "ssl_certificates" {
+variable "custom_ssl_certificates" {
   type = list(string)
 }
 
@@ -52,7 +52,7 @@ variable "docker_build_target" {
   type = string
 }
 
-variable "domains_for_gcp_managed_certificates" {
+variable "domains" {
   type = list(string)
 }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -103,19 +103,19 @@ module "backend" {
     google.public_project   = google.public_project
   }
 
-  region_to_subnet_info_map            = module.network.region_to_subnet_info_map
-  deletion_protection                  = var.deletion_protection
-  env_id                               = var.env_id
-  spanner_datails                      = module.storage.spanner_info
-  docker_repository_details            = module.storage.docker_repository_details
-  datastore_info                       = module.storage.datastore_info
-  vpc_name                             = module.network.vpc_name
-  ssl_certificates                     = var.ssl_certificates
-  domains_for_gcp_managed_certificates = var.backend_domains_for_gcp_managed_certificates
-  projects                             = var.projects
-  cache_duration                       = var.cache_duration
-  redis_env_vars                       = module.storage.redis_env_vars
-  cors_allowed_origin                  = var.backend_cors_allowed_origin
+  region_to_subnet_info_map = module.network.region_to_subnet_info_map
+  deletion_protection       = var.deletion_protection
+  env_id                    = var.env_id
+  spanner_datails           = module.storage.spanner_info
+  docker_repository_details = module.storage.docker_repository_details
+  datastore_info            = module.storage.datastore_info
+  vpc_name                  = module.network.vpc_name
+  domains                   = var.backend_domains
+  custom_ssl_certificates   = var.custom_ssl_certificates_for_backend
+  projects                  = var.projects
+  cache_duration            = var.cache_duration
+  redis_env_vars            = module.storage.redis_env_vars
+  cors_allowed_origin       = var.backend_cors_allowed_origin
 }
 
 module "frontend" {
@@ -125,17 +125,17 @@ module "frontend" {
     google.public_project   = google.public_project
   }
 
-  env_id                               = var.env_id
-  deletion_protection                  = var.deletion_protection
-  docker_repository_details            = module.storage.docker_repository_details
-  backend_api_host                     = var.backend_api_url
-  google_analytics_id                  = var.google_analytics_id
-  region_to_subnet_info_map            = module.network.region_to_subnet_info_map
-  vpc_name                             = module.network.vpc_name
-  docker_build_target                  = var.frontend_docker_build_target
-  ssl_certificates                     = var.ssl_certificates
-  domains_for_gcp_managed_certificates = var.frontend_domains_for_gcp_managed_certificates
-  projects                             = var.projects
+  env_id                    = var.env_id
+  deletion_protection       = var.deletion_protection
+  docker_repository_details = module.storage.docker_repository_details
+  backend_api_host          = var.backend_api_url
+  google_analytics_id       = var.google_analytics_id
+  region_to_subnet_info_map = module.network.region_to_subnet_info_map
+  vpc_name                  = module.network.vpc_name
+  docker_build_target       = var.frontend_docker_build_target
+  domains                   = var.frontend_domains
+  custom_ssl_certificates   = var.custom_ssl_certificates_for_frontend
+  projects                  = var.projects
   firebase_settings = {
     api_key     = local.firebase_api_key
     auth_domain = "${var.projects.internal}.firebaseapp.com"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -97,20 +97,25 @@ variable "frontend_docker_build_target" {
   description = "Dockerfile target for the frontend image"
 }
 
-variable "ssl_certificates" {
+variable "custom_ssl_certificates_for_frontend" {
   type        = list(string)
-  description = "List of custom SSL certs"
+  description = "List of custom SSL certs for frontend that are not managed by GCP"
+}
+
+variable "custom_ssl_certificates_for_backend" {
+  type        = list(string)
+  description = "List of custom SSL certs for backend that are not managed by GCP"
 }
 
 
-variable "frontend_domains_for_gcp_managed_certificates" {
+variable "frontend_domains" {
   type        = list(string)
-  description = "List of domains for the frontend that GCP should manage certs for."
+  description = "List of domains for the frontend"
 }
 
-variable "backend_domains_for_gcp_managed_certificates" {
+variable "backend_domains" {
   type        = list(string)
-  description = "List of domains for the backend that GCP should manage certs for."
+  description = "List of domains for the backend"
 }
 
 variable "cache_duration" {


### PR DESCRIPTION
This PR updates the Terraform configuration for our Cloud Run deployment to enforce hostname-based routing using host_rule within the google_compute_url_map resource.

## Problem:

We observed in the logs that our website was being served on unintended hostnames. This could potentially be due to:

- Misconfigured DNS: Incorrect DNS records could be directing traffic to our load balancer from unintended domains.
- Unintentional Traffic: Other services or users might be inadvertently sending traffic to our load balancer.

## Solution:

To mitigate this, we're implementing the following changes:

- host_rule: We're adding host_rule to the google_compute_url_map to explicitly define the allowed hostnames for our staging environment (website-webstatus-dev.corp.goog) and production environment (webstatus.dev). Same thing for the API hosts too.
  - Redirect Unmatched Requests: Any requests to the IP address without the appropriate hosts will be redirected to https://github.com/GoogleChrome/webstatus.dev.

Benefits:

- Improved Resource Utilization: We prevent our resources from being consumed by unintended traffic.
- Clearer Traffic Management: This provides a more organized and controlled approach to routing traffic to our Cloud Run service.

## Other changes
- staging still uses custom certs to stay behind Uber proxy. Renamed some of the variables so that we could use the existing domains variable.