### PR TITLE
Handle missing values in grammar terms with nil checks in visitor

### DIFF
--- a/antlr/FeatureSearch.g4
+++ b/antlr/FeatureSearch.g4
@@ -19,9 +19,8 @@ BASELINE_STATUS: 'limited' | 'newly' | 'widely';
 DATE:
 	[2][0-9][0-9][0-9]'-' [01][0-9]'-' [0-3][0-9]; // YYYY-MM-DD (starting from 2000)
 ANY_VALUE:
-	'"' [a-zA-Z][a-zA-Z0-9_ -]* '"' // Words with spaces.
-	| [a-zA-Z][a-zA-Z0-9_-]*; // Single words
-
+	'"' [a-zA-Z0-9][a-zA-Z0-9_() -]* '"' // Words with spaces.
+	| [a-zA-Z0-9][a-zA-Z0-9_-]*; // Single words
 // Terms
 available_on_term: 'available_on' COLON BROWSER_NAME;
 baseline_status_term: 'baseline_status' COLON BASELINE_STATUS;

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -1002,6 +1002,39 @@ func TestParseQuery(t *testing.T) {
 				},
 			},
 		},
+		{
+			InputQuery: `name:"has()" OR name:light-dark`,
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Keyword: KeywordOR,
+						Term:    nil,
+						Children: []*SearchNode{
+							{
+								Keyword: KeywordNone,
+								Term: &SearchTerm{
+									Identifier: IdentifierName,
+									Value:      "has()",
+									Operator:   OperatorEq,
+								},
+								Children: nil,
+							},
+							{
+								Keyword: KeywordNone,
+								Term: &SearchTerm{
+									Identifier: IdentifierName,
+									Value:      "light-dark",
+									Operator:   OperatorEq,
+								},
+								Children: nil,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -1087,6 +1120,73 @@ func TestParseQueryBadInput(t *testing.T) {
 		},
 		{
 			input: "available_date:2000-01-01..2000-12-31",
+		},
+		// Terms missing colon and values
+		{
+			input: "available_on",
+		},
+		{
+			input: "available_date",
+		},
+		{
+			input: "baseline_status",
+		},
+		{
+			input: "baseline_date",
+		},
+		{
+			input: "name",
+		},
+		{
+			input: "group",
+		},
+		{
+			input: "id",
+		},
+		{
+			input: "snapshot",
+		},
+		// Terms missing values
+		{
+			input: "available_on:",
+		},
+		{
+			input: "available_date:",
+		},
+		{
+			input: "baseline_status:",
+		},
+		{
+			input: "baseline_date:",
+		},
+		{
+			input: "name:",
+		},
+		{
+			input: "group:",
+		},
+		{
+			input: "id:",
+		},
+		{
+			input: "snapshot:",
+		},
+		// Other input from https://github.com/GoogleChrome/webstatus.dev/issues/286
+		{
+			// nolint:lll // WONTFIX. Repro from issue.
+			input: `available_on:chrome available_on:firefox available_on:safari baseline_status:widely name:"a substring" baseline_status:widely -`,
+		},
+		{
+			input: `available_on:chrome available_on Secured AI available_on:safari available_on:firefox`,
+		},
+		{
+			input: `available_on:chrome available_on generative AI available_on:safari available_on:firefox`,
+		},
+		{
+			input: `baseline_date:2023-01-01`,
+		},
+		{
+			input: `baseline_date:12-26-2024..1-2-2025`,
 		},
 	}
 	for _, tc := range testCases {

--- a/lib/gcpspanner/searchtypes/features_search_visitor.go
+++ b/lib/gcpspanner/searchtypes/features_search_visitor.go
@@ -50,6 +50,22 @@ func (v *FeaturesSearchVisitor) addError(err error) {
 	v.err = errors.Join(v.err, err)
 }
 
+type termMissingValueError struct {
+	term SearchIdentifier
+}
+
+func (e termMissingValueError) Error() string {
+	return fmt.Sprintf("term %s is missing value", e.term)
+}
+
+type termMissingRangeValueError struct {
+	term SearchIdentifier
+}
+
+func (e termMissingRangeValueError) Error() string {
+	return fmt.Sprintf("term %s is missing value", e.term)
+}
+
 func (v *FeaturesSearchVisitor) handleOperator(current *SearchNode, operatorCtx *parser.OperatorContext) *SearchNode {
 	operator := getOperatorType(operatorCtx.GetText())
 
@@ -128,25 +144,31 @@ func (v *FeaturesSearchVisitor) aggregateNodesImplicitAND(nodes []*SearchNode) *
 	return rootNode
 }
 
-func (v *FeaturesSearchVisitor) createIDNode(id string) *SearchNode {
-	return v.createSimpleNode(id, IdentifierID)
+func (v *FeaturesSearchVisitor) createIDNode(idNode antlr.TerminalNode) *SearchNode {
+	return v.createSimpleNode(idNode, IdentifierID)
 }
 
-func (v *FeaturesSearchVisitor) createSnapshotNode(snapshot string) *SearchNode {
-	return v.createSimpleNode(snapshot, IdentifierSnapshot)
+func (v *FeaturesSearchVisitor) createSnapshotNode(snapshotNode antlr.TerminalNode) *SearchNode {
+	return v.createSimpleNode(snapshotNode, IdentifierSnapshot)
 }
 
-func (v *FeaturesSearchVisitor) createGroupNode(group string) *SearchNode {
-	return v.createSimpleNode(group, IdentifierGroup)
+func (v *FeaturesSearchVisitor) createGroupNode(groupNode antlr.TerminalNode) *SearchNode {
+	return v.createSimpleNode(groupNode, IdentifierGroup)
 }
 
-func (v *FeaturesSearchVisitor) createNameNode(name string) *SearchNode {
-	return v.createSimpleNode(name, IdentifierName)
+func (v *FeaturesSearchVisitor) createNameNode(nameNode antlr.TerminalNode) *SearchNode {
+	return v.createSimpleNode(nameNode, IdentifierName)
 }
 
 func (v *FeaturesSearchVisitor) createSimpleNode(
-	value string,
+	node antlr.TerminalNode,
 	identifier SearchIdentifier) *SearchNode {
+	if node == nil {
+		v.addError(termMissingValueError{term: identifier})
+
+		return nil
+	}
+	value := node.GetText()
 	value = strings.Trim(value, `"`)
 
 	return &SearchNode{
@@ -179,6 +201,12 @@ func (v *FeaturesSearchVisitor) VisitQuery(ctx *parser.QueryContext) interface{}
 
 // nolint: revive // Method signature is generated.
 func (v *FeaturesSearchVisitor) VisitAvailable_on_term(ctx *parser.Available_on_termContext) interface{} {
+	browserNameNode := ctx.BROWSER_NAME()
+	if browserNameNode == nil {
+		v.addError(termMissingValueError{term: IdentifierAvailableOn})
+
+		return nil
+	}
 	browserName := strings.ToLower(ctx.BROWSER_NAME().GetText())
 
 	return &SearchNode{
@@ -194,7 +222,13 @@ func (v *FeaturesSearchVisitor) VisitAvailable_on_term(ctx *parser.Available_on_
 
 // nolint: revive // Method signature is generated.
 func (v *FeaturesSearchVisitor) VisitBaseline_status_term(ctx *parser.Baseline_status_termContext) interface{} {
-	baselineStatus := ctx.BASELINE_STATUS().GetText()
+	baselineStatusNode := ctx.BASELINE_STATUS()
+	if baselineStatusNode == nil {
+		v.addError(termMissingValueError{term: IdentifierBaselineStatus})
+
+		return nil
+	}
+	baselineStatus := baselineStatusNode.GetText()
 
 	return &SearchNode{
 		Keyword: KeywordNone,
@@ -309,8 +343,17 @@ func (v *FeaturesSearchVisitor) VisitBaseline_date_term(ctx *parser.Baseline_dat
 // have a date range context. The generated VisitDate_range_query is no longer needed.
 func (v *FeaturesSearchVisitor) VisitDateRangeQuery(ctx parser.IDate_range_queryContext,
 	identifier SearchIdentifier) *SearchNode {
-	startDate := ctx.GetStartDate().GetText()
-	endDate := ctx.GetEndDate().GetText()
+	startDateNode := ctx.GetStartDate()
+	endDateNode := ctx.GetEndDate()
+
+	if startDateNode == nil || endDateNode == nil {
+		v.addError(termMissingRangeValueError{term: identifier})
+
+		return nil
+	}
+
+	startDate := startDateNode.GetText()
+	endDate := endDateNode.GetText()
 
 	return &SearchNode{
 		Keyword: KeywordAND,
@@ -418,22 +461,22 @@ func (v *FeaturesSearchVisitor) VisitCombined_search_criteria(ctx *parser.Combin
 
 // nolint: revive // Method signature is generated.
 func (v *FeaturesSearchVisitor) VisitId_term(ctx *parser.Id_termContext) interface{} {
-	return v.createIDNode(ctx.ANY_VALUE().GetText())
+	return v.createIDNode(ctx.ANY_VALUE())
 }
 
 // nolint: revive // Method signature is generated.
 func (v *FeaturesSearchVisitor) VisitSnapshot_term(ctx *parser.Snapshot_termContext) interface{} {
-	return v.createSnapshotNode(ctx.ANY_VALUE().GetText())
+	return v.createSnapshotNode(ctx.ANY_VALUE())
 }
 
 // nolint: revive // Method signature is generated.
 func (v *FeaturesSearchVisitor) VisitGroup_term(ctx *parser.Group_termContext) interface{} {
-	return v.createGroupNode(ctx.ANY_VALUE().GetText())
+	return v.createGroupNode(ctx.ANY_VALUE())
 }
 
 // nolint: revive // Method signature is generated.
 func (v *FeaturesSearchVisitor) VisitName_term(ctx *parser.Name_termContext) interface{} {
-	return v.createNameNode(ctx.ANY_VALUE().GetText())
+	return v.createNameNode(ctx.ANY_VALUE())
 }
 
 func (v *FeaturesSearchVisitor) VisitTerm(ctx *parser.TermContext) interface{} {
@@ -469,8 +512,10 @@ func (v *FeaturesSearchVisitor) VisitGeneric_search_term(ctx *parser.Generic_sea
 func (v *FeaturesSearchVisitor) VisitSearch_criteria(ctx *parser.Search_criteriaContext) interface{} {
 	// Handle the default ANY_VALUE case.
 	// This is needed for the feature name that does not have the prefix.
+	// Even though createNameNode will return nil if node is nil, it will add an error.
+	// So we proactively check for node.
 	if node := ctx.ANY_VALUE(); node != nil {
-		return v.createNameNode(node.GetText())
+		return v.createNameNode(node)
 	}
 
 	return v.VisitChildren(ctx)

--- a/lib/gcpspanner/searchtypes/features_search_visitor.go
+++ b/lib/gcpspanner/searchtypes/features_search_visitor.go
@@ -63,7 +63,7 @@ type termMissingRangeValueError struct {
 }
 
 func (e termMissingRangeValueError) Error() string {
-	return fmt.Sprintf("term %s is missing value", e.term)
+	return fmt.Sprintf("term %s is missing value range", e.term)
 }
 
 func (v *FeaturesSearchVisitor) handleOperator(current *SearchNode, operatorCtx *parser.OperatorContext) *SearchNode {


### PR DESCRIPTION
When a string is missing the colon or value for a term, the parser still reaches the visitor method with a nil value node. This adds nil checks to handle these cases and returns an error.  This should cause the backend to return 4xx errors instead of 5xx errors.

Test cases have been added to address the reported issues in #286.

Possible future improvement: Explore grammar modifications to prevent these invalid inputs at the parser level.

Other changes:
- Adjust grammar to allow `(` or `)` only in the quoted words to support queries like this: `name:"has()" OR name:light-dark` (also reported in #286)