### PR TITLE
Add http logic for ListBaselineStatusCounts

### DIFF
--- a/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
+++ b/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
@@ -1,0 +1,177 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestListAggregatedBaselineStatusCounts(t *testing.T) {
+	testCases := []struct {
+		name              string
+		mockConfig        MockListBaselineStatusCountsConfig
+		expectedCallCount int
+		request           *http.Request
+		expectedResponse  *http.Response
+	}{
+		{
+			name: "Success Case - no optional params - use defaults",
+			mockConfig: MockListBaselineStatusCountsConfig{
+				expectedStartAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:     time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				pageToken:         nil,
+				err:               nil,
+				page: &backend.BaselineStatusMetricsPage{
+					Metadata: &backend.PageMetadata{
+						NextPageToken: nil,
+					},
+					Data: []backend.BaselineStatusMetric{
+						{
+							Count:     valuePtr[int64](10),
+							Timestamp: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+						},
+						{
+							Count:     valuePtr[int64](9),
+							Timestamp: time.Date(2000, time.January, 9, 0, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+			},
+			expectedCallCount: 1,
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"count":10,
+			"timestamp":"2000-01-10T00:00:00Z"
+		},
+		{
+			"count":9,
+			"timestamp":"2000-01-09T00:00:00Z"
+		}
+	],
+	"metadata":{
+
+	}
+}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/baseline_status/low_date_feature_counts?"+
+					"startAt=2000-01-01&endAt=2000-01-10", nil),
+		},
+		{
+			name: "Success Case - include optional params",
+			mockConfig: MockListBaselineStatusCountsConfig{
+				expectedStartAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:     time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:  50,
+				expectedPageToken: inputPageToken,
+				err:               nil,
+				page: &backend.BaselineStatusMetricsPage{
+					Metadata: &backend.PageMetadata{
+						NextPageToken: nextPageToken,
+					},
+					Data: []backend.BaselineStatusMetric{
+						{
+							Count:     valuePtr[int64](10),
+							Timestamp: time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+						},
+						{
+							Count:     valuePtr[int64](9),
+							Timestamp: time.Date(2000, time.January, 9, 0, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+				pageToken: nextPageToken,
+			},
+			expectedCallCount: 1,
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"count":10,
+			"timestamp":"2000-01-10T00:00:00Z"
+		},
+		{
+			"count":9,
+			"timestamp":"2000-01-09T00:00:00Z"
+		}
+	],
+	"metadata":{
+		"next_page_token":"next-page-token"
+	}
+}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/baseline_status/low_date_feature_counts?"+
+					"startAt=2000-01-01&endAt=2000-01-10&page_size=50&page_token="+*inputPageToken, nil),
+		},
+		{
+			name: "500 case",
+			mockConfig: MockListBaselineStatusCountsConfig{
+				expectedStartAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:     time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				page:              nil,
+				pageToken:         nil,
+				err:               errTest,
+			},
+			expectedCallCount: 1,
+			expectedResponse: testJSONResponse(
+				500, `{"code":500,"message":"unable to get missing one implementation metrics"}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/baseline_status/low_date_feature_counts?"+
+					"startAt=2000-01-01&endAt=2000-01-10", nil),
+		},
+		{
+			name: "400 case - invalid page token",
+			mockConfig: MockListBaselineStatusCountsConfig{
+				expectedStartAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedEndAt:     time.Date(2000, time.January, 10, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:  100,
+				expectedPageToken: badPageToken,
+				page:              nil,
+				pageToken:         nil,
+				err:               backendtypes.ErrInvalidPageToken,
+			},
+			expectedCallCount: 1,
+			expectedResponse:  testJSONResponse(400, `{"code":400,"message":"invalid page token"}`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/baseline_status/low_date_feature_counts?"+
+					"startAt=2000-01-01&endAt=2000-01-10&page_token"+*badPageToken, nil),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// nolint: exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				listBaselineStatusCountsCfg: tc.mockConfig,
+				t:                           t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			assertMockCallCount(t, tc.expectedCallCount, mockStorer.callCountListBaselineStatusCounts,
+				"ListBaselineStatusCounts")
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -97,6 +97,13 @@ type WPTMetricsStorer interface {
 		pageSize int,
 		pageToken *string,
 	) (*backend.BrowserReleaseFeatureMetricsPage, error)
+	ListBaselineStatusCounts(
+		ctx context.Context,
+		startAt time.Time,
+		endAt time.Time,
+		pageSize int,
+		pageToken *string,
+	) (*backend.BaselineStatusMetricsPage, error)
 }
 
 type Server struct {

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -144,17 +144,29 @@ type MockListMissingOneImplCountsConfig struct {
 	err                   error
 }
 
+type MockListBaselineStatusCountsConfig struct {
+	expectedStartAt   time.Time
+	expectedEndAt     time.Time
+	expectedPageSize  int
+	expectedPageToken *string
+	pageToken         *string
+	page              *backend.BaselineStatusMetricsPage
+	err               error
+}
+
 type MockWPTMetricsStorer struct {
 	featureCfg                                        MockListMetricsForFeatureIDBrowserAndChannelConfig
 	aggregateCfg                                      MockListMetricsOverTimeWithAggregatedTotalsConfig
 	featuresSearchCfg                                 MockFeaturesSearchConfig
 	listBrowserFeatureCountMetricCfg                  MockListBrowserFeatureCountMetricConfig
 	listMissingOneImplCountCfg                        MockListMissingOneImplCountsConfig
+	listBaselineStatusCountsCfg                       MockListBaselineStatusCountsConfig
 	listChromiumDailyUsageStatsCfg                    MockListChromiumDailyUsageStatsConfig
 	getFeatureByIDConfig                              MockGetFeatureByIDConfig
 	getIDFromFeatureKeyConfig                         MockGetIDFromFeatureKeyConfig
 	t                                                 *testing.T
 	callCountListMissingOneImplCounts                 int
+	callCountListBaselineStatusCounts                 int
 	callCountListBrowserFeatureCountMetric            int
 	callCountFeaturesSearch                           int
 	callCountListChromiumDailyUsageStats              int
@@ -338,6 +350,27 @@ func (m *MockWPTMetricsStorer) ListMissingOneImplCounts(
 	}
 
 	return m.listMissingOneImplCountCfg.page, m.listMissingOneImplCountCfg.err
+}
+
+func (m *MockWPTMetricsStorer) ListBaselineStatusCounts(
+	_ context.Context,
+	startAt time.Time,
+	endAt time.Time,
+	pageSize int,
+	pageToken *string,
+) (*backend.BaselineStatusMetricsPage, error) {
+	m.callCountListBaselineStatusCounts++
+
+	if !startAt.Equal(m.listBaselineStatusCountsCfg.expectedStartAt) ||
+		!endAt.Equal(m.listBaselineStatusCountsCfg.expectedEndAt) ||
+		pageSize != m.listBaselineStatusCountsCfg.expectedPageSize ||
+		!reflect.DeepEqual(pageToken, m.listBaselineStatusCountsCfg.expectedPageToken) {
+
+		m.t.Errorf("Incorrect arguments. Expected: %v, Got: { %s, %s, %d %v }",
+			m.listBaselineStatusCountsCfg, startAt, endAt, pageSize, pageToken)
+	}
+
+	return m.listBaselineStatusCountsCfg.page, m.listBaselineStatusCountsCfg.err
 }
 
 func TestGetPageSizeOrDefault(t *testing.T) {


### PR DESCRIPTION
This change adds the logic to call the spanner adapter layer for ListBaselineStatusCounts

This is similar to ListMissingOneImplCounts (also used on the stats page)