### PR TITLE
Add DATA_WINDOW_DURATION for web features workflow

### DIFF
--- a/infra/ingestion/workflows.tf
+++ b/infra/ingestion/workflows.tf
@@ -53,6 +53,10 @@ module "web_features_workflow" {
       name  = "DATASTORE_DATABASE"
       value = var.datastore_info.database_name
     },
+    {
+      name  = "DATA_WINDOW_DURATION"
+      value = "262980h" # 30 years in hours (365.25*30*24)
+    }
   ]
 }
 

--- a/lib/gcpspanner/missing_one_implementation_test.go
+++ b/lib/gcpspanner/missing_one_implementation_test.go
@@ -117,7 +117,8 @@ func loadDataForListMissingOneImplCounts(ctx context.Context, t *testing.T, clie
 			t.Errorf("unexpected error during insert. %s", err.Error())
 		}
 	}
-	err := spannerClient.PrecalculateBrowserFeatureSupportEvents(ctx)
+	err := spannerClient.PrecalculateBrowserFeatureSupportEvents(ctx,
+		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Errorf("unexpected error during pre-calculate. %s", err.Error())
 	}

--- a/lib/gcpspanner/spanneradapters/web_features_consumer.go
+++ b/lib/gcpspanner/spanneradapters/web_features_consumer.go
@@ -32,7 +32,7 @@ type WebFeatureSpannerClient interface {
 		featureID string,
 		featureAvailability gcpspanner.BrowserFeatureAvailability) error
 	UpsertFeatureSpec(ctx context.Context, webFeatureID string, input gcpspanner.FeatureSpec) error
-	PrecalculateBrowserFeatureSupportEvents(ctx context.Context) error
+	PrecalculateBrowserFeatureSupportEvents(ctx context.Context, startAt, endAt time.Time) error
 }
 
 // NewWebFeaturesConsumer constructs an adapter for the web features consumer service.
@@ -48,7 +48,8 @@ type WebFeaturesConsumer struct {
 
 func (c *WebFeaturesConsumer) InsertWebFeatures(
 	ctx context.Context,
-	data map[string]web_platform_dx__web_features.FeatureValue) (map[string]string, error) {
+	data map[string]web_platform_dx__web_features.FeatureValue,
+	startAt, endAt time.Time) (map[string]string, error) {
 	ret := make(map[string]string, len(data))
 	for featureID, featureData := range data {
 		webFeature := gcpspanner.WebFeature{
@@ -101,7 +102,7 @@ func (c *WebFeaturesConsumer) InsertWebFeatures(
 
 	// Now that all the feature information is stored, run pre-calculation of
 	// feature support events.
-	err := c.client.PrecalculateBrowserFeatureSupportEvents(ctx)
+	err := c.client.PrecalculateBrowserFeatureSupportEvents(ctx, startAt, endAt)
 	if err != nil {
 		return nil, err
 	}

--- a/util/run_job.sh
+++ b/util/run_job.sh
@@ -40,7 +40,7 @@ kubectl delete job "$job_name" --ignore-not-found=true
 kubectl apply -f "$job_yaml"
 
 # Wait for Job completion
-kubectl wait --for=condition=complete --timeout=90s job/"$job_name"
+kubectl wait --for=condition=complete --timeout=600s job/"$job_name"
 
 # Get Job pod name
 pod_name=$(kubectl get pods --selector=job-name="$job_name" -o jsonpath='{.items[0].metadata.name}')

--- a/workflows/steps/services/web_feature_consumer/cmd/job/main.go
+++ b/workflows/steps/services/web_feature_consumer/cmd/job/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters"
@@ -63,6 +64,15 @@ func main() {
 	// Will be empty if not set and that is okay.
 	token := os.Getenv("GITHUB_TOKEN")
 
+	dataWindowDuration := os.Getenv("DATA_WINDOW_DURATION")
+	duration, err := time.ParseDuration(dataWindowDuration)
+	if err != nil {
+		slog.Error("unable to parse DATA_WINDOW_DURATION duration", "input value", dataWindowDuration)
+		os.Exit(1)
+	}
+	endAt := time.Now().UTC()
+	startAt := endAt.Add(-duration)
+
 	// Currently, only one worker needed
 	numWorkers := 1
 
@@ -90,6 +100,8 @@ func main() {
 			releaseAssetName,
 			repoOwner,
 			repoName,
+			startAt,
+			endAt,
 		),
 	}
 	// Job Execution and Error Handling

--- a/workflows/steps/services/web_feature_consumer/manifests/job.yaml
+++ b/workflows/steps/services/web_feature_consumer/manifests/job.yaml
@@ -38,6 +38,8 @@ spec:
               value: 'local'
             - name: SPANNER_EMULATOR_HOST
               value: 'spanner:9010'
+            - name: DATA_WINDOW_DURATION
+              value: '4383h' # 0.5 year (365.25 / 2 * 24 )
           resources:
             limits:
               cpu: 250m


### PR DESCRIPTION
This is similar to the DATA_WINDOW_DURATION environment variable used in the WPT workflow. [source](https://github.com/search?q=repo%3AGoogleChrome%2Fwebstatus.dev%20DATA_WINDOW_DURATION&type=code)

We do this so that between local and gcp environments, we can control how much data is loaded automatically. Otherwise, the local environment could be overwhelmed by trying to consume all the data.

In GCP environments, we look back 30 years (more than enough time)
In local environments, we look back only half a year.