### PR TITLE
Ensure golangci-lint uses correct Go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ golint-version:
 lint: go-lint node-lint tf-lint shell-lint style-lint dockerfile-lint
 
 go-lint: golint-version go-workspace-setup
-	go list -f '{{.Dir}}/...' -m | xargs golangci-lint run
+	go list -f '{{.Dir}}/...' -m | xargs -t golangci-lint run --go=$$(go version | awk '{print $$3}' | cut -c 3-)
 
 node-lint: node-install
 	npm run lint -w frontend


### PR DESCRIPTION
CI is currently failing due to golangci-lint incorrectly detecting Go 1.17 and flagging an "Implicit memory aliasing in for loop" [error](https://github.com/GoogleChrome/webstatus.dev/pull/1025/files#annotation_30371395591) that is fixed in Go 1.22+. It is currently unable to detect the version so it falls back to thinking that go 1.17 [installed](https://github.com/golangci/golangci-lint/blob/f496cd3a727f353d30fb32a4495b425e98bbc541/pkg/config/config.go#L88)

This commit explicitly passes the correct Go version to golangci-lint to prevent it from defaulting to the fallback version.  The `-t` flag is added to `xargs` for improved debugging in the future.