### PR TITLE
chore: run npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9041,9 +9041,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -9051,6 +9051,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },


### PR DESCRIPTION
There's been a moderate serverity vulnerability that npm keeps reporting for the last month. [1]

While it probably doesn't impact us, I figured, I should resolve it since dependabot has not. I ran npm audit fix as instructed by npm to generate this commit.

More details about the vulnerability in nanoid. [2]

[1] https://github.com/GoogleChrome/webstatus.dev/actions/runs/12549881467/job/34991696781#step:6:5443
[2] https://github.com/advisories/GHSA-mwcw-c2x4-8c55