### PR TITLE
Web Features workflow now calls Precalculate method for feature support events

### DIFF
--- a/lib/gcpspanner/spanneradapters/web_features_consumer.go
+++ b/lib/gcpspanner/spanneradapters/web_features_consumer.go
@@ -32,6 +32,7 @@ type WebFeatureSpannerClient interface {
 		featureID string,
 		featureAvailability gcpspanner.BrowserFeatureAvailability) error
 	UpsertFeatureSpec(ctx context.Context, webFeatureID string, input gcpspanner.FeatureSpec) error
+	PrecalculateBrowserFeatureSupportEvents(ctx context.Context) error
 }
 
 // NewWebFeaturesConsumer constructs an adapter for the web features consumer service.
@@ -96,6 +97,13 @@ func (c *WebFeaturesConsumer) InsertWebFeatures(
 		}
 
 		ret[featureID] = *id
+	}
+
+	// Now that all the feature information is stored, run pre-calculation of
+	// feature support events.
+	err := c.client.PrecalculateBrowserFeatureSupportEvents(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	return ret, nil


### PR DESCRIPTION

This now mandates that the WebFeatureSpannerClient implements PrecalculateBrowserFeatureSupportEvents (which already happened in #872). Since the spanner client already implements this in that mentioned PR, we don't have to do anything else besides modify the expected interface.

Also, modified the tests to accomodate for the fact that we are calling that now.

Addresses: #836