### PR TITLE
Add variables to tune scaling for backend & frontend

### DIFF
--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -80,3 +80,6 @@ auth_github_config_locations = {
   client_id     = "prod-github-client-id"
   client_secret = "prod-github-client-secret"
 }
+
+backend_min_instance_count  = 1
+frontend_min_instance_count = 1

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -81,3 +81,8 @@ auth_github_config_locations = {
   client_id     = "staging-github-client-id"
   client_secret = "staging-github-client-secret"
 }
+
+# TODO: Once staging is public, we should change the minimum instance count to
+# match production.
+backend_min_instance_count  = 0
+frontend_min_instance_count = 0

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -57,6 +57,10 @@ resource "google_cloud_run_v2_service" "service" {
   ingress  = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
 
   template {
+    scaling {
+      min_instance_count = var.min_instance_count
+      max_instance_count = var.max_instance_count
+    }
     containers {
       name  = "backend"
       image = "${docker_image.backend.name}@${docker_registry_image.backend_remote_image.sha256_digest}"

--- a/infra/backend/variables.tf
+++ b/infra/backend/variables.tf
@@ -86,3 +86,11 @@ variable "cors_allowed_origin" {
 variable "deletion_protection" {
   type = bool
 }
+
+variable "min_instance_count" {
+  type = number
+}
+
+variable "max_instance_count" {
+  type = number
+}

--- a/infra/frontend/service.tf
+++ b/infra/frontend/service.tf
@@ -62,6 +62,10 @@ resource "google_cloud_run_v2_service" "service" {
   ingress  = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
 
   template {
+    scaling {
+      min_instance_count = var.min_instance_count
+      max_instance_count = var.max_instance_count
+    }
     containers {
       image = "${docker_image.frontend.name}@${docker_registry_image.frontend_remote_image.sha256_digest}"
       ports {

--- a/infra/frontend/variables.tf
+++ b/infra/frontend/variables.tf
@@ -75,3 +75,11 @@ variable "firebase_settings" {
     tenant_id   = string
   })
 }
+
+variable "min_instance_count" {
+  type = number
+}
+
+variable "max_instance_count" {
+  type = number
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -116,6 +116,8 @@ module "backend" {
   cache_duration            = var.cache_duration
   redis_env_vars            = module.storage.redis_env_vars
   cors_allowed_origin       = var.backend_cors_allowed_origin
+  min_instance_count        = var.backend_min_instance_count
+  max_instance_count        = var.backend_max_instance_count
 }
 
 module "frontend" {
@@ -141,4 +143,6 @@ module "frontend" {
     auth_domain = "${var.projects.internal}.firebaseapp.com"
     tenant_id   = module.auth.tenant_id
   }
+  min_instance_count = var.frontend_min_instance_count
+  max_instance_count = var.frontend_max_instance_count
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -160,3 +160,30 @@ variable "auth_github_config_locations" {
     client_secret = string
   })
 }
+
+variable "backend_min_instance_count" {
+  type        = number
+  description = "Minimum instance count for backend instances"
+}
+
+variable "backend_max_instance_count" {
+  type        = number
+  description = "Maximum instance count for backend instances"
+  # Use default max of 100.
+  # https://cloud.google.com/run/docs/configuring/max-instances#setting
+  default = 100
+}
+
+
+variable "frontend_min_instance_count" {
+  type        = number
+  description = "Minimum instance count for frontend instances"
+}
+
+variable "frontend_max_instance_count" {
+  type        = number
+  description = "Maximum instance count for frontend instances"
+  # Use default max of 100.
+  # https://cloud.google.com/run/docs/configuring/max-instances#setting
+  default = 100
+}


### PR DESCRIPTION
By default cloud run will scale down to zero. Spin ups can hurt the SLO.

This change exposes variables for the minimum and maximum number of instances.

For prod, we set the min to 1. For staging, we set the min to 0 (for now)

For prod and staging, we set the max to 100. This is the default anyhow.

Depends on: #745 