### PR TITLE
Fix dockerfile warnings and add lint command

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,7 +33,7 @@ RUN wget https://www.antlr.org/download/antlr-${ANTLR4_VERSION}-complete.jar
 RUN echo "alias antlr4='java -jar /usr/local/lib/antlr-${ANTLR4_VERSION}-complete.jar'" >> ~/.bashrc
 RUN echo "alias grun='java org.antlr.v4.gui.TestRig'" >> ~/.bashrc
 
-ENV CLASSPATH .:/usr/local/lib/antlr-${ANTLR4_VERSION}-complete.jar:$CLASSPATH
+ENV CLASSPATH=.:/usr/local/lib/antlr-${ANTLR4_VERSION}-complete.jar
 
 # Switch to the default user and append to PATH
 USER vscode

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,17 @@ SHELL := /bin/bash
 NPROCS := $(shell nproc)
 GH_REPO := "GoogleChrome/webstatus.dev"
 
+DOCKERFILES := \
+	images/go_service.Dockerfile \
+	images/nodejs_service.Dockerfile \
+	otel/Dockerfile \
+	./.dev/gcs/Dockerfile \
+	./.dev/auth/Dockerfile \
+	./.dev/datastore/Dockerfile \
+	./.dev/spanner/Dockerfile \
+	./.dev/redis/Dockerfile \
+	./.devcontainer/Dockerfile
+
 .PHONY: all \
 		antlr-gen \
 		clean \
@@ -176,7 +187,7 @@ clean-jsonschema:
 golint-version:
 	golangci-lint --version
 
-lint: go-lint node-lint tf-lint shell-lint style-lint
+lint: go-lint node-lint tf-lint shell-lint style-lint dockerfile-lint
 
 go-lint: golint-version go-workspace-setup
 	go list -f '{{.Dir}}/...' -m | xargs golangci-lint run
@@ -202,6 +213,9 @@ lint-fix: node-install
 
 style-lint:
 	npx stylelint "frontend/src/**/*.css"
+
+dockerfile-lint:
+	@$(foreach dockerfile,$(DOCKERFILES),docker build --check -f $(dockerfile) .;)
 
 ################################
 # Test

--- a/images/go_service.Dockerfile
+++ b/images/go_service.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23.4-alpine3.20 as builder
+FROM golang:1.23.4-alpine3.20 AS builder
 
 WORKDIR /work
 
@@ -52,4 +52,4 @@ FROM alpine:3.21
 COPY --from=builder /work/program .
 
 # Assuming that service has a binary called server, make that the command to run when the image starts.
-CMD ./program
+CMD ["./program"]

--- a/images/nodejs_service.Dockerfile
+++ b/images/nodejs_service.Dockerfile
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:22.11.0-alpine3.20 as base
+FROM node:22.11.0-alpine3.20 AS base
 
-FROM base as builder
+FROM base AS builder
 
 WORKDIR /work
 ARG service_dir
 ARG build_env
-ENV BUILD_ENV ${build_env}
+ENV BUILD_ENV=${build_env}
 COPY package.json package.json
 COPY package-lock.json package-lock.json
 COPY ${service_dir}/package.json ${service_dir}/package.json
@@ -32,7 +32,7 @@ RUN npm run postinstall || true
 RUN npm run build
 
 
-FROM base as production
+FROM base AS production
 
 WORKDIR /work
 ARG service_dir
@@ -44,16 +44,16 @@ RUN --mount=type=cache,target=/root/.npm \
     npm install --ignore-scripts --production
 RUN ln -s /work/node_modules /work/${service_dir}/node_modules
 COPY --from=builder /work/${service_dir}/dist /work/${service_dir}/dist
-CMD npm run start
+CMD ["npm", "run", "start"]
 
-FROM nginx:alpine3.19-slim as placeholder
+FROM nginx:alpine3.19-slim AS placeholder
 
 ARG service_dir
 COPY --from=builder /work/${service_dir}/nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /work/${service_dir}/placeholder/static /usr/share/nginx/html
 COPY --from=builder /work/${service_dir}/scripts/setup_server.sh /docker-entrypoint.d/setup_server.sh
 
-FROM nginx:alpine3.19-slim as static
+FROM nginx:alpine3.19-slim AS static
 
 ARG service_dir
 COPY --from=builder /work/${service_dir}/nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
There are some existing dockerfile lint warnings. This commit fixes them.

Example: https://github.com/GoogleChrome/webstatus.dev/actions/runs/12552250381/job/34997931125?pr=1022#step:9:10621

To future proof it, it also adds a makefile target that does the same check.


Notable things fixed:
- https://docs.docker.com/reference/build-checks/undefined-var/
- https://docs.docker.com/reference/build-checks/legacy-key-value-format/
- https://docs.docker.com/reference/build-checks/json-args-recommended/
- https://docs.docker.com/reference/build-checks/from-as-casing/

All the checks can be found on this page: https://docs.docker.com/reference/build-checks/