### PR TITLE
Pass timeout config to GCP workflow

### DIFF
--- a/infra/modules/single_stage_go_workflow/main.tf
+++ b/infra/modules/single_stage_go_workflow/main.tf
@@ -74,6 +74,7 @@ resource "google_workflows_workflow" "workflow" {
   source_contents = templatefile(
     "${path.root}/modules/single_stage_go_workflow/workflows.yaml.tftpl",
     {
+      timeout      = var.timeout_seconds
       project_id   = each.value.project_id
       job_name     = each.value.name
       job_location = each.key

--- a/infra/modules/single_stage_go_workflow/workflows.yaml.tftpl
+++ b/infra/modules/single_stage_go_workflow/workflows.yaml.tftpl
@@ -5,6 +5,8 @@ main:
         args:
             name: namespaces/${project_id}/jobs/${job_name}
             location: ${job_location}
+            connector_params:
+                timeout: ${timeout}
         result: job_execution
     - finish:
         return: $${job_execution}


### PR DESCRIPTION
Currently: When the GCP workflow calls the cloud run job, the cloud run job runs with a certain timeout configured. But the workflow uses the default timeout.

This leads to the workflow being marked as failed within the default time. But the job actually is still running.

This change makes it so the workflow uses the same timeout as the job.