### PR TITLE
Add concurrent batch writer + have browser feature support event use it

### DIFF
--- a/lib/gcpspanner/browser_availabilities.go
+++ b/lib/gcpspanner/browser_availabilities.go
@@ -99,7 +99,7 @@ func (c *Client) InsertBrowserFeatureAvailability(
 }
 
 func (c *Client) fetchAllBrowserAvailabilitiesWithTransaction(
-	ctx context.Context, txn *spanner.ReadWriteTransaction) ([]spannerBrowserFeatureAvailability, error) {
+	ctx context.Context, txn *spanner.ReadOnlyTransaction) ([]spannerBrowserFeatureAvailability, error) {
 	var availabilities []spannerBrowserFeatureAvailability
 	iter := txn.Read(ctx, browserFeatureAvailabilitiesTable, spanner.AllKeys(), []string{
 		"BrowserName",

--- a/lib/gcpspanner/browser_releases.go
+++ b/lib/gcpspanner/browser_releases.go
@@ -84,7 +84,7 @@ func (c *Client) InsertBrowserRelease(ctx context.Context, release BrowserReleas
 }
 
 func (c *Client) fetchAllBrowserReleasesWithTransaction(
-	ctx context.Context, txn *spanner.ReadWriteTransaction) ([]spannerBrowserRelease, error) {
+	ctx context.Context, txn *spanner.ReadOnlyTransaction) ([]spannerBrowserRelease, error) {
 	var releases []spannerBrowserRelease
 	iter := txn.Read(ctx, browserReleasesTable, spanner.AllKeys(), []string{
 		"BrowserName",

--- a/lib/gcpspanner/web_features.go
+++ b/lib/gcpspanner/web_features.go
@@ -101,7 +101,7 @@ func (c *Client) GetIDFromFeatureKey(ctx context.Context, filter *FeatureIDFilte
 }
 
 func (c *Client) fetchAllWebFeatureIDsWithTransaction(
-	ctx context.Context, txn *spanner.ReadWriteTransaction) ([]string, error) {
+	ctx context.Context, txn *spanner.ReadOnlyTransaction) ([]string, error) {
 	var ids []string
 	iter := txn.Read(ctx, webFeaturesTable, spanner.AllKeys(), []string{"ID"})
 	defer iter.Stop()


### PR DESCRIPTION
This change adds a generic concurrent batch writer. This calls the BatchWriteMutations method from #889 

Background: During testing in GCP, I saw that each batch write call has a limit but we can increase throughput by running concurrent batch writes.

By default, we set the batch size to 10000 entities and 8 concurrent batch writers. In the future, we can allow spanner clients to configure these based on system settings.