### PR TITLE
Support names with periods in ANY_VALUE

### DIFF
--- a/antlr/FeatureSearch.g4
+++ b/antlr/FeatureSearch.g4
@@ -19,8 +19,8 @@ BASELINE_STATUS: 'limited' | 'newly' | 'widely';
 DATE:
 	[2][0-9][0-9][0-9]'-' [01][0-9]'-' [0-3][0-9]; // YYYY-MM-DD (starting from 2000)
 ANY_VALUE:
-	'"' ([a-zA-Z0-9:@] | '<') [a-zA-Z0-9_():<>@ -]* '"' // Words with spaces.
-	| ([a-zA-Z0-9@] | '<') [a-zA-Z0-9_<>@-]*; // Single words
+	'"' ([a-zA-Z0-9:@] | '<') [a-zA-Z0-9_():<>@. -]* '"' // Words with spaces.
+	| ([a-zA-Z0-9@] | '<') ([a-zA-Z0-9_<>@-] | '.' ~('.'))*; // Single words
 // Terms
 available_on_term: 'available_on' COLON BROWSER_NAME;
 baseline_status_term: 'baseline_status' COLON BASELINE_STATUS;

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -1018,6 +1018,78 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
+			InputQuery: `intl.segmenter`,
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Children: nil,
+						Term: &SearchTerm{
+							Identifier: IdentifierName,
+							Value:      "intl.segmenter",
+							Operator:   OperatorEq,
+						},
+						Keyword: KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: `"intl.segmenter"`,
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Children: nil,
+						Term: &SearchTerm{
+							Identifier: IdentifierName,
+							Value:      "intl.segmenter",
+							Operator:   OperatorEq,
+						},
+						Keyword: KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: `name:"intl.segmenter"`,
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Children: nil,
+						Term: &SearchTerm{
+							Identifier: IdentifierName,
+							Value:      "intl.segmenter",
+							Operator:   OperatorEq,
+						},
+						Keyword: KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: `name:intl.segmenter`,
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Children: nil,
+						Term: &SearchTerm{
+							Identifier: IdentifierName,
+							Value:      "intl.segmenter",
+							Operator:   OperatorEq,
+						},
+						Keyword: KeywordNone,
+					},
+				},
+			},
+		},
+		{
 			InputQuery: "baseline_date:2000-01-01..2000-12-31",
 			ExpectedTree: &SearchNode{
 				Keyword: KeywordRoot,


### PR DESCRIPTION
This commit enhances the grammar to correctly parse names containing periods, such as `intl.segmenter`, within the ANY_VALUE rule.

Previously, the ANY_VALUE rule was too restrictive and did not allow for periods in unquoted values. This update modifies the rule to allow periods while still preventing it from incorrectly consuming the `..` used in date range queries.

With this change, the grammar now supports a wider range of valid input values, including names with periods.