### PR TITLE
Add table and logic to store discouraged details

### DIFF
--- a/infra/storage/spanner/migrations/000014.sql
+++ b/infra/storage/spanner/migrations/000014.sql
@@ -1,0 +1,21 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- FeatureDiscouragedDetails contains information about why a feature is discouraged
+CREATE TABLE IF NOT EXISTS FeatureDiscouragedDetails (
+    WebFeatureID STRING(MAX) NOT NULL,
+    AccordingTo ARRAY<STRING(MAX)>,
+    Alternatives ARRAY<STRING(MAX)>,
+    CONSTRAINT FK_DiscouragedDetailsWebFeatureID FOREIGN KEY (WebFeatureID) REFERENCES WebFeatures(ID) ON DELETE CASCADE,
+) PRIMARY KEY (WebFeatureID);

--- a/lib/gcpspanner/feature_discouraged_details.go
+++ b/lib/gcpspanner/feature_discouraged_details.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+)
+
+const featureDiscouragedDetailsTable = "FeatureDiscouragedDetails"
+
+// FeatureDiscouragedDetails contains information about why a feature is discouraged.
+type FeatureDiscouragedDetails struct {
+	AccordingTo  []string `spanner:"AccordingTo"`
+	Alternatives []string `spanner:"Alternatives"`
+}
+
+// SpannerFeatureDiscouragedDetails is a wrapper for the FeatureDiscouragedDetails that is actually
+// stored in spanner.
+type spannerFeatureDiscouragedDetails struct {
+	WebFeatureID string `spanner:"WebFeatureID"`
+	FeatureDiscouragedDetails
+}
+
+// Implements the Mapping interface for FeatureDiscouragedDetails and SpannerFeatureDiscouragedDetails.
+type featureDiscouragedDetailsSpannerMapper struct{}
+
+func (m featureDiscouragedDetailsSpannerMapper) GetKey(in spannerFeatureDiscouragedDetails) string {
+	return in.WebFeatureID
+}
+
+func (m featureDiscouragedDetailsSpannerMapper) Table() string {
+	return featureDiscouragedDetailsTable
+}
+
+func (m featureDiscouragedDetailsSpannerMapper) Merge(
+	incoming spannerFeatureDiscouragedDetails,
+	existing spannerFeatureDiscouragedDetails) spannerFeatureDiscouragedDetails {
+	existing.AccordingTo = incoming.AccordingTo
+	existing.Alternatives = incoming.Alternatives
+
+	return existing
+}
+
+func (m featureDiscouragedDetailsSpannerMapper) SelectOne(id string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		WebFeatureID, AccordingTo, Alternatives
+	FROM %s
+	WHERE WebFeatureID = @webFeatureID
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"webFeatureID": id,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (c *Client) UpsertFeatureDiscouragedDetails(
+	ctx context.Context, featureID string, in FeatureDiscouragedDetails) error {
+	id, err := c.GetIDFromFeatureKey(ctx, NewFeatureKeyFilter(featureID))
+	if err != nil {
+		return err
+	}
+	if id == nil {
+		return ErrInternalQueryFailure
+	}
+
+	return newEntityWriter[featureDiscouragedDetailsSpannerMapper](c).upsert(ctx, spannerFeatureDiscouragedDetails{
+		WebFeatureID:              *id,
+		FeatureDiscouragedDetails: in,
+	})
+}

--- a/lib/gcpspanner/feature_discouraged_details_test.go
+++ b/lib/gcpspanner/feature_discouraged_details_test.go
@@ -1,0 +1,200 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func setupRequiredTablesForFeatureDiscouragedDetails(
+	ctx context.Context,
+	t *testing.T,
+) map[string]string {
+	ret := map[string]string{}
+	sampleFeatures := getSampleFeatures()
+	for _, feature := range sampleFeatures {
+		id, err := spannerClient.UpsertWebFeature(ctx, feature)
+		if err != nil {
+			t.Errorf("unexpected error during insert. %s", err.Error())
+
+			continue
+		}
+		ret[feature.FeatureKey] = *id
+	}
+
+	return ret
+}
+
+func insertTestFeatureDiscouragedDetails(
+	ctx context.Context,
+	client *Client,
+	t *testing.T,
+	values []sampleDiscouragedDetail,
+) {
+	for _, value := range values {
+		err := client.UpsertFeatureDiscouragedDetails(
+			ctx,
+			value.featureID,
+			value.details,
+		)
+		if err != nil {
+			t.Errorf("unexpected error during insert of discouraged details. %s", err.Error())
+		}
+	}
+}
+
+func (c *Client) readAllFeatureDiscouragedDetails(
+	ctx context.Context, _ *testing.T) ([]spannerFeatureDiscouragedDetails, error) {
+	stmt := spanner.NewStatement(
+		`SELECT
+			WebFeatureID, AccordingTo, Alternatives
+		FROM FeatureDiscouragedDetails`)
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []spannerFeatureDiscouragedDetails
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var details spannerFeatureDiscouragedDetails
+		if err := row.ToStruct(&details); err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		ret = append(ret, details)
+	}
+
+	return ret, nil
+}
+
+type sampleDiscouragedDetail struct {
+	featureID string
+	details   FeatureDiscouragedDetails
+}
+
+func getSampleDiscouragedDetails() []sampleDiscouragedDetail {
+	return []sampleDiscouragedDetail{
+		{
+			featureID: "feature1",
+			details: FeatureDiscouragedDetails{
+				AccordingTo:  []string{"source"},
+				Alternatives: nil,
+			},
+		},
+		{
+			featureID: "feature2",
+			details: FeatureDiscouragedDetails{
+				AccordingTo:  nil,
+				Alternatives: []string{"featurefoo"},
+			},
+		},
+	}
+}
+
+func sortFeatureDiscouragedDetails(left, right spannerFeatureDiscouragedDetails) int {
+	return cmp.Compare(left.WebFeatureID, right.WebFeatureID)
+}
+
+func featureDiscouragedDetailsEquality(left, right spannerFeatureDiscouragedDetails) bool {
+	return left.WebFeatureID == right.WebFeatureID &&
+		slices.Equal(left.AccordingTo, right.AccordingTo) &&
+		slices.Equal(left.Alternatives, right.Alternatives)
+}
+
+func TestUpsertFeatureDiscouragedDetails(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+	idMap := setupRequiredTablesForFeatureDiscouragedDetails(ctx, t)
+	discouragedDetails := getSampleDiscouragedDetails()
+	insertTestFeatureDiscouragedDetails(ctx, spannerClient, t, discouragedDetails)
+
+	expected := []spannerFeatureDiscouragedDetails{
+		{
+			WebFeatureID: idMap["feature1"],
+			FeatureDiscouragedDetails: FeatureDiscouragedDetails{
+				AccordingTo:  []string{"source"},
+				Alternatives: nil,
+			},
+		},
+		{
+			WebFeatureID: idMap["feature2"],
+			FeatureDiscouragedDetails: FeatureDiscouragedDetails{
+				AccordingTo:  nil,
+				Alternatives: []string{"featurefoo"},
+			},
+		},
+	}
+	slices.SortFunc(expected, sortFeatureDiscouragedDetails)
+
+	details, err := spannerClient.readAllFeatureDiscouragedDetails(ctx, t)
+	if err != nil {
+		t.Fatalf("unable to get all discouraged details err: %s", err)
+	}
+	slices.SortFunc(details, sortFeatureDiscouragedDetails)
+
+	if !slices.EqualFunc(expected, details, featureDiscouragedDetailsEquality) {
+		t.Errorf("unequal discouraged details.\nexpected %+v\nreceived %+v", expected, details)
+	}
+
+	// Upsert FeatureDiscouragedDetails
+	err = spannerClient.UpsertFeatureDiscouragedDetails(ctx, "feature2", FeatureDiscouragedDetails{
+		AccordingTo: []string{"source2"},
+		// Reset to nil
+		Alternatives: nil,
+	})
+	if err != nil {
+		t.Fatalf("unable to update discouraged details err: %s", err)
+	}
+
+	expected = []spannerFeatureDiscouragedDetails{
+		{
+			WebFeatureID: idMap["feature1"],
+			FeatureDiscouragedDetails: FeatureDiscouragedDetails{
+				AccordingTo:  []string{"source"},
+				Alternatives: nil,
+			},
+		},
+		{
+			WebFeatureID: idMap["feature2"],
+			FeatureDiscouragedDetails: FeatureDiscouragedDetails{
+				AccordingTo:  []string{"source2"},
+				Alternatives: nil,
+			},
+		},
+	}
+	// Should allow resetting of Alternatives. Should allow setting of AccordingTo
+	slices.SortFunc(expected, sortFeatureDiscouragedDetails)
+
+	details, err = spannerClient.readAllFeatureDiscouragedDetails(ctx, t)
+	if err != nil {
+		t.Fatalf("unable to get all discouraged details err: %s", err)
+	}
+	slices.SortFunc(details, sortFeatureDiscouragedDetails)
+
+	if !slices.EqualFunc(expected, details, featureDiscouragedDetailsEquality) {
+		t.Errorf("unequal discouraged details.\nexpected %+v\nreceived %+v", expected, details)
+	}
+}


### PR DESCRIPTION
This change adds a new table: FeatureDiscouragedDetails

It is setup to have a foreign key with its corresponding  Web Feature.

The other fields come from [web features](https://github.com/web-platform-dx/web-features/blob/1332db1a8ceb74af13fbcb58ee8501aa2b948f71/schemas/data.schema.json#L60-L81).

We don't plan on querying for individual details in AccordingTo and Alternatives. Those two fields are marked as nullable because we may get rid of them in the future.