### PR TITLE
Fix frontend test errors

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,16 +8,16 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "build": "npm run tsc-clean && tsc && npx rollup -c",
-    "clean": "rm -rf build && rm -rf static && rm -rf dist && rm -rf node_modules && rm -rf .postinstall",
+    "build": "npm run clean && tsc && npm run cp-imgs && npx rollup -c",
+    "clean": "rm -rf build && rm -rf static && rm -rf dist && tsc --build --clean",
     "lint": "cd .. && prettier frontend/ --check && cd frontend && eslint \"**/*.{js,ts}\" && lit-analyzer \"src/**/*.{js,ts}\" && tsc --noEmit",
     "lint-fix": "cd .. && prettier frontend/ --write && cd frontend && eslint \"**/*.{js,ts}\" --fix",
     "local": "npm run build && TODO",
     "postinstall": "./scripts/postinstall.js",
     "start": "node dist/server/index.js",
-    "test": "npm run tsc-clean && tsc && wtr --coverage --node-resolve --playwright --browsers chromium firefox webkit",
-    "tsc-clean": "tsc --build --clean",
-    "test:watch": "tsc && concurrently -k --raw \"tsc --watch --preserveWatchOutput\"  \"wtr --watch --coverage --node-resolve --playwright --browsers chromium firefox webkit\" "
+    "cp-imgs": "mkdir -p build/public/img && cp -v -r src/static/img/* build/public/img && cp -v .postinstall/static/img/* build/public/img",
+    "test": "npm run build && npm run cp-imgs && wtr --coverage --node-resolve --playwright --browsers chromium firefox webkit",
+    "test:watch": "npm run build && concurrently -k --raw \"tsc --watch --preserveWatchOutput\"  \"wtr --watch --coverage --node-resolve --playwright --browsers chromium firefox webkit\" "
   },
   "devDependencies": {
     "@browser-logos/chrome": "^2.0.0",

--- a/frontend/rollup.config.mjs
+++ b/frontend/rollup.config.mjs
@@ -43,12 +43,8 @@ export default [
       }),
       copy({
         targets: [
-          // Copy all files in img recursively.
-          // Currently copying svg files from https://github.com/mdn/yari/tree/main/client/src/assets/icons/baseline
-          {src: 'src/static/img/**', dest: 'dist/static/public/img'},
           // Copy the img files
-          // Currently copying img files from ./scripts/postinstall.js
-          {src: '.postinstall/static/img/*', dest: 'dist/static/public/img'},
+          {src: 'build/public/img/*', dest: 'dist/static/public/img'},
           // Copy the html file
           {src: 'src/static/index.html', dest: 'dist/static'},
         ],

--- a/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
@@ -24,8 +24,8 @@ import {render} from 'lit';
 describe('webstatus-feature-page', () => {
   let el: FeaturePage;
   let renderDescriptionSpy: sinon.SinonSpy;
+  const location = {params: {featureId: 'some-feature'}, search: ''};
   beforeEach(async () => {
-    const location = {params: {featureId: 'some-feature'}, search: ''};
     el = await fixture<FeaturePage>(
       html`<webstatus-feature-page
         .location=${location}
@@ -144,7 +144,9 @@ describe('webstatus-feature-page', () => {
 
     beforeEach(async () => {
       element = await fixture(
-        html`<webstatus-feature-page></webstatus-feature-page>`,
+        html`<webstatus-feature-page
+          .location=${location}
+        ></webstatus-feature-page>`,
       );
       hostElement = document.createElement('div');
 
@@ -244,7 +246,9 @@ describe('webstatus-feature-page', () => {
 
     beforeEach(async () => {
       element = await fixture(
-        html`<webstatus-feature-page></webstatus-feature-page>`,
+        html`<webstatus-feature-page
+          .location=${location}
+        ></webstatus-feature-page>`,
       );
       element.endDate = new Date('2024-01-01');
       hostElement = document.createElement('div');

--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -133,7 +133,6 @@ export class FeaturePage extends LitElement {
   @state()
   featureMetadata?: {can_i_use?: CanIUseData; description?: string} | undefined;
 
-  @state()
   featureId!: string;
 
   location!: {params: {featureId: string}; search: string}; // Set by router.

--- a/frontend/src/static/js/components/webstatus-overview-filters.ts
+++ b/frontend/src/static/js/components/webstatus-overview-filters.ts
@@ -151,7 +151,6 @@ export class WebstatusOverviewFilters extends LitElement {
   @state()
   exportDataStatus: TaskStatus = TaskStatus.INITIAL;
 
-  @state()
   // A function that returns an array of all features via apiClient.getAllFeatures
   allFeaturesFetcher:
     | undefined

--- a/frontend/src/static/js/components/webstatus-sidebar-menu.ts
+++ b/frontend/src/static/js/components/webstatus-sidebar-menu.ts
@@ -253,7 +253,7 @@ export class WebstatusSidebarMenu extends LitElement {
     const bookmarkIcon = isQueryActive ? 'bookmark-star' : 'bookmark';
 
     return html`
-      <sl-tree-item id=${bookmarkId} ?selected=${isQueryActive}>
+      <sl-tree-item id=${bookmarkId} ?selected=${isQueryActive} lazy>
         <a class="bookmark-link" href="${bookmarkUrl}">
           <sl-icon name="${bookmarkIcon}"></sl-icon> ${bookmark.name}
         </a>
@@ -269,7 +269,8 @@ export class WebstatusSidebarMenu extends LitElement {
 
         <sl-tree-item
           id="${NavigationItemKey.FEATURES}"
-          expanded=${this.isFeaturesDropdownExpanded}
+          .expanded=${this.isFeaturesDropdownExpanded}
+          lazy
         >
           <sl-icon name="menu-button"></sl-icon>
           <a
@@ -288,7 +289,7 @@ export class WebstatusSidebarMenu extends LitElement {
 
         <sl-divider aria-hidden="true"></sl-divider>
 
-        <sl-tree-item class="report-issue-item">
+        <sl-tree-item class="report-issue-item" lazy>
           <sl-icon name="github"></sl-icon>
           <a
             class="report-issue-link"
@@ -298,7 +299,7 @@ export class WebstatusSidebarMenu extends LitElement {
           >
         </sl-tree-item>
 
-        <sl-tree-item class="about-item">
+        <sl-tree-item class="about-item" lazy>
           <sl-icon name="info-circle"></sl-icon>
           <a class="about-link" href="${ABOUT_PAGE_LINK}" target="_blank"
             >About</a

--- a/frontend/src/static/js/components/webstatus-sidebar-menu.ts
+++ b/frontend/src/static/js/components/webstatus-sidebar-menu.ts
@@ -253,7 +253,7 @@ export class WebstatusSidebarMenu extends LitElement {
     const bookmarkIcon = isQueryActive ? 'bookmark-star' : 'bookmark';
 
     return html`
-      <sl-tree-item id=${bookmarkId} ?selected=${isQueryActive} lazy>
+      <sl-tree-item id=${bookmarkId} ?selected=${isQueryActive}>
         <a class="bookmark-link" href="${bookmarkUrl}">
           <sl-icon name="${bookmarkIcon}"></sl-icon> ${bookmark.name}
         </a>
@@ -270,7 +270,6 @@ export class WebstatusSidebarMenu extends LitElement {
         <sl-tree-item
           id="${NavigationItemKey.FEATURES}"
           .expanded=${this.isFeaturesDropdownExpanded}
-          lazy
         >
           <sl-icon name="menu-button"></sl-icon>
           <a
@@ -289,7 +288,7 @@ export class WebstatusSidebarMenu extends LitElement {
 
         <sl-divider aria-hidden="true"></sl-divider>
 
-        <sl-tree-item class="report-issue-item" lazy>
+        <sl-tree-item class="report-issue-item">
           <sl-icon name="github"></sl-icon>
           <a
             class="report-issue-link"
@@ -299,7 +298,7 @@ export class WebstatusSidebarMenu extends LitElement {
           >
         </sl-tree-item>
 
-        <sl-tree-item class="about-item" lazy>
+        <sl-tree-item class="about-item">
           <sl-icon name="info-circle"></sl-icon>
           <a class="about-link" href="${ABOUT_PAGE_LINK}" target="_blank"
             >About</a

--- a/frontend/src/static/js/services/webstatus-firebase-app-service.ts
+++ b/frontend/src/static/js/services/webstatus-firebase-app-service.ts
@@ -15,7 +15,7 @@
  */
 
 import {provide} from '@lit/context';
-import {customElement, property, state} from 'lit/decorators.js';
+import {customElement, property} from 'lit/decorators.js';
 import {
   FirebaseApp,
   firebaseAppContext,
@@ -34,7 +34,6 @@ export class WebstatusFirebaseAppService extends ServiceElement {
   settings?: FirebaseSettings;
 
   @provide({context: firebaseAppContext})
-  @state()
   firebaseApp?: FirebaseApp;
 
   protected firstUpdated(): void {

--- a/frontend/web-test-runner.config.mjs
+++ b/frontend/web-test-runner.config.mjs
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-const filteredLogs = ['Running in dev mode', 'Lit is in dev mode'];
+const filteredLogs = [
+  'Running in dev mode',
+  'Lit is in dev mode',
+  // sl-tree-item has its own reactivity that we cannot control. Ignore for now.
+  'Element sl-tree-item scheduled an update',
+];
 
 export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
   concurrency: 10,

--- a/frontend/web-test-runner.config.mjs
+++ b/frontend/web-test-runner.config.mjs
@@ -24,13 +24,24 @@ export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
   },
 
   // in a monorepo you need to set the root dir to resolve modules
-  rootDir: '../../',
+  rootDir: 'build/',
 
   files: [
     // Have to compile tests
     // Taken from https://github.com/open-wc/create/blob/master/src/generators/testing-wtr-ts/templates/static/web-test-runner.config.mjs
-    'build/**/test/*.test.js',
+    '**/test/*.test.js',
   ],
+  testRunnerHtml: testFramework => `
+  <html>
+    <body>
+      <script type="module" src="${testFramework}"></script>
+      <script type="module">
+        import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path.js';
+        setBasePath('/public/img/shoelace');
+      </script>
+    </body>
+  </html>
+  `,
 
   /** Filter out lit dev mode logs */
   filterBrowserLogs(log) {


### PR DESCRIPTION
Background:
Upon running the frontend tests, you can see there are many unexpected logs being printed out. This ranges from:
1. 404 Network Requests ([Example](https://github.com/GoogleChrome/webstatus.dev/actions/runs/12553689104/job/35001422582#step:6:10143))
2. Uncaught exceptions ([Example](https://github.com/GoogleChrome/webstatus.dev/actions/runs/12553689104/job/35001422582#step:6:10178))
3. Inefficient re-rendering ([Example](https://github.com/GoogleChrome/webstatus.dev/actions/runs/12553689104/job/35001422582#step:6:10338))

Check the full log for all the errors.

**Case 1**
Problem:
- Tests are missing static resources

Remedy:
- Copy the static resources to same folder as the compiled tests with new `cp-imgs` npm target.
  - Simplified rollup config by now only needing one copy statement for the images too.
- Shoelace-only assets: Adjust the test html in web-test-runner.config.mjs to set the path for shoelace assets like we do in our main [index.ts](https://github.com/GoogleChrome/webstatus.dev/blob/4b8b4696cd20c37bec10b187190863266593bd4d/frontend/src/static/js/index.ts#L47)

**Case 2**
Remedy: Adjust the individual tests to fix the problems

**Case 3**
Remedy:
- Remove unnecessary reactivity from certain class members for each instance
- Specifically for `sl-tree-item`: ignore the single message about `Element sl-tree-item scheduled an update`
  - Other things tried but failed:
    - Add [lazy](https://shoelace.style/components/tree-item#properties:~:text=lazy,lazy%20loading%20behavior.) attribute.
    - Override getUpdateComplete to check updatecomplete for all sl-tree-items


---

Long term: It would be great to fail the tests instead when these issues come up instead of silently passing. But I couldn't figure out how. Similar to discussion found in https://github.com/GoogleChrome/chromium-dashboard/issues/2977