### PR TITLE
Upgrade @vaadin/router to resolve dependabot issue.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,7 +66,7 @@
     "@lit/task": "^1.0.0",
     "@shoelace-style/shoelace": "^2.17.1",
     "@types/google.visualization": "^0.0.74",
-    "@vaadin/router": "^1.7.5",
+    "@vaadin/router": "^2.0.0",
     "firebase": "^10.12.5",
     "lit": "^3.2.1",
     "openapi-fetch": "^0.12.0"

--- a/frontend/src/static/js/contexts/router-context.ts
+++ b/frontend/src/static/js/contexts/router-context.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-import type {Router} from '@vaadin/router';
+import type {AnyObject, Router} from '@vaadin/router';
 
 import {createContext} from '@lit/context';
 
 export type {Router} from '@vaadin/router';
-export const routerContext = createContext<Router | undefined>('router');
+export const routerContext = createContext<
+  Router<AnyObject, AnyObject> | undefined
+>('router');

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@lit/task": "^1.0.0",
         "@shoelace-style/shoelace": "^2.17.1",
         "@types/google.visualization": "^0.0.74",
-        "@vaadin/router": "^1.7.5",
+        "@vaadin/router": "^2.0.0",
         "firebase": "^10.12.5",
         "lit": "^3.2.1",
         "openapi-fetch": "^0.12.0"
@@ -2769,12 +2769,26 @@
       "dev": true
     },
     "node_modules/@vaadin/router": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@vaadin/router/-/router-1.7.5.tgz",
-      "integrity": "sha512-uRN3vd1ihgd596bF/NMZqpgxau0nlvIc0/JDd1EwStFNbZID/xIVse5LXdQhIyUKLmSl4T0GeCQK505xerWX0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/router/-/router-2.0.0.tgz",
+      "integrity": "sha512-IjOlzuUsrVhfBId+ypcdDLM3+GZHo64DUlkr8IjFe04A4kMvt0zVFIpPH03X52/tMiwyYOF0Sw6p53DXkWiZcA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@vaadin/vaadin-usage-statistics": "^2.1.0",
-        "path-to-regexp": "2.4.0"
+        "@vaadin/vaadin-usage-statistics": "^2.1.2",
+        "path-to-regexp": "^6.3.0",
+        "type-fest": "^4.26.1"
+      }
+    },
+    "node_modules/@vaadin/router/node_modules/type-fest": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@vaadin/vaadin-development-mode-detector": {
@@ -9350,9 +9364,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
-      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",


### PR DESCRIPTION
There's a dependabot alert on path-to-regexp which vaadin/router depends on.

https://github.com/GoogleChrome/webstatus.dev/security/dependabot/46

This change bumps the version of vaadin/router so that it uses the fixed version.

The new version of vaadin/router slightly changed due to the library using typescript (also going from v1.x.x to v2.x.x). As a result, there were small changes to fix that.