### PR TITLE
Return 400 Bad Request for Invalid Page Tokens

### DIFF
--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
@@ -330,6 +331,39 @@ func TestGetV1Features(t *testing.T) {
 					PageToken:     nil,
 					PageSize:      nil,
 					Q:             valuePtr[string]("%"),
+					Sort:          nil,
+					WptMetricView: nil,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "400 case - invalid page token",
+			mockConfig: MockFeaturesSearchConfig{
+				expectedPageToken:  badPageToken,
+				expectedPageSize:   100,
+				expectedSearchNode: nil,
+				expectedSortBy:     nil,
+				expectedBrowsers: []backend.BrowserPathParam{
+					backend.Chrome,
+					backend.Edge,
+					backend.Firefox,
+					backend.Safari,
+				},
+				expectedWPTMetricView: backend.SubtestCounts,
+				page:                  nil,
+				err:                   backendtypes.ErrInvalidPageToken,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.GetV1Features400JSONResponse{
+				Code:    400,
+				Message: "invalid page token",
+			},
+			request: backend.GetV1FeaturesRequestObject{
+				Params: backend.GetV1FeaturesParams{
+					PageToken:     badPageToken,
+					PageSize:      nil,
+					Q:             nil,
 					Sort:          nil,
 					WptMetricView: nil,
 				},

--- a/backend/pkg/httpserver/list_aggregated_feature_support_test.go
+++ b/backend/pkg/httpserver/list_aggregated_feature_support_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
@@ -162,6 +163,34 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
 					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
 					PageToken: nil,
+					PageSize:  nil,
+				},
+				Browser: backend.Chrome,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "400 case - invalid page token",
+			mockConfig: MockListBrowserFeatureCountMetricConfig{
+				expectedBrowser:   "chrome",
+				expectedStartAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:     time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:  100,
+				expectedPageToken: badPageToken,
+				pageToken:         nil,
+				err:               backendtypes.ErrInvalidPageToken,
+				page:              nil,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListAggregatedFeatureSupport400JSONResponse{
+				Code:    400,
+				Message: "invalid page token",
+			},
+			request: backend.ListAggregatedFeatureSupportRequestObject{
+				Params: backend.ListAggregatedFeatureSupportParams{
+					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					PageToken: badPageToken,
 					PageSize:  nil,
 				},
 				Browser: backend.Chrome,

--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
@@ -156,6 +157,40 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
 					FeatureId: nil,
 					PageToken: nil,
+					PageSize:  nil,
+				},
+				Browser:    backend.Chrome,
+				Channel:    backend.Experimental,
+				MetricView: backend.SubtestCounts,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "400 case - invalid page token",
+			mockConfig: MockListMetricsOverTimeWithAggregatedTotalsConfig{
+				expectedFeatureIDs: []string{},
+				expectedBrowser:    "chrome",
+				expectedChannel:    "experimental",
+				expectedMetric:     backend.SubtestCounts,
+				expectedStartAt:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:      time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:   100,
+				expectedPageToken:  badPageToken,
+				data:               nil,
+				pageToken:          nil,
+				err:                backendtypes.ErrInvalidPageToken,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListAggregatedWPTMetrics400JSONResponse{
+				Code:    400,
+				Message: "invalid page token",
+			},
+			request: backend.ListAggregatedWPTMetricsRequestObject{
+				Params: backend.ListAggregatedWPTMetricsParams{
+					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					FeatureId: nil,
+					PageToken: badPageToken,
 					PageSize:  nil,
 				},
 				Browser:    backend.Chrome,

--- a/backend/pkg/httpserver/list_chromium_usage.go
+++ b/backend/pkg/httpserver/list_chromium_usage.go
@@ -16,8 +16,10 @@ package httpserver
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
@@ -36,6 +38,15 @@ func (s *Server) ListChromiumDailyUsageStats(
 		request.Params.PageToken,
 	)
 	if err != nil {
+		if errors.Is(err, backendtypes.ErrInvalidPageToken) {
+			slog.WarnContext(ctx, "invalid page token", "token", request.Params.PageToken, "error", err)
+
+			return backend.ListChromiumDailyUsageStats400JSONResponse{
+				Code:    400,
+				Message: "invalid page token",
+			}, nil
+		}
+
 		slog.ErrorContext(ctx, "unable to get feature metrics", "error", err)
 
 		return backend.ListChromiumDailyUsageStats500JSONResponse{

--- a/backend/pkg/httpserver/list_chromium_usage_test.go
+++ b/backend/pkg/httpserver/list_chromium_usage_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
@@ -69,6 +70,34 @@ func TestListChromiumDailyUsageStats(t *testing.T) {
 					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
 					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
 					PageToken: nil,
+					PageSize:  nil,
+				},
+				FeatureId: "feature1",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "400 case - invalid page token",
+			mockConfig: MockListChromiumDailyUsageStatsConfig{
+				expectedFeatureID: "feature1",
+				expectedStartAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:     time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:  100,
+				expectedPageToken: badPageToken,
+				pageToken:         nil,
+				err:               backendtypes.ErrInvalidPageToken,
+				data:              nil,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListChromiumDailyUsageStats400JSONResponse{
+				Code:    400,
+				Message: "invalid page token",
+			},
+			request: backend.ListChromiumDailyUsageStatsRequestObject{
+				Params: backend.ListChromiumDailyUsageStatsParams{
+					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					PageToken: badPageToken,
 					PageSize:  nil,
 				},
 				FeatureId: "feature1",

--- a/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
@@ -157,6 +158,40 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
 					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
 					PageToken: nil,
+					PageSize:  nil,
+				},
+				MetricView: backend.SubtestCounts,
+				Browser:    backend.Chrome,
+				Channel:    backend.Experimental,
+				FeatureId:  "feature1",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "400 case - invalid page token",
+			mockConfig: MockListMetricsForFeatureIDBrowserAndChannelConfig{
+				expectedFeatureID: "feature1",
+				expectedBrowser:   "chrome",
+				expectedChannel:   "experimental",
+				expectedMetric:    backend.SubtestCounts,
+				expectedPageToken: badPageToken,
+				data:              nil,
+				pageToken:         nil,
+				expectedStartAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:     time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:  100,
+				err:               backendtypes.ErrInvalidPageToken,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListFeatureWPTMetrics400JSONResponse{
+				Code:    400,
+				Message: "invalid page token",
+			},
+			request: backend.ListFeatureWPTMetricsRequestObject{
+				Params: backend.ListFeatureWPTMetricsParams{
+					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					PageToken: badPageToken,
 					PageSize:  nil,
 				},
 				MetricView: backend.SubtestCounts,

--- a/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
@@ -171,6 +172,38 @@ func TestListMissingOneImplemenationCounts(t *testing.T) {
 					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
 					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
 					PageToken: nil,
+					PageSize:  nil,
+					Browser: []backend.SupportedBrowsers{
+						backend.Edge, backend.Firefox, backend.Safari,
+					},
+				},
+				Browser: backend.Chrome,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "400 case - invalid page token",
+			mockConfig: MockListMissingOneImplCountsConfig{
+				expectedTargetBrowser: "chrome",
+				expectedOtherBrowsers: []string{"edge", "firefox", "safari"},
+				expectedStartAt:       time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:         time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:      100,
+				expectedPageToken:     badPageToken,
+				page:                  nil,
+				pageToken:             nil,
+				err:                   backendtypes.ErrInvalidPageToken,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListMissingOneImplemenationCounts400JSONResponse{
+				Code:    400,
+				Message: "invalid page token",
+			},
+			request: backend.ListMissingOneImplemenationCountsRequestObject{
+				Params: backend.ListMissingOneImplemenationCountsParams{
+					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
+					PageToken: badPageToken,
 					PageSize:  nil,
 					Browser: []backend.SupportedBrowsers{
 						backend.Edge, backend.Firefox, backend.Safari,

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -237,7 +237,9 @@ func (m *MockWPTMetricsStorer) ListChromiumDailyUsageStats(
 			m.listChromiumDailyUsageStatsCfg, featureID, startAt, endAt, pageSize, pageToken)
 	}
 
-	return m.listChromiumDailyUsageStatsCfg.data, m.featureCfg.pageToken, m.featureCfg.err
+	return m.listChromiumDailyUsageStatsCfg.data,
+		m.listChromiumDailyUsageStatsCfg.pageToken,
+		m.listChromiumDailyUsageStatsCfg.err
 }
 
 func (m *MockWPTMetricsStorer) FeaturesSearch(
@@ -356,5 +358,6 @@ func TestGetPageSizeOrDefault(t *testing.T) {
 var (
 	inputPageToken = valuePtr[string]("input-token")
 	nextPageToken  = valuePtr[string]("next-page-token")
+	badPageToken   = valuePtr[string]("")
 	errTest        = errors.New("test error")
 )

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -17,12 +17,14 @@ package spanneradapters
 import (
 	"cmp"
 	"context"
+	"errors"
 	"log/slog"
 	"math/big"
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
@@ -122,6 +124,10 @@ func (s *Backend) ListBrowserFeatureCountMetric(
 		pageToken,
 	)
 	if err != nil {
+		if errors.Is(err, gcpspanner.ErrInvalidCursorFormat) {
+			return nil, errors.Join(err, backendtypes.ErrInvalidPageToken)
+		}
+
 		return nil, err
 	}
 
@@ -163,6 +169,10 @@ func (s *Backend) ListMetricsOverTimeWithAggregatedTotals(
 		pageToken,
 	)
 	if err != nil {
+		if errors.Is(err, gcpspanner.ErrInvalidCursorFormat) {
+			return nil, nil, errors.Join(err, backendtypes.ErrInvalidPageToken)
+		}
+
 		return nil, nil, err
 	}
 
@@ -201,6 +211,10 @@ func (s *Backend) ListMetricsForFeatureIDBrowserAndChannel(
 		pageToken,
 	)
 	if err != nil {
+		if errors.Is(err, gcpspanner.ErrInvalidCursorFormat) {
+			return nil, nil, errors.Join(err, backendtypes.ErrInvalidPageToken)
+		}
+
 		return nil, nil, err
 	}
 
@@ -233,6 +247,10 @@ func (s *Backend) ListChromiumDailyUsageStats(
 		pageToken,
 	)
 	if err != nil {
+		if errors.Is(err, gcpspanner.ErrInvalidCursorFormat) {
+			return nil, nil, errors.Join(err, backendtypes.ErrInvalidPageToken)
+		}
+
 		return nil, nil, err
 	}
 
@@ -270,6 +288,10 @@ func (s *Backend) ListMissingOneImplCounts(
 		pageToken,
 	)
 	if err != nil {
+		if errors.Is(err, gcpspanner.ErrInvalidCursorFormat) {
+			return nil, errors.Join(err, backendtypes.ErrInvalidPageToken)
+		}
+
 		return nil, err
 	}
 
@@ -508,6 +530,10 @@ func (s *Backend) FeaturesSearch(
 		spannerSortOrder, getSpannerWPTMetricView(wptMetricView),
 		BrowserList(browsers).ToStringList())
 	if err != nil {
+		if errors.Is(err, gcpspanner.ErrInvalidCursorFormat) {
+			return nil, errors.Join(err, backendtypes.ErrInvalidPageToken)
+		}
+
 		return nil, err
 	}
 

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
@@ -307,6 +308,15 @@ func TestListMetricsForFeatureIDBrowserAndChannel(t *testing.T) {
 			expectedPageToken: nil,
 			expectedErr:       errTest,
 		},
+		{
+			name:              "invalid cursor",
+			featureData:       nil,
+			pageToken:         valuePtr(""),
+			err:               gcpspanner.ErrInvalidCursorFormat,
+			expectedOutput:    nil,
+			expectedPageToken: nil,
+			expectedErr:       backendtypes.ErrInvalidPageToken,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -386,6 +396,15 @@ func TestListBrowserFeatureCountMetric(t *testing.T) {
 			},
 			expectedPage: nil,
 			expectedErr:  errTest,
+		},
+		{
+			name: "invalid cursor",
+			cfg: mockListBrowserFeatureCountMetricConfig{
+				result:        nil,
+				returnedError: gcpspanner.ErrInvalidCursorFormat,
+			},
+			expectedPage: nil,
+			expectedErr:  backendtypes.ErrInvalidPageToken,
 		},
 	}
 	for _, tc := range testCases {
@@ -484,6 +503,15 @@ func TestListMetricsOverTimeWithAggregatedTotals(t *testing.T) {
 			expectedPageToken: nil,
 			expectedErr:       errTest,
 		},
+		{
+			name:              "invalid cursor",
+			aggregatedData:    nil,
+			pageToken:         valuePtr(""),
+			err:               gcpspanner.ErrInvalidCursorFormat,
+			expectedOutput:    nil,
+			expectedPageToken: nil,
+			expectedErr:       backendtypes.ErrInvalidPageToken,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -570,6 +598,15 @@ func TestListMissingOneImplCounts(t *testing.T) {
 			},
 			expectedPage: nil,
 			expectedErr:  errTest,
+		},
+		{
+			name: "invalid cursor",
+			cfg: mockListMissingOneImplCountsConfig{
+				result:        nil,
+				returnedError: gcpspanner.ErrInvalidCursorFormat,
+			},
+			expectedPage: nil,
+			expectedErr:  backendtypes.ErrInvalidPageToken,
 		},
 	}
 	for _, tc := range testCases {

--- a/lib/gcpspanner/spanneradapters/backendtypes/types.go
+++ b/lib/gcpspanner/spanneradapters/backendtypes/types.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backendtypes
+
+import "errors"
+
+var (
+	// ErrInvalidPageToken indicates the page token is invalid.
+	// Raised by the adapter layer to let the server layer know that the
+	// page token did not meet the expected encoding in the database layer.
+	ErrInvalidPageToken = errors.New("invalid page token")
+)


### PR DESCRIPTION
Background: This change is in response to some 500 errors I saw this week.

Currently, if a user passes an invalid page token, they will receive a 500 error. This is because the page token format is a Base64 encoded string that contains a format potentially unique to each endpoint, and its validity cannot be determined until the database tries to parse it.

This change improves the user experience by returning a more appropriate 400 Bad Request error for invalid page tokens.

This change introduces a new error type, ErrInvalidPageToken, in the adapter layer.

For the spanner adapter, when it receives the invalid cursor error, it will raise the ErrInvalidPageToken error. The server will then return a 400 error to the client.

This pattern is adopted for all endpoints that use page tokens.