### PR TITLE
Fix the UMA metrics fetcher

### DIFF
--- a/util/go.mod
+++ b/util/go.mod
@@ -5,6 +5,7 @@ go 1.22.7
 toolchain go1.23.2
 
 require (
+	cloud.google.com/go v0.116.0
 	cloud.google.com/go/spanner v1.70.0
 	github.com/GoogleChrome/webstatus.dev/lib v0.0.0-20241028191306-75f646a1ea74
 	github.com/GoogleChrome/webstatus.dev/lib/gen v0.0.0-20241028191306-75f646a1ea74
@@ -16,7 +17,6 @@ require (
 
 require (
 	cel.dev/expr v0.18.0 // indirect
-	cloud.google.com/go v0.116.0 // indirect
 	cloud.google.com/go/auth v0.9.9 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.4 // indirect
 	cloud.google.com/go/cloudtasks v1.13.2 // indirect

--- a/workflows/steps/services/uma_export/workflow/job_processor.go
+++ b/workflows/steps/services/uma_export/workflow/job_processor.go
@@ -61,7 +61,7 @@ type MetricStorer interface {
 }
 
 type MetricFetecher interface {
-	Fetch(context.Context, metricdatatypes.UMAExportQuery) (io.ReadCloser, error)
+	Fetch(context.Context, metricdatatypes.UMAExportQuery, civil.Date) (io.ReadCloser, error)
 }
 
 type MetricParser interface {
@@ -90,7 +90,7 @@ func (p UMAExportJobProcessor) Process(ctx context.Context, job JobArguments) er
 	slog.InfoContext(ctx, "No capstone entry found. Will fetch", "date", job.day)
 
 	// Step 2. Fetch results
-	rawData, err := p.metricFetcher.Fetch(ctx, job.queryName)
+	rawData, err := p.metricFetcher.Fetch(ctx, job.queryName, job.day)
 	if err != nil {
 		slog.ErrorContext(ctx, "unable to fetch metrics", "error", err)
 


### PR DESCRIPTION
Currently, it only gets the latest metrics. However, we should be sending the date

[Example](https://github.com/GoogleChrome/chromium-dashboard/blob/19f27ae20f81eaa2106360dd8e2e66ee82547b60/internals/fetchmetrics.py#L92) of doing it in ChromeStatus.


The date provided to the uma export server needs to be in the following format YYYYMMDD. To accomplish that in [Go](https://go.dev/src/time/format.go), we have to specify the format as `20060102`