### PR TITLE
feat: Add saved search endpoints and refine API design [1/4]

### DIFF
--- a/backend/pkg/httpserver/list_saved_searches.go
+++ b/backend/pkg/httpserver/list_saved_searches.go
@@ -22,52 +22,44 @@ import (
 )
 
 func getSavedSearches() []backend.SavedSearchResponse {
-	ownerStatus1 := backend.SavedSearchResponseOwnerStatusNone
-	subscribeStatus1 := backend.SavedSearchResponseSubscriptionStatusActive
-	ownerStatus2 := backend.SavedSearchResponseOwnerStatusAdmin
-	subscribeStatus2 := backend.SavedSearchResponseSubscriptionStatusNone
-	ownerStatus3 := backend.SavedSearchResponseOwnerStatusNone
-	subscribeStatus3 := backend.SavedSearchResponseSubscriptionStatusNone
+	test1Description := "test"
 
 	return []backend.SavedSearchResponse{
 		{
-			CreatedAt:          time.Date(2024, time.September, 1, 1, 0, 0, 0, time.UTC),
-			UpdatedAt:          nil,
-			Id:                 "1",
-			Name:               "a query I subscribe to",
-			Query:              "group:css",
-			OwnerStatus:        &ownerStatus1,
-			SubscriptionStatus: &subscribeStatus1,
+			CreatedAt:   time.Date(2024, time.September, 1, 1, 0, 0, 0, time.UTC),
+			UpdatedAt:   time.Date(2024, time.September, 1, 1, 0, 0, 0, time.UTC),
+			Description: &test1Description,
+			Id:          "1",
+			Name:        "a query I subscribe to",
+			Query:       "group:css",
 		},
 		{
-			CreatedAt:          time.Date(2024, time.September, 1, 1, 0, 0, 0, time.UTC),
-			UpdatedAt:          nil,
-			Id:                 "2",
-			Name:               "my personal query",
-			Query:              "available_on:chrome AND group:css",
-			OwnerStatus:        &ownerStatus2,
-			SubscriptionStatus: &subscribeStatus2,
+			CreatedAt:   time.Date(2024, time.September, 1, 1, 0, 0, 0, time.UTC),
+			UpdatedAt:   time.Date(2024, time.September, 1, 1, 0, 0, 0, time.UTC),
+			Description: nil,
+			Id:          "2",
+			Name:        "my personal query",
+			Query:       "available_on:chrome AND group:css",
 		},
 		{
-			CreatedAt:          time.Date(2024, time.September, 1, 1, 0, 0, 0, time.UTC),
-			UpdatedAt:          nil,
-			Id:                 "3",
-			Name:               "a new query",
-			Query:              "available_on:chrome",
-			OwnerStatus:        &ownerStatus3,
-			SubscriptionStatus: &subscribeStatus3,
+			CreatedAt:   time.Date(2024, time.September, 1, 1, 0, 0, 0, time.UTC),
+			UpdatedAt:   time.Date(2024, time.September, 1, 1, 0, 0, 0, time.UTC),
+			Description: nil,
+			Id:          "3",
+			Name:        "a new query",
+			Query:       "available_on:chrome",
 		},
 	}
 }
 
-// ListSavedSearches implements backend.StrictServerInterface.
+// ListUserSavedSearches implements backend.StrictServerInterface.
 // nolint:ireturn // Expected ireturn for openapi generation.
-func (s *Server) ListSavedSearches(
-	_ context.Context, _ backend.ListSavedSearchesRequestObject) (
-	backend.ListSavedSearchesResponseObject, error) {
+func (s *Server) ListUserSavedSearches(
+	_ context.Context, _ backend.ListUserSavedSearchesRequestObject) (
+	backend.ListUserSavedSearchesResponseObject, error) {
 	searches := getSavedSearches()
 
-	return backend.ListSavedSearches200JSONResponse{
+	return backend.ListUserSavedSearches200JSONResponse{
 		Metadata: nil,
 		Data:     &searches,
 	}, nil

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -103,6 +103,71 @@ type Server struct {
 	wptMetricsStorer WPTMetricsStorer
 }
 
+// RemoveSavedSearch implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Name generated from openapi
+func (s *Server) RemoveSavedSearch(
+	ctx context.Context, request backend.RemoveSavedSearchRequestObject) (
+	backend.RemoveSavedSearchResponseObject, error) {
+	return backend.RemoveSavedSearch400JSONResponse{
+		Code:    http.StatusBadRequest,
+		Message: "TODO",
+	}, nil
+}
+
+// UpdateSavedSearch implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Name generated from openapi
+func (s *Server) UpdateSavedSearch(
+	ctx context.Context, request backend.UpdateSavedSearchRequestObject) (
+	backend.UpdateSavedSearchResponseObject, error) {
+	return backend.UpdateSavedSearch400JSONResponse{
+		Code:    http.StatusBadRequest,
+		Message: "TODO",
+	}, nil
+}
+
+// CreateSavedSearch implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Name generated from openapi
+func (s *Server) CreateSavedSearch(ctx context.Context, request backend.CreateSavedSearchRequestObject) (
+	backend.CreateSavedSearchResponseObject, error) {
+	return backend.CreateSavedSearch400JSONResponse{
+		Code:    http.StatusBadRequest,
+		Message: "TODO",
+	}, nil
+}
+
+// GetUserSavedSearchBookmark implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Name generated from openapi
+func (s *Server) GetUserSavedSearchBookmark(
+	ctx context.Context, request backend.GetUserSavedSearchBookmarkRequestObject) (
+	backend.GetUserSavedSearchBookmarkResponseObject, error) {
+	return backend.GetUserSavedSearchBookmark400JSONResponse{
+		Code:    http.StatusBadRequest,
+		Message: "TODO",
+	}, nil
+}
+
+// PutUserSavedSearchBookmark implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Name generated from openapi
+func (s *Server) PutUserSavedSearchBookmark(
+	ctx context.Context, request backend.PutUserSavedSearchBookmarkRequestObject) (
+	backend.PutUserSavedSearchBookmarkResponseObject, error) {
+	return backend.PutUserSavedSearchBookmark400JSONResponse{
+		Code:    http.StatusBadRequest,
+		Message: "TODO",
+	}, nil
+}
+
+// RemoveUserSavedSearchBookmark implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Name generated from openapi
+func (s *Server) RemoveUserSavedSearchBookmark(
+	ctx context.Context, request backend.RemoveUserSavedSearchBookmarkRequestObject) (
+	backend.RemoveUserSavedSearchBookmarkResponseObject, error) {
+	return backend.RemoveUserSavedSearchBookmark400JSONResponse{
+		Code:    http.StatusBadRequest,
+		Message: "TODO",
+	}, nil
+}
+
 func defaultBrowsers() []backend.BrowserPathParam {
 	return []backend.BrowserPathParam{
 		backend.Chrome,

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -617,7 +617,7 @@ paths:
       operationId: removeUserSavedSearchBookmark
       responses:
         '204':
-          description: No content
+          description: No Content
         '400':
           description: Bad Input
           content:

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -460,17 +460,237 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasicErrorModel'
-  /v1/saved-searches:
+  /v1/users/me/saved-searches:
     get:
-      summary: List saved searches
-      operationId: listSavedSearches
+      summary: List user saved searches
+      operationId: listUserSavedSearches
+      parameters:
+        - $ref: '#/components/parameters/paginationTokenParam'
+        - $ref: '#/components/parameters/paginationSizeParam'
+        - in: query
+          name: role
+          schema:
+            type: string
+            enum:
+              - owner
+          description: Filter by role (currently only 'owner' is supported).
+        - in: query
+          name: bookmark_status
+          schema:
+            type: string
+            enum:
+              - active
+          description: Filter by bookmark status (currently only 'active' is supported).
+        - in: query
+          name: sort
+          schema:
+            type: string
+            enum:
+              - search_updated_at_asc
+              - search_updated_at_desc
+          description: Sort order to apply to the results.
+      security:
+        - bearerAuth:
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SavedSearchPage'
+                $ref: '#/components/schemas/UserSavedSearchPage'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+  /v1/users/me/saved-searches/{search_id}/bookmark_status:
+    parameters:
+      - name: search_id
+        in: path
+        description: Saved Search ID
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get a user's bookmark status
+      operationId: getUserSavedSearchBookmark
+      security:
+        - bearerAuth:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSavedSearchBookmark'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found (saved search does not exist)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+    put:
+      summary: Add bookmark status for a particular saved search.
+      operationId: putUserSavedSearchBookmark
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserSavedSearchBookmark'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found (saved search does not exist)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+    delete:
+      summary: Remove bookmark status for a particular saved search.
+      operationId: removeUserSavedSearchBookmark
+      responses:
+        '204':
+          description: No content
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found (saved search does not exist)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+  /v1/saved-searches:
+    post:
+      summary: Create a saved search
+      operationId: createSavedSearch
+      security:
+        - bearerAuth:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SavedSearch'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedSearchResponse'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
   /v1/saved-searches/{search_id}:
     parameters:
       - name: search_id
@@ -491,6 +711,84 @@ paths:
                 $ref: '#/components/schemas/SavedSearchResponse'
         '404':
           description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+    patch:
+      operationId: updateSavedSearch
+      security:
+        - bearerAuth:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SavedSearchUpdateRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavedSearchResponse'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+    delete:
+      operationId: removeSavedSearch
+      security:
+        - bearerAuth:
+      responses:
+        '204':
+          description: No Content (successful deletion)
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
           content:
             application/json:
               schema:
@@ -797,39 +1095,57 @@ components:
       required:
         - id
         - created_at
+        - updated_at
     SavedSearch:
       type: object
+      description: |
+        Represents a saved search with a name and a query.
+        Both `name` and `query` are required when creating a new saved search.
       properties:
         name:
           type: string
+          minLength: 1
+        description:
+          type: string
+          minLength: 1
         query:
           type: string
+          minLength: 1
       required:
         - name
         - query
+    SavedSearchUpdateRequest:
+      type: object
+      description: |
+        Represents the data required to update a saved search.
+        Only the fields that need to be modified need to be included in the request.
+      properties:
+        name:
+          type: string
+          minLength: 1
+        description:
+          type: string
+          minLength: 1
+        query:
+          type: string
+          minLength: 1
+    UserSavedSearchBookmark:
+      type: object
+      properties:
+        status:
+          type: string
+          description: |
+            The bookmark status for a saved search for a user.
+          enum:
+            - none
+            - active
+      required:
+        - status
     SavedSearchResponse:
       allOf:
         - $ref: '#/components/schemas/GenericUpdatableUniqueModel'
         - $ref: '#/components/schemas/SavedSearch'
-        - type: object
-          properties:
-            subscription_status:
-              type: string
-              description: |
-                The subscription status for a saved search for a user.
-                This field is only populated when the request is authenticated.
-              enum:
-                - none
-                - active
-            owner_status:
-              type: string
-              description: |
-                The owner status for a saved search for a user.
-                This field is only populated when the request is authenticated.
-              enum:
-                - none
-                - admin
-    SavedSearchPage:
+    UserSavedSearchPage:
       type: object
       properties:
         metadata:
@@ -904,3 +1220,8 @@ components:
           properties:
             rootCause:
               type: string
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT


### PR DESCRIPTION
This commit introduces new endpoints for managing saved searches and refines the existing saved searches API design for consistency and clarity.

To better organize the API, endpoints are grouped into two primary namespaces:

* `/v1/saved-searches`: This namespace focuses on the saved search resource itself and includes endpoints for creating (`POST`) and updating (`PATCH`) saved searches. This structure reflects that these actions operate directly on the saved search, regardless of ownership or user context.

* `/v1/users/me/saved-searches`: This namespace focuses on user-specific actions related to saved searches. It includes endpoints for listing saved searches (`GET`) and managing bookmarks (`GET`, `PUT`, `DELETE`). This grouping emphasizes the user's interaction with and management of saved searches.

Key changes:

* Endpoints:
    * Added `POST /v1/saved-searches` to create a new saved search.
    * Added `PATCH /v1/saved-searches/{search_id}` to update an existing saved search.
    * Added `DELETE /v1/saved-searches/{search_id}` to delete a saved search.
    * Added `GET /v1/users/me/saved-searches/{search_id}/bookmark_status` to retrieve a user's bookmark status for a saved search.
      * When retrieving a bookmark status a `404 Not Found` is returned only if the saved search itself does not exist. If the search exists but doesn't have an active bookmark, a `200 OK` response with a `status: none` is returned instead. This distinction provides a more accurate representation of the saved search's bookmark status, clarifying whether the search is missing entirely or simply unbookmarked.
    * Added `PUT /v1/users/me/saved-searches/{search_id}/bookmark_status` to add a bookmark for a saved search.
    * Added `DELETE /v1/users/me/saved-searches/{search_id}/bookmark_status` to remove a bookmark for a saved search.
    * Changed `GET /v1/saved-searches` to GET /v1/users/me/saved-searches` to retrieve a user's owned or bookmarked saved searches

* Components:
    * Modified `SavedSearch` component to contain the optional description field.
    * Added `SavedSearchUpdateRequest` component for partial updates to saved searches.
    * Added `UserSavedSearchBookmark` to represent the status of a bookmark.
    * Added `GenericUpdatableUniqueModel` for reusability.

Other changes:
* Added placeholder implementations for each endpoint.