### PR TITLE
Add webstatus-form-date-range-picker component

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-form-date-range-picker.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-form-date-range-picker.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {expect, fixture, html} from '@open-wc/testing';
+import {
+  WebstatusFormDateRangePicker,
+  DateChangeEvent,
+} from '../webstatus-form-date-range-picker.js';
+import {customElement, property} from 'lit/decorators.js';
+import {LitElement} from 'lit';
+import '../webstatus-form-date-range-picker.js';
+import '@shoelace-style/shoelace/dist/components/input/input.js';
+
+// TestComponent to listen for events from WebstatusFormDateRangePicker
+@customElement('test-component')
+class TestComponent extends LitElement {
+  @property({type: Object}) startDate: Date | undefined;
+  @property({type: Object}) endDate: Date | undefined;
+
+  handleStartDateChange(event: CustomEvent<DateChangeEvent>) {
+    this.startDate = event.detail.date;
+  }
+
+  handleEndDateChange(event: CustomEvent<DateChangeEvent>) {
+    this.endDate = event.detail.date;
+  }
+
+  render() {
+    return html`
+      <webstatus-form-date-range-picker
+        .minimumDate=${new Date(2023, 0, 1)}
+        .maximumDate=${new Date(2024, 11, 31)}
+        .startDate=${new Date(2023, 5, 1)}
+        .endDate=${new Date(2023, 10, 31)}
+        @webstatus-start-date-change=${this.handleStartDateChange}
+        @webstatus-end-date-change=${this.handleEndDateChange}
+      ></webstatus-form-date-range-picker>
+    `;
+  }
+}
+
+describe('WebstatusFormDateRangePicker', () => {
+  let parent: TestComponent;
+  let el: WebstatusFormDateRangePicker;
+
+  beforeEach(async () => {
+    // Create the parent component, which now renders the date picker
+    parent = await fixture<TestComponent>(
+      html`<test-component></test-component>`,
+    );
+    el = parent.shadowRoot!.querySelector<WebstatusFormDateRangePicker>(
+      'webstatus-form-date-range-picker',
+    )!;
+  });
+
+  it('should render the date range picker with default values', () => {
+    const startDateInput = el.startDateEl!;
+    const endDateInput = el.endDateEl!;
+
+    expect(startDateInput).to.exist;
+    expect(endDateInput).to.exist;
+    expect(startDateInput.valueAsDate).to.deep.equal(el.startDate);
+    expect(endDateInput.valueAsDate).to.deep.equal(el.endDate);
+    expect(startDateInput.min).to.equal(el.toIsoDate(el.minimumDate));
+    expect(startDateInput.max).to.equal(el.toIsoDate(el.endDate));
+    expect(endDateInput.min).to.equal(el.toIsoDate(el.startDate));
+    expect(endDateInput.max).to.equal(el.toIsoDate(el.maximumDate));
+  });
+
+  describe('Start Date Validation and Events', () => {
+    it('should update start date and emit event when valid date is entered', async () => {
+      const newStartDate = new Date(2023, 5, 15);
+
+      el.startDateEl!.valueAsDate = newStartDate;
+      await el.updateComplete;
+      await parent.updateComplete;
+      el.startDateEl!.dispatchEvent(new Event('sl-blur'));
+
+      expect(el.startDate).to.deep.equal(newStartDate);
+      expect(parent.startDate).to.deep.equal(newStartDate);
+    });
+
+    it('should not update start date if invalid date is entered', async () => {
+      const newStartDate = new Date('invalid-date');
+
+      el.startDateEl!.valueAsDate = newStartDate;
+      await el.updateComplete;
+      await parent.updateComplete;
+      el.startDateEl!.dispatchEvent(new Event('sl-blur'));
+
+      expect(el.startDate).to.deep.equal(el.startDate);
+      expect(parent.startDate).to.be.undefined;
+    });
+
+    it('should not update start date if new date is before minimum date', async () => {
+      const newStartDate = new Date(el.minimumDate.getFullYear() - 1, 0, 1);
+
+      el.startDateEl!.valueAsDate = newStartDate;
+      await el.updateComplete;
+      await parent.updateComplete;
+      el.startDateEl!.dispatchEvent(new Event('sl-blur'));
+
+      expect(el.startDate).to.deep.equal(el.startDate);
+      expect(parent.startDate).to.be.undefined;
+    });
+
+    it('should not update start date if new date is after end date', async () => {
+      const newStartDate = new Date(el.endDate.getFullYear() + 1, 0, 1);
+
+      el.startDateEl!.valueAsDate = newStartDate;
+      await el.updateComplete;
+      await parent.updateComplete;
+      el.startDateEl!.dispatchEvent(new Event('sl-blur'));
+
+      expect(el.startDate).to.deep.equal(el.startDate);
+      expect(parent.startDate).to.be.undefined;
+    });
+  });
+
+  describe('End Date Validation and Events', () => {
+    it('should update end date and emit event when valid date is entered', async () => {
+      const newEndDate = new Date(2023, 10, 15);
+
+      el.endDateEl!.valueAsDate = newEndDate;
+      await el.updateComplete;
+      await parent.updateComplete;
+      el.endDateEl!.dispatchEvent(new Event('sl-blur'));
+
+      expect(el.endDate).to.deep.equal(newEndDate);
+      expect(parent.endDate).to.deep.equal(newEndDate);
+    });
+
+    it('should not update end date if invalid date is entered', async () => {
+      const newEndDate = new Date('invalid-date');
+
+      el.endDateEl!.valueAsDate = newEndDate;
+      await el.updateComplete;
+      await parent.updateComplete;
+      el.endDateEl!.dispatchEvent(new Event('sl-blur'));
+
+      expect(el.endDate).to.deep.equal(el.endDate);
+      expect(parent.endDate).to.be.undefined;
+    });
+
+    it('should not update end date if new date is before start date', async () => {
+      const newEndDate = new Date(el.startDate.getFullYear() - 1, 0, 1);
+
+      el.endDateEl!.valueAsDate = newEndDate;
+      await el.updateComplete;
+      await parent.updateComplete;
+      el.endDateEl!.dispatchEvent(new Event('sl-blur'));
+
+      expect(el.endDate).to.deep.equal(el.endDate);
+      expect(parent.endDate).to.be.undefined;
+    });
+
+    it('should not update end date if new date is after maximum date', async () => {
+      const newEndDate = new Date(el.maximumDate.getFullYear() + 1, 0, 1);
+
+      el.endDateEl!.valueAsDate = newEndDate;
+      await el.updateComplete;
+      await parent.updateComplete;
+      el.endDateEl!.dispatchEvent(new Event('sl-blur'));
+
+      expect(el.endDate).to.deep.equal(el.endDate);
+      expect(parent.endDate).to.be.undefined;
+    });
+  });
+});

--- a/frontend/src/static/js/components/test/webstatus-form-date-range-picker.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-form-date-range-picker.test.ts
@@ -79,6 +79,75 @@ describe('WebstatusFormDateRangePicker', () => {
     expect(endDateInput.max).to.equal(el.toIsoDate(el.maximumDate));
   });
 
+  describe('Initialization Validation', () => {
+    it('should throw an error if minimumDate is not provided', async () => {
+      try {
+        await fixture(
+          html`<webstatus-form-date-range-picker
+            .maximumDate="${new Date('2024-01-01')}"
+            .startDate="${new Date('2023-01-01')}"
+            .endDate="${new Date('2023-12-31')}"
+          ></webstatus-form-date-range-picker>`,
+        );
+        throw new Error('Expected an error to be thrown');
+      } catch (error) {
+        expect((error as Error).message).to.eq(
+          'WebstatusFormDateRangePicker: minimumDate, maximumDate, startDate, and endDate are required properties.',
+        );
+      }
+    });
+    it('should throw an error if maximumDate is not provided', async () => {
+      try {
+        await fixture(
+          html`<webstatus-form-date-range-picker
+            .minimumDate="${new Date('2023-01-01')}"
+            .startDate="${new Date('2023-01-01')}"
+            .endDate="${new Date('2023-12-31')}"
+          ></webstatus-form-date-range-picker>`,
+        );
+        throw new Error('Expected an error to be thrown');
+      } catch (error: unknown) {
+        expect((error as Error).message).to.eq(
+          'WebstatusFormDateRangePicker: minimumDate, maximumDate, startDate, and endDate are required properties.',
+        );
+      }
+    });
+
+    it('should throw an error if startDate is not provided', async () => {
+      try {
+        await fixture(
+          html`<webstatus-form-date-range-picker
+            .minimumDate="${new Date('2023-01-01')}"
+            .maximumDate="${new Date('2024-01-01')}"
+            .endDate="${new Date('2023-12-31')}"
+          ></webstatus-form-date-range-picker>`,
+        );
+        throw new Error('Expected an error to be thrown');
+      } catch (error: unknown) {
+        expect((error as Error).message).to.eq(
+          'WebstatusFormDateRangePicker: minimumDate, maximumDate, startDate, and endDate are required properties.',
+        );
+      }
+    });
+
+    it('should throw an error if endDate is not provided', async () => {
+      try {
+        await fixture(
+          html`<webstatus-form-date-range-picker
+            .minimumDate="${new Date('2023-01-01')}"
+            .maximumDate="${new Date('2024-01-01')}"
+            .startDate="${new Date('2023-01-01')}"
+          ></webstatus-form-date-range-picker>`,
+        );
+        throw new Error('Expected an error to be thrown');
+      } catch (error: unknown) {
+        expect((error as Error).message).to.eq(
+          'WebstatusFormDateRangePicker: minimumDate, maximumDate, startDate, and endDate are required properties.',
+        );
+      }
+    });
+  });
+
   describe('showPicker', () => {
     it('should call showPicker on the startDateEl when clicked', async () => {
       // Stub showPicker to avoid the "NotAllowedError" in the unit test

--- a/frontend/src/static/js/components/webstatus-form-date-range-picker.ts
+++ b/frontend/src/static/js/components/webstatus-form-date-range-picker.ts
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SlChangeEvent, SlInput, SlInputEvent} from '@shoelace-style/shoelace';
+import {CSSResultGroup, LitElement, css, html} from 'lit';
+import {customElement, property, query} from 'lit/decorators.js';
+import {SHARED_STYLES} from '../css/shared-css.js';
+
+export interface DateChangeEvent {
+  date: Date;
+}
+
+/**
+ * @summary Date range picker
+ * @event CustomEvent<DateChangeEvent> webstatus-start-date-change - Emitted when the start date is changed.
+ * @event CustomEvent<DateChangeEvent> webstatus-end-date-change - Emitted when the end date is changed.
+ */
+@customElement('webstatus-form-date-range-picker')
+export class WebstatusFormDateRangePicker extends LitElement {
+  @property({type: Object})
+  minimumDate: Date = new Date();
+
+  @property({type: Object})
+  maximumDate: Date = new Date();
+
+  @property({type: Object})
+  startDate: Date = new Date();
+
+  @property({type: Object})
+  endDate: Date = new Date();
+
+  @query('#start-date')
+  startDateEl?: SlInput;
+
+  @query('#end-date')
+  endDateEl?: SlInput;
+
+  isValidDate(d: Date): boolean {
+    return !isNaN(d.getTime());
+  }
+
+  toIsoDate(date: Date): string {
+    return date.toISOString().slice(0, 10);
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      SHARED_STYLES,
+      css`
+        .hbox,
+        .vbox {
+          gap: var(--content-padding-large);
+        }
+      `,
+    ];
+  }
+
+  async handleStartDateChange(_: SlChangeEvent) {
+    const currentStartDate = this.startDate;
+    const newStartDate = new Date(this.startDateEl?.valueAsDate || '');
+    if (
+      !this.isValidDate(newStartDate) ||
+      this.minimumDate > newStartDate ||
+      this.endDate < newStartDate
+    ) {
+      this.startDateEl?.setCustomValidity(
+        `Date range should be ${this.toIsoDate(this.minimumDate)} to ${this.toIsoDate(this.endDate)} inclusive`,
+      );
+      this.startDateEl?.reportValidity();
+      return;
+    }
+    if (newStartDate.getTime() !== currentStartDate.getTime()) {
+      this.startDateEl?.setCustomValidity('');
+      this.startDateEl?.reportValidity();
+      this.startDate = newStartDate;
+      const event = new CustomEvent<DateChangeEvent>(
+        'webstatus-start-date-change',
+        {
+          detail: {
+            date: this.startDate,
+          },
+        },
+      );
+      this.dispatchEvent(event);
+    }
+  }
+
+  async handleEndDateChange(_: SlInputEvent) {
+    const currentEndDate = this.endDate;
+    const newEndDate = new Date(this.endDateEl?.valueAsDate || '');
+    if (
+      !this.isValidDate(newEndDate) ||
+      this.startDate > newEndDate ||
+      this.maximumDate < newEndDate
+    ) {
+      this.endDateEl?.setCustomValidity(
+        `Date range should be ${this.toIsoDate(this.startDate)} to ${this.toIsoDate(this.maximumDate)} inclusive`,
+      );
+      this.endDateEl?.reportValidity();
+      return;
+    }
+    if (newEndDate.getTime() !== currentEndDate.getTime()) {
+      this.endDateEl?.setCustomValidity('');
+      this.endDateEl?.reportValidity();
+      this.endDate = newEndDate;
+      const event = new CustomEvent<DateChangeEvent>(
+        'webstatus-end-date-change',
+        {
+          detail: {
+            date: this.endDate,
+          },
+        },
+      );
+      this.dispatchEvent(event);
+    }
+  }
+  render() {
+    return html`
+      <div class="hbox wrap">
+        <label>
+          Start date
+          <sl-input
+            id="start-date"
+            @sl-blur=${this.handleStartDateChange}
+            type="date"
+            .min=${this.toIsoDate(this.minimumDate)}
+            .max=${this.toIsoDate(this.endDate)}
+            .valueAsDate="${this.startDate}"
+          ></sl-input>
+        </label>
+        <label>
+          End date
+          <sl-input
+            id="end-date"
+            @sl-blur=${this.handleEndDateChange}
+            type="date"
+            .min=${this.toIsoDate(this.startDate)}
+            .max=${this.toIsoDate(this.maximumDate)}
+            .valueAsDate="${this.endDate}"
+          ></sl-input>
+        </label>
+      </div>
+    `;
+  }
+}

--- a/frontend/src/static/js/components/webstatus-form-date-range-picker.ts
+++ b/frontend/src/static/js/components/webstatus-form-date-range-picker.ts
@@ -80,6 +80,7 @@ export class WebstatusFormDateRangePicker extends LitElement {
         }
         #date-range-picker-btn {
           justify-content: center;
+          margin-top: var(--sl-input-label-font-size-medium);
         }
       `,
     ];

--- a/frontend/src/static/js/components/webstatus-form-date-range-picker.ts
+++ b/frontend/src/static/js/components/webstatus-form-date-range-picker.ts
@@ -61,10 +61,10 @@ export class WebstatusFormDateRangePicker extends LitElement {
   readonly submitBtn?: SlButton;
 
   @state()
-  private _pendingStartDate = false;
+  private _startHasChanged = false;
 
   @state()
-  private _pendingEndDate = false;
+  private _endHasChanged = false;
 
   updated(changedProperties: PropertyValues<this>) {
     if (
@@ -124,7 +124,7 @@ export class WebstatusFormDateRangePicker extends LitElement {
         `Date range should be ${this.toIsoDate(this.minimumDate)} to ${this.toIsoDate(this.endDate)} inclusive`,
       );
       this.startDateEl?.reportValidity();
-      this._pendingStartDate = false;
+      this._startHasChanged = false;
       return;
     }
 
@@ -133,7 +133,7 @@ export class WebstatusFormDateRangePicker extends LitElement {
       this.startDateEl?.setCustomValidity('');
       this.startDateEl?.reportValidity();
       this.startDate = newStartDate;
-      this._pendingStartDate = true;
+      this._startHasChanged = true;
     }
   }
 
@@ -148,7 +148,7 @@ export class WebstatusFormDateRangePicker extends LitElement {
         `Date range should be ${this.toIsoDate(this.startDate)} to ${this.toIsoDate(this.maximumDate)} inclusive`,
       );
       this.endDateEl?.reportValidity();
-      this._pendingEndDate = false;
+      this._endHasChanged = false;
       return;
     }
 
@@ -157,14 +157,14 @@ export class WebstatusFormDateRangePicker extends LitElement {
       this.endDateEl?.setCustomValidity('');
       this.endDateEl?.reportValidity();
       this.endDate = newEndDate;
-      this._pendingEndDate = true;
+      this._endHasChanged = true;
     }
   }
 
   handleSubmit() {
     // Reset pending flags
-    this._pendingStartDate = false;
-    this._pendingEndDate = false;
+    this._startHasChanged = false;
+    this._endHasChanged = false;
 
     if (!this.startDate || !this.endDate) return;
 
@@ -184,7 +184,7 @@ export class WebstatusFormDateRangePicker extends LitElement {
   isSubmitButtonEnabled() {
     // Only enable the button if there component has validated new date(s) that
     // are ready to be emitted.
-    return this._pendingStartDate || this._pendingEndDate;
+    return this._startHasChanged || this._endHasChanged;
   }
   render() {
     return html`

--- a/frontend/web-test-runner.config.mjs
+++ b/frontend/web-test-runner.config.mjs
@@ -19,6 +19,8 @@ const filteredLogs = [
   'Lit is in dev mode',
   // sl-tree-item has its own reactivity that we cannot control. Ignore for now.
   'Element sl-tree-item scheduled an update',
+  // From the date range picker
+  'WebstatusFormDateRangePicker: minimumDate, maximumDate, startDate, and endDate are required properties.',
 ];
 
 export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({


### PR DESCRIPTION
This component will be a reusable component for date range picking.

![image](https://github.com/user-attachments/assets/d3b04dbd-f553-404d-9276-b78cbf1cb920)


This takes mostly the implementation used on the feature detail page and puts it into this component.

Notable differences:
- Add max and min constraints for native <input> tag. This will help the user pick sensible dates by limiting the calendar dates.
- Displaying messages for invalid input.
- Reset invalid input back to a sane default.
- Emit events on successful date changes for start and end dates ([link](https://lit.dev/docs/composition/component-composition/#:~:text=When%20exchanging%20data%20with%20subcomponents%2C%20the%20general%20rule%20is%20to%20follow%20the%20model%20of%20the%20DOM%3A%20properties%20down%2C%20events%20up)).
- Adds a search button to apply the new dates. I was inspired by GCP metrics dashboard where it is clearer when a user wants to submit a date range.  We now prevent users from typing dates manually. Instead, whenever a user clicks anywhere on the sl-input, it will open the appropriate picker.  This removes the need to balance debouncing and showing error messages. The button becomes active when there are new dates to submit. Feel free to check out the updated playwright test in #1058 

Future PRs:
- Replace the individual implementation of date pickers on the feature and detail page with this.

Split up of #1055  