### PR TITLE
Use different port for datastore than gcloud auth

### DIFF
--- a/.dev/datastore/Dockerfile
+++ b/.dev/datastore/Dockerfile
@@ -15,4 +15,4 @@
 FROM google/cloud-sdk:495.0.0-emulators
 
 # https://cloud.google.com/datastore/docs/tools/datastore-emulator
-ENTRYPOINT [ "gcloud", "beta", "emulators", "datastore", "start", "--host-port=0.0.0.0:8085", "--project=local", "--log-http", "--verbosity=debug", "--use-firestore-in-datastore-mode" ]
+ENTRYPOINT [ "gcloud", "beta", "emulators", "datastore", "start", "--host-port=0.0.0.0:8086", "--project=local", "--log-http", "--verbosity=debug", "--use-firestore-in-datastore-mode" ]

--- a/.dev/datastore/manifests/pod.yaml
+++ b/.dev/datastore/manifests/pod.yaml
@@ -24,7 +24,7 @@ spec:
       image: datastore
       imagePullPolicy: Never # Need this for pushing directly into minikube
       ports:
-        - containerPort: 8085
+        - containerPort: 8086
           name: datastore-port
       resources:
         limits:

--- a/.dev/datastore/manifests/service.yaml
+++ b/.dev/datastore/manifests/service.yaml
@@ -21,5 +21,5 @@ spec:
     app.kubernetes.io/name: datastore
   ports:
     - protocol: TCP
-      port: 8085
+      port: 8086
       targetPort: datastore-port

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -70,6 +70,10 @@
       ]
     }
   },
+  "forwardPorts": [
+    // gcloud CLI
+    8085
+  ],
   "runArgs": ["--env-file", ".devcontainer/devcontainer.env"],
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,7 +88,7 @@ The above skaffold command deploys multiple resources:
 | --------- | ------------------------------ | ---------------------------------------------------------- | --------------------------------------------------- |
 | backend   | Backend service in ./backend   | http://localhost:8080                                      | http://backend:8080                                 |
 | frontend  | Frontend service in ./frontend | http://localhost:5555                                      | http://frontend:5555                                |
-| datastore | Datastore Emulator             | N/A                                                        | http://datastore:8085                               |
+| datastore | Datastore Emulator             | N/A                                                        | http://datastore:8086                               |
 | spanner   | Spanner Emulator               | N/A                                                        | spanner:9010 (grpc)<br />http://spanner:9020 (rest) |
 | redis     | Redis                          | N/A                                                        | redis:6379                                          |
 | gcs       | Google Cloud Storage Emulator  | N/A                                                        | http://gcs:4443                                     |

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ port-forward-terminate:
 minikube-running:
 		# Check if minikube is running using a shell command
 		@if ! minikube status -p "$${MINIKUBE_PROFILE}" | grep -q "Running"; then \
-				minikube start -p "$${MINIKUBE_PROFILE}" --disk-size=10gb --cpus=2 --memory=4096m; \
+				minikube start -p "$${MINIKUBE_PROFILE}" --cni calico --disk-size=10gb --cpus=2 --memory=4096m; \
 		fi
 minikube-clean-restart: minikube-delete minikube-running
 minikube-delete:
@@ -383,11 +383,11 @@ dev_fake_users: build
 dev_fake_data: build is_local_migration_ready
 	fuser -k 9010/tcp || true
 	kubectl port-forward --address 127.0.0.1 pod/spanner 9010:9010 2>&1 >/dev/null &
-	fuser -k 8085/tcp || true
-	kubectl port-forward --address 127.0.0.1 pod/datastore 8085:8085 2>&1 >/dev/null &
-	SPANNER_EMULATOR_HOST=localhost:9010 DATASTORE_EMULATOR_HOST=localhost:8085 go run ./util/cmd/load_fake_data/main.go -spanner_project=local -spanner_instance=local -spanner_database=local -datastore_project=local
+	fuser -k 8086/tcp || true
+	kubectl port-forward --address 127.0.0.1 pod/datastore 8086:8086 2>&1 >/dev/null &
+	SPANNER_EMULATOR_HOST=localhost:9010 DATASTORE_EMULATOR_HOST=localhost:8086 go run ./util/cmd/load_fake_data/main.go -spanner_project=local -spanner_instance=local -spanner_database=local -datastore_project=local
 	fuser -k 9010/tcp || true
-	fuser -k 8085/tcp || true
+	fuser -k 8086/tcp || true
 is_local_migration_ready:
 	kubectl wait --for=condition=ready --timeout=300s pod/spanner
 	@MAX_RETRIES=5; SLEEP_INTERVAL=5 ; \

--- a/backend/manifests/pod.yaml
+++ b/backend/manifests/pod.yaml
@@ -38,7 +38,7 @@ spec:
         - name: DATASTORE_DATABASE
           value: ''
         - name: DATASTORE_EMULATOR_HOST
-          value: 'datastore:8085'
+          value: 'datastore:8086'
         - name: CORS_ALLOWED_ORIGIN
           value: 'http://*'
         - name: REDISHOST

--- a/lib/gds/client_test.go
+++ b/lib/gds/client_test.go
@@ -43,8 +43,8 @@ func getTestDatabase(ctx context.Context, t *testing.T) (*Client, func()) {
 			Dockerfile: filepath.Join("Dockerfile"),
 			Context:    datastoreFolder,
 		},
-		ExposedPorts: []string{"8085/tcp"},
-		WaitingFor:   wait.ForHTTP("/").WithPort("8085/tcp"),
+		ExposedPorts: []string{"8086/tcp"},
+		WaitingFor:   wait.ForHTTP("/").WithPort("8086/tcp"),
 		Name:         "webstatus-dev-test-datastore",
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
@@ -55,7 +55,7 @@ func getTestDatabase(ctx context.Context, t *testing.T) (*Client, func()) {
 		t.Fatal(err)
 	}
 
-	mappedPort, err := container.MappedPort(ctx, "8085")
+	mappedPort, err := container.MappedPort(ctx, "8086")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/workflows/steps/services/common/repo_downloader/manifests/pod.yaml
+++ b/workflows/steps/services/common/repo_downloader/manifests/pod.yaml
@@ -36,7 +36,7 @@ spec:
         - name: DATASTORE_DATABASE
           value: ''
         - name: DATASTORE_EMULATOR_HOST
-          value: 'datastore:8085'
+          value: 'datastore:8086'
       resources:
         limits:
           cpu: 250m

--- a/workflows/steps/services/web_feature_consumer/manifests/pod.yaml
+++ b/workflows/steps/services/web_feature_consumer/manifests/pod.yaml
@@ -32,7 +32,7 @@ spec:
         - name: DATASTORE_DATABASE
           value: ''
         - name: DATASTORE_EMULATOR_HOST
-          value: 'datastore:8085'
+          value: 'datastore:8086'
         - name: SPANNER_DATABASE
           value: 'local'
         - name: SPANNER_INSTANCE

--- a/workflows/steps/services/wpt_consumer/manifests/job.yaml
+++ b/workflows/steps/services/wpt_consumer/manifests/job.yaml
@@ -31,7 +31,7 @@ spec:
             - name: DATASTORE_DATABASE
               value: ''
             - name: DATASTORE_EMULATOR_HOST
-              value: 'datastore:8085'
+              value: 'datastore:8086'
             - name: SPANNER_DATABASE
               value: 'local'
             - name: SPANNER_INSTANCE


### PR DESCRIPTION
Before this change:

Datastore and the redirect from `gcloud auth login` both use port 8085. Sometimes, a developer who is actively deploying and developing can get into a situation where port 8085 no longer works for one of the other. Meaning, either they cannot run `make dev_fake_data` or deploy anymore until they restart their devcontainer. This should help with that.

This change:

Changes datastore to use port 8086 instead everywhere.
- Why not change the port for gcloud auth login? I could not find instructions on the docs: https://cloud.google.com/sdk/gcloud/reference/auth/login

Other changes:
- Use calico for better networking.
    - Why: My environment actually stopped working. When debugging, it was because the pods could not talk internally to each other. Calico is a popular container network interface and it fixed it. https://minikube.sigs.k8s.io/docs/handbook/network_policy/#enabling-calico-on-a-minikube-cluster
- Modify devcontainer.json to almost forward 8085 so that the gcloud auth login will work. (we can look at this for our actual apps later too).