### PR TITLE
feat(devcontainer): adjust file permissions

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Set umask inside the container for new files.
+umask 022
+
+# Make sure all files have read everyone for existing files.
+chmod -R a+r ./*
+
 # Clean up minikube just in case to ensure a fresh cluster.
 make minikube-delete
 


### PR DESCRIPTION
Set the default umask to 022 within the devcontainer to ensure new files are created with read permissions for all users.

Additionally, recursively add read permission to all existing files in the devcontainer to ensure consistent access.

This prevents permission issues when working within the development container that otherwise would be set by a different umask on the host.