### PR TITLE
Implement Caching for ListAggregatedWPTMetrics

### DIFF
--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
@@ -55,9 +56,59 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 					},
 				},
 			},
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key: `listAggregatedWPTMetrics-{"browser":"chrome","channel":"experimental",` +
+						`"metric_view":"subtest_counts","Params":{"startAt":"2000-01-01","endAt":"2000-01-10"}}`,
+					Value: nil,
+					Err:   cachetypes.ErrCachedDataNotFound,
+				},
+			},
+			expectedCacheCalls: []*ExpectedCacheCall{
+				{
+					Key: `listAggregatedWPTMetrics-{"browser":"chrome","channel":"experimental",` +
+						`"metric_view":"subtest_counts","Params":{"startAt":"2000-01-01","endAt":"2000-01-10"}}`,
+					Value: []byte(
+						`{"data":[{"run_timestamp":"2000-01-01T00:00:00Z","test_pass_count":2,` +
+							`"total_tests_count":2}],"metadata":{}}`,
+					),
+				},
+			},
+			expectedCallCount: 1,
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"run_timestamp":"2000-01-01T00:00:00Z",
+			"test_pass_count":2,
+			"total_tests_count":2
+		}
+	],
+	"metadata":{
+
+	}
+}
+			`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/wpt/browsers/chrome/channels/experimental/subtest_counts"+
+					"?startAt=2000-01-01&endAt=2000-01-10", nil),
+		},
+		{
+			name:       "Success Case - no optional params - use defaults - cached",
+			mockConfig: nil,
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key: `listAggregatedWPTMetrics-{"browser":"chrome","channel":"experimental",` +
+						`"metric_view":"subtest_counts","Params":{"startAt":"2000-01-01","endAt":"2000-01-10"}}`,
+					Value: []byte(
+						`{"data":[{"run_timestamp":"2000-01-01T00:00:00Z","test_pass_count":2,` +
+							`"total_tests_count":2}],"metadata":{}}`,
+					),
+					Err: nil,
+				},
+			},
 			expectedCacheCalls: nil,
-			expectedGetCalls:   nil,
-			expectedCallCount:  1,
+			expectedCallCount:  0,
 			expectedResponse: testJSONResponse(200, `
 {
 	"data":[
@@ -97,9 +148,64 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 				},
 				pageToken: nextPageToken,
 			},
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key: `listAggregatedWPTMetrics-{"browser":"chrome","channel":"experimental",` +
+						`"metric_view":"subtest_counts","Params":{"startAt":"2000-01-01","endAt":"2000-01-10",` +
+						`"page_token":"input-token","page_size":50,"featureId":["feature1","feature2"]}}`,
+					Value: nil,
+					Err:   cachetypes.ErrCachedDataNotFound,
+				},
+			},
+			expectedCacheCalls: []*ExpectedCacheCall{
+				{
+					Key: `listAggregatedWPTMetrics-{"browser":"chrome","channel":"experimental",` +
+						`"metric_view":"subtest_counts","Params":{"startAt":"2000-01-01","endAt":"2000-01-10",` +
+						`"page_token":"input-token","page_size":50,"featureId":["feature1","feature2"]}}`,
+					Value: []byte(
+						`{"data":[{"run_timestamp":"2000-01-01T00:00:00Z","test_pass_count":2,` +
+							`"total_tests_count":2}],"metadata":{"next_page_token":"next-page-token"}}`,
+					),
+				},
+			},
+			expectedCallCount: 1,
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"run_timestamp":"2000-01-01T00:00:00Z",
+			"test_pass_count":2,
+			"total_tests_count":2
+		}
+	],
+	"metadata":{
+		"next_page_token":"next-page-token"
+	}
+}
+			`),
+			request: httptest.NewRequest(http.MethodGet,
+				"/v1/stats/wpt/browsers/chrome/channels/experimental/subtest_counts"+
+					"?startAt=2000-01-01&endAt=2000-01-10&page_size=50&"+
+					"featureId=feature1&featureId=feature2&"+
+					"page_token="+*inputPageToken, nil),
+		},
+		{
+			name:       "Success Case - include optional params - cached",
+			mockConfig: nil,
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key: `listAggregatedWPTMetrics-{"browser":"chrome","channel":"experimental",` +
+						`"metric_view":"subtest_counts","Params":{"startAt":"2000-01-01","endAt":"2000-01-10",` +
+						`"page_token":"input-token","page_size":50,"featureId":["feature1","feature2"]}}`,
+					Value: []byte(
+						`{"data":[{"run_timestamp":"2000-01-01T00:00:00Z","test_pass_count":2,` +
+							`"total_tests_count":2}],"metadata":{"next_page_token":"next-page-token"}}`,
+					),
+					Err: nil,
+				},
+			},
 			expectedCacheCalls: nil,
-			expectedGetCalls:   nil,
-			expectedCallCount:  1,
+			expectedCallCount:  0,
 			expectedResponse: testJSONResponse(200, `
 {
 	"data":[
@@ -135,8 +241,15 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 				pageToken:          nil,
 				err:                errTest,
 			},
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key: `listAggregatedWPTMetrics-{"browser":"chrome","channel":"experimental",` +
+						`"metric_view":"subtest_counts","Params":{"startAt":"2000-01-01","endAt":"2000-01-10"}}`,
+					Value: nil,
+					Err:   cachetypes.ErrCachedDataNotFound,
+				},
+			},
 			expectedCacheCalls: nil,
-			expectedGetCalls:   nil,
 			expectedCallCount:  1,
 			expectedResponse:   testJSONResponse(500, `{"code":500,"message":"unable to get aggregated metrics"}`),
 			request: httptest.NewRequest(http.MethodGet,
@@ -158,8 +271,16 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 				pageToken:          nil,
 				err:                backendtypes.ErrInvalidPageToken,
 			},
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key: `listAggregatedWPTMetrics-{"browser":"chrome","channel":"experimental",` +
+						`"metric_view":"subtest_counts","Params":{"startAt":"2000-01-01","endAt":"2000-01-10",` +
+						`"page_token":""}}`,
+					Value: nil,
+					Err:   cachetypes.ErrCachedDataNotFound,
+				},
+			},
 			expectedCacheCalls: nil,
-			expectedGetCalls:   nil,
 			expectedCallCount:  1,
 			expectedResponse:   testJSONResponse(400, `{"code":400,"message":"invalid page token"}`),
 			request: httptest.NewRequest(http.MethodGet,


### PR DESCRIPTION
Depends on #1187

This pull request implements caching for the ListAggregatedWPTMetrics API handler

This is part of a split up of https://github.com/GoogleChrome/webstatus.dev/compare/jcscottiii/fix-backend-cache?expand=1