### PR TITLE
Introduce `operationResponseCaches` struct

### DIFF
--- a/backend/pkg/httpserver/cache.go
+++ b/backend/pkg/httpserver/cache.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
 // operationResponseCache caches operation results using a RawBytesDataCacher.
@@ -106,4 +107,100 @@ func (c operationResponseCache[Key, Response]) Lookup(ctx context.Context, key K
 	}
 
 	return true
+}
+
+// operationResponseCaches is a struct that holds multiple instances of
+// operationResponseCache, each managing caching for a specific API operation.
+// Each operationResponseCache instance wraps the underlying RawBytesDataCacher
+// to provide type-safe caching and retrieval for its associated operation.
+type operationResponseCaches struct {
+	getFeatureCache operationResponseCache[
+		backend.GetFeatureRequestObject,
+		backend.GetFeature200JSONResponse,
+	]
+	listFeaturesCache operationResponseCache[
+		backend.ListFeaturesRequestObject,
+		backend.ListFeatures200JSONResponse,
+	]
+	getFeatureMetadataCache operationResponseCache[
+		backend.GetFeatureMetadataRequestObject,
+		backend.GetFeatureMetadata200JSONResponse,
+	]
+	listFeatureWPTMetricsCache operationResponseCache[
+		backend.ListFeatureWPTMetricsRequestObject,
+		backend.ListFeatureWPTMetrics200JSONResponse,
+	]
+	listChromiumDailyUsageStatsCache operationResponseCache[
+		backend.ListChromiumDailyUsageStatsRequestObject,
+		backend.ListChromiumDailyUsageStats200JSONResponse,
+	]
+	listAggregatedFeatureSupportCache operationResponseCache[
+		backend.ListAggregatedFeatureSupportRequestObject,
+		backend.ListAggregatedFeatureSupport200JSONResponse,
+	]
+	listMissingOneImplemenationCountsCache operationResponseCache[
+		backend.ListMissingOneImplemenationCountsRequestObject,
+		backend.ListMissingOneImplemenationCounts200JSONResponse,
+	]
+	listAggregatedWPTMetricsCache operationResponseCache[
+		backend.ListAggregatedWPTMetricsRequestObject,
+		backend.ListAggregatedWPTMetrics200JSONResponse,
+	]
+	listAggregatedBaselineStatusCountsCache operationResponseCache[
+		backend.ListAggregatedBaselineStatusCountsRequestObject,
+		backend.ListAggregatedBaselineStatusCounts200JSONResponse,
+	]
+}
+
+// initOperationResponseCaches initializes and configures each
+// operationResponseCache instance within the operationResponseCaches struct.
+// While each cache instance uses the same underlying RawBytesDataCacher for storage,
+// they operate independently and are specialized for their respective API operations.
+func initOperationResponseCaches(dataCacher RawBytesDataCacher) *operationResponseCaches {
+	return &operationResponseCaches{
+		getFeatureCache: operationResponseCache[
+			backend.GetFeatureRequestObject,
+			backend.GetFeature200JSONResponse,
+		]{cacher: dataCacher, operationID: "getFeature"},
+
+		listFeaturesCache: operationResponseCache[
+			backend.ListFeaturesRequestObject,
+			backend.ListFeatures200JSONResponse,
+		]{cacher: dataCacher, operationID: "listFeatures"},
+
+		getFeatureMetadataCache: operationResponseCache[
+			backend.GetFeatureMetadataRequestObject,
+			backend.GetFeatureMetadata200JSONResponse,
+		]{cacher: dataCacher, operationID: "getFeatureMetadata"},
+
+		listFeatureWPTMetricsCache: operationResponseCache[
+			backend.ListFeatureWPTMetricsRequestObject,
+			backend.ListFeatureWPTMetrics200JSONResponse,
+		]{cacher: dataCacher, operationID: "listFeatureWPTMetrics"},
+
+		listChromiumDailyUsageStatsCache: operationResponseCache[
+			backend.ListChromiumDailyUsageStatsRequestObject,
+			backend.ListChromiumDailyUsageStats200JSONResponse,
+		]{cacher: dataCacher, operationID: "listChromiumDailyUsageStats"},
+
+		listAggregatedFeatureSupportCache: operationResponseCache[
+			backend.ListAggregatedFeatureSupportRequestObject,
+			backend.ListAggregatedFeatureSupport200JSONResponse,
+		]{cacher: dataCacher, operationID: "listAggregatedFeatureSupport"},
+
+		listMissingOneImplemenationCountsCache: operationResponseCache[
+			backend.ListMissingOneImplemenationCountsRequestObject,
+			backend.ListMissingOneImplemenationCounts200JSONResponse,
+		]{cacher: dataCacher, operationID: "listMissingOneImplemenationCounts"},
+
+		listAggregatedWPTMetricsCache: operationResponseCache[
+			backend.ListAggregatedWPTMetricsRequestObject,
+			backend.ListAggregatedWPTMetrics200JSONResponse,
+		]{cacher: dataCacher, operationID: "listAggregatedWPTMetrics"},
+
+		listAggregatedBaselineStatusCountsCache: operationResponseCache[
+			backend.ListAggregatedBaselineStatusCountsRequestObject,
+			backend.ListAggregatedBaselineStatusCounts200JSONResponse,
+		]{cacher: dataCacher, operationID: "listAggregatedBaselineStatusCounts"},
+	}
 }

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -107,8 +107,9 @@ type WPTMetricsStorer interface {
 }
 
 type Server struct {
-	metadataStorer   WebFeatureMetadataStorer
-	wptMetricsStorer WPTMetricsStorer
+	metadataStorer          WebFeatureMetadataStorer
+	wptMetricsStorer        WPTMetricsStorer
+	operationResponseCaches *operationResponseCaches
 }
 
 // RemoveSavedSearch implements backend.StrictServerInterface.
@@ -220,13 +221,14 @@ func NewHTTPServer(
 	port string,
 	metadataStorer WebFeatureMetadataStorer,
 	wptMetricsStorer WPTMetricsStorer,
-	_ RawBytesDataCacher,
+	rawBytesDataCacher RawBytesDataCacher,
 	preRequestValidationMiddlewares []func(http.Handler) http.Handler,
 	authMiddleware func(http.Handler) http.Handler) *http.Server {
 	// Create an instance of our handler which satisfies the generated interface
 	srv := &Server{
-		metadataStorer:   metadataStorer,
-		wptMetricsStorer: wptMetricsStorer,
+		metadataStorer:          metadataStorer,
+		wptMetricsStorer:        wptMetricsStorer,
+		operationResponseCaches: initOperationResponseCaches(rawBytesDataCacher),
 	}
 
 	return createOpenAPIServerServer(port, srv, preRequestValidationMiddlewares, authMiddleware)

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -155,15 +155,15 @@ type MockListBaselineStatusCountsConfig struct {
 }
 
 type MockWPTMetricsStorer struct {
-	featureCfg                                        MockListMetricsForFeatureIDBrowserAndChannelConfig
-	aggregateCfg                                      MockListMetricsOverTimeWithAggregatedTotalsConfig
-	featuresSearchCfg                                 MockFeaturesSearchConfig
-	listBrowserFeatureCountMetricCfg                  MockListBrowserFeatureCountMetricConfig
-	listMissingOneImplCountCfg                        MockListMissingOneImplCountsConfig
-	listBaselineStatusCountsCfg                       MockListBaselineStatusCountsConfig
-	listChromiumDailyUsageStatsCfg                    MockListChromiumDailyUsageStatsConfig
-	getFeatureByIDConfig                              MockGetFeatureByIDConfig
-	getIDFromFeatureKeyConfig                         MockGetIDFromFeatureKeyConfig
+	featureCfg                                        *MockListMetricsForFeatureIDBrowserAndChannelConfig
+	aggregateCfg                                      *MockListMetricsOverTimeWithAggregatedTotalsConfig
+	featuresSearchCfg                                 *MockFeaturesSearchConfig
+	listBrowserFeatureCountMetricCfg                  *MockListBrowserFeatureCountMetricConfig
+	listMissingOneImplCountCfg                        *MockListMissingOneImplCountsConfig
+	listBaselineStatusCountsCfg                       *MockListBaselineStatusCountsConfig
+	listChromiumDailyUsageStatsCfg                    *MockListChromiumDailyUsageStatsConfig
+	getFeatureByIDConfig                              *MockGetFeatureByIDConfig
+	getIDFromFeatureKeyConfig                         *MockGetIDFromFeatureKeyConfig
 	t                                                 *testing.T
 	callCountListMissingOneImplCounts                 int
 	callCountListBaselineStatusCounts                 int
@@ -475,11 +475,13 @@ func compareJSONBodies(t *testing.T, actualBody, expectedBody []byte) {
 	}
 }
 
-func assertMockCallCount(t *testing.T, expectedCallCount, actualCallCount int, methodName string) {
+func assertMocksExpectations(t *testing.T, expectedCallCount, actualCallCount int, methodName string,
+	mockCacher *MockRawBytesDataCacher) {
 	if expectedCallCount != actualCallCount {
 		t.Errorf("expected %s to be called %d times. it was called %d times",
 			methodName, expectedCallCount, actualCallCount)
 	}
+	mockCacher.AssertExpectations()
 }
 
 func assertTestServerRequest(t *testing.T, srv *Server, req *http.Request, expectedResponse *http.Response) {


### PR DESCRIPTION
Summary:

The `operationResponseCaches` struct a provides a collection of type-safe caches that wrap around the raw bytes data cacher. `operationResponseCaches`` is integrated directly into the Server struct, providing easy access to all handlers. This PR also refactors the testing infrastructure to support future cache testing by renaming assertMockCallCount to assertMocksExpectations and allowing the passing in of a MockRawBytesDataCacher. We use the handler's request object (converted to JSON) as the key for the cache. 

The format of the key is `K_REVISION`-`OperationID`-`RequestDataInJSON`. The value type is the 2xx response object for that handler.

Changes:

operationResponseCaches Struct:
- A new operationResponseCaches struct is introduced in pkg/httpserver/cache.go.
- This struct acts as a container for multiple instances of operationResponseCache.
- Each field in operationResponseCaches corresponds to a specific API operation (e.g., getFeatureCache, listFeaturesCache) and is an instance of operationResponseCache.
- The operationResponseCache instances wrap a RawBytesDataCacher (e.g., Valkey) for data storage, providing type-safe caching using generics.
- Each operationResponseCache instance is dedicated to its respective operation.
- The caches are able to all read and write to the same underlying cache.
- The caches are type-safe.
- The operationID is used as a prefix for each cache instance, allowing for grouping and future prefix-based deletion.

initOperationResponseCaches Function:
- A new initOperationResponseCaches function is introduced in pkg/httpserver/cache.go.
- This function takes a RawBytesDataCacher as input.
- It creates and initializes all the operationResponseCache instances within an operationResponseCaches struct.
- Each operationResponseCache is provided with the RawBytesDataCacher for storage and its own unique operationID for key prefixing.

operationResponseCaches in Server:
- The operationResponseCaches struct is now a field within the Server struct in pkg/httpserver/server.go.
- Handler Access: This allows all HTTP handlers associated with the Server to access the operationResponseCaches instance, and thus the operationResponseCache instances, for caching purposes.

Renamed assertMockCallCount to assertMocksExpectations:
- The test helper function previously named `assertMockCallCount`` has been renamed to `assertMocksExpectations``.
- This function now takes a MockRawBytesDataCacher instance as a parameter, preparing it to verify Get and Cache calls to the mock cache in future tests.
- All the test files are updated to use assertMocksExpectations.
- Added mockCacher to test files
- All the test files now include a mockCacher, that is passed to the operationResponseCaches initialization.
- This enables us to start validating that the mock is used when caching is implemented.

Other changes:
- Change each mock db config to be a pointer because there will now be cases where the cache will respond so the db layer will not need a config.

Future Work:
- Adding Caching Logic: Subsequent pull requests will introduce the actual caching logic into each applicable HTTP handler. A PR will be done per operation.

This is part of a split up of https://github.com/GoogleChrome/webstatus.dev/compare/jcscottiii/fix-backend-cache?expand=1