### PR TITLE
Overview page UI for bookmarks

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-overview-content.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-overview-content.test.ts
@@ -109,8 +109,6 @@ describe('webstatus-overview-content', () => {
     });
 
     it('should display the bookmark title and description when query is matched', async () => {
-      let parent: FakeParentElement;
-      let element: WebstatusOverviewContent;
       container = document.createElement('div');
       container.innerHTML = `
         <fake-parent-element>
@@ -118,10 +116,10 @@ describe('webstatus-overview-content', () => {
           </webstatus-overview-content>
         </fake-parent-element>
       `;
-      parent = container.querySelector(
+      const parent: FakeParentElement = container.querySelector(
         'fake-parent-element',
       ) as FakeParentElement;
-      element = container.querySelector(
+      const element: WebstatusOverviewContent = container.querySelector(
         'webstatus-overview-content',
       ) as WebstatusOverviewContent;
       // Set location to one of the DEFAULT_BOOKMARKS.
@@ -155,8 +153,6 @@ describe('webstatus-overview-content', () => {
       expect(description!.textContent).to.contain('test description1');
     });
     it('should not display description UI when it is empty', async () => {
-      let parent: FakeParentElement;
-      let element: WebstatusOverviewContent;
       container = document.createElement('div');
       container.innerHTML = `
         <fake-parent-element>
@@ -164,10 +160,10 @@ describe('webstatus-overview-content', () => {
           </webstatus-overview-content>
         </fake-parent-element>
       `;
-      parent = container.querySelector(
+      const parent: FakeParentElement = container.querySelector(
         'fake-parent-element',
       ) as FakeParentElement;
-      element = container.querySelector(
+      const element: WebstatusOverviewContent = container.querySelector(
         'webstatus-overview-content',
       ) as WebstatusOverviewContent;
       // Set location to one of the DEFAULT_BOOKMARKS.

--- a/frontend/src/static/js/components/test/webstatus-overview-content.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-overview-content.test.ts
@@ -59,6 +59,8 @@ describe('webstatus-overview-content', () => {
       element = container.querySelector(
         'webstatus-overview-content',
       ) as WebstatusOverviewContent;
+      // Set location to one of the DEFAULT_BOOKMARKS.
+      element.location = {search: '?q=baseline_date:2023-01-01..2023-12-31'};
       document.body.appendChild(container);
       await parent.updateComplete;
       await element.updateComplete;
@@ -98,6 +100,98 @@ describe('webstatus-overview-content', () => {
       expect(testContainer.textContent?.trim()).to.match(
         /Percentage of features mapped:\s*75%/,
       );
+    });
+  });
+  describe('RenderBookmarkUI', () => {
+    let container: HTMLElement;
+    afterEach(() => {
+      document.body.removeChild(container);
+    });
+
+    it('should display the bookmark title and description when query is matched', async () => {
+      let parent: FakeParentElement;
+      let element: WebstatusOverviewContent;
+      container = document.createElement('div');
+      container.innerHTML = `
+        <fake-parent-element>
+          <webstatus-overview-content>
+          </webstatus-overview-content>
+        </fake-parent-element>
+      `;
+      parent = container.querySelector(
+        'fake-parent-element',
+      ) as FakeParentElement;
+      element = container.querySelector(
+        'webstatus-overview-content',
+      ) as WebstatusOverviewContent;
+      // Set location to one of the DEFAULT_BOOKMARKS.
+      element.location = {search: '?q=test_query_1'};
+      element.bookmarks = [
+        {
+          name: 'Test Bookmark 1',
+          query: 'test_query_1',
+          description: 'test description1',
+        },
+        {
+          name: 'Test Bookmark 2',
+          query: 'test_query_2',
+          description: 'test description2',
+        },
+      ];
+      document.body.appendChild(container);
+      await parent.updateComplete;
+      await element.updateComplete;
+
+      assert.exists(element.getBookmarkFromQuery());
+
+      const title = element?.shadowRoot?.querySelector('#overview-title');
+      expect(title).to.exist;
+      expect(title!.textContent!.trim()).to.equal('Test Bookmark 1');
+
+      const description = element?.shadowRoot?.querySelector(
+        '#overview-description',
+      );
+      expect(description).to.exist;
+      expect(description!.textContent).to.contain('test description1');
+    });
+    it('should not display description UI when it is empty', async () => {
+      let parent: FakeParentElement;
+      let element: WebstatusOverviewContent;
+      container = document.createElement('div');
+      container.innerHTML = `
+        <fake-parent-element>
+          <webstatus-overview-content>
+          </webstatus-overview-content>
+        </fake-parent-element>
+      `;
+      parent = container.querySelector(
+        'fake-parent-element',
+      ) as FakeParentElement;
+      element = container.querySelector(
+        'webstatus-overview-content',
+      ) as WebstatusOverviewContent;
+      // Set location to one of the DEFAULT_BOOKMARKS.
+      element.location = {search: '?q=test_query_1'};
+      element.bookmarks = [
+        {
+          name: 'Test Bookmark 1',
+          query: 'test_query_1',
+        },
+      ];
+      document.body.appendChild(container);
+      await parent.updateComplete;
+      await element.updateComplete;
+
+      assert.exists(element.getBookmarkFromQuery());
+
+      const title = element?.shadowRoot?.querySelector('#overview-title');
+      expect(title).to.exist;
+      expect(title!.textContent!.trim()).to.equal('Test Bookmark 1');
+
+      const description = element?.shadowRoot?.querySelector(
+        '#overview-description',
+      );
+      expect(description).to.not.exist;
     });
   });
 });

--- a/frontend/src/static/js/components/test/webstatus-sidebar-menu.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-sidebar-menu.test.ts
@@ -16,13 +16,22 @@
 
 import {expect, fixture, html} from '@open-wc/testing';
 import sinon from 'sinon';
-import {Bookmark, WebstatusSidebarMenu} from '../webstatus-sidebar-menu.js';
+import {WebstatusSidebarMenu} from '../webstatus-sidebar-menu.js';
 import {SlTreeItem} from '@shoelace-style/shoelace';
 import '../webstatus-sidebar-menu.js';
+import {Bookmark} from '../../utils/constants.js';
 
 const testBookmarks: Bookmark[] = [
-  {name: 'Test Bookmark 1', query: 'test_query_1'},
-  {name: 'Test Bookmark 2', query: 'test_query_2'},
+  {
+    name: 'Test Bookmark 1',
+    query: 'test_query_1',
+    description: 'test description1',
+  },
+  {
+    name: 'Test Bookmark 2',
+    query: 'test_query_2',
+    description: 'test description2',
+  },
 ];
 describe('webstatus-sidebar-menu', () => {
   let el: WebstatusSidebarMenu;

--- a/frontend/src/static/js/components/webstatus-overview-content.ts
+++ b/frontend/src/static/js/components/webstatus-overview-content.ts
@@ -126,7 +126,7 @@ export class WebstatusOverviewContent extends LitElement {
 
   render(): TemplateResult {
     const bookmark = this.getBookmarkFromQuery();
-    const pageTitle = bookmark ? bookmark.name : `Features overview`;
+    const pageTitle = bookmark ? bookmark.name : 'Features overview';
     const pageDescription = bookmark?.description;
     return html`
       <div class="main">

--- a/frontend/src/static/js/components/webstatus-overview-content.ts
+++ b/frontend/src/static/js/components/webstatus-overview-content.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import {LitElement, type TemplateResult, CSSResultGroup, css, html} from 'lit';
+import {
+  LitElement,
+  type TemplateResult,
+  CSSResultGroup,
+  css,
+  html,
+  nothing,
+} from 'lit';
 import {TaskStatus} from '@lit/task';
 import {customElement, state} from 'lit/decorators.js';
 import {type components} from 'webstatus.dev-backend';
@@ -31,6 +38,8 @@ import {
   webFeatureProgressContext,
 } from '../contexts/webfeature-progress-context.js';
 import {Toast} from '../utils/toast.js';
+import {getSearchQuery} from '../utils/urls.js';
+import {DEFAULT_BOOKMARKS, Bookmark} from '../utils/constants.js';
 
 const webFeaturesRepoUrl = 'https://github.com/web-platform-dx/web-features';
 
@@ -50,6 +59,9 @@ export class WebstatusOverviewContent extends LitElement {
   @state()
   webFeaturesProgress?: WebFeatureProgress;
 
+  @state()
+  bookmarks: Bookmark[] = DEFAULT_BOOKMARKS;
+
   static get styles(): CSSResultGroup {
     return [
       SHARED_STYLES,
@@ -63,6 +75,11 @@ export class WebstatusOverviewContent extends LitElement {
         }
       `,
     ];
+  }
+
+  getBookmarkFromQuery(): Bookmark | undefined {
+    const currentQuery = getSearchQuery(this.location);
+    return this.bookmarks.find(bookmark => bookmark.query === currentQuery);
   }
 
   renderMappingPercentage(): TemplateResult {
@@ -108,11 +125,19 @@ export class WebstatusOverviewContent extends LitElement {
   }
 
   render(): TemplateResult {
+    const bookmark = this.getBookmarkFromQuery();
+    const pageTitle = bookmark ? bookmark.name : `Features overview`;
+    const pageDescription = bookmark?.description;
     return html`
       <div class="main">
         <div class="hbox halign-items-space-between header-line">
-          <h1 class="halign-stretch">Features overview</h1>
+          <h1 class="halign-stretch" id="overview-title">${pageTitle}</h1>
         </div>
+        ${pageDescription
+          ? html`<div class="hbox wrap" id="overview-description">
+              <h3>${pageDescription}</h3>
+            </div>`
+          : nothing}
         <div class="hbox wrap">
           ${this.renderCount()}
           <div class="spacer"></div>

--- a/frontend/src/static/js/components/webstatus-sidebar-menu.ts
+++ b/frontend/src/static/js/components/webstatus-sidebar-menu.ts
@@ -30,7 +30,12 @@ import {
   navigateToUrl,
 } from '../utils/app-router.js';
 
-import {GITHUB_REPO_ISSUE_LINK, ABOUT_PAGE_LINK} from '../utils/constants.js';
+import {
+  GITHUB_REPO_ISSUE_LINK,
+  ABOUT_PAGE_LINK,
+  DEFAULT_BOOKMARKS,
+  Bookmark,
+} from '../utils/constants.js';
 
 // Map from sl-tree-item ids to paths.
 enum NavigationItemKey {
@@ -58,13 +63,6 @@ const navigationMap: NavigationMap = {
   },
 };
 
-export interface Bookmark {
-  // Display name
-  name: string;
-  // Query for filtering
-  query: string;
-}
-
 interface GetLocationFunction {
   (): AppLocation;
 }
@@ -72,10 +70,6 @@ interface GetLocationFunction {
 interface NavigateToUrlFunction {
   (url: string, event?: MouseEvent): void;
 }
-
-const DEFAULT_BOOKMARKS: Bookmark[] = [
-  {name: 'Baseline 2023', query: 'baseline_date:2023-01-01..2023-12-31'},
-];
 
 @customElement('webstatus-sidebar-menu')
 export class WebstatusSidebarMenu extends LitElement {

--- a/frontend/src/static/js/utils/constants.ts
+++ b/frontend/src/static/js/utils/constants.ts
@@ -20,3 +20,20 @@ export const SEARCH_QUERY_README_LINK =
   'https://github.com/GoogleChrome/webstatus.dev/blob/main/antlr/FeatureSearch.md';
 export const ABOUT_PAGE_LINK =
   'https://github.com/GoogleChrome/webstatus.dev/wiki/About-Web-Platform-Status';
+
+export interface Bookmark {
+  // Bookmark display name
+  name: string;
+  // Query for filtering
+  query: string;
+  // Overview page description
+  description?: string;
+}
+
+export const DEFAULT_BOOKMARKS: Bookmark[] = [
+  {
+    name: 'Baseline 2023',
+    query: 'baseline_date:2023-01-01..2023-12-31',
+    description: 'All Baseline 2023 features',
+  },
+];


### PR DESCRIPTION
#764 and a follow-up for https://github.com/GoogleChrome/webstatus.dev/pull/931. Add a custom overview page title and description when it shows a bookmark query.

Mock UI:
![Screenshot 2024-11-27 12 59 46 PM](https://github.com/user-attachments/assets/d44312de-bacc-4987-a935-f12436de4220)

It is a similar placement between title and description to feature page:
![Screenshot 2024-11-27 12 32 38 PM](https://github.com/user-attachments/assets/6f71309d-2d6b-4d23-9936-ff7675532cd1)

