### PR TITLE
chore: update web-features from 1.0.0 to 2.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ JSONSCHEMA_OUT_DIR = lib/gen/jsonschema
 
 download-schemas:
 	wget -O jsonschema/web-platform-dx_web-features/defs.schema.json \
-		https://raw.githubusercontent.com/web-platform-dx/feature-set/main/schemas/defs.schema.json
+		https://raw.githubusercontent.com/web-platform-dx/web-features/refs/heads/main/schemas/data.schema.json
 	wget -O jsonschema/mdn_browser-compat-data/browsers.schema.json \
 		https://raw.githubusercontent.com/mdn/browser-compat-data/main/schemas/browsers.schema.json
 

--- a/jsonschema/web-platform-dx_web-features/defs.schema.json
+++ b/jsonschema/web-platform-dx_web-features/defs.schema.json
@@ -1,5 +1,4 @@
 {
-  "$id": "defs",
   "$ref": "#/definitions/WebFeaturesData",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
@@ -18,12 +17,34 @@
         }
       ]
     },
+    "BrowserData": {
+      "additionalProperties": false,
+      "description": "Browser information",
+      "properties": {
+        "name": {
+          "description": "The name of the browser, as in \"Edge\" or \"Safari on iOS\"",
+          "type": "string"
+        },
+        "releases": {
+          "description": "The browser's releases",
+          "items": {
+            "$ref": "#/definitions/Release"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "releases"
+      ],
+      "type": "object"
+    },
     "FeatureData": {
       "additionalProperties": false,
       "properties": {
         "caniuse": {
           "$ref": "#/definitions/StringOrStringArray",
-          "description": "caniuse.com identifier"
+          "description": "caniuse.com identifier(s)"
         },
         "compat_features": {
           "description": "Sources of support data for this feature",
@@ -40,9 +61,31 @@
           "description": "Short description of the feature, as an HTML string",
           "type": "string"
         },
+        "discouraged": {
+          "additionalProperties": false,
+          "description": "Whether developers are formally discouraged from using this feature",
+          "properties": {
+            "according_to": {
+              "description": "Links to a formal discouragement notice, such as specification text, intent-to-unship, etc.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "alternatives": {
+              "description": "IDs for features that substitute some or all of this feature's utility",
+              "items": {},
+              "type": "array"
+            }
+          },
+          "required": [
+            "according_to"
+          ],
+          "type": "object"
+        },
         "group": {
           "$ref": "#/definitions/StringOrStringArray",
-          "description": "Group identifier"
+          "description": "Group identifier(s)"
         },
         "name": {
           "description": "Short name",
@@ -50,33 +93,27 @@
         },
         "snapshot": {
           "$ref": "#/definitions/StringOrStringArray",
-          "description": "Snapshot identifier"
+          "description": "Snapshot identifier(s)"
         },
         "spec": {
           "$ref": "#/definitions/StringOrStringArray",
-          "description": "Specification"
+          "description": "Specification URL(s)"
         },
         "status": {
           "additionalProperties": false,
           "description": "Whether a feature is considered a \"baseline\" web platform feature and when it achieved that status",
           "properties": {
             "baseline": {
-              "anyOf": [
-                {
-                  "enum": [
-                    "high",
-                    "low"
-                  ],
-                  "type": "string"
-                },
-                {
-                  "enum": [
-                    false
-                  ],
-                  "type": "boolean"
-                }
+              "description": "Whether the feature is Baseline (low substatus), Baseline (high substatus), or not (false)",
+              "enum": [
+                "high",
+                "low",
+                false
               ],
-              "description": "Whether the feature is Baseline (low substatus), Baseline (high substatus), or not (false)"
+              "type": [
+                "string",
+                "boolean"
+              ]
             },
             "baseline_high_date": {
               "description": "Date the feature achieved Baseline high status",
@@ -85,6 +122,68 @@
             "baseline_low_date": {
               "description": "Date the feature achieved Baseline low status",
               "type": "string"
+            },
+            "by_compat_key": {
+              "additionalProperties": {
+                "additionalProperties": false,
+                "properties": {
+                  "baseline": {
+                    "description": "Whether the feature is Baseline (low substatus), Baseline (high substatus), or not (false)",
+                    "enum": [
+                      "high",
+                      "low",
+                      false
+                    ],
+                    "type": [
+                      "string",
+                      "boolean"
+                    ]
+                  },
+                  "baseline_high_date": {
+                    "description": "Date the feature achieved Baseline high status",
+                    "type": "string"
+                  },
+                  "baseline_low_date": {
+                    "description": "Date the feature achieved Baseline low status",
+                    "type": "string"
+                  },
+                  "support": {
+                    "additionalProperties": false,
+                    "description": "Browser versions that most-recently introduced the feature",
+                    "properties": {
+                      "chrome": {
+                        "type": "string"
+                      },
+                      "chrome_android": {
+                        "type": "string"
+                      },
+                      "edge": {
+                        "type": "string"
+                      },
+                      "firefox": {
+                        "type": "string"
+                      },
+                      "firefox_android": {
+                        "type": "string"
+                      },
+                      "safari": {
+                        "type": "string"
+                      },
+                      "safari_ios": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "baseline",
+                  "support"
+                ],
+                "type": "object"
+              },
+              "description": "Statuses for each key in the feature's compat_features list, if applicable. Not available to the npm release of web-features.",
+              "type": "object"
             },
             "support": {
               "additionalProperties": false,
@@ -148,6 +247,25 @@
       ],
       "type": "object"
     },
+    "Release": {
+      "additionalProperties": false,
+      "description": "Browser release information",
+      "properties": {
+        "date": {
+          "description": "The release date, as in \"2023-12-11\"",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version string, as in \"10\" or \"17.1\"",
+          "type": "string"
+        }
+      },
+      "required": [
+        "version",
+        "date"
+      ],
+      "type": "object"
+    },
     "SnapshotData": {
       "additionalProperties": false,
       "properties": {
@@ -157,7 +275,6 @@
         },
         "spec": {
           "description": "Specification",
-          "format": "uri",
           "type": "string"
         }
       },
@@ -170,6 +287,43 @@
     "WebFeaturesData": {
       "additionalProperties": false,
       "properties": {
+        "browsers": {
+          "additionalProperties": false,
+          "description": "Browsers and browser release data",
+          "properties": {
+            "chrome": {
+              "$ref": "#/definitions/BrowserData"
+            },
+            "chrome_android": {
+              "$ref": "#/definitions/BrowserData"
+            },
+            "edge": {
+              "$ref": "#/definitions/BrowserData"
+            },
+            "firefox": {
+              "$ref": "#/definitions/BrowserData"
+            },
+            "firefox_android": {
+              "$ref": "#/definitions/BrowserData"
+            },
+            "safari": {
+              "$ref": "#/definitions/BrowserData"
+            },
+            "safari_ios": {
+              "$ref": "#/definitions/BrowserData"
+            }
+          },
+          "required": [
+            "chrome",
+            "chrome_android",
+            "edge",
+            "firefox",
+            "firefox_android",
+            "safari",
+            "safari_ios"
+          ],
+          "type": "object"
+        },
         "features": {
           "additionalProperties": {
             "$ref": "#/definitions/FeatureData"
@@ -193,6 +347,7 @@
         }
       },
       "required": [
+        "browsers",
         "features",
         "groups",
         "snapshots"

--- a/lib/gcpspanner/spanneradapters/web_feature_groups_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/web_feature_groups_consumer_test.go
@@ -208,6 +208,7 @@ func TestInsertWebFeatureGroups(t *testing.T) {
 					CompatFeatures:  nil,
 					Description:     "",
 					DescriptionHTML: "",
+					Discouraged:     nil,
 					Name:            "",
 					Snapshot:        nil,
 					Spec:            nil,
@@ -215,7 +216,8 @@ func TestInsertWebFeatureGroups(t *testing.T) {
 						Baseline:         nil,
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         nil,
 							ChromeAndroid:  nil,
 							Edge:           nil,
@@ -235,6 +237,7 @@ func TestInsertWebFeatureGroups(t *testing.T) {
 					CompatFeatures:  nil,
 					Description:     "",
 					DescriptionHTML: "",
+					Discouraged:     nil,
 					Name:            "",
 					Snapshot:        nil,
 					Spec:            nil,
@@ -242,7 +245,8 @@ func TestInsertWebFeatureGroups(t *testing.T) {
 						Baseline:         nil,
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         nil,
 							ChromeAndroid:  nil,
 							Edge:           nil,

--- a/lib/gcpspanner/spanneradapters/web_feature_snapshots_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/web_feature_snapshots_consumer_test.go
@@ -148,6 +148,7 @@ func TestInsertWebFeatureSnapshots(t *testing.T) {
 			},
 			featureData: map[string]web_platform_dx__web_features.FeatureValue{
 				"feature1": {
+					Discouraged: nil,
 					Snapshot: &web_platform_dx__web_features.StringOrStringArray{
 						StringArray: []string{"snapshot1", "snapshot2"},
 						String:      nil,
@@ -160,10 +161,11 @@ func TestInsertWebFeatureSnapshots(t *testing.T) {
 					Group:           nil,
 					Spec:            nil,
 					Status: web_platform_dx__web_features.Status{
+						ByCompatKey:      nil,
 						Baseline:         nil,
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         nil,
 							ChromeAndroid:  nil,
 							Edge:           nil,
@@ -175,6 +177,7 @@ func TestInsertWebFeatureSnapshots(t *testing.T) {
 					},
 				},
 				"feature2": {
+					Discouraged: nil,
 					Snapshot: &web_platform_dx__web_features.StringOrStringArray{
 						String:      valuePtr("snapshot1"),
 						StringArray: nil,
@@ -190,7 +193,8 @@ func TestInsertWebFeatureSnapshots(t *testing.T) {
 						Baseline:         nil,
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         nil,
 							ChromeAndroid:  nil,
 							Edge:           nil,

--- a/lib/gcpspanner/spanneradapters/web_features_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/web_features_consumer_test.go
@@ -59,7 +59,7 @@ func TestGetBaselineStatusEnum(t *testing.T) {
 		{
 			name: "undefined status",
 			input: web_platform_dx__web_features.Status{
-				Support: web_platform_dx__web_features.Support{
+				Support: web_platform_dx__web_features.StatusSupport{
 					Chrome:         nil,
 					ChromeAndroid:  nil,
 					Edge:           nil,
@@ -71,6 +71,7 @@ func TestGetBaselineStatusEnum(t *testing.T) {
 				Baseline:         nil,
 				BaselineHighDate: nil,
 				BaselineLowDate:  nil,
+				ByCompatKey:      nil,
 			},
 			expected: nil,
 		},
@@ -79,7 +80,8 @@ func TestGetBaselineStatusEnum(t *testing.T) {
 			input: web_platform_dx__web_features.Status{
 				BaselineHighDate: nil,
 				BaselineLowDate:  nil,
-				Support: web_platform_dx__web_features.Support{
+				ByCompatKey:      nil,
+				Support: web_platform_dx__web_features.StatusSupport{
 					Chrome:         nil,
 					ChromeAndroid:  nil,
 					Edge:           nil,
@@ -97,7 +99,8 @@ func TestGetBaselineStatusEnum(t *testing.T) {
 			input: web_platform_dx__web_features.Status{
 				BaselineHighDate: nil,
 				BaselineLowDate:  nil,
-				Support: web_platform_dx__web_features.Support{
+				ByCompatKey:      nil,
+				Support: web_platform_dx__web_features.StatusSupport{
 					Chrome:         nil,
 					ChromeAndroid:  nil,
 					Edge:           nil,
@@ -118,7 +121,8 @@ func TestGetBaselineStatusEnum(t *testing.T) {
 			input: web_platform_dx__web_features.Status{
 				BaselineHighDate: nil,
 				BaselineLowDate:  nil,
-				Support: web_platform_dx__web_features.Support{
+				ByCompatKey:      nil,
+				Support: web_platform_dx__web_features.StatusSupport{
 					Chrome:         nil,
 					ChromeAndroid:  nil,
 					Edge:           nil,
@@ -139,7 +143,8 @@ func TestGetBaselineStatusEnum(t *testing.T) {
 			input: web_platform_dx__web_features.Status{
 				BaselineHighDate: nil,
 				BaselineLowDate:  nil,
-				Support: web_platform_dx__web_features.Support{
+				ByCompatKey:      nil,
+				Support: web_platform_dx__web_features.StatusSupport{
 					Chrome:         nil,
 					ChromeAndroid:  nil,
 					Edge:           nil,
@@ -160,7 +165,8 @@ func TestGetBaselineStatusEnum(t *testing.T) {
 			input: web_platform_dx__web_features.Status{
 				BaselineHighDate: nil,
 				BaselineLowDate:  nil,
-				Support: web_platform_dx__web_features.Support{
+				ByCompatKey:      nil,
+				Support: web_platform_dx__web_features.StatusSupport{
 					Chrome:         nil,
 					ChromeAndroid:  nil,
 					Edge:           nil,
@@ -487,6 +493,7 @@ func TestInsertWebFeatures(t *testing.T) {
 					Name:           "Feature 1",
 					Caniuse:        nil,
 					CompatFeatures: nil,
+					Discouraged:    nil,
 					Spec: &web_platform_dx__web_features.StringOrStringArray{
 						StringArray: []string{"feature1-link1", "feature1-link2"},
 						String:      nil,
@@ -494,7 +501,8 @@ func TestInsertWebFeatures(t *testing.T) {
 					Status: web_platform_dx__web_features.Status{
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         valuePtr("100"),
 							ChromeAndroid:  nil,
 							Edge:           valuePtr("101"),
@@ -517,6 +525,7 @@ func TestInsertWebFeatures(t *testing.T) {
 					Name:           "Feature 2",
 					Caniuse:        nil,
 					CompatFeatures: nil,
+					Discouraged:    nil,
 					Spec: &web_platform_dx__web_features.StringOrStringArray{
 						StringArray: nil,
 						String:      valuePtr("feature2-link"),
@@ -524,7 +533,8 @@ func TestInsertWebFeatures(t *testing.T) {
 					Status: web_platform_dx__web_features.Status{
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         nil,
 							ChromeAndroid:  nil,
 							Edge:           nil,
@@ -591,11 +601,13 @@ func TestInsertWebFeatures(t *testing.T) {
 					Name:           "Feature 1",
 					Caniuse:        nil,
 					CompatFeatures: nil,
+					Discouraged:    nil,
 					Spec:           nil,
 					Status: web_platform_dx__web_features.Status{
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         nil,
 							ChromeAndroid:  nil,
 							Edge:           nil,
@@ -662,11 +674,13 @@ func TestInsertWebFeatures(t *testing.T) {
 					Name:           "Feature 1",
 					Caniuse:        nil,
 					CompatFeatures: nil,
+					Discouraged:    nil,
 					Spec:           nil,
 					Status: web_platform_dx__web_features.Status{
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         nil,
 							ChromeAndroid:  nil,
 							Edge:           nil,
@@ -748,11 +762,13 @@ func TestInsertWebFeatures(t *testing.T) {
 					Name:           "Feature 1",
 					Caniuse:        nil,
 					CompatFeatures: nil,
+					Discouraged:    nil,
 					Spec:           nil,
 					Status: web_platform_dx__web_features.Status{
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         valuePtr("100"),
 							ChromeAndroid:  nil,
 							Edge:           valuePtr("101"),
@@ -855,6 +871,7 @@ func TestInsertWebFeatures(t *testing.T) {
 					Name:           "Feature 1",
 					Caniuse:        nil,
 					CompatFeatures: nil,
+					Discouraged:    nil,
 					Spec: &web_platform_dx__web_features.StringOrStringArray{
 						StringArray: []string{"feature1-link1", "feature1-link2"},
 						String:      nil,
@@ -862,7 +879,8 @@ func TestInsertWebFeatures(t *testing.T) {
 					Status: web_platform_dx__web_features.Status{
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         valuePtr("100"),
 							ChromeAndroid:  nil,
 							Edge:           valuePtr("101"),
@@ -995,6 +1013,7 @@ func TestInsertWebFeatures(t *testing.T) {
 					Name:           "Feature 1",
 					Caniuse:        nil,
 					CompatFeatures: nil,
+					Discouraged:    nil,
 					Spec: &web_platform_dx__web_features.StringOrStringArray{
 						StringArray: []string{"feature1-link1", "feature1-link2"},
 						String:      nil,
@@ -1002,7 +1021,8 @@ func TestInsertWebFeatures(t *testing.T) {
 					Status: web_platform_dx__web_features.Status{
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         valuePtr("100"),
 							ChromeAndroid:  nil,
 							Edge:           valuePtr("101"),
@@ -1025,6 +1045,7 @@ func TestInsertWebFeatures(t *testing.T) {
 					Name:           "Feature 2",
 					Caniuse:        nil,
 					CompatFeatures: nil,
+					Discouraged:    nil,
 					Spec: &web_platform_dx__web_features.StringOrStringArray{
 						StringArray: nil,
 						String:      valuePtr("feature2-link"),
@@ -1032,7 +1053,8 @@ func TestInsertWebFeatures(t *testing.T) {
 					Status: web_platform_dx__web_features.Status{
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         nil,
 							ChromeAndroid:  nil,
 							Edge:           nil,

--- a/lib/gds/datastoreadapters/web_features_consumer_test.go
+++ b/lib/gds/datastoreadapters/web_features_consumer_test.go
@@ -63,11 +63,13 @@ func TestInsertWebFeaturesMetadata(t *testing.T) {
 						StringArray: nil,
 					},
 					DescriptionHTML: "<html>1",
+					Discouraged:     nil,
 					Status: web_platform_dx__web_features.Status{
 						Baseline:         nil,
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         nil,
 							ChromeAndroid:  nil,
 							Edge:           nil,
@@ -96,6 +98,7 @@ func TestInsertWebFeaturesMetadata(t *testing.T) {
 					CompatFeatures: nil,
 					Name:           "feature 2",
 					Description:    "Feature 2 description",
+					Discouraged:    nil,
 					Caniuse: &web_platform_dx__web_features.StringOrStringArray{
 						String:      nil,
 						StringArray: []string{"caniuse-id2a", "caniuse-id2b"},
@@ -105,7 +108,8 @@ func TestInsertWebFeaturesMetadata(t *testing.T) {
 						Baseline:         nil,
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         nil,
 							ChromeAndroid:  nil,
 							Edge:           nil,
@@ -140,11 +144,13 @@ func TestInsertWebFeaturesMetadata(t *testing.T) {
 					Name:            "feature 3",
 					Description:     "Feature 3 description",
 					DescriptionHTML: "<html>3",
+					Discouraged:     nil,
 					Status: web_platform_dx__web_features.Status{
 						Baseline:         nil,
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         nil,
 							ChromeAndroid:  nil,
 							Edge:           nil,
@@ -173,11 +179,13 @@ func TestInsertWebFeaturesMetadata(t *testing.T) {
 					Name:            "feature 4",
 					Description:     "Feature 4 description",
 					DescriptionHTML: "<html>4",
+					Discouraged:     nil,
 					Status: web_platform_dx__web_features.Status{
 						Baseline:         nil,
 						BaselineHighDate: nil,
 						BaselineLowDate:  nil,
-						Support: web_platform_dx__web_features.Support{
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
 							Chrome:         nil,
 							ChromeAndroid:  nil,
 							Edge:           nil,

--- a/workflows/steps/services/web_feature_consumer/pkg/data/parser.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/data/parser.go
@@ -63,6 +63,7 @@ func postProcessFeatureValue(
 			Snapshot:        postProcessStringOrStringArray(value.Snapshot),
 			Spec:            postProcessStringOrStringArray(value.Spec),
 			Status:          postProcessStatus(value.Status),
+			Discouraged:     nil,
 		}
 	}
 }
@@ -86,6 +87,7 @@ func postProcessStatus(value web_platform_dx__web_features.Status) web_platform_
 		BaselineHighDate: postProcessBaselineDates(value.BaselineHighDate),
 		BaselineLowDate:  postProcessBaselineDates(value.BaselineLowDate),
 		Support:          postProcessBaselineSupport(value.Support),
+		ByCompatKey:      nil,
 	}
 }
 
@@ -119,8 +121,9 @@ func postProcessBaselineSupportBrowser(value *string) *string {
 	return value
 }
 
-func postProcessBaselineSupport(value web_platform_dx__web_features.Support) web_platform_dx__web_features.Support {
-	return web_platform_dx__web_features.Support{
+func postProcessBaselineSupport(
+	value web_platform_dx__web_features.StatusSupport) web_platform_dx__web_features.StatusSupport {
+	return web_platform_dx__web_features.StatusSupport{
 		Chrome:         postProcessBaselineSupportBrowser(value.Chrome),
 		ChromeAndroid:  postProcessBaselineSupportBrowser(value.ChromeAndroid),
 		Edge:           postProcessBaselineSupportBrowser(value.Edge),

--- a/workflows/steps/services/web_feature_consumer/pkg/data/parser_test.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/data/parser_test.go
@@ -96,6 +96,36 @@ func TestPostProcess(t *testing.T) {
 		{
 			name: "catch-all case",
 			featureData: &web_platform_dx__web_features.FeatureData{
+				Browsers: web_platform_dx__web_features.Browsers{
+					Chrome: web_platform_dx__web_features.BrowserData{
+						Name:     "chrome",
+						Releases: nil,
+					},
+					ChromeAndroid: web_platform_dx__web_features.BrowserData{
+						Name:     "chrome_android",
+						Releases: nil,
+					},
+					Edge: web_platform_dx__web_features.BrowserData{
+						Name:     "edge",
+						Releases: nil,
+					},
+					Firefox: web_platform_dx__web_features.BrowserData{
+						Name:     "firefox",
+						Releases: nil,
+					},
+					FirefoxAndroid: web_platform_dx__web_features.BrowserData{
+						Name:     "firefox_android",
+						Releases: nil,
+					},
+					Safari: web_platform_dx__web_features.BrowserData{
+						Name:     "safari",
+						Releases: nil,
+					},
+					SafariIos: web_platform_dx__web_features.BrowserData{
+						Name:     "safari_ios",
+						Releases: nil,
+					},
+				},
 				Groups:    nil,
 				Snapshots: nil,
 				Features: map[string]web_platform_dx__web_features.FeatureValue{
@@ -103,6 +133,7 @@ func TestPostProcess(t *testing.T) {
 						CompatFeatures:  []string{"compat1", "compat2"},
 						Description:     "description",
 						DescriptionHTML: "description html",
+						Discouraged:     nil,
 						Name:            "feature 1 name",
 						Caniuse: &web_platform_dx__web_features.StringOrStringArray{
 							String: valuePtr("caniuse_data"),
@@ -139,7 +170,8 @@ func TestPostProcess(t *testing.T) {
 							},
 							BaselineHighDate: valuePtr("≤2023-01-01"),
 							BaselineLowDate:  valuePtr("≤2022-12-01"),
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         valuePtr("≤99"),
 								ChromeAndroid:  valuePtr("≤98"),
 								Firefox:        valuePtr("≤97"),
@@ -156,6 +188,7 @@ func TestPostProcess(t *testing.T) {
 				CompatFeatures:  []string{"compat1", "compat2"},
 				Description:     "description",
 				DescriptionHTML: "description html",
+				Discouraged:     nil,
 				Name:            "feature 1 name",
 				Caniuse: &web_platform_dx__web_features.StringOrStringArray{
 					String: valuePtr("caniuse_data"),
@@ -186,13 +219,14 @@ func TestPostProcess(t *testing.T) {
 					},
 				},
 				Status: web_platform_dx__web_features.Status{
+					ByCompatKey: nil,
 					Baseline: &web_platform_dx__web_features.BaselineUnion{
 						Bool: valuePtr(false),
 						Enum: valuePtr(web_platform_dx__web_features.High),
 					},
 					BaselineHighDate: valuePtr("2023-01-01"),
 					BaselineLowDate:  valuePtr("2022-12-01"),
-					Support: web_platform_dx__web_features.Support{
+					Support: web_platform_dx__web_features.StatusSupport{
 						Chrome:         valuePtr("99"),
 						ChromeAndroid:  valuePtr("98"),
 						Firefox:        valuePtr("97"),

--- a/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker_test.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker_test.go
@@ -88,6 +88,36 @@ func (m *mockAssetParser) Parse(file io.ReadCloser) (*web_platform_dx__web_featu
 var (
 	testInsertWebFeaturesStartAt = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 	testInsertWebFeaturesEndAt   = time.Date(3000, 1, 1, 0, 0, 0, 0, time.UTC)
+	fakeBrowsersData             = web_platform_dx__web_features.Browsers{
+		Chrome: web_platform_dx__web_features.BrowserData{
+			Name:     "chrome",
+			Releases: nil,
+		},
+		ChromeAndroid: web_platform_dx__web_features.BrowserData{
+			Name:     "chrome_android",
+			Releases: nil,
+		},
+		Edge: web_platform_dx__web_features.BrowserData{
+			Name:     "edge",
+			Releases: nil,
+		},
+		Firefox: web_platform_dx__web_features.BrowserData{
+			Name:     "firefox",
+			Releases: nil,
+		},
+		FirefoxAndroid: web_platform_dx__web_features.BrowserData{
+			Name:     "firefox_android",
+			Releases: nil,
+		},
+		Safari: web_platform_dx__web_features.BrowserData{
+			Name:     "safari",
+			Releases: nil,
+		},
+		SafariIos: web_platform_dx__web_features.BrowserData{
+			Name:     "safari_ios",
+			Releases: nil,
+		},
+	}
 )
 
 type mockInsertWebFeaturesConfig struct {
@@ -222,17 +252,20 @@ func TestProcess(t *testing.T) {
 			mockParseCfg: mockParseConfig{
 				expectedFileContents: "hi features",
 				returnData: &web_platform_dx__web_features.FeatureData{
+					Browsers: fakeBrowsersData,
 					Features: map[string]web_platform_dx__web_features.FeatureValue{
 						"feature1": {
 							Name:           "Feature 1",
 							Caniuse:        nil,
 							CompatFeatures: nil,
+							Discouraged:    nil,
 							Spec:           nil,
 							Status: web_platform_dx__web_features.Status{
 								Baseline:         nil,
 								BaselineHighDate: nil,
 								BaselineLowDate:  nil,
-								Support: web_platform_dx__web_features.Support{
+								ByCompatKey:      nil,
+								Support: web_platform_dx__web_features.StatusSupport{
 									Chrome:         nil,
 									ChromeAndroid:  nil,
 									Edge:           nil,
@@ -269,12 +302,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -301,12 +336,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -333,12 +370,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -371,12 +410,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -493,17 +534,20 @@ func TestProcess(t *testing.T) {
 			mockParseCfg: mockParseConfig{
 				expectedFileContents: "hi features",
 				returnData: &web_platform_dx__web_features.FeatureData{
+					Browsers: fakeBrowsersData,
 					Features: map[string]web_platform_dx__web_features.FeatureValue{
 						"feature1": {
 							Name:           "Feature 1",
 							Caniuse:        nil,
 							CompatFeatures: nil,
+							Discouraged:    nil,
 							Spec:           nil,
 							Status: web_platform_dx__web_features.Status{
 								Baseline:         nil,
 								BaselineHighDate: nil,
 								BaselineLowDate:  nil,
-								Support: web_platform_dx__web_features.Support{
+								ByCompatKey:      nil,
+								Support: web_platform_dx__web_features.StatusSupport{
 									Chrome:         nil,
 									ChromeAndroid:  nil,
 									Edge:           nil,
@@ -530,12 +574,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -587,17 +633,20 @@ func TestProcess(t *testing.T) {
 			mockParseCfg: mockParseConfig{
 				expectedFileContents: "hi features",
 				returnData: &web_platform_dx__web_features.FeatureData{
+					Browsers: fakeBrowsersData,
 					Features: map[string]web_platform_dx__web_features.FeatureValue{
 						"feature1": {
 							Name:           "Feature 1",
 							Caniuse:        nil,
 							CompatFeatures: nil,
+							Discouraged:    nil,
 							Spec:           nil,
 							Status: web_platform_dx__web_features.Status{
 								Baseline:         nil,
 								BaselineHighDate: nil,
 								BaselineLowDate:  nil,
-								Support: web_platform_dx__web_features.Support{
+								ByCompatKey:      nil,
+								Support: web_platform_dx__web_features.StatusSupport{
 									Chrome:         nil,
 									ChromeAndroid:  nil,
 									Edge:           nil,
@@ -624,12 +673,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -656,12 +707,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -708,17 +761,20 @@ func TestProcess(t *testing.T) {
 			mockParseCfg: mockParseConfig{
 				expectedFileContents: "hi features",
 				returnData: &web_platform_dx__web_features.FeatureData{
+					Browsers: fakeBrowsersData,
 					Features: map[string]web_platform_dx__web_features.FeatureValue{
 						"feature1": {
 							Name:           "Feature 1",
 							Caniuse:        nil,
 							CompatFeatures: nil,
+							Discouraged:    nil,
 							Spec:           nil,
 							Status: web_platform_dx__web_features.Status{
 								Baseline:         nil,
 								BaselineHighDate: nil,
 								BaselineLowDate:  nil,
-								Support: web_platform_dx__web_features.Support{
+								ByCompatKey:      nil,
+								Support: web_platform_dx__web_features.StatusSupport{
 									Chrome:         nil,
 									ChromeAndroid:  nil,
 									Edge:           nil,
@@ -750,12 +806,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -782,12 +840,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -814,12 +874,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -866,17 +928,20 @@ func TestProcess(t *testing.T) {
 			mockParseCfg: mockParseConfig{
 				expectedFileContents: "hi features",
 				returnData: &web_platform_dx__web_features.FeatureData{
+					Browsers: fakeBrowsersData,
 					Features: map[string]web_platform_dx__web_features.FeatureValue{
 						"feature1": {
 							Name:           "Feature 1",
 							Caniuse:        nil,
 							CompatFeatures: nil,
+							Discouraged:    nil,
 							Spec:           nil,
 							Status: web_platform_dx__web_features.Status{
 								Baseline:         nil,
 								BaselineHighDate: nil,
 								BaselineLowDate:  nil,
-								Support: web_platform_dx__web_features.Support{
+								ByCompatKey:      nil,
+								Support: web_platform_dx__web_features.StatusSupport{
 									Chrome:         nil,
 									ChromeAndroid:  nil,
 									Edge:           nil,
@@ -913,12 +978,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -945,12 +1012,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -977,12 +1046,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,
@@ -1015,12 +1086,14 @@ func TestProcess(t *testing.T) {
 						Name:           "Feature 1",
 						Caniuse:        nil,
 						CompatFeatures: nil,
+						Discouraged:    nil,
 						Spec:           nil,
 						Status: web_platform_dx__web_features.Status{
 							Baseline:         nil,
 							BaselineHighDate: nil,
 							BaselineLowDate:  nil,
-							Support: web_platform_dx__web_features.Support{
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
 								Chrome:         nil,
 								ChromeAndroid:  nil,
 								Edge:           nil,


### PR DESCRIPTION
Notable things that have been added:
- Browser Release data. Now, we could actually remove the bcd job and migrate the logic into the web features job since we can get the same data from the v2.15.0 of the schema.

This commit also modifies the go code to add the new fields with sensible null / zero values since we don't need them yet. We have to add these fields to satisfy the [exhaustruct](https://github.com/GaijinEntertainment/go-exhaustruct) linter

Manual changes that we kept from #531:
- Add an explicit StringorStringArray definition. Because it otherwise it takes the name of the first variable of it (previously Alias and now Caniuse) and uses it everywhere else. So all the usages would use Caniuse And that does not explain that the value could be a String of String Array.