### PR TITLE
Add id term to featuresearch.g4

### DIFF
--- a/antlr/FeatureSearch.g4
+++ b/antlr/FeatureSearch.g4
@@ -33,12 +33,14 @@ baseline_date_term: 'baseline_date' COLON (date_range_query);
 name_term: 'name' COLON ANY_VALUE;
 group_term: 'group' COLON ANY_VALUE;
 snapshot_term: 'snapshot' COLON ANY_VALUE;
+id_term: 'id' COLON ANY_VALUE;
 term:
 	available_date_term
 	| available_on_term
 	| baseline_status_term
 	| baseline_date_term
 	| group_term
+	| id_term
 	| snapshot_term
 	| name_term;
 

--- a/antlr/FeatureSearch.md
+++ b/antlr/FeatureSearch.md
@@ -39,6 +39,10 @@ This query language enables you to construct flexible searches to find features 
     - Option 1: Searches for an inclusive date range (DATE..DATE) where features reached baseline.
   - `group`: Searches for features that belong to a group defined in the web-features [repository](https://github.com/web-platform-dx/web-features/tree/main/groups).
   - `snapshot`: Searches for features that belong to a snapshot defined in the web-features [repository](https://github.com/web-platform-dx/web-features/tree/main/snapshots).
+  - `id`: Searches for features whose feature identifiers (FeatureKey) match the search value exactly.
+    - Examples:
+    - `id:grid`
+    - `id:"CSS Grid"`
 - **Negation:** Prepend a term with a minus sign (-) to indicate negation (search for features not matching that criterion).
 - **Keywords:** These are reserved words used in the grammar, such as `AND`, `OR`
   - `AND`: Combine terms with the AND keyword for explicit logical AND, or use a space between terms for implied AND.
@@ -57,6 +61,7 @@ This query language enables you to construct flexible searches to find features 
 - `baseline_date:2023-01-01..2023-12-31` - Searches for all features that reached baseline in 2023.
 - `group:css` - Searches for features that belong to the `css` group and any groups that are descendants of that group.
 - `snapshot:ecmascript-5` - Searches for features that belong to the `ecmascript-5` snapshot.
+- `id:css` - Searches for a feature whose feature identifier (featurekey) is `css`.
 
 ### Complex Queries
 

--- a/lib/gcpspanner/feature_search_query.go
+++ b/lib/gcpspanner/feature_search_query.go
@@ -111,6 +111,7 @@ func (b *FeatureSearchFilterBuilder) traverseAndGenerateFilters(node *searchtype
 
 	case node.Term != nil && (node.Keyword == searchtypes.KeywordNone):
 		var filter string
+		// nolint: exhaustive // Temporarily disable this.
 		switch node.Term.Identifier {
 		case searchtypes.IdentifierAvailableDate:
 			// Currently not a terminal identifier.

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -735,6 +735,72 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
+			InputQuery: "id:html",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Children: nil,
+						Term: &SearchTerm{
+							Identifier: IdentifierID,
+							Value:      "html",
+							Operator:   OperatorEq,
+						},
+						Keyword: KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: `baseline_date:2000-01-01..2000-12-31 OR id:css`,
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Keyword: KeywordOR,
+						Term:    nil,
+						Children: []*SearchNode{
+							{
+								Keyword: KeywordAND,
+								Term:    nil,
+								Children: []*SearchNode{
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierBaselineDate,
+											Value:      "2000-01-01",
+											Operator:   OperatorGtEq,
+										},
+										Children: nil,
+									},
+									{
+										Keyword: KeywordNone,
+										Term: &SearchTerm{
+											Identifier: IdentifierBaselineDate,
+											Value:      "2000-12-31",
+											Operator:   OperatorLtEq,
+										},
+										Children: nil,
+									},
+								},
+							},
+							{
+								Keyword:  KeywordNone,
+								Children: nil,
+								Term: &SearchTerm{
+									Identifier: IdentifierID,
+									Value:      "css",
+									Operator:   OperatorEq,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			// Should remove the quotes
 			InputQuery: `name:"CSS Grid"`,
 			ExpectedTree: &SearchNode{

--- a/lib/gcpspanner/searchtypes/features_search_visitor.go
+++ b/lib/gcpspanner/searchtypes/features_search_visitor.go
@@ -128,6 +128,10 @@ func (v *FeaturesSearchVisitor) aggregateNodesImplicitAND(nodes []*SearchNode) *
 	return rootNode
 }
 
+func (v *FeaturesSearchVisitor) createIDNode(id string) *SearchNode {
+	return v.createSimpleNode(id, IdentifierID, OperatorEq)
+}
+
 func (v *FeaturesSearchVisitor) createSnapshotNode(snapshot string) *SearchNode {
 	return v.createSimpleNode(snapshot, IdentifierSnapshot, OperatorEq)
 }
@@ -388,6 +392,10 @@ func (v *FeaturesSearchVisitor) Visit(tree antlr.ParseTree) any {
 		return v.VisitGeneric_search_term(tree)
 	case *parser.Group_termContext:
 		return v.VisitGroup_term(tree)
+	case *parser.Snapshot_termContext:
+		return v.VisitSnapshot_term(tree)
+	case *parser.Id_termContext:
+		return v.VisitId_term(tree)
 	case *parser.Name_termContext:
 		return v.VisitName_term(tree)
 	case *parser.OperatorContext:
@@ -441,6 +449,11 @@ func (v *FeaturesSearchVisitor) VisitCombined_search_criteria(ctx *parser.Combin
 	root = current
 
 	return root
+}
+
+// nolint: revive // Method signature is generated.
+func (v *FeaturesSearchVisitor) VisitId_term(ctx *parser.Id_termContext) interface{} {
+	return v.createIDNode(ctx.ANY_VALUE().GetText())
 }
 
 // nolint: revive // Method signature is generated.

--- a/lib/gcpspanner/searchtypes/features_search_visitor.go
+++ b/lib/gcpspanner/searchtypes/features_search_visitor.go
@@ -129,25 +129,24 @@ func (v *FeaturesSearchVisitor) aggregateNodesImplicitAND(nodes []*SearchNode) *
 }
 
 func (v *FeaturesSearchVisitor) createIDNode(id string) *SearchNode {
-	return v.createSimpleNode(id, IdentifierID, OperatorEq)
+	return v.createSimpleNode(id, IdentifierID)
 }
 
 func (v *FeaturesSearchVisitor) createSnapshotNode(snapshot string) *SearchNode {
-	return v.createSimpleNode(snapshot, IdentifierSnapshot, OperatorEq)
+	return v.createSimpleNode(snapshot, IdentifierSnapshot)
 }
 
 func (v *FeaturesSearchVisitor) createGroupNode(group string) *SearchNode {
-	return v.createSimpleNode(group, IdentifierGroup, OperatorEq)
+	return v.createSimpleNode(group, IdentifierGroup)
 }
 
 func (v *FeaturesSearchVisitor) createNameNode(name string) *SearchNode {
-	return v.createSimpleNode(name, IdentifierName, OperatorEq)
+	return v.createSimpleNode(name, IdentifierName)
 }
 
 func (v *FeaturesSearchVisitor) createSimpleNode(
 	value string,
-	identifier SearchIdentifier,
-	operator SearchOperator) *SearchNode {
+	identifier SearchIdentifier) *SearchNode {
 	value = strings.Trim(value, `"`)
 
 	return &SearchNode{
@@ -156,7 +155,7 @@ func (v *FeaturesSearchVisitor) createSimpleNode(
 		Term: &SearchTerm{
 			Identifier: identifier,
 			Value:      value,
-			Operator:   operator,
+			Operator:   OperatorEq,
 		},
 	}
 }
@@ -373,41 +372,7 @@ func (v *FeaturesSearchVisitor) VisitChildren(node antlr.RuleNode) interface{} {
 	return nil
 }
 
-// Similar to https://github.com/google/mangle/blob/28db3310648ee110b108523b3df943ce22b61e2a/parse/parse.go#L154
 func (v *FeaturesSearchVisitor) Visit(tree antlr.ParseTree) any {
-	switch tree := tree.(type) {
-	case *parser.Available_date_termContext:
-		return v.VisitAvailable_date_term(tree)
-	case *parser.Available_on_termContext:
-		return v.VisitAvailable_on_term(tree)
-	case *parser.Baseline_status_termContext:
-		return v.VisitBaseline_status_term(tree)
-	case *parser.Baseline_date_termContext:
-		return v.VisitBaseline_date_term(tree)
-	case *parser.Combined_search_criteriaContext:
-		return v.VisitCombined_search_criteria(tree)
-	case *parser.Date_range_queryContext:
-		return v.VisitDate_range_query(tree)
-	case *parser.Generic_search_termContext:
-		return v.VisitGeneric_search_term(tree)
-	case *parser.Group_termContext:
-		return v.VisitGroup_term(tree)
-	case *parser.Snapshot_termContext:
-		return v.VisitSnapshot_term(tree)
-	case *parser.Id_termContext:
-		return v.VisitId_term(tree)
-	case *parser.Name_termContext:
-		return v.VisitName_term(tree)
-	case *parser.OperatorContext:
-		return v.VisitOperator(tree)
-	case *parser.QueryContext:
-		return v.VisitQuery(tree)
-	case *parser.Search_criteriaContext:
-		return v.VisitSearch_criteria(tree)
-	case *parser.TermContext:
-		return v.VisitTerm(tree)
-	}
-
 	return tree.Accept(v)
 }
 

--- a/lib/gcpspanner/searchtypes/searchtypes.go
+++ b/lib/gcpspanner/searchtypes/searchtypes.go
@@ -94,4 +94,5 @@ const (
 	IdentifierName                 SearchIdentifier = "name"
 	IdentifierGroup                SearchIdentifier = "group"
 	IdentifierSnapshot             SearchIdentifier = "snapshot"
+	IdentifierID                   SearchIdentifier = "id"
 )


### PR DESCRIPTION
Fix [#786](https://github.com/GoogleChrome/webstatus.dev/issues/786). Add a search atom `id` to the parser. `id` searches for features whose feature identifier matches the search value exactly.

Also a drive-by change for the `Snapshot_termContext` switch case in `visit()`.