### PR TITLE
Refactor: Use httptest for HTTP layer testing

### DIFF
--- a/backend/pkg/httpserver/get_feature_metadata_test.go
+++ b/backend/pkg/httpserver/get_feature_metadata_test.go
@@ -15,9 +15,8 @@
 package httpserver
 
 import (
-	"context"
-	"errors"
-	"reflect"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
@@ -28,9 +27,8 @@ func TestGetFeatureMetadata(t *testing.T) {
 		name                  string
 		mockGetIDConfig       MockGetIDFromFeatureKeyConfig
 		mockGetMetadataConfig MockGetFeatureMetadataConfig
-		request               backend.GetFeatureMetadataRequestObject
-		expectedResponse      backend.GetFeatureMetadataResponseObject
-		expectedError         error
+		request               *http.Request
+		expectedResponse      *http.Response
 	}{
 		{
 			name: "success",
@@ -53,22 +51,10 @@ func TestGetFeatureMetadata(t *testing.T) {
 				},
 				err: nil,
 			},
-			request: backend.GetFeatureMetadataRequestObject{
-				FeatureId: "key1",
-			},
-			expectedResponse: backend.GetFeatureMetadata200JSONResponse(
-				backend.FeatureMetadata{
-					CanIUse: &backend.CanIUseInfo{
-						Items: &[]backend.CanIUseItem{
-							{
-								Id: valuePtr("caniuse1"),
-							},
-						},
-					},
-					Description: valuePtr("desc"),
-				},
+			request: httptest.NewRequest(http.MethodGet, "/v1/features/key1/feature-metadata", nil),
+			expectedResponse: testJSONResponse(200,
+				`{"can_i_use":{"items":[{"id":"caniuse1"}]},"description":"desc"}`,
 			),
-			expectedError: nil,
 		},
 		// TODO(jcscottiii). Add more test cases later.
 	}
@@ -84,18 +70,7 @@ func TestGetFeatureMetadata(t *testing.T) {
 				t:                         t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: mockMetadataStorer}
-
-			// Call the function under test
-			resp, err := myServer.GetFeatureMetadata(context.Background(), tc.request)
-
-			// Assertions
-			if !errors.Is(err, tc.expectedError) {
-				t.Errorf("Unexpected error: %v", err)
-			}
-
-			if !reflect.DeepEqual(tc.expectedResponse, resp) {
-				t.Errorf("Unexpected response: %v", resp)
-			}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 		})
 	}
 }

--- a/backend/pkg/httpserver/get_feature_metadata_test.go
+++ b/backend/pkg/httpserver/get_feature_metadata_test.go
@@ -71,6 +71,7 @@ func TestGetFeatureMetadata(t *testing.T) {
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: mockMetadataStorer}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			// TODO: Start tracking call count and assert call count.
 		})
 	}
 }

--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -194,6 +194,8 @@ func TestGetFeature(t *testing.T) {
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			assertMockCallCount(t, tc.expectedCallCount, mockStorer.callCountGetFeature,
+				"GetFeature")
 		})
 	}
 }

--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -15,9 +15,8 @@
 package httpserver
 
 import (
-	"context"
-	"errors"
-	"reflect"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -31,13 +30,12 @@ func TestGetFeature(t *testing.T) {
 		name              string
 		mockConfig        MockGetFeatureByIDConfig
 		expectedCallCount int // For the mock method
-		request           backend.GetFeatureRequestObject
-		expectedResponse  backend.GetFeatureResponseObject
-		expectedError     error
+		request           *http.Request
+		expectedResponse  *http.Response
 	}{
+		// nolint:dupl // WONTFIX - being explicit for short list of tests.
 		{
 			name: "Success Case - no optional params - use defaults",
-			// nolint:dupl // WONTFIX - being explicit for short list of tests.
 			mockConfig: MockGetFeatureByIDConfig{
 				expectedFeatureID:     "feature1",
 				expectedWPTMetricView: backend.SubtestCounts,
@@ -73,40 +71,28 @@ func TestGetFeature(t *testing.T) {
 				err: nil,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.GetFeature200JSONResponse{
-				Baseline: &backend.BaselineInfo{
-					Status: valuePtr(backend.Widely),
-					LowDate: valuePtr(
-						openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					),
-					HighDate: valuePtr(
-						openapi_types.Date{Time: time.Date(2001, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					),
+			request:           httptest.NewRequest(http.MethodGet, "/v1/features/feature1", nil),
+			expectedResponse: testJSONResponse(200, `
+			{
+				"baseline":{
+				   "high_date":"2001-01-01",
+				   "low_date":"2000-01-01",
+				   "status":"widely"
 				},
-				BrowserImplementations: &map[string]backend.BrowserImplementation{
-					"chrome": {
-						Status:  valuePtr(backend.Available),
-						Date:    &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
-						Version: valuePtr("100"),
-					},
+				"browser_implementations":{
+				   "chrome":{
+					  "date":"1999-01-01",
+					  "status":"available",
+					  "version":"100"
+				   }
 				},
-				FeatureId: "feature1",
-				Name:      "feature 1",
-				Spec:      nil,
-				Usage:     nil,
-				Wpt:       nil,
-			},
-			request: backend.GetFeatureRequestObject{
-				FeatureId: "feature1",
-				Params: backend.GetFeatureParams{
-					WptMetricView: nil,
-				},
-			},
-			expectedError: nil,
+				"feature_id":"feature1",
+				"name":"feature 1"
+			 }`),
 		},
+		// nolint:dupl // WONTFIX - being explicit for short list of tests.
 		{
 			name: "Success Case - with optional params",
-			// nolint:dupl // WONTFIX - being explicit for short list of tests.
 			mockConfig: MockGetFeatureByIDConfig{
 				expectedFeatureID:     "feature1",
 				expectedWPTMetricView: backend.TestCounts,
@@ -142,36 +128,25 @@ func TestGetFeature(t *testing.T) {
 				err: nil,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.GetFeature200JSONResponse{
-				Baseline: &backend.BaselineInfo{
-					Status: valuePtr(backend.Widely),
-					LowDate: valuePtr(
-						openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					),
-					HighDate: valuePtr(
-						openapi_types.Date{Time: time.Date(2001, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					),
-				},
-				BrowserImplementations: &map[string]backend.BrowserImplementation{
-					"chrome": {
-						Status:  valuePtr(backend.Available),
-						Date:    &openapi_types.Date{Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
-						Version: valuePtr("100"),
-					},
-				},
-				FeatureId: "feature1",
-				Name:      "feature 1",
-				Spec:      nil,
-				Usage:     nil,
-				Wpt:       nil,
-			},
-			request: backend.GetFeatureRequestObject{
-				FeatureId: "feature1",
-				Params: backend.GetFeatureParams{
-					WptMetricView: valuePtr(backend.TestCounts),
-				},
-			},
-			expectedError: nil,
+			request:           httptest.NewRequest(http.MethodGet, "/v1/features/feature1?wpt_metric_view=test_counts", nil),
+			expectedResponse: testJSONResponse(200, `
+{
+	"baseline":{
+		"high_date":"2001-01-01",
+		"low_date":"2000-01-01",
+		"status":"widely"
+	},
+	"browser_implementations":{
+		"chrome":{
+			"date":"1999-01-01",
+			"status":"available",
+			"version":"100"
+		}
+	},
+	"feature_id":"feature1",
+	"name":"feature 1"
+}`,
+			),
 		},
 		{
 			name: "404",
@@ -188,17 +163,8 @@ func TestGetFeature(t *testing.T) {
 				err:  gcpspanner.ErrQueryReturnedNoResults,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.GetFeature404JSONResponse{
-				Code:    404,
-				Message: "feature id feature1 is not found",
-			},
-			request: backend.GetFeatureRequestObject{
-				FeatureId: "feature1",
-				Params: backend.GetFeatureParams{
-					WptMetricView: nil,
-				},
-			},
-			expectedError: nil,
+			request:           httptest.NewRequest(http.MethodGet, "/v1/features/feature1", nil),
+			expectedResponse:  testJSONResponse(404, `{"code":404,"message":"feature id feature1 is not found"}`),
 		},
 		{
 			name: "500",
@@ -215,17 +181,8 @@ func TestGetFeature(t *testing.T) {
 				err:  errTest,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.GetFeature500JSONResponse{
-				Code:    500,
-				Message: "unable to get feature",
-			},
-			request: backend.GetFeatureRequestObject{
-				FeatureId: "feature1",
-				Params: backend.GetFeatureParams{
-					WptMetricView: nil,
-				},
-			},
-			expectedError: nil,
+			request:           httptest.NewRequest(http.MethodGet, "/v1/features/feature1", nil),
+			expectedResponse:  testJSONResponse(500, `{"code":500,"message":"unable to get feature"}`),
 		},
 	}
 	for _, tc := range testCases {
@@ -236,24 +193,7 @@ func TestGetFeature(t *testing.T) {
 				t:                    t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
-
-			// Call the function under test
-			resp, err := myServer.GetFeature(context.Background(), tc.request)
-
-			// Assertions
-			if mockStorer.callCountGetFeature != tc.expectedCallCount {
-				t.Errorf("Incorrect call count: expected %d, got %d",
-					tc.expectedCallCount,
-					mockStorer.callCountGetFeature)
-			}
-
-			if !errors.Is(err, tc.expectedError) {
-				t.Errorf("Unexpected error: %v", err)
-			}
-
-			if !reflect.DeepEqual(tc.expectedResponse, resp) {
-				t.Errorf("Unexpected response: %v", resp)
-			}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 		})
 	}
 }

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -15,10 +15,10 @@
 package httpserver
 
 import (
-	"context"
-	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"testing"
 	"time"
 
@@ -33,9 +33,8 @@ func TestListFeatures(t *testing.T) {
 		name              string
 		mockConfig        MockFeaturesSearchConfig
 		expectedCallCount int // For the mock method
-		request           backend.ListFeaturesRequestObject
-		expectedResponse  backend.ListFeaturesResponseObject
-		expectedError     error
+		request           *http.Request
+		expectedResponse  *http.Response
 	}{
 		{
 			name: "Success Case - no optional params - use defaults",
@@ -85,47 +84,31 @@ func TestListFeatures(t *testing.T) {
 				err: nil,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListFeatures200JSONResponse{
-				Data: []backend.Feature{
-					{
-						Baseline: &backend.BaselineInfo{
-							Status: valuePtr(backend.Widely),
-							LowDate: valuePtr(
-								openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-							),
-							HighDate: valuePtr(
-								openapi_types.Date{Time: time.Date(2001, time.January, 1, 0, 0, 0, 0, time.UTC)},
-							),
-						},
-						FeatureId: "feature1",
-						Name:      "feature 1",
-						Spec:      nil,
-						Usage:     nil,
-						Wpt:       nil,
-						BrowserImplementations: &map[string]backend.BrowserImplementation{
-							"browser1": {
-								Status:  valuePtr(backend.Available),
-								Date:    nil,
-								Version: valuePtr("101"),
-							},
-						},
-					},
-				},
-				Metadata: backend.PageMetadataWithTotal{
-					NextPageToken: nil,
-					Total:         100,
-				},
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"baseline":{
+				"high_date":"2001-01-01",
+				"low_date":"2000-01-01",
+				"status":"widely"
 			},
-			request: backend.ListFeaturesRequestObject{
-				Params: backend.ListFeaturesParams{
-					PageToken:     nil,
-					PageSize:      nil,
-					Q:             nil,
-					Sort:          nil,
-					WptMetricView: nil,
-				},
+			"browser_implementations":{
+				"browser1":{
+				"status":"available",
+				"version":"101"
+				}
 			},
-			expectedError: nil,
+			"feature_id":"feature1",
+			"name":"feature 1"
+		}
+	],
+	"metadata":{
+		"total":100
+	}
+}`,
+			),
+			request: httptest.NewRequest(http.MethodGet, "/v1/features", nil),
 		},
 		{
 			name: "Success Case - include optional params",
@@ -205,48 +188,39 @@ func TestListFeatures(t *testing.T) {
 				err: nil,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListFeatures200JSONResponse{
-				Data: []backend.Feature{
-					{
-						Baseline: &backend.BaselineInfo{
-							Status: valuePtr(backend.Widely),
-							LowDate: valuePtr(
-								openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-							),
-							HighDate: valuePtr(
-								openapi_types.Date{Time: time.Date(2001, time.January, 1, 0, 0, 0, 0, time.UTC)},
-							),
-						},
-						FeatureId: "feature1",
-						Name:      "feature 1",
-						Spec:      nil,
-						Usage:     nil,
-						Wpt:       nil,
-						BrowserImplementations: &map[string]backend.BrowserImplementation{
-							"chrome": {
-								Status: valuePtr(backend.Available),
-								Date: &openapi_types.Date{
-									Time: time.Date(1999, time.January, 1, 0, 0, 0, 0, time.UTC)},
-								Version: valuePtr("101"),
-							},
-						},
-					},
-				},
-				Metadata: backend.PageMetadataWithTotal{
-					NextPageToken: nextPageToken,
-					Total:         100,
-				},
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"baseline":{
+				"high_date":"2001-01-01",
+				"low_date":"2000-01-01",
+				"status":"widely"
 			},
-			request: backend.ListFeaturesRequestObject{
-				Params: backend.ListFeaturesParams{
-					PageToken:     inputPageToken,
-					PageSize:      valuePtr[int](50),
-					Q:             valuePtr(url.QueryEscape("available_on:chrome AND name:grid")),
-					Sort:          valuePtr[backend.ListFeaturesParamsSort](backend.NameDesc),
-					WptMetricView: valuePtr(backend.TestCounts),
-				},
+			"browser_implementations":{
+				"chrome":{
+				"date":"1999-01-01",
+				"status":"available",
+				"version":"101"
+				}
 			},
-			expectedError: nil,
+			"feature_id":"feature1",
+			"name":"feature 1"
+		}
+	],
+	"metadata":{
+		"next_page_token":"next-page-token",
+		"total":100
+	}
+}`,
+			),
+			request: httptest.NewRequest(
+				http.MethodGet,
+				fmt.Sprintf("/v1/features?page_token=%s&page_size=50&q=%s&sort=name_desc&wpt_metric_view=test_counts",
+					*inputPageToken,
+					url.QueryEscape("available_on:chrome AND name:grid"),
+				),
+				nil),
 		},
 		{
 			name: "500 case",
@@ -266,20 +240,10 @@ func TestListFeatures(t *testing.T) {
 				err:                   errTest,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListFeatures500JSONResponse{
-				Code:    500,
-				Message: "unable to get list of features",
-			},
-			request: backend.ListFeaturesRequestObject{
-				Params: backend.ListFeaturesParams{
-					PageToken:     nil,
-					PageSize:      nil,
-					Q:             nil,
-					Sort:          nil,
-					WptMetricView: nil,
-				},
-			},
-			expectedError: nil,
+			expectedResponse: testJSONResponse(500,
+				`{"code":500,"message":"unable to get list of features"}`,
+			),
+			request: httptest.NewRequest(http.MethodGet, "/v1/features", nil),
 		},
 		{
 			name: "400 case - query string does not match grammar",
@@ -294,20 +258,10 @@ func TestListFeatures(t *testing.T) {
 				err:                   errTest,
 			},
 			expectedCallCount: 0,
-			expectedResponse: backend.ListFeatures400JSONResponse{
-				Code:    400,
-				Message: "query string does not match expected grammar",
-			},
-			request: backend.ListFeaturesRequestObject{
-				Params: backend.ListFeaturesParams{
-					PageToken:     nil,
-					PageSize:      nil,
-					Sort:          nil,
-					Q:             valuePtr[string]("badterm:foo"),
-					WptMetricView: nil,
-				},
-			},
-			expectedError: nil,
+			expectedResponse: testJSONResponse(400,
+				`{"code":400,"message":"query string does not match expected grammar"}`,
+			),
+			request: httptest.NewRequest(http.MethodGet, "/v1/features?q=badterm:foo", nil),
 		},
 		{
 			name: "400 case - query string not safe",
@@ -322,20 +276,10 @@ func TestListFeatures(t *testing.T) {
 				err:                   errTest,
 			},
 			expectedCallCount: 0,
-			expectedResponse: backend.ListFeatures400JSONResponse{
-				Code:    400,
-				Message: "query string cannot be decoded",
-			},
-			request: backend.ListFeaturesRequestObject{
-				Params: backend.ListFeaturesParams{
-					PageToken:     nil,
-					PageSize:      nil,
-					Q:             valuePtr[string]("%"),
-					Sort:          nil,
-					WptMetricView: nil,
-				},
-			},
-			expectedError: nil,
+			expectedResponse: testJSONResponse(400,
+				`{"code":400,"message":"query string cannot be decoded"}`,
+			),
+			request: httptest.NewRequest(http.MethodGet, "/v1/features?q="+url.QueryEscape("%"), nil),
 		},
 		{
 			name: "400 case - invalid page token",
@@ -355,20 +299,10 @@ func TestListFeatures(t *testing.T) {
 				err:                   backendtypes.ErrInvalidPageToken,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListFeatures400JSONResponse{
-				Code:    400,
-				Message: "invalid page token",
-			},
-			request: backend.ListFeaturesRequestObject{
-				Params: backend.ListFeaturesParams{
-					PageToken:     badPageToken,
-					PageSize:      nil,
-					Q:             nil,
-					Sort:          nil,
-					WptMetricView: nil,
-				},
-			},
-			expectedError: nil,
+			expectedResponse: testJSONResponse(400,
+				`{"code":400,"message":"invalid page token"}`,
+			),
+			request: httptest.NewRequest(http.MethodGet, "/v1/features?page_token="+*badPageToken, nil),
 		},
 	}
 	for _, tc := range testCases {
@@ -379,24 +313,7 @@ func TestListFeatures(t *testing.T) {
 				t:                 t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
-
-			// Call the function under test
-			resp, err := myServer.ListFeatures(context.Background(), tc.request)
-
-			// Assertions
-			if mockStorer.callCountFeaturesSearch != tc.expectedCallCount {
-				t.Errorf("Incorrect call count: expected %d, got %d",
-					tc.expectedCallCount,
-					mockStorer.callCountFeaturesSearch)
-			}
-
-			if !errors.Is(err, tc.expectedError) {
-				t.Errorf("Unexpected error: %v", err)
-			}
-
-			if !reflect.DeepEqual(tc.expectedResponse, resp) {
-				t.Errorf("Unexpected response: %v", resp)
-			}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 		})
 	}
 }

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -314,6 +314,7 @@ func TestListFeatures(t *testing.T) {
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			assertMockCallCount(t, tc.expectedCallCount, mockStorer.callCountFeaturesSearch, "FeaturesSearch")
 		})
 	}
 }

--- a/backend/pkg/httpserver/list_aggregated_feature_support_test.go
+++ b/backend/pkg/httpserver/list_aggregated_feature_support_test.go
@@ -15,15 +15,13 @@
 package httpserver
 
 import (
-	"context"
-	"errors"
-	"reflect"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 func TestListAggregatedFeatureSupport(t *testing.T) {
@@ -31,9 +29,8 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 		name              string
 		mockConfig        MockListBrowserFeatureCountMetricConfig
 		expectedCallCount int // For the mock method
-		request           backend.ListAggregatedFeatureSupportRequestObject
-		expectedResponse  backend.ListAggregatedFeatureSupportResponseObject
-		expectedError     error
+		request           *http.Request
+		expectedResponse  *http.Response
 	}{
 		{
 			name: "Success Case - no optional params - use defaults",
@@ -62,31 +59,24 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 				},
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListAggregatedFeatureSupport200JSONResponse{
-				Data: []backend.BrowserReleaseFeatureMetric{
-					{
-						Count:     valuePtr[int64](10),
-						Timestamp: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
-					},
-					{
-						Count:     valuePtr[int64](9),
-						Timestamp: time.Date(2000, time.January, 9, 0, 0, 0, 0, time.UTC),
-					},
-				},
-				Metadata: &backend.PageMetadata{
-					NextPageToken: nil,
-				},
-			},
-			request: backend.ListAggregatedFeatureSupportRequestObject{
-				Params: backend.ListAggregatedFeatureSupportParams{
-					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
-					PageToken: nil,
-					PageSize:  nil,
-				},
-				Browser: backend.Chrome,
-			},
-			expectedError: nil,
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"count":10,
+			"timestamp":"2000-01-10T00:00:00Z"
+		},
+		{
+			"count":9,
+			"timestamp":"2000-01-09T00:00:00Z"
+		}
+	],
+	"metadata":{
+
+	}
+}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/features/browsers/chrome/feature_counts?startAt=2000-01-01&endAt=2000-01-10", nil),
 		},
 		{
 			name: "Success Case - include optional params",
@@ -115,31 +105,27 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 				pageToken: nextPageToken,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListAggregatedFeatureSupport200JSONResponse{
-				Metadata: &backend.PageMetadata{
-					NextPageToken: nextPageToken,
-				},
-				Data: []backend.BrowserReleaseFeatureMetric{
-					{
-						Count:     valuePtr[int64](10),
-						Timestamp: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
-					},
-					{
-						Count:     valuePtr[int64](9),
-						Timestamp: time.Date(2000, time.January, 9, 0, 0, 0, 0, time.UTC),
-					},
-				},
-			},
-			request: backend.ListAggregatedFeatureSupportRequestObject{
-				Params: backend.ListAggregatedFeatureSupportParams{
-					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
-					PageToken: inputPageToken,
-					PageSize:  valuePtr[int](50),
-				},
-				Browser: backend.Chrome,
-			},
-			expectedError: nil,
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"count":10,
+			"timestamp":"2000-01-10T00:00:00Z"
+		},
+		{
+			"count":9,
+			"timestamp":"2000-01-09T00:00:00Z"
+		}
+	],
+	"metadata":{
+		"next_page_token":"next-page-token"
+	}
+}`),
+			request: httptest.NewRequest(
+				http.MethodGet,
+				"/v1/stats/features/browsers/chrome/feature_counts?startAt="+
+					"2000-01-01&endAt=2000-01-10&page_token="+*inputPageToken+"&page_size=50",
+				nil),
 		},
 		{
 			name: "500 case",
@@ -154,20 +140,9 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 				err:               errTest,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListAggregatedFeatureSupport500JSONResponse{
-				Code:    500,
-				Message: "unable to get feature support metrics",
-			},
-			request: backend.ListAggregatedFeatureSupportRequestObject{
-				Params: backend.ListAggregatedFeatureSupportParams{
-					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
-					PageToken: nil,
-					PageSize:  nil,
-				},
-				Browser: backend.Chrome,
-			},
-			expectedError: nil,
+			expectedResponse:  testJSONResponse(500, `{"code":500,"message":"unable to get feature support metrics"}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/features/browsers/chrome/feature_counts?startAt=2000-01-01&endAt=2000-01-10", nil),
 		},
 		{
 			name: "400 case - invalid page token",
@@ -182,20 +157,10 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 				page:              nil,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListAggregatedFeatureSupport400JSONResponse{
-				Code:    400,
-				Message: "invalid page token",
-			},
-			request: backend.ListAggregatedFeatureSupportRequestObject{
-				Params: backend.ListAggregatedFeatureSupportParams{
-					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
-					PageToken: badPageToken,
-					PageSize:  nil,
-				},
-				Browser: backend.Chrome,
-			},
-			expectedError: nil,
+			expectedResponse:  testJSONResponse(400, `{"code":400,"message":"invalid page token"}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/features/browsers/chrome/feature_counts?startAt=2000-01-01"+
+					"&endAt=2000-01-10&page_token="+*badPageToken, nil),
 		},
 	}
 
@@ -207,24 +172,7 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 				t:                                t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
-
-			// Call the function under test
-			resp, err := myServer.ListAggregatedFeatureSupport(context.Background(), tc.request)
-
-			// Assertions
-			if mockStorer.callCountListBrowserFeatureCountMetric != tc.expectedCallCount {
-				t.Errorf("Incorrect call count: expected %d, got %d",
-					tc.expectedCallCount,
-					mockStorer.callCountListBrowserFeatureCountMetric)
-			}
-
-			if !errors.Is(err, tc.expectedError) {
-				t.Errorf("Unexpected error: %v", err)
-			}
-
-			if !reflect.DeepEqual(tc.expectedResponse, resp) {
-				t.Errorf("Unexpected response: %v", resp)
-			}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 		})
 	}
 }

--- a/backend/pkg/httpserver/list_aggregated_feature_support_test.go
+++ b/backend/pkg/httpserver/list_aggregated_feature_support_test.go
@@ -173,6 +173,9 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			assertMockCallCount(t, tc.expectedCallCount, mockStorer.callCountListBrowserFeatureCountMetric,
+				"ListBrowserFeatureCountMetric")
+
 		})
 	}
 }

--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
@@ -167,6 +167,8 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			assertMockCallCount(t, tc.expectedCallCount, mockStorer.callCountListMetricsOverTimeWithAggregatedTotals,
+				"ListMetricsOverTimeWithAggregatedTotals")
 		})
 	}
 }

--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
@@ -15,15 +15,13 @@
 package httpserver
 
 import (
-	"context"
-	"errors"
-	"reflect"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 func TestListAggregatedWPTMetrics(t *testing.T) {
@@ -31,9 +29,8 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 		name              string
 		mockConfig        MockListMetricsOverTimeWithAggregatedTotalsConfig
 		expectedCallCount int // For the mock method
-		request           backend.ListAggregatedWPTMetricsRequestObject
-		expectedResponse  backend.ListAggregatedWPTMetricsResponseObject
-		expectedError     error
+		request           *http.Request
+		expectedResponse  *http.Response
 	}{
 		{
 			name: "Success Case - no optional params - use defaults",
@@ -57,31 +54,23 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 				},
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListAggregatedWPTMetrics200JSONResponse{
-				Data: []backend.WPTRunMetric{
-					{
-						RunTimestamp:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-						TestPassCount:   valuePtr[int64](2),
-						TotalTestsCount: valuePtr[int64](2),
-					},
-				},
-				Metadata: &backend.PageMetadata{
-					NextPageToken: nil,
-				},
-			},
-			request: backend.ListAggregatedWPTMetricsRequestObject{
-				Params: backend.ListAggregatedWPTMetricsParams{
-					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
-					PageToken: nil,
-					PageSize:  nil,
-					FeatureId: nil,
-				},
-				Browser:    backend.Chrome,
-				Channel:    backend.Experimental,
-				MetricView: backend.SubtestCounts,
-			},
-			expectedError: nil,
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"run_timestamp":"2000-01-01T00:00:00Z",
+			"test_pass_count":2,
+			"total_tests_count":2
+		}
+	],
+	"metadata":{
+
+	}
+}
+			`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/wpt/browsers/chrome/channels/experimental/subtest_counts"+
+					"?startAt=2000-01-01&endAt=2000-01-10", nil),
 		},
 		{
 			name: "Success Case - include optional params",
@@ -105,31 +94,25 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 				pageToken: nextPageToken,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListAggregatedWPTMetrics200JSONResponse{
-				Data: []backend.WPTRunMetric{
-					{
-						RunTimestamp:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-						TestPassCount:   valuePtr[int64](2),
-						TotalTestsCount: valuePtr[int64](2),
-					},
-				},
-				Metadata: &backend.PageMetadata{
-					NextPageToken: nextPageToken,
-				},
-			},
-			request: backend.ListAggregatedWPTMetricsRequestObject{
-				Params: backend.ListAggregatedWPTMetricsParams{
-					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
-					PageToken: inputPageToken,
-					FeatureId: valuePtr[[]string]([]string{"feature1", "feature2"}),
-					PageSize:  valuePtr[int](50),
-				},
-				Browser:    backend.Chrome,
-				Channel:    backend.Experimental,
-				MetricView: backend.SubtestCounts,
-			},
-			expectedError: nil,
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"run_timestamp":"2000-01-01T00:00:00Z",
+			"test_pass_count":2,
+			"total_tests_count":2
+		}
+	],
+	"metadata":{
+		"next_page_token":"next-page-token"
+	}
+}
+			`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/wpt/browsers/chrome/channels/experimental/subtest_counts"+
+					"?startAt=2000-01-01&endAt=2000-01-10&page_size=50&"+
+					"featureId=feature1&featureId=feature2&"+
+					"page_token="+*inputPageToken, nil),
 		},
 		{
 			name: "500 case",
@@ -147,23 +130,10 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 				err:                errTest,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListAggregatedWPTMetrics500JSONResponse{
-				Code:    500,
-				Message: "unable to get aggregated metrics",
-			},
-			request: backend.ListAggregatedWPTMetricsRequestObject{
-				Params: backend.ListAggregatedWPTMetricsParams{
-					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
-					FeatureId: nil,
-					PageToken: nil,
-					PageSize:  nil,
-				},
-				Browser:    backend.Chrome,
-				Channel:    backend.Experimental,
-				MetricView: backend.SubtestCounts,
-			},
-			expectedError: nil,
+			expectedResponse:  testJSONResponse(500, `{"code":500,"message":"unable to get aggregated metrics"}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/wpt/browsers/chrome/channels/experimental/subtest_counts"+
+					"?startAt=2000-01-01&endAt=2000-01-10", nil),
 		},
 		{
 			name: "400 case - invalid page token",
@@ -181,23 +151,10 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 				err:                backendtypes.ErrInvalidPageToken,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListAggregatedWPTMetrics400JSONResponse{
-				Code:    400,
-				Message: "invalid page token",
-			},
-			request: backend.ListAggregatedWPTMetricsRequestObject{
-				Params: backend.ListAggregatedWPTMetricsParams{
-					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
-					FeatureId: nil,
-					PageToken: badPageToken,
-					PageSize:  nil,
-				},
-				Browser:    backend.Chrome,
-				Channel:    backend.Experimental,
-				MetricView: backend.SubtestCounts,
-			},
-			expectedError: nil,
+			expectedResponse:  testJSONResponse(400, `{"code":400,"message":"invalid page token"}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/wpt/browsers/chrome/channels/experimental/subtest_counts"+
+					"?startAt=2000-01-01&endAt=2000-01-10&page_token="+*badPageToken, nil),
 		},
 	}
 
@@ -209,24 +166,7 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 				t:            t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
-
-			// Call the function under test
-			resp, err := myServer.ListAggregatedWPTMetrics(context.Background(), tc.request)
-
-			// Assertions
-			if mockStorer.callCountListMetricsOverTimeWithAggregatedTotals != tc.expectedCallCount {
-				t.Errorf("Incorrect call count: expected %d, got %d",
-					tc.expectedCallCount,
-					mockStorer.callCountListMetricsOverTimeWithAggregatedTotals)
-			}
-
-			if !errors.Is(err, tc.expectedError) {
-				t.Errorf("Unexpected error: %v", err)
-			}
-
-			if !reflect.DeepEqual(tc.expectedResponse, resp) {
-				t.Errorf("Unexpected response: %v", resp)
-			}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 		})
 	}
 }

--- a/backend/pkg/httpserver/list_chromium_usage_test.go
+++ b/backend/pkg/httpserver/list_chromium_usage_test.go
@@ -94,6 +94,8 @@ func TestListChromiumDailyUsageStats(t *testing.T) {
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			assertMockCallCount(t, tc.expectedCallCount, mockStorer.callCountListChromiumDailyUsageStats,
+				"ListChromiumDailyUsageStats")
 		})
 	}
 }

--- a/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
@@ -15,15 +15,13 @@
 package httpserver
 
 import (
-	"context"
-	"errors"
-	"reflect"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
-	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 func TestListFeatureWPTMetrics(t *testing.T) {
@@ -31,9 +29,8 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 		name              string
 		mockConfig        MockListMetricsForFeatureIDBrowserAndChannelConfig
 		expectedCallCount int // For the mock method
-		request           backend.ListFeatureWPTMetricsRequestObject
-		expectedResponse  backend.ListFeatureWPTMetricsResponseObject
-		expectedError     error
+		request           *http.Request
+		expectedResponse  *http.Response
 	}{
 		{
 			name: "Success Case - no optional params - use defaults",
@@ -58,31 +55,20 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 				},
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListFeatureWPTMetrics200JSONResponse{
-				Data: []backend.WPTRunMetric{
-					{
-						RunTimestamp:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-						TestPassCount:   valuePtr[int64](2),
-						TotalTestsCount: valuePtr[int64](2),
-					},
-				},
-				Metadata: &backend.PageMetadata{
-					NextPageToken: nil,
-				},
-			},
-			request: backend.ListFeatureWPTMetricsRequestObject{
-				Params: backend.ListFeatureWPTMetricsParams{
-					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
-					PageToken: nil,
-					PageSize:  nil,
-				},
-				Browser:    backend.Chrome,
-				Channel:    backend.Experimental,
-				MetricView: backend.SubtestCounts,
-				FeatureId:  "feature1",
-			},
-			expectedError: nil,
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"run_timestamp":"2000-01-01T00:00:00Z",
+			"test_pass_count":2,
+			"total_tests_count":2
+		}
+	],
+	"metadata":{}
+}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/features/feature1/stats/wpt/browsers/chrome/channels/experimental/subtest_counts"+
+					"?startAt=2000-01-01&endAt=2000-01-10", nil),
 		},
 		{
 			name: "Success Case - include optional params",
@@ -107,31 +93,23 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 				pageToken: nextPageToken,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListFeatureWPTMetrics200JSONResponse{
-				Data: []backend.WPTRunMetric{
-					{
-						RunTimestamp:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
-						TestPassCount:   valuePtr[int64](2),
-						TotalTestsCount: valuePtr[int64](2),
-					},
-				},
-				Metadata: &backend.PageMetadata{
-					NextPageToken: nextPageToken,
-				},
-			},
-			request: backend.ListFeatureWPTMetricsRequestObject{
-				Params: backend.ListFeatureWPTMetricsParams{
-					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
-					PageToken: inputPageToken,
-					PageSize:  valuePtr[int](50),
-				},
-				Browser:    backend.Chrome,
-				Channel:    backend.Experimental,
-				MetricView: backend.SubtestCounts,
-				FeatureId:  "feature1",
-			},
-			expectedError: nil,
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"run_timestamp":"2000-01-01T00:00:00Z",
+			"test_pass_count":2,
+			"total_tests_count":2
+		}
+	],
+	"metadata":{
+		"next_page_token":"next-page-token"
+	}
+}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/features/feature1/stats/wpt/browsers/chrome/channels/experimental/subtest_counts"+
+					"?startAt=2000-01-01&endAt=2000-01-10&"+
+					"page_size=50&page_token="+*inputPageToken, nil),
 		},
 		{
 			name: "500 case",
@@ -149,23 +127,10 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 				err:               errTest,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListFeatureWPTMetrics500JSONResponse{
-				Code:    500,
-				Message: "unable to get feature metrics",
-			},
-			request: backend.ListFeatureWPTMetricsRequestObject{
-				Params: backend.ListFeatureWPTMetricsParams{
-					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
-					PageToken: nil,
-					PageSize:  nil,
-				},
-				MetricView: backend.SubtestCounts,
-				Browser:    backend.Chrome,
-				Channel:    backend.Experimental,
-				FeatureId:  "feature1",
-			},
-			expectedError: nil,
+			expectedResponse:  testJSONResponse(500, `{"code":500,"message":"unable to get feature metrics"}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/features/feature1/stats/wpt/browsers/chrome/channels/experimental/subtest_counts"+
+					"?startAt=2000-01-01&endAt=2000-01-10", nil),
 		},
 		{
 			name: "400 case - invalid page token",
@@ -183,23 +148,10 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 				err:               backendtypes.ErrInvalidPageToken,
 			},
 			expectedCallCount: 1,
-			expectedResponse: backend.ListFeatureWPTMetrics400JSONResponse{
-				Code:    400,
-				Message: "invalid page token",
-			},
-			request: backend.ListFeatureWPTMetricsRequestObject{
-				Params: backend.ListFeatureWPTMetricsParams{
-					StartAt:   openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
-					EndAt:     openapi_types.Date{Time: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC)},
-					PageToken: badPageToken,
-					PageSize:  nil,
-				},
-				MetricView: backend.SubtestCounts,
-				Browser:    backend.Chrome,
-				Channel:    backend.Experimental,
-				FeatureId:  "feature1",
-			},
-			expectedError: nil,
+			expectedResponse:  testJSONResponse(400, `{"code":400,"message":"invalid page token"}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/features/feature1/stats/wpt/browsers/chrome/channels/experimental/subtest_counts"+
+					"?startAt=2000-01-01&endAt=2000-01-10&page_token="+*badPageToken, nil),
 		},
 	}
 
@@ -211,24 +163,7 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 				t:          t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
-
-			// Call the function under test
-			resp, err := myServer.ListFeatureWPTMetrics(context.Background(), tc.request)
-
-			// Assertions
-			if mockStorer.callCountListMetricsForFeatureIDBrowserAndChannel != tc.expectedCallCount {
-				t.Errorf("Incorrect call count: expected %d, got %d",
-					tc.expectedCallCount,
-					mockStorer.callCountListMetricsOverTimeWithAggregatedTotals)
-			}
-
-			if !errors.Is(err, tc.expectedError) {
-				t.Errorf("Unexpected error: %v", err)
-			}
-
-			if !reflect.DeepEqual(tc.expectedResponse, resp) {
-				t.Errorf("Unexpected response: %v", resp)
-			}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 		})
 	}
 }

--- a/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
@@ -164,6 +164,8 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			assertMockCallCount(t, tc.expectedCallCount, mockStorer.callCountListMetricsForFeatureIDBrowserAndChannel,
+				"ListMetricsForFeatureIDBrowserAndChannel")
 		})
 	}
 }

--- a/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
@@ -182,6 +182,8 @@ func TestListMissingOneImplemenationCounts(t *testing.T) {
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			assertMockCallCount(t, tc.expectedCallCount, mockStorer.callCountListMissingOneImplCounts,
+				"ListMissingOneImplCounts")
 		})
 	}
 }

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -152,6 +152,7 @@ type MockWPTMetricsStorer struct {
 	getFeatureByIDConfig                              MockGetFeatureByIDConfig
 	getIDFromFeatureKeyConfig                         MockGetIDFromFeatureKeyConfig
 	t                                                 *testing.T
+	callCountListMissingOneImplCounts                 int
 	callCountListBrowserFeatureCountMetric            int
 	callCountFeaturesSearch                           int
 	callCountListChromiumDailyUsageStats              int
@@ -321,7 +322,7 @@ func (m *MockWPTMetricsStorer) ListMissingOneImplCounts(
 	pageSize int,
 	pageToken *string,
 ) (*backend.BrowserReleaseFeatureMetricsPage, error) {
-	m.callCountListBrowserFeatureCountMetric++
+	m.callCountListMissingOneImplCounts++
 
 	if targetBrowser != m.listMissingOneImplCountCfg.expectedTargetBrowser ||
 		!slices.Equal(otherBrowsers, m.listMissingOneImplCountCfg.expectedOtherBrowsers) ||
@@ -436,6 +437,13 @@ func compareJSONBodies(t *testing.T, actualBody, expectedBody []byte) {
 
 	if !reflect.DeepEqual(actualObj, expectedObj) {
 		t.Errorf("expected body %+v. received %+v", string(expectedBody), string(actualBody))
+	}
+}
+
+func assertMockCallCount(t *testing.T, expectedCallCount, actualCallCount int, methodName string) {
+	if expectedCallCount != actualCallCount {
+		t.Errorf("expected %s to be called %d times. it was called %d times",
+			methodName, expectedCallCount, actualCallCount)
 	}
 }
 

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -409,6 +409,7 @@ paths:
         - $ref: '#/components/parameters/paginationTokenParam'
         - $ref: '#/components/parameters/paginationSizeParam'
         - in: query
+          # TODO: Create a feature_id version of this parameter
           name: featureId
           description: >
             A list of feature IDs to filter results. TThe list is provided by
@@ -512,6 +513,7 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/WPTMetricView'
+    # TODO: Create a start_at version of this parameter
     startAtParam:
       in: query
       name: startAt
@@ -520,6 +522,7 @@ components:
         format: date
       description: Start date (RFC 3339, section 5.6, for example, 2017-07-21). The date is inclusive.
       required: true
+    # TODO: Create a end_at version of this parameter
     endAtParam:
       in: query
       name: endAt


### PR DESCRIPTION
This PR improves the reliability and maintainability of our HTTP tests by transitioning from direct calls to the generated OpenAPI server methods to using the `httptest` package for true HTTP-level testing. 

**Motivation:**

Currently, our tests bypass the HTTP layer, which limits their ability to identify issues with request handling, middleware, and serialization. This refactor provides a more accurate representation of real-world scenarios and enables better testing of components like the upcoming auth middleware.

**Changes:**

* **`httptest` Integration:**  All HTTP handler tests now utilize `httptest` to simulate actual HTTP requests and responses. This involves updating test inputs to `*http.Request` and expected outputs to `*http.Response`.
* **Centralized Assertions:**  Common assertion logic has been extracted into helper functions like `assertTestServerRequest` and `assertMockCallCount` to reduce code duplication and improve consistency across tests.
* **OpenAPI Updates:**  Added TODO notes to deprecate outdated parameters in the OpenAPI document to maintain API consistency with other parameters.

**Benefits:**

* **Increased Test Accuracy:** Tests now accurately reflect the HTTP request lifecycle.
* **Improved Code Maintainability:**  Centralized assertions reduce redundancy and simplify test updates.
* **Enhanced Testability:** Enables easier testing of middleware and other HTTP-related components.

**Future Work:**

*  This refactor facilitates the implementation of the auth middleware in a subsequent PR. Needed for the saved searches work.