### PR TITLE
Add batchWriter interface for spanner

### DIFF
--- a/util/cmd/load_fake_data/main.go
+++ b/util/cmd/load_fake_data/main.go
@@ -432,11 +432,8 @@ func generateRunsAndMetrics(
 					}
 					mutations = append(mutations, m)
 				}
-				// BatchWrite is not implemented in the emulator.
-				// https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/154
-				// Instead, do Apply which does multiple statements atomically.
-				// Revisit this once the emulator supports BatchWrite.
-				_, err = client.Apply(ctx, mutations)
+				writer := gcpspanner.LocalBatchWriter{}
+				err = writer.BatchWriteMutations(ctx, client.Client, mutations)
 				if err != nil {
 					return runsGenerated, metricsGenerated, err
 				}


### PR DESCRIPTION
The spanner emulator does not currently support the batch write API. Probably because it is in Preview on GCP. But we should leverage this here for our workflows when possible.

This new interface is used by the Client. Upon construction, it determines which batch writer to use.