### PR TITLE
Warn for certain DailyChromiumHistogramMetrics errors

### DIFF
--- a/lib/gcpspanner/chromium_histogram_enum_values_test.go
+++ b/lib/gcpspanner/chromium_histogram_enum_values_test.go
@@ -42,6 +42,12 @@ func getSampleChromiumHistogramEnumValues(histogramIDMap map[string]string) []Ch
 			BucketID:                2,
 			Label:                   "ViewTransitions",
 		},
+		// Create an enum that does not have a match in the web features table.
+		{
+			ChromiumHistogramEnumID: histogramIDMap["WebDXFeatureObserver"],
+			BucketID:                3,
+			Label:                   "WritingSuggestions",
+		},
 	}
 }
 
@@ -109,8 +115,8 @@ func TestUpsertChromiumHistogramEnumValue(t *testing.T) {
 	}
 	sampleHistogramsEnumValues := getSampleChromiumHistogramEnumValues(enumIDMap)
 	slices.SortFunc(enumValues, sortChromiumHistogramEnumValues)
-	if !slices.Equal[[]ChromiumHistogramEnumValue](sampleHistogramsEnumValues, enumValues) {
-		t.Errorf("unequal enums. expected %+v actual %+v", sampleHistogramsEnumValues, enumValues)
+	if !slices.Equal(sampleHistogramsEnumValues, enumValues) {
+		t.Errorf("unequal enums.\nexpected %+v\nreceived %+v", sampleHistogramsEnumValues, enumValues)
 	}
 
 	_, err = spannerClient.UpsertChromiumHistogramEnumValue(ctx, ChromiumHistogramEnumValue{
@@ -130,8 +136,8 @@ func TestUpsertChromiumHistogramEnumValue(t *testing.T) {
 	slices.SortFunc(enumValues, sortChromiumHistogramEnumValues)
 
 	// Should be the same. No updates should happen.
-	if !slices.Equal[[]ChromiumHistogramEnumValue](sampleHistogramsEnumValues, enumValues) {
-		t.Errorf("unequal enum values after update. expected %+v actual %+v", sampleHistogramsEnumValues, enumValues)
+	if !slices.Equal(sampleHistogramsEnumValues, enumValues) {
+		t.Errorf("unequal enum values after update.\nexpected %+v\nreceived %+v", sampleHistogramsEnumValues, enumValues)
 	}
 }
 

--- a/lib/gcpspanner/client.go
+++ b/lib/gcpspanner/client.go
@@ -47,6 +47,25 @@ var ErrFailedToEstablishClient = errors.New("failed to establish spanner client"
 // ErrInvalidCursorFormat indicates the cursor is not the correct format.
 var ErrInvalidCursorFormat = errors.New("invalid cursor format")
 
+// DailyChromiumHistogramMetrics specific errors.
+var (
+	// ErrUsageMetricUpsertNoFeatureIDFound indicates that no web feature ID was found
+	// when attempting to upsert a usage metric using the chromiumHistogramEnumValueID.
+	// This typically occurs when there is no corresponding web feature associated with
+	// the given chromiumHistogramEnumValueID.
+	ErrUsageMetricUpsertNoFeatureIDFound = errors.New("no web feature id found when upserting usage metric")
+
+	// ErrUsageMetricUpsertNoHistogramFound indicates that the chromium histogram metric
+	// was not found when attempting to upsert a usage metric.
+	ErrUsageMetricUpsertNoHistogramFound = errors.New("histogram not found when upserting usage metric")
+
+	// ErrUsageMetricUpsertNoHistogramEnumFound indicates that the chromium histogram enum
+	// was not found when attempting to upsert a usage metric. This typically occurs when
+	// the histogram name associated with the metric is not found, possibly due to
+	// a draft or obsolete feature for which the corresponding enum ID has not been created.
+	ErrUsageMetricUpsertNoHistogramEnumFound = errors.New("histogram enum not found when upserting usage metric")
+)
+
 // Client is the client for interacting with GCP Spanner.
 type Client struct {
 	*spanner.Client

--- a/lib/gcpspanner/spanneradapters/uma_metric_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/uma_metric_consumer_test.go
@@ -214,6 +214,38 @@ func TestUMAMetricConsumer_SaveMetrics(t *testing.T) {
 			},
 			expectedErr: ErrMetricsSaveFailed,
 		},
+		{
+			name: "UpsertDailyChromiumHistogramMetric skips on ErrUsageMetricUpsertNoHistogramEnumFound",
+			client: &mockUMAMetricsClient{
+				hasDailyChromiumHistogramCapstone:    nil,
+				upsertDailyChromiumHistogramCapstone: nil,
+				upsertDailyChromiumHistogramMetric: func(_ context.Context, _ metricdatatypes.HistogramName,
+					_ int64, _ gcpspanner.DailyChromiumHistogramMetric) error {
+					return gcpspanner.ErrUsageMetricUpsertNoHistogramEnumFound
+				},
+			},
+			day: civil.Date{Year: 2024, Month: 1, Day: 1},
+			data: metricdatatypes.BucketDataMetrics{
+				1: {Rate: 0.5, LowVolume: false, Milestone: ""},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "UpsertDailyChromiumHistogramMetric skips on ErrUsageMetricUpsertNoFeatureIDFound",
+			client: &mockUMAMetricsClient{
+				hasDailyChromiumHistogramCapstone:    nil,
+				upsertDailyChromiumHistogramCapstone: nil,
+				upsertDailyChromiumHistogramMetric: func(_ context.Context, _ metricdatatypes.HistogramName,
+					_ int64, _ gcpspanner.DailyChromiumHistogramMetric) error {
+					return gcpspanner.ErrUsageMetricUpsertNoFeatureIDFound
+				},
+			},
+			day: civil.Date{Year: 2024, Month: 1, Day: 1},
+			data: metricdatatypes.BucketDataMetrics{
+				1: {Rate: 0.5, LowVolume: false, Milestone: ""},
+			},
+			expectedErr: nil,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/lib/gcpspanner/wpt_run_feature_metric.go
+++ b/lib/gcpspanner/wpt_run_feature_metric.go
@@ -213,7 +213,7 @@ func getLatestWPTRunFeatureMetricTimeStart(
 	if err != nil {
 		if errors.Is(err, iterator.Done) {
 			// No row found, return zero time
-			return &time.Time{}, nil
+			return &time.Time{}, errors.Join(ErrQueryReturnedNoResults, err)
 		}
 		slog.ErrorContext(ctx, "error querying for latest run time", "error", err)
 
@@ -339,7 +339,7 @@ func (c *Client) UpsertWPTRunFeatureMetrics(
 		for _, metric := range spannerMetrics {
 			existingTimeStart, err := getLatestWPTRunFeatureMetricTimeStart(ctx, txn, metric)
 			if err != nil {
-				if !errors.Is(err, iterator.Done) { // Handle errors other than "not found"
+				if !errors.Is(err, ErrQueryReturnedNoResults) { // Handle errors other than "not found"
 					return errors.Join(ErrInternalQueryFailure, err)
 				}
 				// No existing entry, proceed with insert (existingTimeStart will be zero time)


### PR DESCRIPTION
Previously, we returned an error for any error when ingesting the metrics.

There are certain errors we should warn instead of stopping execution.

Added DailyChromiumHistogramMetrics specific errors and modified the logic to check for errors. A subset of 2 errors will warn instead of returning the error back up the stack. This resolves an existing TODO comment.

Other changes:
- Use ErrQueryReturnedNoResults in places it should be to be consistent with other places. ([example](https://github.com/GoogleChrome/webstatus.dev/blob/2901887e4c0201aa40c0a2304c24669c590f026a/lib/gcpspanner/client.go#L378-L380))