### PR TITLE
Add plumbing between spanner & http for missing one implementation

### DIFF
--- a/backend/pkg/httpserver/list_aggregated_feature_support.go
+++ b/backend/pkg/httpserver/list_aggregated_feature_support.go
@@ -22,7 +22,7 @@ import (
 )
 
 // ListAggregatedFeatureSupport implements backend.StrictServerInterface.
-// nolint: revive, ireturn // Signature generated from openapi
+// nolint: ireturn // Signature generated from openapi
 func (s *Server) ListAggregatedFeatureSupport(
 	ctx context.Context,
 	request backend.ListAggregatedFeatureSupportRequestObject) (
@@ -37,7 +37,7 @@ func (s *Server) ListAggregatedFeatureSupport(
 	)
 	if err != nil {
 		// TODO check error type
-		slog.ErrorContext(ctx, "unable to get list of features", "error", err)
+		slog.ErrorContext(ctx, "unable to get count of supported features", "error", err)
 
 		return backend.ListAggregatedFeatureSupport500JSONResponse{
 			Code:    500,

--- a/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
@@ -1,0 +1,213 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+func TestListMissingOneImplemenationCounts(t *testing.T) {
+	testCases := []struct {
+		name              string
+		mockConfig        MockListMissingOneImplCountsConfig
+		expectedCallCount int // For the mock method
+		request           backend.ListMissingOneImplemenationCountsRequestObject
+		expectedResponse  backend.ListMissingOneImplemenationCountsResponseObject
+		expectedError     error
+	}{
+		{
+			name: "Success Case - no optional params - use defaults",
+			mockConfig: MockListMissingOneImplCountsConfig{
+				expectedTargetBrowser: "chrome",
+				expectedOtherBrowsers: []string{"edge", "firefox", "safari"},
+				expectedStartAt:       time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:         time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:      100,
+				expectedPageToken:     nil,
+				pageToken:             nil,
+				err:                   nil,
+				page: &backend.BrowserReleaseFeatureMetricsPage{
+					Metadata: &backend.PageMetadata{
+						NextPageToken: nil,
+					},
+					Data: []backend.BrowserReleaseFeatureMetric{
+						{
+							Count:     valuePtr[int64](10),
+							Timestamp: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+						},
+						{
+							Count:     valuePtr[int64](9),
+							Timestamp: time.Date(2000, time.January, 9, 0, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListMissingOneImplemenationCounts200JSONResponse{
+				Data: []backend.BrowserReleaseFeatureMetric{
+					{
+						Count:     valuePtr[int64](10),
+						Timestamp: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+					},
+					{
+						Count:     valuePtr[int64](9),
+						Timestamp: time.Date(2000, time.January, 9, 0, 0, 0, 0, time.UTC),
+					},
+				},
+				Metadata: &backend.PageMetadata{
+					NextPageToken: nil,
+				},
+			},
+			request: backend.ListMissingOneImplemenationCountsRequestObject{
+				Params: backend.ListMissingOneImplemenationCountsParams{
+					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					PageToken: nil,
+					PageSize:  nil,
+					Browser: []backend.SupportedBrowsers{
+						backend.Edge, backend.Firefox, backend.Safari,
+					},
+				},
+				Browser: backend.Chrome,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success Case - include optional params",
+			mockConfig: MockListMissingOneImplCountsConfig{
+				expectedTargetBrowser: "chrome",
+				expectedOtherBrowsers: []string{"edge", "firefox", "safari"},
+				expectedStartAt:       time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:         time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:      50,
+				expectedPageToken:     inputPageToken,
+				err:                   nil,
+				page: &backend.BrowserReleaseFeatureMetricsPage{
+					Metadata: &backend.PageMetadata{
+						NextPageToken: nextPageToken,
+					},
+					Data: []backend.BrowserReleaseFeatureMetric{
+						{
+							Count:     valuePtr[int64](10),
+							Timestamp: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+						},
+						{
+							Count:     valuePtr[int64](9),
+							Timestamp: time.Date(2000, time.January, 9, 0, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+				pageToken: nextPageToken,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListMissingOneImplemenationCounts200JSONResponse{
+				Metadata: &backend.PageMetadata{
+					NextPageToken: nextPageToken,
+				},
+				Data: []backend.BrowserReleaseFeatureMetric{
+					{
+						Count:     valuePtr[int64](10),
+						Timestamp: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+					},
+					{
+						Count:     valuePtr[int64](9),
+						Timestamp: time.Date(2000, time.January, 9, 0, 0, 0, 0, time.UTC),
+					},
+				},
+			},
+			request: backend.ListMissingOneImplemenationCountsRequestObject{
+				Params: backend.ListMissingOneImplemenationCountsParams{
+					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					PageToken: inputPageToken,
+					PageSize:  valuePtr[int](50),
+					Browser: []backend.SupportedBrowsers{
+						backend.Edge, backend.Firefox, backend.Safari,
+					},
+				},
+				Browser: backend.Chrome,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "500 case",
+			mockConfig: MockListMissingOneImplCountsConfig{
+				expectedTargetBrowser: "chrome",
+				expectedOtherBrowsers: []string{"edge", "firefox", "safari"},
+				expectedStartAt:       time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:         time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:      100,
+				expectedPageToken:     nil,
+				page:                  nil,
+				pageToken:             nil,
+				err:                   errTest,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListMissingOneImplemenationCounts500JSONResponse{
+				Code:    500,
+				Message: "unable to get missing one implementation metrics",
+			},
+			request: backend.ListMissingOneImplemenationCountsRequestObject{
+				Params: backend.ListMissingOneImplemenationCountsParams{
+					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					PageToken: nil,
+					PageSize:  nil,
+					Browser: []backend.SupportedBrowsers{
+						backend.Edge, backend.Firefox, backend.Safari,
+					},
+				},
+				Browser: backend.Chrome,
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// nolint: exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				listMissingOneImplCountCfg: tc.mockConfig,
+				t:                          t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
+
+			// Call the function under test
+			resp, err := myServer.ListMissingOneImplemenationCounts(context.Background(), tc.request)
+
+			// Assertions
+			if mockStorer.callCountListBrowserFeatureCountMetric != tc.expectedCallCount {
+				t.Errorf("Incorrect call count: expected %d, got %d",
+					tc.expectedCallCount,
+					mockStorer.callCountListBrowserFeatureCountMetric)
+			}
+
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tc.expectedResponse, resp) {
+				t.Errorf("Unexpected response: %v", resp)
+			}
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -88,6 +88,14 @@ type WPTMetricsStorer interface {
 		ctx context.Context,
 		featureID string,
 	) (*string, error)
+	ListMissingOneImplCounts(
+		ctx context.Context,
+		targetBrowser string,
+		otherBrowsers []string,
+		startAt, endAt time.Time,
+		pageSize int,
+		pageToken *string,
+	) (*backend.BrowserReleaseFeatureMetricsPage, error)
 }
 
 type Server struct {

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -125,11 +125,24 @@ type MockListBrowserFeatureCountMetricConfig struct {
 	err               error
 }
 
+type MockListMissingOneImplCountsConfig struct {
+	expectedTargetBrowser string
+	expectedOtherBrowsers []string
+	expectedStartAt       time.Time
+	expectedEndAt         time.Time
+	expectedPageSize      int
+	expectedPageToken     *string
+	pageToken             *string
+	page                  *backend.BrowserReleaseFeatureMetricsPage
+	err                   error
+}
+
 type MockWPTMetricsStorer struct {
 	featureCfg                                        MockListMetricsForFeatureIDBrowserAndChannelConfig
 	aggregateCfg                                      MockListMetricsOverTimeWithAggregatedTotalsConfig
 	featuresSearchCfg                                 MockFeaturesSearchConfig
 	listBrowserFeatureCountMetricCfg                  MockListBrowserFeatureCountMetricConfig
+	listMissingOneImplCountCfg                        MockListMissingOneImplCountsConfig
 	listChromiumDailyUsageStatsCfg                    MockListChromiumDailyUsageStatsConfig
 	getFeatureByIDConfig                              MockGetFeatureByIDConfig
 	getIDFromFeatureKeyConfig                         MockGetIDFromFeatureKeyConfig
@@ -290,6 +303,31 @@ func (m *MockWPTMetricsStorer) ListBrowserFeatureCountMetric(
 	}
 
 	return m.listBrowserFeatureCountMetricCfg.page, m.listBrowserFeatureCountMetricCfg.err
+}
+
+func (m *MockWPTMetricsStorer) ListMissingOneImplCounts(
+	_ context.Context,
+	targetBrowser string,
+	otherBrowsers []string,
+	startAt time.Time,
+	endAt time.Time,
+	pageSize int,
+	pageToken *string,
+) (*backend.BrowserReleaseFeatureMetricsPage, error) {
+	m.callCountListBrowserFeatureCountMetric++
+
+	if targetBrowser != m.listMissingOneImplCountCfg.expectedTargetBrowser ||
+		!slices.Equal(otherBrowsers, m.listMissingOneImplCountCfg.expectedOtherBrowsers) ||
+		!startAt.Equal(m.listMissingOneImplCountCfg.expectedStartAt) ||
+		!endAt.Equal(m.listMissingOneImplCountCfg.expectedEndAt) ||
+		pageSize != m.listMissingOneImplCountCfg.expectedPageSize ||
+		pageToken != m.listMissingOneImplCountCfg.expectedPageToken {
+
+		m.t.Errorf("Incorrect arguments. Expected: %v, Got: { %v, %s, %s, %s, %d %v }",
+			m.listMissingOneImplCountCfg, targetBrowser, otherBrowsers, startAt, endAt, pageSize, pageToken)
+	}
+
+	return m.listMissingOneImplCountCfg.page, m.listMissingOneImplCountCfg.err
 }
 
 func TestGetPageSizeOrDefault(t *testing.T) {


### PR DESCRIPTION
Fixes #880

This change adds the spanner adapter conversion layer for the missing one implementation endpoint. This converts the data from spanner to the expected missing one implementation page that is documented in the openapi yaml for the endpoint.

This change has the http layer call this layer for the endpoint.

Heavily inspired by:
- [backend/pkg/httpserver/list_aggregated_feature_support.go](https://github.com/GoogleChrome/webstatus.dev/blob/main/backend/pkg/httpserver/list_aggregated_feature_support.go)
- The [ListBrowserFeatureCountMetric method in lib/gcpspanner/spanneradapters/backend.go](https://github.com/GoogleChrome/webstatus.dev/blob/40b461b550bbb32b432a6dd219e9ccf94b249d23/lib/gcpspanner/spanneradapters/backend.go#L99-L133)

Other changes:
- Fix log statement in backend/pkg/httpserver/list_aggregated_feature_support.go