### PR TITLE
Enhance `webstatus-gchart` with point selection events

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-gchart.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-gchart.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {assert, html} from '@open-wc/testing';
+import {assert, expect, html} from '@open-wc/testing';
 import '../../services/webstatus-gcharts-loader-service.js';
 import '../webstatus-gchart.js';
 import {type WebstatusGChart} from '../webstatus-gchart.js';
@@ -90,5 +90,75 @@ describe('webstatus-gchart', () => {
 
     // Assert that chartWrapper.draw was called
     assert.isTrue(drawSpy.calledOnce);
+  });
+
+  describe('Selection events', () => {
+    beforeEach(async () => {
+      // Set up the chart with some data and options
+      component.dataObj = {
+        cols: [
+          {type: 'date', label: 'Date', role: 'domain'},
+          {type: 'number', label: 'Value 1', role: 'data'},
+          {type: 'number', label: 'Value 2', role: 'data'},
+        ],
+        rows: [
+          [new Date('2024-01-01'), 10, 20],
+          [new Date('2024-01-02'), 20, 30],
+        ],
+      };
+      component.options = {};
+      await component.updateComplete;
+    });
+
+    it('dispatches point-selected event on data point click', async () => {
+      const chart =
+        component.chartWrapper!.getChart() as google.visualization.LineChart;
+      const dispatchEventSpy = sinon.spy(component, 'dispatchEvent');
+
+      // Simulate a click on the first data point of the second series ('Value 2')
+      chart.setSelection([{row: 0, column: 2}]);
+      google.visualization.events.trigger(chart, 'select');
+
+      await component.updateComplete;
+
+      expect(dispatchEventSpy).to.have.been.calledOnce;
+      const dispatchedEvent = dispatchEventSpy.getCall(0)
+        .args[0] as unknown as CustomEvent;
+      expect(dispatchedEvent.type).to.equal('point-selected');
+      expect(dispatchedEvent.detail).to.deep.equal({
+        label: 'Value 2',
+        timestamp: new Date('2024-01-01'),
+        value: 20,
+      });
+    });
+
+    it('dispatches point-deselected event on deselection', async () => {
+      const chart =
+        component.chartWrapper!.getChart() as google.visualization.LineChart;
+      const dispatchEventSpy = sinon.spy(component, 'dispatchEvent');
+
+      // Simulate a click to select a data point
+      chart.setSelection([{row: 0, column: 1}]);
+      google.visualization.events.trigger(chart, 'select');
+
+      // Simulate a click on an empty area to deselect
+      chart.setSelection([]);
+      google.visualization.events.trigger(chart, 'select');
+
+      // Assert that point-deselected was dispatched
+      expect(dispatchEventSpy).to.have.been.calledTwice; // Called for select and deselect
+      const selectEvent = dispatchEventSpy.getCall(0)
+        .args[0] as unknown as CustomEvent;
+      expect(selectEvent.type).to.equal('point-selected');
+      expect(selectEvent.detail).to.deep.equal({
+        label: 'Value 1',
+        timestamp: new Date('2024-01-01'),
+        value: 10,
+      });
+      const deselectEvent = dispatchEventSpy.getCall(1)
+        .args[0] as unknown as CustomEvent; // Get the second call (deselect)
+      expect(deselectEvent.type).to.equal('point-deselected');
+      expect(deselectEvent.detail).to.be.null;
+    });
   });
 });


### PR DESCRIPTION
This PR enhances the `webstatus-gchart` component by adding the ability to detect and dispatch events when data points on the chart are selected or deselected. This functionality enables parent components to react to user interactions with the chart and provide more context-specific information or actions.

**Key changes:**

* **`point-selected` and `point-deselected` events:** The component now dispatches these custom events when a data point is selected or deselected, respectively.
* **Event details:** The `point-selected` event provides details about the selected point, including the series `label`, `timestamp`, and `value`. The `point-deselected` event has no detail.
* **JSDoc updates:** The component's JSDoc comment is updated to include documentation for the new events.

This enhancement enables richer interactions with the `webstatus-gchart` component and allows for more dynamic and responsive data visualizations. It lays the groundwork for the `WebstatusLineChartPanel` abstract class to provide a callback mechanism for handling these events, as described in a separate PR.