### PR TITLE
Add Missing Operation IDs to OpenAPI Routes

### DIFF
--- a/backend/pkg/httpserver/get_feature.go
+++ b/backend/pkg/httpserver/get_feature.go
@@ -25,19 +25,19 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-// GetV1FeaturesFeatureId implements backend.StrictServerInterface.
+// GetFeature implements backend.StrictServerInterface.
 // nolint: revive, ireturn // Name generated from openapi
-func (s *Server) GetV1FeaturesFeatureId(
+func (s *Server) GetFeature(
 	ctx context.Context,
-	request backend.GetV1FeaturesFeatureIdRequestObject,
-) (backend.GetV1FeaturesFeatureIdResponseObject, error) {
+	request backend.GetFeatureRequestObject,
+) (backend.GetFeatureResponseObject, error) {
 	feature, err := s.wptMetricsStorer.GetFeature(ctx, request.FeatureId,
 		getWPTMetricViewOrDefault(request.Params.WptMetricView),
 		defaultBrowsers(),
 	)
 	if err != nil {
 		if errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {
-			return backend.GetV1FeaturesFeatureId404JSONResponse{
+			return backend.GetFeature404JSONResponse{
 				Code:    http.StatusNotFound,
 				Message: fmt.Sprintf("feature id %s is not found", request.FeatureId),
 			}, nil
@@ -45,11 +45,11 @@ func (s *Server) GetV1FeaturesFeatureId(
 		// Catch all for all other errors.
 		slog.ErrorContext(ctx, "unable to get feature", "error", err)
 
-		return backend.GetV1FeaturesFeatureId500JSONResponse{
+		return backend.GetFeature500JSONResponse{
 			Code:    500,
 			Message: "unable to get feature",
 		}, nil
 	}
 
-	return backend.GetV1FeaturesFeatureId200JSONResponse(*feature), nil
+	return backend.GetFeature200JSONResponse(*feature), nil
 }

--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -26,13 +26,13 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
-func TestGetV1FeaturesFeatureId(t *testing.T) {
+func TestGetFeature(t *testing.T) {
 	testCases := []struct {
 		name              string
 		mockConfig        MockGetFeatureByIDConfig
 		expectedCallCount int // For the mock method
-		request           backend.GetV1FeaturesFeatureIdRequestObject
-		expectedResponse  backend.GetV1FeaturesFeatureIdResponseObject
+		request           backend.GetFeatureRequestObject
+		expectedResponse  backend.GetFeatureResponseObject
 		expectedError     error
 	}{
 		{
@@ -73,7 +73,7 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 				err: nil,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.GetV1FeaturesFeatureId200JSONResponse{
+			expectedResponse: backend.GetFeature200JSONResponse{
 				Baseline: &backend.BaselineInfo{
 					Status: valuePtr(backend.Widely),
 					LowDate: valuePtr(
@@ -96,9 +96,9 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 				Usage:     nil,
 				Wpt:       nil,
 			},
-			request: backend.GetV1FeaturesFeatureIdRequestObject{
+			request: backend.GetFeatureRequestObject{
 				FeatureId: "feature1",
-				Params: backend.GetV1FeaturesFeatureIdParams{
+				Params: backend.GetFeatureParams{
 					WptMetricView: nil,
 				},
 			},
@@ -142,7 +142,7 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 				err: nil,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.GetV1FeaturesFeatureId200JSONResponse{
+			expectedResponse: backend.GetFeature200JSONResponse{
 				Baseline: &backend.BaselineInfo{
 					Status: valuePtr(backend.Widely),
 					LowDate: valuePtr(
@@ -165,9 +165,9 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 				Usage:     nil,
 				Wpt:       nil,
 			},
-			request: backend.GetV1FeaturesFeatureIdRequestObject{
+			request: backend.GetFeatureRequestObject{
 				FeatureId: "feature1",
-				Params: backend.GetV1FeaturesFeatureIdParams{
+				Params: backend.GetFeatureParams{
 					WptMetricView: valuePtr(backend.TestCounts),
 				},
 			},
@@ -188,13 +188,13 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 				err:  gcpspanner.ErrQueryReturnedNoResults,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.GetV1FeaturesFeatureId404JSONResponse{
+			expectedResponse: backend.GetFeature404JSONResponse{
 				Code:    404,
 				Message: "feature id feature1 is not found",
 			},
-			request: backend.GetV1FeaturesFeatureIdRequestObject{
+			request: backend.GetFeatureRequestObject{
 				FeatureId: "feature1",
-				Params: backend.GetV1FeaturesFeatureIdParams{
+				Params: backend.GetFeatureParams{
 					WptMetricView: nil,
 				},
 			},
@@ -215,13 +215,13 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 				err:  errTest,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.GetV1FeaturesFeatureId500JSONResponse{
+			expectedResponse: backend.GetFeature500JSONResponse{
 				Code:    500,
 				Message: "unable to get feature",
 			},
-			request: backend.GetV1FeaturesFeatureIdRequestObject{
+			request: backend.GetFeatureRequestObject{
 				FeatureId: "feature1",
-				Params: backend.GetV1FeaturesFeatureIdParams{
+				Params: backend.GetFeatureParams{
 					WptMetricView: nil,
 				},
 			},
@@ -238,7 +238,7 @@ func TestGetV1FeaturesFeatureId(t *testing.T) {
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
 
 			// Call the function under test
-			resp, err := myServer.GetV1FeaturesFeatureId(context.Background(), tc.request)
+			resp, err := myServer.GetFeature(context.Background(), tc.request)
 
 			// Assertions
 			if mockStorer.callCountGetFeature != tc.expectedCallCount {

--- a/backend/pkg/httpserver/get_features.go
+++ b/backend/pkg/httpserver/get_features.go
@@ -26,12 +26,12 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-// GetV1Features implements backend.StrictServerInterface.
+// ListFeatures implements backend.StrictServerInterface.
 // nolint:ireturn // Expected ireturn for openapi generation.
-func (s *Server) GetV1Features(
+func (s *Server) ListFeatures(
 	ctx context.Context,
-	req backend.GetV1FeaturesRequestObject,
-) (backend.GetV1FeaturesResponseObject, error) {
+	req backend.ListFeaturesRequestObject,
+) (backend.ListFeaturesResponseObject, error) {
 	var node *searchtypes.SearchNode
 	if req.Params.Q != nil {
 		// Try to decode the url.
@@ -39,7 +39,7 @@ func (s *Server) GetV1Features(
 		if err != nil {
 			slog.WarnContext(ctx, "unable to decode string", "input string", *req.Params.Q, "error", err)
 
-			return backend.GetV1Features400JSONResponse{
+			return backend.ListFeatures400JSONResponse{
 				Code:    http.StatusBadRequest,
 				Message: "query string cannot be decoded",
 			}, nil
@@ -50,7 +50,7 @@ func (s *Server) GetV1Features(
 		if err != nil {
 			slog.WarnContext(ctx, "unable to parse query string", "query", decodedStr, "error", err)
 
-			return backend.GetV1Features400JSONResponse{
+			return backend.ListFeatures400JSONResponse{
 				Code:    http.StatusBadRequest,
 				Message: "query string does not match expected grammar",
 			}, nil
@@ -70,7 +70,7 @@ func (s *Server) GetV1Features(
 		if errors.Is(err, backendtypes.ErrInvalidPageToken) {
 			slog.WarnContext(ctx, "invalid page token", "token", req.Params.PageToken, "error", err)
 
-			return backend.GetV1Features400JSONResponse{
+			return backend.ListFeatures400JSONResponse{
 				Code:    400,
 				Message: "invalid page token",
 			}, nil
@@ -78,13 +78,13 @@ func (s *Server) GetV1Features(
 
 		slog.ErrorContext(ctx, "unable to get list of features", "error", err)
 
-		return backend.GetV1Features500JSONResponse{
+		return backend.ListFeatures500JSONResponse{
 			Code:    500,
 			Message: "unable to get list of features",
 		}, nil
 	}
 
-	return backend.GetV1Features200JSONResponse{
+	return backend.ListFeatures200JSONResponse{
 		Metadata: featurePage.Metadata,
 		Data:     featurePage.Data,
 	}, nil

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -28,13 +28,13 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
-func TestGetV1Features(t *testing.T) {
+func TestListFeatures(t *testing.T) {
 	testCases := []struct {
 		name              string
 		mockConfig        MockFeaturesSearchConfig
 		expectedCallCount int // For the mock method
-		request           backend.GetV1FeaturesRequestObject
-		expectedResponse  backend.GetV1FeaturesResponseObject
+		request           backend.ListFeaturesRequestObject
+		expectedResponse  backend.ListFeaturesResponseObject
 		expectedError     error
 	}{
 		{
@@ -85,7 +85,7 @@ func TestGetV1Features(t *testing.T) {
 				err: nil,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.GetV1Features200JSONResponse{
+			expectedResponse: backend.ListFeatures200JSONResponse{
 				Data: []backend.Feature{
 					{
 						Baseline: &backend.BaselineInfo{
@@ -116,8 +116,8 @@ func TestGetV1Features(t *testing.T) {
 					Total:         100,
 				},
 			},
-			request: backend.GetV1FeaturesRequestObject{
-				Params: backend.GetV1FeaturesParams{
+			request: backend.ListFeaturesRequestObject{
+				Params: backend.ListFeaturesParams{
 					PageToken:     nil,
 					PageSize:      nil,
 					Q:             nil,
@@ -169,7 +169,7 @@ func TestGetV1Features(t *testing.T) {
 						},
 					},
 				},
-				expectedSortBy: valuePtr[backend.GetV1FeaturesParamsSort](backend.NameDesc),
+				expectedSortBy: valuePtr[backend.ListFeaturesParamsSort](backend.NameDesc),
 				page: &backend.FeaturePage{
 					Metadata: backend.PageMetadataWithTotal{
 						NextPageToken: nextPageToken,
@@ -205,7 +205,7 @@ func TestGetV1Features(t *testing.T) {
 				err: nil,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.GetV1Features200JSONResponse{
+			expectedResponse: backend.ListFeatures200JSONResponse{
 				Data: []backend.Feature{
 					{
 						Baseline: &backend.BaselineInfo{
@@ -237,12 +237,12 @@ func TestGetV1Features(t *testing.T) {
 					Total:         100,
 				},
 			},
-			request: backend.GetV1FeaturesRequestObject{
-				Params: backend.GetV1FeaturesParams{
+			request: backend.ListFeaturesRequestObject{
+				Params: backend.ListFeaturesParams{
 					PageToken:     inputPageToken,
 					PageSize:      valuePtr[int](50),
 					Q:             valuePtr(url.QueryEscape("available_on:chrome AND name:grid")),
-					Sort:          valuePtr[backend.GetV1FeaturesParamsSort](backend.NameDesc),
+					Sort:          valuePtr[backend.ListFeaturesParamsSort](backend.NameDesc),
 					WptMetricView: valuePtr(backend.TestCounts),
 				},
 			},
@@ -266,12 +266,12 @@ func TestGetV1Features(t *testing.T) {
 				err:                   errTest,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.GetV1Features500JSONResponse{
+			expectedResponse: backend.ListFeatures500JSONResponse{
 				Code:    500,
 				Message: "unable to get list of features",
 			},
-			request: backend.GetV1FeaturesRequestObject{
-				Params: backend.GetV1FeaturesParams{
+			request: backend.ListFeaturesRequestObject{
+				Params: backend.ListFeaturesParams{
 					PageToken:     nil,
 					PageSize:      nil,
 					Q:             nil,
@@ -294,12 +294,12 @@ func TestGetV1Features(t *testing.T) {
 				err:                   errTest,
 			},
 			expectedCallCount: 0,
-			expectedResponse: backend.GetV1Features400JSONResponse{
+			expectedResponse: backend.ListFeatures400JSONResponse{
 				Code:    400,
 				Message: "query string does not match expected grammar",
 			},
-			request: backend.GetV1FeaturesRequestObject{
-				Params: backend.GetV1FeaturesParams{
+			request: backend.ListFeaturesRequestObject{
+				Params: backend.ListFeaturesParams{
 					PageToken:     nil,
 					PageSize:      nil,
 					Sort:          nil,
@@ -322,12 +322,12 @@ func TestGetV1Features(t *testing.T) {
 				err:                   errTest,
 			},
 			expectedCallCount: 0,
-			expectedResponse: backend.GetV1Features400JSONResponse{
+			expectedResponse: backend.ListFeatures400JSONResponse{
 				Code:    400,
 				Message: "query string cannot be decoded",
 			},
-			request: backend.GetV1FeaturesRequestObject{
-				Params: backend.GetV1FeaturesParams{
+			request: backend.ListFeaturesRequestObject{
+				Params: backend.ListFeaturesParams{
 					PageToken:     nil,
 					PageSize:      nil,
 					Q:             valuePtr[string]("%"),
@@ -355,12 +355,12 @@ func TestGetV1Features(t *testing.T) {
 				err:                   backendtypes.ErrInvalidPageToken,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.GetV1Features400JSONResponse{
+			expectedResponse: backend.ListFeatures400JSONResponse{
 				Code:    400,
 				Message: "invalid page token",
 			},
-			request: backend.GetV1FeaturesRequestObject{
-				Params: backend.GetV1FeaturesParams{
+			request: backend.ListFeaturesRequestObject{
+				Params: backend.ListFeaturesParams{
 					PageToken:     badPageToken,
 					PageSize:      nil,
 					Q:             nil,
@@ -381,7 +381,7 @@ func TestGetV1Features(t *testing.T) {
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
 
 			// Call the function under test
-			resp, err := myServer.GetV1Features(context.Background(), tc.request)
+			resp, err := myServer.ListFeatures(context.Background(), tc.request)
 
 			// Assertions
 			if mockStorer.callCountFeaturesSearch != tc.expectedCallCount {

--- a/backend/pkg/httpserver/get_saved_search.go
+++ b/backend/pkg/httpserver/get_saved_search.go
@@ -21,19 +21,19 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-// GetV1SavedSearchesSearchId implements backend.StrictServerInterface.
+// GetSavedSearch implements backend.StrictServerInterface.
 // nolint:ireturn, revive // Expected ireturn for openapi generation.
-func (s *Server) GetV1SavedSearchesSearchId(
-	_ context.Context, req backend.GetV1SavedSearchesSearchIdRequestObject) (
-	backend.GetV1SavedSearchesSearchIdResponseObject, error) {
+func (s *Server) GetSavedSearch(
+	_ context.Context, req backend.GetSavedSearchRequestObject) (
+	backend.GetSavedSearchResponseObject, error) {
 	savedSearches := getSavedSearches()
 	for _, search := range savedSearches {
 		if req.SearchId == search.Id {
-			return backend.GetV1SavedSearchesSearchId200JSONResponse(search), nil
+			return backend.GetSavedSearch200JSONResponse(search), nil
 		}
 	}
 
-	return backend.GetV1SavedSearchesSearchId404JSONResponse{
+	return backend.GetSavedSearch404JSONResponse{
 		Code:    404,
 		Message: fmt.Sprintf("unable to find search %s", req.SearchId),
 	}, nil

--- a/backend/pkg/httpserver/list_saved_searches.go
+++ b/backend/pkg/httpserver/list_saved_searches.go
@@ -60,14 +60,14 @@ func getSavedSearches() []backend.SavedSearchResponse {
 	}
 }
 
-// GetV1SavedSearches implements backend.StrictServerInterface.
+// ListSavedSearches implements backend.StrictServerInterface.
 // nolint:ireturn // Expected ireturn for openapi generation.
-func (s *Server) GetV1SavedSearches(
-	_ context.Context, _ backend.GetV1SavedSearchesRequestObject) (
-	backend.GetV1SavedSearchesResponseObject, error) {
+func (s *Server) ListSavedSearches(
+	_ context.Context, _ backend.ListSavedSearchesRequestObject) (
+	backend.ListSavedSearchesResponseObject, error) {
 	searches := getSavedSearches()
 
-	return backend.GetV1SavedSearches200JSONResponse{
+	return backend.ListSavedSearches200JSONResponse{
 		Metadata: nil,
 		Data:     &searches,
 	}, nil

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -66,7 +66,7 @@ type WPTMetricsStorer interface {
 		pageToken *string,
 		pageSize int,
 		searchNode *searchtypes.SearchNode,
-		sortOrder *backend.GetV1FeaturesParamsSort,
+		sortOrder *backend.ListFeaturesParamsSort,
 		wptMetricType backend.WPTMetricView,
 		browsers []backend.BrowserPathParam,
 	) (*backend.FeaturePage, error)

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -93,7 +93,7 @@ type MockFeaturesSearchConfig struct {
 	expectedPageToken     *string
 	expectedPageSize      int
 	expectedSearchNode    *searchtypes.SearchNode
-	expectedSortBy        *backend.GetV1FeaturesParamsSort
+	expectedSortBy        *backend.ListFeaturesParamsSort
 	expectedWPTMetricView backend.WPTMetricView
 	expectedBrowsers      []backend.BrowserPathParam
 	page                  *backend.FeaturePage
@@ -247,7 +247,7 @@ func (m *MockWPTMetricsStorer) FeaturesSearch(
 	pageToken *string,
 	pageSize int,
 	node *searchtypes.SearchNode,
-	sortBy *backend.GetV1FeaturesParamsSort,
+	sortBy *backend.ListFeaturesParamsSort,
 	view backend.WPTMetricView,
 	browsers []backend.BrowserPathParam,
 ) (*backend.FeaturePage, error) {

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -521,7 +521,7 @@ func (s *Backend) FeaturesSearch(
 	pageToken *string,
 	pageSize int,
 	searchNode *searchtypes.SearchNode,
-	sortOrder *backend.GetV1FeaturesParamsSort,
+	sortOrder *backend.ListFeaturesParamsSort,
 	wptMetricView backend.WPTMetricView,
 	browsers []backend.BrowserPathParam,
 ) (*backend.FeaturePage, error) {
@@ -556,7 +556,7 @@ func (s *Backend) FeaturesSearch(
 
 // TODO: Pass in context to be used by slog.ErrorContext.
 func getFeatureSearchSortOrder(
-	sortOrder *backend.GetV1FeaturesParamsSort) gcpspanner.Sortable {
+	sortOrder *backend.ListFeaturesParamsSort) gcpspanner.Sortable {
 	if sortOrder == nil {
 		return gcpspanner.NewBaselineStatusSort(false)
 	}

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -749,7 +749,7 @@ func TestFeaturesSearch(t *testing.T) {
 		inputWPTMetricView backend.WPTMetricView
 		inputBrowsers      BrowserList
 		searchNode         *searchtypes.SearchNode
-		sortOrder          *backend.GetV1FeaturesParamsSort
+		sortOrder          *backend.ListFeaturesParamsSort
 		expectedPage       *backend.FeaturePage
 	}{
 		{
@@ -1252,24 +1252,24 @@ func TestGetFeature(t *testing.T) {
 
 func TestGetFeatureSearchSortOrder(t *testing.T) {
 	sortOrderTests := []struct {
-		input *backend.GetV1FeaturesParamsSort
+		input *backend.ListFeaturesParamsSort
 		want  gcpspanner.Sortable
 	}{
 		{input: nil, want: gcpspanner.NewBaselineStatusSort(false)},
 		{
-			input: valuePtr[backend.GetV1FeaturesParamsSort](backend.NameAsc),
+			input: valuePtr[backend.ListFeaturesParamsSort](backend.NameAsc),
 			want:  gcpspanner.NewFeatureNameSort(true),
 		},
 		{
-			input: valuePtr[backend.GetV1FeaturesParamsSort](backend.NameDesc),
+			input: valuePtr[backend.ListFeaturesParamsSort](backend.NameDesc),
 			want:  gcpspanner.NewFeatureNameSort(false),
 		},
 		{
-			input: valuePtr[backend.GetV1FeaturesParamsSort](backend.BaselineStatusAsc),
+			input: valuePtr[backend.ListFeaturesParamsSort](backend.BaselineStatusAsc),
 			want:  gcpspanner.NewBaselineStatusSort(true),
 		},
 		{
-			input: valuePtr[backend.GetV1FeaturesParamsSort](backend.BaselineStatusDesc),
+			input: valuePtr[backend.ListFeaturesParamsSort](backend.BaselineStatusDesc),
 			want:  gcpspanner.NewBaselineStatusSort(false),
 		},
 		{

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -14,14 +14,20 @@
 
 openapi: '3.0.2'
 info:
-  title: API Title
-  version: '1.0'
+  title: webstatus.dev API
+  version: 0.1.0
+  description: >
+    A tool to monitor and track the status of all Web Platform features across
+    dimensions that are related to availability and implementation quality
+    across browsers, and adoption by web developers.
 servers:
-  - url: https://api.server.test/v1
+  - url: https://api.webstatus.dev
+    description: Production
 paths:
   /v1/features:
     get:
       summary: List features
+      operationId: listFeatures
       parameters:
         - $ref: '#/components/parameters/paginationTokenParam'
         - $ref: '#/components/parameters/paginationSizeParam'
@@ -115,6 +121,7 @@ paths:
           $ref: '#/components/schemas/WPTMetricView'
     get:
       summary: Get Feature
+      operationId: getFeature
       responses:
         '200':
           description: OK
@@ -446,6 +453,7 @@ paths:
   /v1/saved-searches:
     get:
       summary: List saved searches
+      operationId: listSavedSearches
       responses:
         '200':
           description: OK
@@ -463,6 +471,7 @@ paths:
           type: string
     get:
       summary: Get saved search
+      operationId: getSavedSearch
       responses:
         '200':
           description: OK


### PR DESCRIPTION
This PR adds operation IDs to several routes in the OpenAPI specification that were previously missing them.

**Naming Conventions:**

* `list`: Used for operations that return an array of data.
* `get`: Used for operations that return a single entity.

These conventions are consistent with existing operation IDs in the specification.

**Benefits:**

Adding operation IDs makes the API specification more complete and easier to use with tools and libraries that rely on them.

Other changes:
- Metadata changes about the server and version (Because of #383).