### PR TITLE
Call clean-openapi before generating new opeanpi Go code.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,9 +132,9 @@ go-openapi: $(OPENAPI_OUT_DIR)/backend/types.gen.go \
 			$(OPENAPI_OUT_DIR)/workflows/steps/common/repo_downloader/server.gen.go
 
 clean-go-openapi:
-	rm -rf $(addprefix $(OPENAPI_OUT_DIR)/backend, */types.gen.go */server.gen.go)
-	rm -rf $(addprefix $(OPENAPI_OUT_DIR)/workflows/steps/web_feature_consumer, */types.gen.go */server.gen.go)
-	rm -rf $(addprefix $(OPENAPI_OUT_DIR)/workflows/steps/common/repo_downloader, */types.gen.go */server.gen.go)
+	rm -rf $(addprefix $(OPENAPI_OUT_DIR)/backend, /types.gen.go /server.gen.go)
+	rm -rf $(addprefix $(OPENAPI_OUT_DIR)/workflows/steps/web_feature_consumer, /types.gen.go /server.gen.go)
+	rm -rf $(addprefix $(OPENAPI_OUT_DIR)/workflows/steps/common/repo_downloader, /types.gen.go /server.gen.go)
 
 node-openapi:
 	npx openapi-typescript openapi/backend/openapi.yaml -o lib/gen/openapi/ts-webstatus.dev-backend-types/types.d.ts

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ GH_REPO := "GoogleChrome/webstatus.dev"
 		clean \
 		test \
 		gen \
+		clean-openapi \
+		go-openapi \
+		node-openapi \
 		openapi \
 		jsonschema \
 		lint \
@@ -98,7 +101,7 @@ clean-gen: clean-openapi clean-jsonschema clean-antlr
 ################################
 # Generated Files: From OpenAPI
 ################################
-openapi: go-openapi node-openapi
+openapi: clean-openapi go-openapi node-openapi
 
 clean-openapi: clean-go-openapi
 
@@ -129,7 +132,9 @@ go-openapi: $(OPENAPI_OUT_DIR)/backend/types.gen.go \
 			$(OPENAPI_OUT_DIR)/workflows/steps/common/repo_downloader/server.gen.go
 
 clean-go-openapi:
-	rm -rf $(addprefix $(OPENAPI_OUT_DIR)/, */types.gen.go */server.gen.go)
+	rm -rf $(addprefix $(OPENAPI_OUT_DIR)/backend, */types.gen.go */server.gen.go)
+	rm -rf $(addprefix $(OPENAPI_OUT_DIR)/workflows/steps/web_feature_consumer, */types.gen.go */server.gen.go)
+	rm -rf $(addprefix $(OPENAPI_OUT_DIR)/workflows/steps/common/repo_downloader, */types.gen.go */server.gen.go)
 
 node-openapi:
 	npx openapi-typescript openapi/backend/openapi.yaml -o lib/gen/openapi/ts-webstatus.dev-backend-types/types.d.ts


### PR DESCRIPTION
Right now, the Makefile target for the go openapi code only re-generates if the [openapi.yaml](https://github.com/GoogleChrome/webstatus.dev/blob/ddf30251ca40fc008f338d33c0fe31bdd0b61984/Makefile#L108-L119) itself has changed.

But if the underlying libraries changed, a developer's environment will fail to re-generate.

This change:
- Now, we just wipe out all the generated openapi Go code which guarantees re-generation during `make build` (which happens before `make start-local`)

The typescript openapi code doesn't have the same problem because the rule for it is a little different.