### PR TITLE
Convert ChromiumUsage field to backend struct

### DIFF
--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -18,6 +18,7 @@ import (
 	"cmp"
 	"context"
 	"log/slog"
+	"math/big"
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
@@ -252,6 +253,18 @@ func convertBaselineSpannerToBackend(strStatus *string,
 	return ret
 }
 
+func convertChromiumUsageToBackend(chromiumUsage *big.Rat) *backend.ChromiumUsageInfo {
+	ret := &backend.ChromiumUsageInfo{
+		Daily: nil,
+	}
+	if chromiumUsage != nil {
+		usage, _ := chromiumUsage.Float64()
+		ret.Daily = &usage
+	}
+
+	return ret
+}
+
 func convertImplementationStatusToBackend(
 	status gcpspanner.BrowserImplementationStatus) backend.BrowserImplementationStatus {
 	switch status {
@@ -318,9 +331,13 @@ func (s *Backend) convertFeatureResult(featureResult *gcpspanner.FeatureResult) 
 			featureResult.LowDate,
 			featureResult.HighDate,
 		),
-		Wpt:                    nil,
-		Spec:                   nil,
-		Usage:                  nil,
+		Wpt:  nil,
+		Spec: nil,
+		Usage: &struct {
+			Chromium *backend.ChromiumUsageInfo "json:\"chromium,omitempty\""
+		}{
+			Chromium: convertChromiumUsageToBackend(featureResult.ChromiumUsage),
+		},
 		BrowserImplementations: nil,
 	}
 

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -333,9 +333,7 @@ func (s *Backend) convertFeatureResult(featureResult *gcpspanner.FeatureResult) 
 		),
 		Wpt:  nil,
 		Spec: nil,
-		Usage: &struct {
-			Chromium *backend.ChromiumUsageInfo "json:\"chromium,omitempty\""
-		}{
+		Usage: &backend.BrowserUsage{
 			Chromium: convertChromiumUsageToBackend(featureResult.ChromiumUsage),
 		},
 		BrowserImplementations: nil,

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -729,9 +729,7 @@ func TestFeaturesSearch(t *testing.T) {
 						FeatureId: "feature1",
 						Name:      "feature 1",
 						Spec:      nil,
-						Usage: &struct {
-							Chromium *backend.ChromiumUsageInfo "json:\"chromium,omitempty\""
-						}{
+						Usage: &backend.BrowserUsage{
 							Chromium: &backend.ChromiumUsageInfo{
 								Daily: valuePtr[float64](0.91),
 							},
@@ -781,9 +779,7 @@ func TestFeaturesSearch(t *testing.T) {
 								},
 							},
 						},
-						Usage: &struct {
-							Chromium *backend.ChromiumUsageInfo "json:\"chromium,omitempty\""
-						}{
+						Usage: &backend.BrowserUsage{
 							Chromium: &backend.ChromiumUsageInfo{
 								Daily: valuePtr[float64](0.1),
 							},
@@ -1035,9 +1031,7 @@ func TestGetFeature(t *testing.T) {
 						},
 					},
 				},
-				Usage: &struct {
-					Chromium *backend.ChromiumUsageInfo "json:\"chromium,omitempty\""
-				}{
+				Usage: &backend.BrowserUsage{
 					Chromium: &backend.ChromiumUsageInfo{
 						Daily: nil,
 					},
@@ -1231,9 +1225,7 @@ func TestConvertFeatureResult(t *testing.T) {
 				FeatureId: "feature1",
 				Name:      "feature 1",
 				Spec:      nil,
-				Usage: &struct {
-					Chromium *backend.ChromiumUsageInfo "json:\"chromium,omitempty\""
-				}{
+				Usage: &backend.BrowserUsage{
 					Chromium: &backend.ChromiumUsageInfo{
 						Daily: valuePtr[float64](0.08),
 					},

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -895,7 +895,7 @@ func CompareFeatures(f1, f2 backend.Feature) bool {
 }
 
 func compareChromiumUsage(c1, c2 backend.ChromiumUsageInfo) bool {
-	return c1.Daily == c2.Daily
+	return reflect.DeepEqual(c1.Daily, c2.Daily)
 }
 
 func compareImplementationStatus(s1, s2 *map[string]backend.BrowserImplementation) bool {

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -638,7 +638,7 @@ func TestFeaturesSearch(t *testing.T) {
 								},
 							},
 							SpecLinks:     nil,
-							ChromiumUsage: nil,
+							ChromiumUsage: big.NewRat(91, 100),
 						},
 						{
 							Name:       "feature 2",
@@ -692,7 +692,7 @@ func TestFeaturesSearch(t *testing.T) {
 								"link1",
 								"link2",
 							},
-							ChromiumUsage: nil,
+							ChromiumUsage: big.NewRat(10, 100),
 						},
 					},
 				},
@@ -729,7 +729,13 @@ func TestFeaturesSearch(t *testing.T) {
 						FeatureId: "feature1",
 						Name:      "feature 1",
 						Spec:      nil,
-						Usage:     nil,
+						Usage: &struct {
+							Chromium *backend.ChromiumUsageInfo "json:\"chromium,omitempty\""
+						}{
+							Chromium: &backend.ChromiumUsageInfo{
+								Daily: valuePtr[float64](0.91),
+							},
+						},
 						Wpt: &backend.FeatureWPTSnapshots{
 							Experimental: &map[string]backend.WPTFeatureData{
 								"browser3": {
@@ -775,7 +781,13 @@ func TestFeaturesSearch(t *testing.T) {
 								},
 							},
 						},
-						Usage: nil,
+						Usage: &struct {
+							Chromium *backend.ChromiumUsageInfo "json:\"chromium,omitempty\""
+						}{
+							Chromium: &backend.ChromiumUsageInfo{
+								Daily: valuePtr[float64](0.1),
+							},
+						},
 						Wpt: &backend.FeatureWPTSnapshots{
 							Experimental: &map[string]backend.WPTFeatureData{
 								"browser1": {
@@ -851,8 +863,7 @@ func TestFeaturesSearch(t *testing.T) {
 func CompareFeatures(f1, f2 backend.Feature) bool {
 	// 1. Basic Equality Checks
 	if f1.FeatureId != f2.FeatureId ||
-		f1.Name != f2.Name ||
-		f1.Usage != f2.Usage {
+		f1.Name != f2.Name {
 		return false
 	}
 
@@ -866,7 +877,7 @@ func CompareFeatures(f1, f2 backend.Feature) bool {
 		return false
 	}
 
-	if !compareImplementationStatus(f1.BrowserImplementations, f1.BrowserImplementations) {
+	if !compareImplementationStatus(f1.BrowserImplementations, f2.BrowserImplementations) {
 		return false
 	}
 
@@ -875,8 +886,16 @@ func CompareFeatures(f1, f2 backend.Feature) bool {
 		return false
 	}
 
+	if !compareChromiumUsage(*f1.Usage.Chromium, *f2.Usage.Chromium) {
+		return false
+	}
+
 	// All fields match
 	return true
+}
+
+func compareChromiumUsage(c1, c2 backend.ChromiumUsageInfo) bool {
+	return c1.Daily == c2.Daily
 }
 
 func compareImplementationStatus(s1, s2 *map[string]backend.BrowserImplementation) bool {
@@ -1016,7 +1035,13 @@ func TestGetFeature(t *testing.T) {
 						},
 					},
 				},
-				Usage: nil,
+				Usage: &struct {
+					Chromium *backend.ChromiumUsageInfo "json:\"chromium,omitempty\""
+				}{
+					Chromium: &backend.ChromiumUsageInfo{
+						Daily: nil,
+					},
+				},
 				Wpt: &backend.FeatureWPTSnapshots{
 					Experimental: &map[string]backend.WPTFeatureData{
 						"browser3": {
@@ -1033,7 +1058,13 @@ func TestGetFeature(t *testing.T) {
 						},
 					},
 				},
-				BrowserImplementations: nil,
+				BrowserImplementations: &map[string]backend.BrowserImplementation{
+					"browser3": {
+						Status:  valuePtr(backend.Available),
+						Date:    nil,
+						Version: nil,
+					},
+				},
 			},
 		},
 	}
@@ -1186,7 +1217,7 @@ func TestConvertFeatureResult(t *testing.T) {
 				},
 				ImplementationStatuses: nil,
 				SpecLinks:              nil,
-				ChromiumUsage:          nil,
+				ChromiumUsage:          big.NewRat(8, 100),
 			},
 
 			expectedFeature: &backend.Feature{
@@ -1197,10 +1228,16 @@ func TestConvertFeatureResult(t *testing.T) {
 					),
 					HighDate: nil,
 				},
-				FeatureId:              "feature1",
-				Name:                   "feature 1",
-				Spec:                   nil,
-				Usage:                  nil,
+				FeatureId: "feature1",
+				Name:      "feature 1",
+				Spec:      nil,
+				Usage: &struct {
+					Chromium *backend.ChromiumUsageInfo "json:\"chromium,omitempty\""
+				}{
+					Chromium: &backend.ChromiumUsageInfo{
+						Daily: valuePtr[float64](0.08),
+					},
+				},
 				Wpt:                    nil,
 				BrowserImplementations: nil,
 			},

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -757,16 +757,18 @@ components:
         baseline:
           $ref: '#/components/schemas/BaselineInfo'
         usage:
-          type: object
-          properties:
-            chromium:
-              $ref: '#/components/schemas/ChromiumUsageInfo'
+          $ref: '#/components/schemas/BrowserUsage'
         wpt:
           $ref: '#/components/schemas/FeatureWPTSnapshots'
       required:
         - feature_id
         - name
         - baseline_status
+    BrowserUsage:
+      type: object
+      properties:
+        chromium:
+          $ref: '#/components/schemas/ChromiumUsageInfo'
     ChromiumUsageInfo:
       type: object
       properties:


### PR DESCRIPTION
Fixes #845 

Additionally, a small fix in `lib/gcpspanner/spanneradapters/backend.go` is present.