### PR TITLE
Factor in ExcludedFeatureKeys for aggregation calls

### DIFF
--- a/lib/gcpspanner/browser_feature_count.go
+++ b/lib/gcpspanner/browser_feature_count.go
@@ -54,19 +54,25 @@ func (c *Client) ListBrowserFeatureCountMetric(
 
 	txn := c.ReadOnlyTransaction()
 	defer txn.Close()
-	// 1. Calculate initial cumulative count
-	cumulativeCount, err := c.getInitialBrowserFeatureCount(ctx, txn, parsedToken, browser, startAt)
+	// 1. Get excluded feature IDs
+	excludedFeatureIDs, err := c.getFeatureIDsForEachExcludedFeatureKey(ctx, txn)
+	if err != nil {
+		return nil, err
+	}
+	// 2. Calculate initial cumulative count
+	cumulativeCount, err := c.getInitialBrowserFeatureCount(ctx, txn, parsedToken, browser, startAt, excludedFeatureIDs)
 	if err != nil {
 		return nil, errors.Join(ErrInternalQueryFailure, err)
 	}
 
-	// 2. Process results and update cumulative count
+	// 3. Process results and update cumulative count
 	stmt := createListBrowserFeatureCountMetricStatement(
 		browser,
 		startAt,
 		endAt,
 		pageSize,
 		parsedToken,
+		excludedFeatureIDs,
 	)
 	it := txn.Query(ctx, stmt)
 	defer it.Stop()
@@ -109,28 +115,41 @@ func (c *Client) getInitialBrowserFeatureCount(
 	txn *spanner.ReadOnlyTransaction,
 	parsedToken *BrowserFeatureCountCursor,
 	browser string,
-	startAt time.Time) (int64, error) {
+	startAt time.Time,
+	excludedFeatureIDs []string) (int64, error) {
 	// For pagination, we have the existing count. Return early.
 	if parsedToken != nil {
 		return parsedToken.LastCumulativeCount, nil
 	}
+
+	params := map[string]interface{}{
+		"browserName": browser,
+		"startAt":     startAt,
+	}
+
+	var excludedFeatureFilter string
+	if len(excludedFeatureIDs) > 0 {
+		excludedFeatureFilter = `
+            AND WebFeatureID NOT IN UNNEST(@excludedFeatureIDs)`
+		params["excludedFeatureIDs"] = excludedFeatureIDs
+	}
+
 	// On the initial page, we need to get the sum of all the features before the start.
 	var initialCount int64
 	err := txn.Query(ctx, spanner.Statement{
-		SQL: `SELECT COALESCE(SUM(daily_feature_count), 0)
+		SQL: fmt.Sprintf(`SELECT COALESCE(SUM(daily_feature_count), 0)
 					FROM (
 						SELECT COUNT(DISTINCT WebFeatureID) AS daily_feature_count
-						FROM BrowserFeatureAvailabilities bfa
-						JOIN BrowserReleases
-						ON bfa.BrowserName = BrowserReleases.BrowserName
-						AND bfa.BrowserVersion = BrowserReleases.BrowserVersion
+						FROM BrowserReleases br
+						LEFT JOIN BrowserFeatureAvailabilities bfa
+						ON bfa.BrowserName = br.BrowserName
+						AND bfa.BrowserVersion = br.BrowserVersion
+						%s
 						WHERE bfa.BrowserName = @browserName AND ReleaseDate < @startAt
 						GROUP BY ReleaseDate
 					)`,
-		Params: map[string]interface{}{
-			"browserName": browser,
-			"startAt":     startAt,
-		},
+			excludedFeatureFilter),
+		Params: params,
 	}).Do(func(r *spanner.Row) error {
 		return r.Column(0, &initialCount)
 	})
@@ -144,6 +163,7 @@ func createListBrowserFeatureCountMetricStatement(
 	endAt time.Time,
 	pageSize int,
 	pageToken *BrowserFeatureCountCursor,
+	excludedFeatureIDs []string,
 ) spanner.Statement {
 	params := map[string]interface{}{
 		"browserName": browser,
@@ -159,12 +179,18 @@ func createListBrowserFeatureCountMetricStatement(
 		params["lastReleaseDate"] = pageToken.LastReleaseDate
 	}
 
+	var excludedFeatureFilter string
+	if len(excludedFeatureIDs) > 0 {
+		params["excludedFeatureIDs"] = excludedFeatureIDs
+		excludedFeatureFilter = "AND bfa.WebFeatureID NOT IN UNNEST(@excludedFeatureIDs)"
+	}
+
 	// Construct the query
 	// This query selects the 'ReleaseDate' and the feature counts for each release date.
 	query := fmt.Sprintf(`
 SELECT
     BrowserReleases.ReleaseDate AS ReleaseDate,
-    COUNT(DISTINCT WebFeatureID) AS FeatureCount
+    COUNT(DISTINCT CASE WHEN bfa.WebFeatureID IS NOT NULL %s THEN bfa.WebFeatureID ELSE NULL END) AS FeatureCount
 FROM BrowserFeatureAvailabilities bfa
 JOIN BrowserReleases
 ON bfa.BrowserName = BrowserReleases.BrowserName
@@ -177,7 +203,7 @@ WHERE
 GROUP BY ReleaseDate
 ORDER BY ReleaseDate ASC
 LIMIT @pageSize
-`, pageFilter)
+`, excludedFeatureFilter, pageFilter)
 
 	stmt := spanner.NewStatement(query)
 	stmt.Params = params

--- a/lib/gcpspanner/excluded_feature_keys.go
+++ b/lib/gcpspanner/excluded_feature_keys.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func (c *Client) getFeatureIDsForEachExcludedFeatureKey(ctx context.Context, txn *spanner.ReadOnlyTransaction) (
+	[]string, error) {
+	var featureIDs []string
+	stmt := spanner.NewStatement(`SELECT wf.ID FROM ExcludedFeatureKeys efk
+		INNER JOIN WebFeatures wf ON wf.FeatureKey = efk.FeatureKey`)
+
+	iter := txn.Query(ctx, stmt)
+	defer iter.Stop()
+
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+
+		var featureID string
+		if err := row.Columns(&featureID); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+
+		featureIDs = append(featureIDs, featureID)
+	}
+
+	return featureIDs, nil
+}

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -2615,3 +2615,13 @@ func (c *Client) InsertExcludedFeatureKey(ctx context.Context, featureKey string
 
 	return err
 }
+
+func (c *Client) ClearExcludedFeatureKeys(ctx context.Context) error {
+	_, err := c.ReadWriteTransaction(ctx, func(_ context.Context, txn *spanner.ReadWriteTransaction) error {
+		mutation := spanner.Delete("ExcludedFeatureKeys", spanner.AllKeys())
+
+		return txn.BufferWrite([]*spanner.Mutation{mutation})
+	})
+
+	return err
+}


### PR DESCRIPTION
Unlike feature-specific statistic Spanner calls, the aggregation calls (`ListBrowserFeatureCountMetric`, `ListMissingOneImplCounts`) account for all features but do not consider the `ExcludedFeatureKeys` table.

This table contains manually entered human-readable feature keys that should be excluded from the calculations.

This change addresses this by:

1. Retrieving the Spanner UUIDs for each feature key in the `ExcludedFeatureKeys` table.
2. Filtering out these excluded features during the count calculations in the `ListBrowserFeatureCountMetric` and `ListMissingOneImplCounts` functions.

This improvement ensures that the aggregation calls accurately reflect the desired feature counts by excluding manually specified features.

Note: There is one more aggregation call that needs this treatment but is not currently used (not part of the stats page). We can address it in a future PR. This change focuses on the calls actively used on the stats page as part of #1102.