### PR TITLE
Ingest discouraged details in web features job

### DIFF
--- a/jsonschema/web-platform-dx_web-features/defs.schema.json
+++ b/jsonschema/web-platform-dx_web-features/defs.schema.json
@@ -74,7 +74,9 @@
             },
             "alternatives": {
               "description": "IDs for features that substitute some or all of this feature's utility",
-              "items": {},
+              "items": {
+                "type": "string"
+              },
               "type": "array"
             }
           },


### PR DESCRIPTION
This change modifies the web features workflow to call the spanner logic that inserts discouraged details (if those details exist for a feature)

Other changes:
- Manually add missing data type to discouraged field: See https://github.com/web-platform-dx/web-features/pull/2697

Builds on #1211