### PR TITLE
Change issue link from /new to /new/choose

### DIFF
--- a/frontend/src/static/js/utils/constants.ts
+++ b/frontend/src/static/js/utils/constants.ts
@@ -15,7 +15,7 @@
  */
 
 export const GITHUB_REPO_ISSUE_LINK =
-  'https://github.com/GoogleChrome/webstatus.dev/issues/new';
+  'https://github.com/GoogleChrome/webstatus.dev/issues/new/choose';
 export const SEARCH_QUERY_README_LINK =
   'https://github.com/GoogleChrome/webstatus.dev/blob/main/antlr/FeatureSearch.md';
 export const ABOUT_PAGE_LINK =


### PR DESCRIPTION
Closes #806

This will lead users to the different templates instead of the empty one.