### PR TITLE
Fix enum parsing in enum pipeline

### DIFF
--- a/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer.go
+++ b/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer.go
@@ -114,6 +114,10 @@ func enumLabelToFeatureKey(label string) string {
 
 			continue
 		}
+		// Add hyphen if previous character is a letter and current character is a digit
+		if idx > 0 && unicode.IsLetter(rune(label[idx-1])) && unicode.IsDigit(c) {
+			b.WriteRune('-')
+		}
 		b.WriteRune(c)
 	}
 

--- a/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer_test.go
@@ -212,9 +212,24 @@ func TestEnumLabelToFeatureKey(t *testing.T) {
 			want:  "typical-case",
 		},
 		{
-			name:  "With numbers",
+			name:  "With numbers in the middle",
 			label: "With123Numbers",
-			want:  "with123-numbers",
+			want:  "with-123-numbers",
+		},
+		{
+			name:  "Starting with number",
+			label: "123Abc",
+			want:  "123-abc",
+		},
+		{
+			name:  "Consecutive uppercase letters",
+			label: "ABCTest",
+			want:  "a-b-c-test",
+		},
+		{
+			name:  "Mixed case with numbers and consecutive uppercase",
+			label: "ABC123defGHI456Jkl",
+			want:  "a-b-c-123def-g-h-i-456-jkl",
 		},
 	}
 	for _, tc := range tests {

--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_parser.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_parser.go
@@ -95,8 +95,8 @@ func (p ChromiumCodesearchEnumParser) Parse(
 			if bucketIDToSkip != nil && *bucketIDToSkip == value.Value {
 				continue
 			}
-			// Skip labels with DRAFT_ prefix
-			if strings.HasPrefix(value.Label, "DRAFT_") {
+			// Skip labels with DRAFT_ or OBSOLETE_ prefix
+			if strings.HasPrefix(value.Label, "DRAFT_") || strings.HasPrefix(value.Label, "OBSOLETE_") {
 				continue
 			}
 

--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_parser_test.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_parser_test.go
@@ -47,6 +47,7 @@ func TestChromiumCodesearchEnumParser_Parse(t *testing.T) {
                             <int value="1" label="CompressionStreams"/>
                             <int value="2" label="ViewTransitions"/>
                             <int value="3" label="DRAFT_Serial"/>
+                            <int value="3" label="OBSOLETE_CanvasColorManagement"/>
                         </enum>
                         <enum name="OtherEnum">
                             <int value="10" label="SomeValue"/>


### PR DESCRIPTION
This changes contains fixes for the enum consumption and metric pipelines.

Enum consumption pipeline:
- Previously we only skipped the draft enums, we also skip the obsolete ones now.
- When storing the details about the enum, we use enumLabelToFeatureKey to convert into the expected key. If a feature key did not exist, we skipped storing the enum value for it. As a result, it previously missed some of the canvas2d* ones. Fixes it and added a test case for it. And more test cases in general with numbers. This will fix the issue when consuming uma metrics because they could not find the enum ID since it was skipped and not stored.