### PR TITLE
Introduce operationResponseCache for Handler-Specific Caching

### DIFF
--- a/backend/pkg/httpserver/cache_test.go
+++ b/backend/pkg/httpserver/cache_test.go
@@ -1,0 +1,308 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
+)
+
+// MockRawBytesDataCacher is a mock implementation of RawBytesDataCacher for testing.
+type MockRawBytesDataCacher struct {
+	t                   *testing.T
+	expectedCacheCalls  []*ExpectedCacheCall
+	expectedGetCalls    []*ExpectedGetCall
+	actualCacheCalls    []*ActualCacheCall
+	actualGetCalls      []*ActualGetCall
+	currentCacheCallIdx int
+	currentGetCallIdx   int
+}
+
+// NewMockRawBytesDataCacher creates a new MockRawBytesDataCacher.
+func NewMockRawBytesDataCacher(
+	t *testing.T,
+	expectedCacheCalls []*ExpectedCacheCall,
+	expectedGetCalls []*ExpectedGetCall) *MockRawBytesDataCacher {
+	return &MockRawBytesDataCacher{
+		t:                   t,
+		expectedCacheCalls:  expectedCacheCalls,
+		expectedGetCalls:    expectedGetCalls,
+		actualCacheCalls:    []*ActualCacheCall{},
+		actualGetCalls:      []*ActualGetCall{},
+		currentCacheCallIdx: 0,
+		currentGetCallIdx:   0,
+	}
+}
+
+// Cache implements the Cache method of the RawBytesDataCacher interface.
+func (m *MockRawBytesDataCacher) Cache(_ context.Context, key string, value []byte) error {
+	if m.currentCacheCallIdx >= len(m.expectedCacheCalls) {
+		m.t.Errorf("unexpected call to Cache with key: %s", key)
+
+		return nil
+	}
+
+	expectedCall := m.expectedCacheCalls[m.currentCacheCallIdx]
+	if expectedCall.Key != key {
+		m.t.Errorf("expected Cache key: %s, got: %s", expectedCall.Key, key)
+	}
+	if !reflect.DeepEqual(expectedCall.Value, value) {
+		m.t.Errorf("expected Cache value: %v, got: %v", string(expectedCall.Value), string(value))
+	}
+
+	m.actualCacheCalls = append(m.actualCacheCalls, &ActualCacheCall{
+		Key:   key,
+		Value: value,
+	})
+	m.currentCacheCallIdx++
+
+	return nil
+}
+
+// Get implements the Get method of the RawBytesDataCacher interface.
+func (m *MockRawBytesDataCacher) Get(_ context.Context, key string) ([]byte, error) {
+	if m.currentGetCallIdx >= len(m.expectedGetCalls) {
+		m.t.Errorf("unexpected call to Get with key: %s", key)
+
+		return nil, nil
+	}
+
+	expectedCall := m.expectedGetCalls[m.currentGetCallIdx]
+	if expectedCall.Key != key {
+		m.t.Errorf("expected Get key: %s, got: %s", expectedCall.Key, key)
+	}
+
+	m.actualGetCalls = append(m.actualGetCalls, &ActualGetCall{
+		Key: key,
+	})
+
+	m.currentGetCallIdx++
+
+	return expectedCall.Value, expectedCall.Err
+}
+
+// AssertExpectations asserts that all expected calls were made.
+func (m *MockRawBytesDataCacher) AssertExpectations() {
+	if len(m.expectedCacheCalls) != m.currentCacheCallIdx {
+		m.t.Errorf("expected %d Cache calls, got %d", len(m.expectedCacheCalls), m.currentCacheCallIdx)
+		for i, expectedCall := range m.expectedCacheCalls {
+			if i < len(m.actualCacheCalls) {
+				actualCall := m.actualCacheCalls[i]
+				m.t.Errorf("Expected Cache Call: %+v, got: %+v \n", expectedCall, actualCall)
+			} else {
+				m.t.Errorf("Expected Cache Call: %+v\n", expectedCall)
+			}
+		}
+	}
+
+	if len(m.expectedGetCalls) != m.currentGetCallIdx {
+		m.t.Errorf("expected %d Get calls, got %d", len(m.expectedGetCalls), m.currentGetCallIdx)
+		for i, expectedCall := range m.expectedGetCalls {
+			if i < len(m.actualGetCalls) {
+				actualCall := m.actualGetCalls[i]
+				m.t.Errorf("Expected Get Call: %+v, got: %+v \n", expectedCall, actualCall)
+			} else {
+				m.t.Errorf("Expected Get Call: %+v\n", expectedCall)
+			}
+		}
+	}
+}
+
+// ExpectedCacheCall represents an expected call to Cache.
+type ExpectedCacheCall struct {
+	Key   string
+	Value []byte
+}
+
+// ActualCacheCall represents an actual call made to Cache.
+type ActualCacheCall struct {
+	Key   string
+	Value []byte
+}
+
+// ExpectedGetCall represents an expected call to Get.
+type ExpectedGetCall struct {
+	Key   string
+	Value []byte
+	Err   error
+}
+
+// ActualGetCall represents an actual call made to Get.
+type ActualGetCall struct {
+	Key string
+}
+
+// Test Types.
+type TestKey struct {
+	ID    string
+	Param string
+}
+
+type TestValue struct {
+	Name  string
+	Value int
+}
+
+func TestOperationResponseCache_AttemptCache(t *testing.T) {
+	testCases := []struct {
+		name               string
+		key                TestKey
+		value              *TestValue
+		expectedCacheCalls []*ExpectedCacheCall
+	}{
+		{
+			name: "Valid Cache Operation",
+			key: TestKey{
+				ID:    "test-id",
+				Param: "test-param",
+			},
+			value: &TestValue{
+				Name:  "Test Item",
+				Value: 123,
+			},
+			expectedCacheCalls: []*ExpectedCacheCall{
+				{
+					Key:   `customOperation-{"ID":"test-id","Param":"test-param"}`,
+					Value: []byte(`{"Name":"Test Item","Value":123}`),
+				},
+			},
+		},
+		{
+			name: "Nil value - should not cache",
+			key: TestKey{
+				ID:    "test-id",
+				Param: "test-param",
+			},
+			value:              nil,
+			expectedCacheCalls: []*ExpectedCacheCall{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, nil)
+			cache := operationResponseCache[
+				TestKey,
+				TestValue,
+			]{cacher: mockCacher, operationID: "customOperation"}
+
+			cache.AttemptCache(context.Background(), tc.key, tc.value)
+			mockCacher.AssertExpectations()
+		})
+	}
+}
+
+func TestOperationResponseCache_Lookup(t *testing.T) {
+	testCases := []struct {
+		name             string
+		key              TestKey
+		expectedGetCalls []*ExpectedGetCall
+		expectedResult   bool
+		expectedValue    *TestValue
+	}{
+		{
+			name: "Valid Lookup - Data Found",
+			key: TestKey{
+				ID:    "test-id",
+				Param: "test-param",
+			},
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key:   `customOperation-{"ID":"test-id","Param":"test-param"}`,
+					Value: []byte(`{"Name":"Test Item","Value":123}`),
+					Err:   nil,
+				},
+			},
+			expectedResult: true,
+			expectedValue: &TestValue{
+				Name:  "Test Item",
+				Value: 123,
+			},
+		},
+		{
+			name: "Lookup - Data Not Found",
+			key: TestKey{
+				ID:    "test-id",
+				Param: "test-param",
+			},
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key:   `customOperation-{"ID":"test-id","Param":"test-param"}`,
+					Value: nil,
+					Err:   cachetypes.ErrCachedDataNotFound,
+				},
+			},
+			expectedResult: false,
+			expectedValue:  nil,
+		},
+		{
+			name: "Lookup - Cache Error",
+			key: TestKey{
+				ID:    "test-id",
+				Param: "test-param",
+			},
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key:   `customOperation-{"ID":"test-id","Param":"test-param"}`,
+					Value: nil,
+					Err:   errors.New("some error"),
+				},
+			},
+			expectedResult: false,
+			expectedValue:  nil,
+		},
+		{
+			name: "Lookup - invalid cached value",
+			key: TestKey{
+				ID:    "test-id",
+				Param: "test-param",
+			},
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key:   `customOperation-{"ID":"test-id","Param":"test-param"}`,
+					Value: []byte(`invalid json`),
+					Err:   nil,
+				},
+			},
+			expectedResult: false,
+			expectedValue:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCacher := NewMockRawBytesDataCacher(t, nil, tc.expectedGetCalls)
+			cache := operationResponseCache[
+				TestKey,
+				TestValue,
+			]{cacher: mockCacher, operationID: "customOperation"}
+
+			var actualValue TestValue
+			result := cache.Lookup(context.Background(), tc.key, &actualValue)
+
+			if result != tc.expectedResult {
+				t.Errorf("Expected result %t, got %t", tc.expectedResult, result)
+			}
+			if tc.expectedResult && !reflect.DeepEqual(&actualValue, tc.expectedValue) {
+				t.Errorf("Expected value %v, got %v", tc.expectedValue, &actualValue)
+			}
+			mockCacher.AssertExpectations()
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces the operationResponseCache utility, a generic caching mechanism designed to simplify the management of cached operation results. This is a foundational step towards enabling individual HTTP handlers to manage their own caching logic.

Changes:

operationResponseCache struct:
- A new operationResponseCache struct is introduced in pkg/httpserver/cache.go.
- It provides a consistent way to cache and retrieve operation results, using a RawBytesDataCacher (e.g., Valkey) as its underlying storage mechanism.
- The operationID acts as a prefix for all cache keys, allowing for logical grouping of cached data per operation. This also enables future batch operations, such as bulk deletion of cache entries by prefix.
- It handles json serialization and deserialization of keys and values.

key method:
- Generates a cache key using the OpenAPI operationID as a prefix.

AttemptCache method:
- Caches an operation result (key-value pair).
- Serializes both the key and the value into JSON for storage.
- Logs errors during serialization or caching but doesn't return errors, ensuring that caching failures do not interrupt the main operation.

Lookup method:
- Retrieves a cached operation result by key.
- Serializes the given key into JSON to generate the cache key.
- Deserializes the cached value from JSON.
- Returns true if the value is found and successfully deserialized, false otherwise.
- Logs any errors encountered during key serialization, cache retrieval, or value deserialization, but doesn't return them, maintaining non-blocking behavior.
- When a cached key is not found, then false is returned.

In the future, we could allow configuring of custom cache durations as well.

This is part of a split up of https://github.com/GoogleChrome/webstatus.dev/compare/jcscottiii/fix-backend-cache?expand=1