### PR TITLE
Add BaseChartsPage common component

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-base-charts-page.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-base-charts-page.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {expect, fixture, html} from '@open-wc/testing';
+import {
+  BaseChartsPage,
+  DEFAULT_END_DATE,
+  DEFAULT_START_DATE,
+} from '../webstatus-base-charts-page.js';
+import {DateRangeChangeEvent} from '../webstatus-form-date-range-picker.js';
+import {customElement} from 'lit/decorators.js';
+import sinon from 'sinon';
+import '../webstatus-base-charts-page.js';
+
+// Create a subclass for testing purposes
+@customElement('test-base-charts-page')
+class TestBaseChartsPage extends BaseChartsPage {
+  render() {
+    return html`${this.renderDateRangePicker()}`;
+  }
+}
+
+describe('BaseChartsPage', () => {
+  const mockNow = new Date(2024, 5, 1).getTime(); // June 1, 2024
+  const mockDefaultEndDate = new Date(mockNow);
+  const mockDefaultStartDate = new Date(2023, 5, 2);
+  // let el: TestBaseChartsPage;
+  const location = {
+    params: {},
+    search: '',
+    pathname: '/some-path',
+  };
+
+  let getDateRangeStub: sinon.SinonStub;
+  let updatePageUrlStub: sinon.SinonStub;
+
+  beforeEach(async () => {
+    sinon.useFakeTimers({now: mockNow});
+    // Change the values of the constants before creating the fixture
+    DEFAULT_END_DATE.setTime(mockDefaultEndDate.getTime());
+    DEFAULT_START_DATE.setTime(mockDefaultStartDate.getTime());
+    getDateRangeStub = sinon.stub();
+    updatePageUrlStub = sinon.stub();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should render the date range picker', async () => {
+    const el = await fixture<TestBaseChartsPage>(
+      html`<test-base-charts-page
+        .location=${location}
+      ></test-base-charts-page>`,
+    );
+    await el.updateComplete;
+    const picker = el.shadowRoot!.querySelector(
+      'webstatus-form-date-range-picker',
+    );
+    expect(picker).to.exist;
+  });
+
+  it('should initialize with default dates if no query params', async () => {
+    const el = await fixture<TestBaseChartsPage>(
+      html`<test-base-charts-page
+        .location=${location}
+        ._getDateRange=${getDateRangeStub}
+        ._updatePageUrl=${updatePageUrlStub}
+      ></test-base-charts-page>`,
+    );
+    getDateRangeStub.returns({});
+    await el.updateComplete;
+    expect(el.startDate).to.deep.equal(mockDefaultStartDate);
+    expect(el.endDate).to.deep.equal(mockDefaultEndDate);
+    expect(updatePageUrlStub).to.not.be.called;
+  });
+
+  it('should use default start date if start date param is invalid', async () => {
+    location.search = '?startDate=invalid-date';
+
+    getDateRangeStub.returns({start: new Date('invalid-date'), end: undefined});
+    const el = await fixture<TestBaseChartsPage>(
+      html`<test-base-charts-page
+        .location=${location}
+        ._getDateRange=${getDateRangeStub}
+        ._updatePageUrl=${updatePageUrlStub}
+      ></test-base-charts-page>`,
+    );
+
+    await el.updateComplete;
+
+    expect(el.startDate).to.deep.equal(mockDefaultStartDate);
+    expect(el.endDate).to.deep.equal(mockDefaultEndDate);
+    expect(updatePageUrlStub).to.have.been.calledWith(
+      location.pathname,
+      location,
+      {
+        dateRange: {start: mockDefaultStartDate, end: mockDefaultEndDate},
+      },
+    );
+  });
+
+  it('should use default end date if start date param is invalid', async () => {
+    location.search = '?endDate=invalid-date';
+
+    getDateRangeStub.returns({start: undefined, end: new Date('invalid-date')});
+    const el = await fixture<TestBaseChartsPage>(
+      html`<test-base-charts-page
+        .location=${location}
+        ._getDateRange=${getDateRangeStub}
+        ._updatePageUrl=${updatePageUrlStub}
+      ></test-base-charts-page>`,
+    );
+
+    await el.updateComplete;
+
+    expect(el.startDate).to.deep.equal(mockDefaultStartDate);
+    expect(el.endDate).to.deep.equal(mockDefaultEndDate);
+    expect(updatePageUrlStub).to.have.been.calledWith(
+      location.pathname,
+      location,
+      {
+        dateRange: {start: mockDefaultStartDate, end: mockDefaultEndDate},
+      },
+    );
+  });
+
+  it('should use default dates if both start and end date params are invalid', async () => {
+    location.search = '?startDate=invalid-date&endDate=invalid-date';
+
+    getDateRangeStub.returns({
+      start: new Date('invalid-date'),
+      end: new Date('invalid-date'),
+    });
+    const el = await fixture<TestBaseChartsPage>(
+      html`<test-base-charts-page
+        .location=${location}
+        ._getDateRange=${getDateRangeStub}
+        ._updatePageUrl=${updatePageUrlStub}
+      ></test-base-charts-page>`,
+    );
+
+    await el.updateComplete;
+
+    expect(el.startDate).to.deep.equal(mockDefaultStartDate);
+    expect(el.endDate).to.deep.equal(mockDefaultEndDate);
+    expect(updatePageUrlStub).to.have.been.calledWith(
+      location.pathname,
+      location,
+      {
+        dateRange: {start: mockDefaultStartDate, end: mockDefaultEndDate},
+      },
+    );
+  });
+
+  it('should use updateUrl if valid start date is provided', async () => {
+    location.search = '?startDate=2023-06-15';
+    const newStartDate = new Date(2023, 5, 15);
+
+    getDateRangeStub.returns({start: newStartDate, end: undefined});
+    const el = await fixture<TestBaseChartsPage>(
+      html`<test-base-charts-page
+        .location=${location}
+        ._getDateRange=${getDateRangeStub}
+        ._updatePageUrl=${updatePageUrlStub}
+      ></test-base-charts-page>`,
+    );
+
+    await el.updateComplete;
+
+    expect(el.startDate).to.deep.equal(newStartDate);
+    expect(el.endDate).to.deep.equal(mockDefaultEndDate);
+    expect(updatePageUrlStub).to.have.been.calledWith(
+      location.pathname,
+      location,
+      {
+        dateRange: {start: newStartDate, end: mockDefaultEndDate},
+      },
+    );
+  });
+
+  it('should use updateUrl if valid end date is provided', async () => {
+    location.search = '?endDate=2023-06-15';
+    const newEndDate = new Date(2023, 5, 15);
+
+    getDateRangeStub.returns({start: undefined, end: newEndDate});
+    const el = await fixture<TestBaseChartsPage>(
+      html`<test-base-charts-page
+        .location=${location}
+        ._getDateRange=${getDateRangeStub}
+        ._updatePageUrl=${updatePageUrlStub}
+      ></test-base-charts-page>`,
+    );
+
+    await el.updateComplete;
+
+    expect(el.startDate).to.deep.equal(mockDefaultStartDate);
+    expect(el.endDate).to.deep.equal(newEndDate);
+    expect(updatePageUrlStub).to.have.been.calledWith(
+      location.pathname,
+      location,
+      {
+        dateRange: {start: mockDefaultStartDate, end: newEndDate},
+      },
+    );
+  });
+
+  it('should use updateUrl if valid start and end dates are provided', async () => {
+    location.search = '?startDate=2022-06-15&endDate=2023-06-15';
+    const newStartDate = new Date(2022, 5, 15);
+    const newEndDate = new Date(2023, 5, 15);
+
+    getDateRangeStub.returns({start: newStartDate, end: newEndDate});
+    const el = await fixture<TestBaseChartsPage>(
+      html`<test-base-charts-page
+        .location=${location}
+        ._getDateRange=${getDateRangeStub}
+        ._updatePageUrl=${updatePageUrlStub}
+      ></test-base-charts-page>`,
+    );
+
+    await el.updateComplete;
+
+    expect(el.startDate).to.deep.equal(newStartDate);
+    expect(el.endDate).to.deep.equal(newEndDate);
+    expect(updatePageUrlStub).to.have.been.calledWith(
+      location.pathname,
+      location,
+      {
+        dateRange: {start: newStartDate, end: newEndDate},
+      },
+    );
+  });
+
+  it('should handle date range change event and update URL', async () => {
+    const newStartDate = new Date(2023, 5, 15);
+    const newEndDate = new Date(2024, 10, 20);
+
+    getDateRangeStub.returns({});
+    const el = await fixture<TestBaseChartsPage>(
+      html`<test-base-charts-page
+        .location=${location}
+        ._getDateRange=${getDateRangeStub}
+        ._updatePageUrl=${updatePageUrlStub}
+      ></test-base-charts-page>`,
+    );
+
+    // Simulate date range change
+    const dateRangeEvent = new CustomEvent<DateRangeChangeEvent>(
+      'webstatus-date-range-change',
+      {detail: {startDate: newStartDate, endDate: newEndDate}},
+    );
+    el.shadowRoot
+      ?.querySelector('webstatus-form-date-range-picker')
+      ?.dispatchEvent(dateRangeEvent);
+
+    // Assert that _updatePageUrl was called with the new start date and the current end date
+    expect(updatePageUrlStub).to.have.been.calledWith(
+      location.pathname,
+      location,
+      {
+        dateRange: {start: newStartDate, end: newEndDate},
+      },
+    );
+
+    expect(el.startDate).to.deep.equal(newStartDate);
+    expect(el.endDate).to.deep.equal(newEndDate);
+  });
+});

--- a/frontend/src/static/js/components/test/webstatus-base-charts-page.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-base-charts-page.test.ts
@@ -37,7 +37,6 @@ describe('BaseChartsPage', () => {
   const mockNow = new Date(2024, 5, 1).getTime(); // June 1, 2024
   const mockDefaultEndDate = new Date(mockNow);
   const mockDefaultStartDate = new Date(2023, 5, 2);
-  // let el: TestBaseChartsPage;
   const location = {
     params: {},
     search: '',
@@ -113,7 +112,7 @@ describe('BaseChartsPage', () => {
     );
   });
 
-  it('should use default end date if start date param is invalid', async () => {
+  it('should use default end date if end date param is invalid', async () => {
     location.search = '?endDate=invalid-date';
 
     getDateRangeStub.returns({start: undefined, end: new Date('invalid-date')});

--- a/frontend/src/static/js/components/webstatus-base-charts-page.ts
+++ b/frontend/src/static/js/components/webstatus-base-charts-page.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {CSSResultGroup, LitElement, css, html} from 'lit';
+import {DateRange, getDateRange, updatePageUrl} from '../utils/urls.js';
+import {DateRangeChangeEvent} from './webstatus-form-date-range-picker.js';
+import './webstatus-form-date-range-picker.js';
+import {IndexedParams} from '@vaadin/router';
+import {SHARED_STYLES} from '../css/shared-css.js';
+
+// Date.now()
+export const DEFAULT_END_DATE = new Date(Date.now());
+// Date.now() - 1 year.
+export const DEFAULT_START_DATE = new Date(
+  Date.now() - 365 * 24 * 60 * 60 * 1000,
+);
+
+const DEFAULT_MINIMUM_DATE = new Date(2000, 0, 1);
+
+// 1 day after DEFAULT_END_DATE
+const DEFAULT_MAXIMUM_DATE = new Date(
+  DEFAULT_END_DATE.getTime() + 24 * 60 * 60 * 1000,
+);
+
+/**
+ * Base class for pages that display charts.
+ *
+ * This class provides common functionality for pages that display charts,
+ * including a date range picker and methods for updating the URL with
+ * the selected date range.
+ *
+ * Notes:
+ * - If a child class overrides firstUpdated, it must call super.firstUpdated() first.
+ */
+
+export class BaseChartsPage extends LitElement {
+  minDate: Date = DEFAULT_MINIMUM_DATE;
+  maxDate: Date = DEFAULT_MAXIMUM_DATE;
+  startDate: Date = DEFAULT_START_DATE;
+  endDate: Date = DEFAULT_END_DATE;
+
+  location!: {params: IndexedParams; search: string; pathname: string}; // Set by router.
+
+  // Members that are used for testing with sinon.
+  _getDateRange: (options: {search: string}) => DateRange = getDateRange;
+  _updatePageUrl: (
+    pathname: string,
+    location: {search: string},
+    overrides: {dateRange?: DateRange},
+  ) => void = updatePageUrl;
+
+  static get styles(): CSSResultGroup {
+    return [
+      SHARED_STYLES,
+      css`
+        .hbox,
+        .vbox {
+          gap: var(--content-padding-large);
+        }
+      `,
+    ];
+  }
+
+  async firstUpdated(): Promise<void> {
+    // Get date range from query parameters.
+    const dateRange = this._getDateRange({search: this.location.search});
+    if (dateRange && (dateRange.start || dateRange.end)) {
+      // Use default values if the URL dates are invalid
+      this.startDate =
+        dateRange.start &&
+        dateRange.start >= this.minDate &&
+        dateRange.start <= this.maxDate
+          ? dateRange.start
+          : DEFAULT_START_DATE;
+
+      this.endDate =
+        dateRange.end &&
+        dateRange.end >= this.minDate &&
+        dateRange.end <= this.maxDate &&
+        dateRange.end >= this.startDate
+          ? dateRange.end
+          : DEFAULT_END_DATE;
+
+      // Update the URL with the potentially reset dates
+      // TODO. We should display a message that we reset the values.
+      this._updatePageUrl(this.location.pathname, this.location, {
+        dateRange: {start: this.startDate, end: this.endDate},
+      });
+    }
+  }
+
+  async handleDateRangeChangeEvent(event: CustomEvent<DateRangeChangeEvent>) {
+    this.startDate = event.detail.startDate;
+    this.endDate = event.detail.endDate;
+    this._updatePageUrl(this.location.pathname, this.location, {
+      dateRange: {start: this.startDate, end: this.endDate},
+    });
+  }
+  renderDateRangePicker() {
+    return html`
+      <webstatus-form-date-range-picker
+        .startDate=${this.startDate}
+        .endDate=${this.endDate}
+        .minimumDate=${this.minDate}
+        .maximumDate=${this.maxDate}
+        @webstatus-date-range-change=${this.handleDateRangeChangeEvent}
+      ></webstatus-form-date-range-picker>
+    `;
+  }
+}

--- a/frontend/src/static/js/components/webstatus-base-charts-page.ts
+++ b/frontend/src/static/js/components/webstatus-base-charts-page.ts
@@ -45,7 +45,6 @@ const DEFAULT_MAXIMUM_DATE = new Date(
  * Notes:
  * - If a child class overrides firstUpdated, it must call super.firstUpdated() first.
  */
-
 export class BaseChartsPage extends LitElement {
   minDate: Date = DEFAULT_MINIMUM_DATE;
   maxDate: Date = DEFAULT_MAXIMUM_DATE;
@@ -109,6 +108,7 @@ export class BaseChartsPage extends LitElement {
       dateRange: {start: this.startDate, end: this.endDate},
     });
   }
+
   renderDateRangePicker() {
     return html`
       <webstatus-form-date-range-picker

--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -47,7 +47,7 @@ import {
   formatOverviewPageUrl,
   getDateRange,
   getWPTMetricView,
-  updateFeaturePageUrl,
+  updatePageUrl,
 } from '../utils/urls.js';
 import {apiClientContext} from '../contexts/api-client-context.js';
 import {
@@ -308,7 +308,8 @@ export class FeaturePage extends LitElement {
   updateUrl() {
     // Update the URL to include the current date range.
     const overrides = {dateRange: {start: this.startDate, end: this.endDate}};
-    updateFeaturePageUrl({feature_id: this.featureId}, location, overrides);
+    // TODO. This is temporary. All of updateUrl will be removed once it moves to using BaseChartsPage as its base class.
+    updatePageUrl(`/features/${this.featureId}`, location, overrides);
   }
 
   async handleBrowserSelection(event: Event) {

--- a/frontend/src/static/js/utils/urls.ts
+++ b/frontend/src/static/js/utils/urls.ts
@@ -177,12 +177,13 @@ export function formatFeaturePageUrl(
   return `/features/${feature.feature_id}${qs}`;
 }
 
-/* Update URL for the feature page */
-export function updateFeaturePageUrl(
-  feature: FeatureURLDetails,
+/* Update URL for a page */
+export function updatePageUrl(
+  pathname: string,
   location: {search: string},
   overrides: QueryStringOverrides = {},
 ): void {
-  const url = formatFeaturePageUrl(feature, location, overrides);
+  const qs = getContextualQueryStringParams(location, overrides);
+  const url = `${pathname}${qs}`;
   window.history.replaceState({}, '', url);
 }


### PR DESCRIPTION
BaseChartsPage is a component that all pages with charts can use. It provides a renderDateRangePicker() method that any child class can use in its main render method. It also centralizes the event handling for the start and end date changes.

We also rename the existing updateFeaturePageUrl util method to updatePageUrl. The BaseChartsPage component uses it to update the page's url appropriately when the date range changes.

Each child class can override things like the default dates if needed.

Split up of #1055 