### PR TITLE
feat: introduce SavedSearches, SavedSearchUserRoles, & UserSavedSearchBookmarks tables

### DIFF
--- a/infra/storage/spanner/migrations/000009.sql
+++ b/infra/storage/spanner/migrations/000009.sql
@@ -22,12 +22,12 @@ CREATE TABLE IF NOT EXISTS SavedSearches (
     Name STRING(MAX) NOT NULL,
     -- Query is the query string of the saved search.
     Query STRING(MAX) NOT NULL,
-    -- Scope is the scope of the saved search, which can be one of the following:
-    -- USER_PUBLIC: The saved search is created by a user and is publicly accessible.
+    -- Scope is the scope of the saved search.
+    -- Refer to the SavedSearchScope enum in lib/gcpspanner/saved_searches.go for possible values.
     Scope STRING(MAX) NOT NULL,
-    -- AuthorID is only for auditing purposes. The author may not always be the
-    -- owner. Instead, we should always rely on SavedSearchUserRoles for current
-    -- roles.
+    -- AuthorID is only for auditing purposes. The author may not always be the owner.
+    -- Instead, we should always rely on SavedSearchUserRoles for current roles.
+    -- This ID is the unique ID for each user managed by Google Cloud Identity Platform.
     AuthorID STRING(MAX) NOT NULL,
     -- CreatedAt is the timestamp of the first saved search revision.
     CreatedAt TIMESTAMP OPTIONS (allow_commit_timestamp=true),
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS SavedSearches (
 CREATE TABLE IF NOT EXISTS SavedSearchUserRoles (
     SavedSearchID STRING(36) NOT NULL,
     UserID STRING(MAX) NOT NULL,
+    -- Refer to the SavedSearchRole enum in lib/gcpspanner/saved_search_user_roles.go for possible values.
     UserRole STRING(MAX) NOT NULL,
     FOREIGN KEY (SavedSearchID) REFERENCES SavedSearches(ID)  ON DELETE CASCADE
 ) PRIMARY KEY (UserID, SavedSearchID);

--- a/infra/storage/spanner/migrations/000009.sql
+++ b/infra/storage/spanner/migrations/000009.sql
@@ -1,0 +1,51 @@
+-- Copyright 2024 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- SavedSearches contains the most current revisions of saved searches.
+--
+-- A future table will contain the historical revisions of saved searches
+-- allowing for auditing and reverting to older versions of the saved search.
+CREATE TABLE IF NOT EXISTS SavedSearches (
+    ID STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
+    -- Name is the name of the saved search.
+    Name STRING(MAX) NOT NULL,
+    -- Query is the query string of the saved search.
+    Query STRING(MAX) NOT NULL,
+    -- Scope is the scope of the saved search, which can be one of the following:
+    -- USER_PUBLIC: The saved search is created by a user and is publicly accessible.
+    Scope STRING(MAX) NOT NULL,
+    -- AuthorID is only for auditing purposes. The author may not always be the
+    -- owner. Instead, we should always rely on SavedSearchUserRoles for current
+    -- roles.
+    AuthorID STRING(MAX) NOT NULL,
+    -- CreatedAt is the timestamp of the first saved search revision.
+    CreatedAt TIMESTAMP OPTIONS (allow_commit_timestamp=true),
+    -- UpdatedAt is the timestamp of the most recent revision.
+    UpdatedAt TIMESTAMP OPTIONS (allow_commit_timestamp=true)
+) PRIMARY KEY (ID);
+
+-- SavedSearchUserRoles keeps track of the user's role for a given saved search.
+CREATE TABLE IF NOT EXISTS SavedSearchUserRoles (
+    SavedSearchID STRING(36) NOT NULL,
+    UserID STRING(MAX) NOT NULL,
+    UserRole STRING(MAX) NOT NULL,
+    FOREIGN KEY (SavedSearchID) REFERENCES SavedSearches(ID)  ON DELETE CASCADE
+) PRIMARY KEY (UserID, SavedSearchID);
+
+-- UserSavedSearchBookmarks keeps track of the user's bookmarks for user-created saved searches.
+CREATE TABLE IF NOT EXISTS UserSavedSearchBookmarks (
+    SavedSearchID STRING(36) NOT NULL,
+    UserID STRING(MAX) NOT NULL,
+    FOREIGN KEY (SavedSearchID) REFERENCES SavedSearches(ID)  ON DELETE CASCADE
+) PRIMARY KEY (UserID, SavedSearchID);

--- a/lib/gcpspanner/saved_search_user_roles.go
+++ b/lib/gcpspanner/saved_search_user_roles.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+// SavedSearchRole is the enum for the saved searches role.
+type SavedSearchRole string
+
+const (
+	// SavedSearchOwner indicates the user owns the saved search query.
+	SavedSearchOwner SavedSearchRole = "OWNER"
+)

--- a/lib/gcpspanner/saved_searches.go
+++ b/lib/gcpspanner/saved_searches.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+// SavedSearchScope represents the scope of a saved search.
+type SavedSearchScope string
+
+const (
+	// UserPublicScope indicates that this is user created saved search meant to be publicly accessible.
+	UserPublicScope SavedSearchScope = "USER_PUBLIC"
+)

--- a/lib/gcpspanner/user_search_bookmarks.go
+++ b/lib/gcpspanner/user_search_bookmarks.go
@@ -1,0 +1,15 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner


### PR DESCRIPTION
This commit introduces the following three new tables to the database schema:

- SavedSearches: Stores the saved searches, including their name, query, scope (user-specific or global), author, and timestamps.
- SavedSearchUserRoles: Manages the roles of users in relation to saved searches (e.g., owner, editor).
- UserSavedSearchBookmarks: Tracks which user-specific saved searches are bookmarked by which users.

These tables provide the foundation for managing saved searches, user roles, and bookmarks, enabling features like creating, retrieving, updating, and deleting saved searches, assigning roles, and bookmarking searches for easy access.

Fixes #765 

Split up of #766 