### PR TITLE
feat: Expose ListBaselineStatusCount in OpenAPI spec

### DIFF
--- a/backend/pkg/httpserver/list_aggregated_baseline_status_counts.go
+++ b/backend/pkg/httpserver/list_aggregated_baseline_status_counts.go
@@ -1,0 +1,33 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// ListAggregatedBaselineStatusCounts implements backend.StrictServerInterface.
+// nolint: revive, ireturn // Name generated from openapi
+func (s *Server) ListAggregatedBaselineStatusCounts(
+	ctx context.Context, request backend.ListAggregatedBaselineStatusCountsRequestObject) (
+	backend.ListAggregatedBaselineStatusCountsResponseObject, error) {
+	return backend.ListAggregatedBaselineStatusCounts400JSONResponse{
+		Code:    http.StatusBadRequest,
+		Message: "TODO",
+	}, nil
+}

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -469,6 +469,16 @@ type mockServerInterface struct {
 	callCount         int
 }
 
+// ListAggregatedBaselineStatusCounts implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) ListAggregatedBaselineStatusCounts(
+	ctx context.Context, _ backend.ListAggregatedBaselineStatusCountsRequestObject) (
+	backend.ListAggregatedBaselineStatusCountsResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
 // CreateSavedSearch implements backend.StrictServerInterface.
 // nolint: ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) CreateSavedSearch(ctx context.Context, _ backend.CreateSavedSearchRequestObject) (

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -460,6 +460,48 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasicErrorModel'
+  /v1/stats/baseline_status/low_date_feature_counts:
+    get:
+      summary: >
+        Returns the count of features supported that have reached baseline
+        according to the specified date type (currently only low_date).
+      operationId: listAggregatedBaselineStatusCounts
+      parameters:
+        - $ref: '#/components/parameters/startAtParam'
+        - $ref: '#/components/parameters/endAtParam'
+        - $ref: '#/components/parameters/paginationTokenParam'
+        - $ref: '#/components/parameters/paginationSizeParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BaselineStatusMetricsPage'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '429':
+          description: Rate Limit
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
   /v1/users/me/saved-searches:
     get:
       summary: List user saved searches
@@ -901,6 +943,31 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BrowserReleaseFeatureMetric'
+      required:
+        - data
+    BaselineStatusMetric:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        count:
+          type: integer
+          description: Total count of features.
+          format: int64
+      required:
+        # For now, only require timestamp in case the definition
+        # of the metric needs to change. Similar to WPTRunMetric.
+        - timestamp
+    BaselineStatusMetricsPage:
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/PageMetadata'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/BaselineStatusMetric'
       required:
         - data
     WPTRunMetric:


### PR DESCRIPTION
Depends on #1132 

This PR updates the OpenAPI documentation to reflect the new /v1/stats/baseline_status/low_date_feature_counts endpoint.

This endpoint will return a paginated list of baseline status metrics, providing the count of features that have reached low baseline over time.

Next Steps:

- Implement the corresponding HTTP handler function to handle requests to this endpoint.
- Connect the handler function to the ListBaselineStatusCount Spanner logic implemented in the previous PR.
- Add appropriate error handling and logging to the handler.

This PR lays the groundwork for exposing the baseline status count functionality through the API.