### PR TITLE
Add description column to saved searches table

### DIFF
--- a/infra/storage/spanner/migrations/000013.sql
+++ b/infra/storage/spanner/migrations/000013.sql
@@ -1,0 +1,16 @@
+-- Copyright 2024 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Add optional description to saved searches.
+ALTER TABLE SavedSearches ADD COLUMN Description STRING(MAX);

--- a/lib/gcpspanner/client.go
+++ b/lib/gcpspanner/client.go
@@ -739,3 +739,11 @@ func runConcurrentBatch[SpannerStruct any](ctx context.Context, c *Client,
 		return nil
 	}
 }
+
+// OptionallySet allows distinguishing between setting a value
+// and leaving it unchanged. Useful for PATCH operations where
+// only specific fields are updated.
+type OptionallySet[T any] struct {
+	Value T
+	IsSet bool
+}

--- a/lib/gcpspanner/create_user_saved_search.go
+++ b/lib/gcpspanner/create_user_saved_search.go
@@ -28,6 +28,7 @@ type CreateUserSavedSearchRequest struct {
 	Name        string
 	Query       string
 	OwnerUserID string
+	Description *string
 }
 
 var (
@@ -71,13 +72,14 @@ func (c *Client) CreateNewUserSavedSearch(
 		// TODO: In the future, look into using an entityMapper for SavedSearch.
 		// Then, we can use createInsertMutation.
 		m1, err := spanner.InsertStruct(savedSearchesTable, SavedSearch{
-			ID:        id,
-			Name:      newSearch.Name,
-			Query:     newSearch.Query,
-			Scope:     UserPublicScope,
-			AuthorID:  newSearch.OwnerUserID,
-			CreatedAt: spanner.CommitTimestamp,
-			UpdatedAt: spanner.CommitTimestamp,
+			ID:          id,
+			Name:        newSearch.Name,
+			Query:       newSearch.Query,
+			Description: newSearch.Description,
+			Scope:       UserPublicScope,
+			AuthorID:    newSearch.OwnerUserID,
+			CreatedAt:   spanner.CommitTimestamp,
+			UpdatedAt:   spanner.CommitTimestamp,
 		})
 		if err != nil {
 			return errors.Join(ErrInternalQueryFailure, err)

--- a/lib/gcpspanner/create_user_saved_search_test.go
+++ b/lib/gcpspanner/create_user_saved_search_test.go
@@ -31,6 +31,7 @@ func TestCreateNewUserSavedSearch(t *testing.T) {
 			Name:        "my little search",
 			Query:       "group:css",
 			OwnerUserID: "userID1",
+			Description: valuePtr("description1"),
 		})
 		if err != nil {
 			t.Errorf("expected nil error. received %s", err)
@@ -43,6 +44,7 @@ func TestCreateNewUserSavedSearch(t *testing.T) {
 			Name:        "my little search part 2",
 			Query:       "group:avif",
 			OwnerUserID: "userID1",
+			Description: valuePtr("description2"),
 		})
 		if err != nil {
 			t.Errorf("expected nil error. received %s", err)
@@ -55,6 +57,7 @@ func TestCreateNewUserSavedSearch(t *testing.T) {
 			Name:        "my little search part 3",
 			Query:       "name:subgrid",
 			OwnerUserID: "userID1",
+			Description: valuePtr("description3"),
 		})
 		if !errors.Is(err, ErrOwnerSavedSearchLimitExceeded) {
 			t.Errorf("unexpected error. received %v", err)

--- a/lib/gcpspanner/get_user_saved_search.go
+++ b/lib/gcpspanner/get_user_saved_search.go
@@ -39,6 +39,7 @@ func (m unauthenticatedUserSavedSearchMapper) SelectOne(
 	SELECT
 		ID,
 		Name,
+		Description,
 		Query,
 		Scope,
 		AuthorID,
@@ -72,6 +73,7 @@ func (m authenticatedUserSavedSearchMapper) SelectOne(
 	SELECT
 		ID,
 		Name,
+		Description,
 		Query,
 		Scope,
 		AuthorID,

--- a/lib/gcpspanner/get_user_saved_search_test.go
+++ b/lib/gcpspanner/get_user_saved_search_test.go
@@ -30,6 +30,7 @@ func TestGetUserSavedSearch(t *testing.T) {
 		Name:        "my little search",
 		Query:       "group:css",
 		OwnerUserID: "userID1",
+		Description: valuePtr("desc"),
 	})
 	if err != nil {
 		t.Errorf("expected nil error. received %s", err)
@@ -43,11 +44,12 @@ func TestGetUserSavedSearch(t *testing.T) {
 			IsBookmarked: nil,
 			Role:         nil,
 			SavedSearch: SavedSearch{
-				ID:       *savedSearchID,
-				Name:     "my little search",
-				Query:    "group:css",
-				Scope:    "USER_PUBLIC",
-				AuthorID: "userID1",
+				ID:          *savedSearchID,
+				Name:        "my little search",
+				Query:       "group:css",
+				Scope:       "USER_PUBLIC",
+				AuthorID:    "userID1",
+				Description: valuePtr("desc"),
 				// Don't actually compare the last two values.
 				CreatedAt: spanner.CommitTimestamp,
 				UpdatedAt: spanner.CommitTimestamp,
@@ -66,11 +68,12 @@ func TestGetUserSavedSearch(t *testing.T) {
 			IsBookmarked: valuePtr(true),
 			Role:         valuePtr(string(SavedSearchOwner)),
 			SavedSearch: SavedSearch{
-				ID:       *savedSearchID,
-				Name:     "my little search",
-				Query:    "group:css",
-				Scope:    "USER_PUBLIC",
-				AuthorID: "userID1",
+				ID:          *savedSearchID,
+				Name:        "my little search",
+				Query:       "group:css",
+				Scope:       "USER_PUBLIC",
+				AuthorID:    "userID1",
+				Description: valuePtr("desc"),
 				// Don't actually compare the last two values.
 				CreatedAt: spanner.CommitTimestamp,
 				UpdatedAt: spanner.CommitTimestamp,
@@ -90,11 +93,12 @@ func TestGetUserSavedSearch(t *testing.T) {
 			IsBookmarked: valuePtr(false),
 			Role:         nil,
 			SavedSearch: SavedSearch{
-				ID:       *savedSearchID,
-				Name:     "my little search",
-				Query:    "group:css",
-				Scope:    "USER_PUBLIC",
-				AuthorID: "userID1",
+				ID:          *savedSearchID,
+				Name:        "my little search",
+				Query:       "group:css",
+				Scope:       "USER_PUBLIC",
+				AuthorID:    "userID1",
+				Description: valuePtr("desc"),
 				// Don't actually compare the last two values.
 				CreatedAt: spanner.CommitTimestamp,
 				UpdatedAt: spanner.CommitTimestamp,
@@ -125,6 +129,7 @@ func savedSearchEquality(left, right SavedSearch) bool {
 		left.Query == right.Query &&
 		left.Scope == right.Scope &&
 		left.AuthorID == right.AuthorID &&
+		reflect.DeepEqual(left.Description, right.Description) &&
 		// Just make sure the times are non zero.
 		!left.CreatedAt.IsZero() && !right.CreatedAt.IsZero() &&
 		!left.UpdatedAt.IsZero() && !right.UpdatedAt.IsZero()

--- a/lib/gcpspanner/saved_searches.go
+++ b/lib/gcpspanner/saved_searches.go
@@ -30,11 +30,12 @@ const savedSearchesTable = "SavedSearches"
 
 // SavedSearch represents a saved search row in the SavedSearches table.
 type SavedSearch struct {
-	ID        string           `spanner:"ID"`
-	Name      string           `spanner:"Name"`
-	Query     string           `spanner:"Query"`
-	Scope     SavedSearchScope `spanner:"Scope"`
-	AuthorID  string           `spanner:"AuthorID"`
-	CreatedAt time.Time        `spanner:"CreatedAt"`
-	UpdatedAt time.Time        `spanner:"UpdatedAt"`
+	ID          string           `spanner:"ID"`
+	Name        string           `spanner:"Name"`
+	Description *string          `spanner:"Description"`
+	Query       string           `spanner:"Query"`
+	Scope       SavedSearchScope `spanner:"Scope"`
+	AuthorID    string           `spanner:"AuthorID"`
+	CreatedAt   time.Time        `spanner:"CreatedAt"`
+	UpdatedAt   time.Time        `spanner:"UpdatedAt"`
 }

--- a/lib/gcpspanner/update_user_saved_search_test.go
+++ b/lib/gcpspanner/update_user_saved_search_test.go
@@ -30,6 +30,7 @@ func TestUpdateUserSavedSearch(t *testing.T) {
 		Name:        "my little search",
 		Query:       "group:css",
 		OwnerUserID: "userID1",
+		Description: valuePtr("initial description"),
 	})
 	if err != nil {
 		t.Errorf("expected nil error. received %s", err)
@@ -43,11 +44,12 @@ func TestUpdateUserSavedSearch(t *testing.T) {
 			IsBookmarked: valuePtr(true),
 			Role:         valuePtr(string(SavedSearchOwner)),
 			SavedSearch: SavedSearch{
-				ID:       *savedSearchID,
-				Name:     "my little search",
-				Query:    "group:css",
-				Scope:    "USER_PUBLIC",
-				AuthorID: "userID1",
+				ID:          *savedSearchID,
+				Name:        "my little search",
+				Query:       "group:css",
+				Scope:       "USER_PUBLIC",
+				AuthorID:    "userID1",
+				Description: valuePtr("initial description"),
 				// Don't actually compare the last two values.
 				CreatedAt: spanner.CommitTimestamp,
 				UpdatedAt: spanner.CommitTimestamp,
@@ -56,11 +58,64 @@ func TestUpdateUserSavedSearch(t *testing.T) {
 		err := spannerClient.UpdateUserSavedSearch(ctx, UpdateSavedSearchRequest{
 			ID:       *savedSearchID,
 			AuthorID: "non-owner",
-			Query:    valuePtr("junkquery"),
-			Name:     valuePtr("junkName"),
+			Query: OptionallySet[string]{
+				IsSet: true,
+				Value: "junkquery",
+			},
+			Name: OptionallySet[string]{
+				IsSet: true,
+				Value: "junkName",
+			},
+			Description: OptionallySet[*string]{
+				IsSet: true,
+				Value: valuePtr("junkdesc"),
+			},
 		})
 		if !errors.Is(err, ErrMissingRequiredRole) {
 			t.Errorf("expected error trying to update %s", err)
+		}
+		actual, err := spannerClient.GetUserSavedSearch(ctx, *savedSearchID, valuePtr("userID1"))
+		if err != nil {
+			t.Errorf("expected nil error. received %s", err)
+		}
+		if !userSavedSearchEquality(expectedSavedSearch, actual) {
+			t.Errorf("different saved searches\nexpected: %+v\nreceived: %v", expectedSavedSearch, actual)
+		}
+	})
+	t.Run("owner can edit but leave optional values unchanged", func(t *testing.T) {
+		expectedSavedSearch := &UserSavedSearch{
+			IsBookmarked: valuePtr(true),
+			Role:         valuePtr(string(SavedSearchOwner)),
+			SavedSearch: SavedSearch{
+				ID:          *savedSearchID,
+				Name:        "my little search",
+				Query:       "group:css",
+				Scope:       "USER_PUBLIC",
+				AuthorID:    "userID1",
+				Description: valuePtr("initial description"),
+				// Don't actually compare the last two values.
+				CreatedAt: spanner.CommitTimestamp,
+				UpdatedAt: spanner.CommitTimestamp,
+			},
+		}
+		err := spannerClient.UpdateUserSavedSearch(ctx, UpdateSavedSearchRequest{
+			ID:       *savedSearchID,
+			AuthorID: "userID1",
+			Query: OptionallySet[string]{
+				IsSet: false,
+				Value: "",
+			},
+			Name: OptionallySet[string]{
+				IsSet: false,
+				Value: "",
+			},
+			Description: OptionallySet[*string]{
+				IsSet: false,
+				Value: nil,
+			},
+		})
+		if !errors.Is(err, nil) {
+			t.Errorf("expected nil error trying to update %s", err)
 		}
 		actual, err := spannerClient.GetUserSavedSearch(ctx, *savedSearchID, valuePtr("userID1"))
 		if err != nil {
@@ -75,11 +130,12 @@ func TestUpdateUserSavedSearch(t *testing.T) {
 			IsBookmarked: valuePtr(true),
 			Role:         valuePtr(string(SavedSearchOwner)),
 			SavedSearch: SavedSearch{
-				ID:       *savedSearchID,
-				Name:     "my new search",
-				Query:    "group:grid",
-				Scope:    "USER_PUBLIC",
-				AuthorID: "userID1",
+				ID:          *savedSearchID,
+				Name:        "my new search",
+				Query:       "group:grid",
+				Scope:       "USER_PUBLIC",
+				AuthorID:    "userID1",
+				Description: nil,
 				// Don't actually compare the last two values.
 				CreatedAt: spanner.CommitTimestamp,
 				UpdatedAt: spanner.CommitTimestamp,
@@ -88,8 +144,18 @@ func TestUpdateUserSavedSearch(t *testing.T) {
 		err := spannerClient.UpdateUserSavedSearch(ctx, UpdateSavedSearchRequest{
 			ID:       *savedSearchID,
 			AuthorID: "userID1",
-			Query:    valuePtr("group:grid"),
-			Name:     valuePtr("my new search"),
+			Query: OptionallySet[string]{
+				IsSet: true,
+				Value: "group:grid",
+			},
+			Name: OptionallySet[string]{
+				IsSet: true,
+				Value: "my new search",
+			},
+			Description: OptionallySet[*string]{
+				IsSet: true,
+				Value: nil,
+			},
 		})
 		if !errors.Is(err, nil) {
 			t.Errorf("expected nil error trying to update %s", err)

--- a/lib/gcpspanner/user_search_bookmarks_test.go
+++ b/lib/gcpspanner/user_search_bookmarks_test.go
@@ -29,6 +29,7 @@ func TestUserSearchBookmark(t *testing.T) {
 		Name:        "my little search",
 		Query:       "group:css",
 		OwnerUserID: "userID1",
+		Description: nil,
 	})
 	if err != nil {
 		t.Errorf("expected nil error. received %s", err)
@@ -44,11 +45,12 @@ func TestUserSearchBookmark(t *testing.T) {
 		IsBookmarked: valuePtr(false),
 		Role:         nil,
 		SavedSearch: SavedSearch{
-			ID:       *savedSearchID,
-			Name:     "my little search",
-			Query:    "group:css",
-			Scope:    "USER_PUBLIC",
-			AuthorID: "userID1",
+			ID:          *savedSearchID,
+			Name:        "my little search",
+			Query:       "group:css",
+			Scope:       "USER_PUBLIC",
+			AuthorID:    "userID1",
+			Description: nil,
 			// Don't actually compare the last two values.
 			CreatedAt: spanner.CommitTimestamp,
 			UpdatedAt: spanner.CommitTimestamp,
@@ -67,11 +69,12 @@ func TestUserSearchBookmark(t *testing.T) {
 		IsBookmarked: valuePtr(true),
 		Role:         nil,
 		SavedSearch: SavedSearch{
-			ID:       *savedSearchID,
-			Name:     "my little search",
-			Query:    "group:css",
-			Scope:    "USER_PUBLIC",
-			AuthorID: "userID1",
+			ID:          *savedSearchID,
+			Name:        "my little search",
+			Query:       "group:css",
+			Scope:       "USER_PUBLIC",
+			AuthorID:    "userID1",
+			Description: nil,
 			// Don't actually compare the last two values.
 			CreatedAt: spanner.CommitTimestamp,
 			UpdatedAt: spanner.CommitTimestamp,


### PR DESCRIPTION
Fixes #951

This change modifies the database schema to add an optional description column to the existing saved searches table. This new column will allow users to store a brief description of their saved search, making it easier to understand its purpose later.

Other changes:

- Add new type: OptionallySet. Previously we allowed callers to let the spanner layer know that we want to update one field by setting a pointer. That worked on fields that were not optional. But since the description can be null, I added this new type to capture that.
- Modified tests to use the new description field and ensure that saving and retrieving descriptions works as expected.