### PR TITLE
Fix Async Tasks data cache issue

### DIFF
--- a/frontend/src/static/js/components/webstatus-overview-page.ts
+++ b/frontend/src/static/js/components/webstatus-overview-page.ts
@@ -17,7 +17,7 @@
 import {consume} from '@lit/context';
 import {Task, TaskStatus} from '@lit/task';
 import {LitElement, type TemplateResult, html} from 'lit';
-import {customElement, state} from 'lit/decorators.js';
+import {customElement, state, property} from 'lit/decorators.js';
 import {type components} from 'webstatus.dev-backend';
 
 import {
@@ -55,8 +55,11 @@ export class OverviewPage extends LitElement {
     data: null,
   };
 
-  @state()
+  @property({type: Object})
   location!: {search: string}; // Set by router.
+
+  @state()
+  currentLocation?: {search: string};
 
   constructor() {
     super();
@@ -67,7 +70,17 @@ export class OverviewPage extends LitElement {
       task: async ([apiClient, routerLocation]): Promise<
         components['schemas']['FeaturePage']
       > => {
-        return this._fetchFeatures(apiClient, routerLocation);
+        if (this.location.search !== this.currentLocation?.search) {
+          // Reset taskTracker here due to a Task data cache issue.
+          this.taskTracker = {
+            status: TaskStatus.INITIAL,
+            error: null,
+            data: null,
+          };
+          this.currentLocation = this.location;
+          return this._fetchFeatures(apiClient, routerLocation);
+        }
+        return {} as components['schemas']['FeaturePage'];
       },
       onComplete: page => {
         this.taskTracker = {

--- a/frontend/src/static/js/components/webstatus-overview-page.ts
+++ b/frontend/src/static/js/components/webstatus-overview-page.ts
@@ -80,7 +80,7 @@ export class OverviewPage extends LitElement {
           this.currentLocation = this.location;
           return this._fetchFeatures(apiClient, routerLocation);
         }
-        return {} as components['schemas']['FeaturePage'];
+        return this.taskTracker.data ?? {metadata: {total: 0}, data: []};
       },
       onComplete: page => {
         this.taskTracker = {


### PR DESCRIPTION
Fix the timing bug mentioned in https://github.com/GoogleChrome/webstatus.dev/pull/992#pullrequestreview-2509041075. There is a weird Async Tasks cache issue, possibly due to [Saves the last completion value or error of the task function](https://lit.dev/docs/data/task/#features). It reassigns an old value of `this.TasktaskTracker` after `New Task` is defined but before the callback executes.

As a result, the pending UI on the overview page loads correctly when users navigate.

