### PR TITLE
Reduce Playwright Workers to 1 and Add SKIP_FRESH_ENV Option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,11 @@ license-fix:
 ################################
 # Playwright
 ################################
-fresh-env-for-playwright: playwright-install delete-local build deploy-local dev_fake_data dev_fake_users port-forward-manual
+# Set this variable to any non-empty value (e.g., SKIP_FRESH_ENV=1) to skip the
+# fresh-env-for-playwright prerequisite. If unset, the fresh environment will be created.
+SKIP_FRESH_ENV ?=
+
+fresh-env-for-playwright: $(if $(SKIP_FRESH_ENV),,playwright-install delete-local build deploy-local dev_fake_data dev_fake_users port-forward-manual)
 
 playwright-install:
 	npx playwright install --with-deps

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -56,7 +56,28 @@ Some lint errors can be fixed automatically. This command will try to fix all th
 
 Developers may still need to inspect and manually fix the error.
 
-## Run Playwright Tests
+## Playwright Tests
+
+### Note about running Playwright Makefile Targets
+
+If you have a running local development environment
+(established via `make start-local`) with the necessary fake data
+(`make dev_fake_data`), fake users (`make dev_fake_users`), and port forwarding
+(`make port-forward-manual`), you can expedite Playwright testing by skipping
+the environment setup.
+
+To do this, prefix your `make` command with `SKIP_FRESH_ENV=1`. This is
+particularly useful for rapid iteration, as `make start-local` leverages
+Skaffold to rebuild the application on file saves.
+
+For example: `make playwright-test` becomes `SKIP_FRESH_ENV=1 make playwright-test`.
+
+**Important:** Skipping the environment setup assumes your existing local
+environment is in a known good state. If inconsistencies arise, ensure you run
+the Playwright target without `SKIP_FRESH_ENV=1` to create a clean environment.
+This is the default behavior to guarantee a reliable testing environment.
+
+### Running Playwright Tests
 
 Run the following command to run the Playwright tests: `make playwright-test`.
 

--- a/e2e/tests/feature-page.spec.ts
+++ b/e2e/tests/feature-page.spec.ts
@@ -81,7 +81,7 @@ test('chart width resizes with window', async ({page}) => {
   await page.setViewportSize({width: narrowWidth, height});
   // We may be able to remove the following waitForTimeout after we address:
   // https://github.com/GoogleChrome/webstatus.dev/issues/278
-  await page.waitForTimeout(15000);
+  await page.waitForTimeout(2000);
   const newChartWidth3 = await chartContainer.evaluate(el => el.clientWidth);
   expect(newChartWidth3).toEqual(newChartWidth);
 

--- a/e2e/tests/overview-page.spec.ts
+++ b/e2e/tests/overview-page.spec.ts
@@ -18,7 +18,6 @@ import {test, expect} from '@playwright/test';
 import {gotoOverviewPageUrl, getOverviewPageFeatureCount} from './utils';
 
 test('matches the screenshot', async ({page}) => {
-  test.slow();
   await gotoOverviewPageUrl(page, 'http://localhost:5555/');
   const pageContainer = page.locator('.page-container');
   await expect(pageContainer).toHaveScreenshot();

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -56,11 +56,11 @@ export async function waitForOverviewPageLoad(page: Page) {
   // Wait for the loading indicator to disappear and be replaced (with timeout):
   await page
     .locator('webstatus-overview-content >> text=Loading features...')
-    .waitFor({state: 'hidden', timeout: 60000});
+    .waitFor({state: 'hidden', timeout: 15000});
 }
 
 export async function gotoOverviewPageUrl(page: Page, url: string) {
-  await page.goto(url, {timeout: 60000});
+  await page.goto(url);
 
   await waitForOverviewPageLoad(page);
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,8 +34,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Always run with one worker for increased stability. */
+  workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
_tl;dr_: No more manually setting CI=true for playwright commands.

This came up again in the developer sync this week and has been going on for awhile

This pull request introduces two key changes to improve the reliability and efficiency of Playwright tests in local development:

1.  **Reduce Playwright Workers to 1:**
    -  The number of Playwright workers has been consistently set to 1, regardless of the environment (local or CI).
    -  This change addresses potential resource contention and instability that can occur with multiple workers, particularly in local development environments.
    -  Consistently using one worker reduces the chance of flaky tests due to resource limitations.

2.  **Add `SKIP_FRESH_ENV=1` Option for Faster Local Iteration:**
    -  A new `SKIP_FRESH_ENV=1` option has been added to the Playwright `Makefile` targets.
    -  When this option is used (e.g., `SKIP_FRESH_ENV=1 make playwright-test`), the `fresh-env-for-playwright` prerequisite is skipped.
    -  This allows developers to quickly iterate on Playwright tests in local environments where the necessary dependencies and data have already been set up (via `make start-local`, `make dev_fake_data`, etc.).
    -  This is especially helpful when leveraging Skaffold's rapid rebuild capabilities.
    -  **Important:** This option should only be used when the local environment is known to be in a consistent state. The default behavior (without `SKIP_FRESH_ENV=1`) ensures a clean environment for reliable testing.

**Rationale:**

- Reducing the number of workers improves stability and consistency across environments.
- The `SKIP_FRESH_ENV=1` option accelerates local development cycles without sacrificing the reliability of clean environment testing when needed.

**Testing:**

- Playwright tests have been run with and without the `SKIP_FRESH_ENV=1` option to verify functionality.
- Local testing has been performed to ensure the worker count has been reduced.

**Documentation:**

-   Documentation has been updated to reflect the new `SKIP_FRESH_ENV=1` option and its usage.