### PR TITLE
Fix enum URL for histograms

### DIFF
--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher.go
@@ -42,7 +42,8 @@ type ChromiumCodesearchEnumFetcher struct {
 	enumURL    *url.URL
 }
 
-const enumURL = "https://chromium.googlesource.com/chromium/src/+/main/tools/metrics/histograms/enums.xml?format=TEXT"
+const enumURL = "https://chromium.googlesource.com/chromium/src/+/main/tools/metrics/histograms/metadata/blink/" +
+	"enums.xml?format=TEXT"
 
 func (f ChromiumCodesearchEnumFetcher) Fetch(ctx context.Context) (io.ReadCloser, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.enumURL.String(), nil)

--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher_test.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -50,5 +51,12 @@ func TestChromiumCodesearchEnumFetcher_Fetch_Base64Encoded(t *testing.T) {
 	b, err := base64.StdEncoding.DecodeString(fetchedData)
 	if err != nil {
 		t.Errorf("Fetched data is not valid base64: %v\nData:\n%s", err, string(b))
+	}
+
+	// Quick sanity check that it contains the WebDX histogram.
+	// Example of it moving:
+	// https://chromium.googlesource.com/chromium/src/+/5d15720921afb24de54a64b766138c45962cbcef
+	if !strings.Contains(string(b), "WebDXFeatureObserver") {
+		t.Error("enum file does not contain WebDXFeatureObserver histogram")
 	}
 }


### PR DESCRIPTION
Background: https://github.com/GoogleChrome/chromium-dashboard/pull/4740

Dashboard reported a failure:

![image](https://github.com/user-attachments/assets/05075e05-1161-4ebf-97c1-5d889969dd8e)

![image](https://github.com/user-attachments/assets/027f4153-5e84-49bb-996a-6aa7e677fba6)

