### PR TITLE
Fix 500 error bugs - 2025-01-27

### DIFF
--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -1171,6 +1171,9 @@ func TestParseQueryBadInput(t *testing.T) {
 		{
 			input: "snapshot:",
 		},
+		{
+			input: "available_date:chrome",
+		},
 		// Other input from https://github.com/GoogleChrome/webstatus.dev/issues/286
 		{
 			// nolint:lll // WONTFIX. Repro from issue.
@@ -1187,6 +1190,10 @@ func TestParseQueryBadInput(t *testing.T) {
 		},
 		{
 			input: `baseline_date:12-26-2024..1-2-2025`,
+		},
+		// Other input from 2025-01-27 weekly review
+		{
+			input: `available_on:chrome -available_date:chrome available_on:safari`,
 		},
 	}
 	for _, tc := range testCases {

--- a/lib/gcpspanner/searchtypes/features_search_visitor.go
+++ b/lib/gcpspanner/searchtypes/features_search_visitor.go
@@ -259,8 +259,14 @@ func (v *FeaturesSearchVisitor) VisitAvailable_date_term(ctx *parser.Available_d
 
 func (v *FeaturesSearchVisitor) VisitAvailableBrowserDateTerm(
 	ctx parser.IDate_range_queryContext, browserName string) interface{} {
-	startDate := ctx.GetStartDate().GetText()
-	endDate := ctx.GetEndDate().GetText()
+	startDate := ctx.GetStartDate()
+	endDate := ctx.GetEndDate()
+
+	if startDate == nil || endDate == nil {
+		v.addError(termMissingRangeValueError{term: IdentifierAvailableBrowserDate})
+
+		return nil
+	}
 
 	// Create two nodes for start and end dates
 	startDateNode := &SearchNode{
@@ -284,7 +290,7 @@ func (v *FeaturesSearchVisitor) VisitAvailableBrowserDateTerm(
 				Keyword: KeywordNone,
 				Term: &SearchTerm{
 					Identifier: IdentifierAvailableDate,
-					Value:      startDate,
+					Value:      startDate.GetText(),
 					Operator:   OperatorGtEq,
 				},
 				Children: nil,
@@ -313,7 +319,7 @@ func (v *FeaturesSearchVisitor) VisitAvailableBrowserDateTerm(
 				Keyword: KeywordNone,
 				Term: &SearchTerm{
 					Identifier: IdentifierAvailableDate,
-					Value:      endDate,
+					Value:      endDate.GetText(),
 					Operator:   OperatorLtEq,
 				},
 				Children: nil,


### PR DESCRIPTION
This commit contains changes to fix errors during the weekly review of the 500 errors.

This week:
- When a non date range is given for available_date, the node was nil (even though the type is not a pointer). When we tried to read GetText() of the node, it fails and returns a 500 error. This change does a nil check first.