### PR TITLE
Exclude discouraged features from spanner calls used on stats page

### DIFF
--- a/lib/gcpspanner/baseline_status_count.go
+++ b/lib/gcpspanner/baseline_status_count.go
@@ -96,21 +96,21 @@ func (c *Client) ListBaselineStatusCounts(
 		return nil, errors.Join(ErrInternalQueryFailure, fmt.Errorf("invalid BaselineDateType: %s", dateType))
 	}
 
-	// 2. Get excluded feature IDs
-	excludedFeatureIDs, err := c.getFeatureIDsForEachExcludedFeatureKey(ctx, txn)
+	// 2. Get ignored feature IDs
+	ignoredFeatureIDs, err := c.getIgnoredFeatureIDsForStats(ctx, txn)
 	if err != nil {
 		return nil, err
 	}
 
 	// 3. Calculate initial cumulative count
 	cumulativeCount, err := c.getInitialBaselineStatusCount(
-		ctx, txn, parsedToken, startAt, excludedFeatureIDs, dateType)
+		ctx, txn, parsedToken, startAt, ignoredFeatureIDs, dateType)
 	if err != nil {
 		return nil, errors.Join(ErrInternalQueryFailure, err)
 	}
 
 	// 4. Process results and update cumulative count
-	stmt := createListBaselineStatusCountsStatement(dateType, startAt, endAt, pageSize, parsedToken, excludedFeatureIDs)
+	stmt := createListBaselineStatusCountsStatement(dateType, startAt, endAt, pageSize, parsedToken, ignoredFeatureIDs)
 
 	iter := txn.Query(ctx, stmt)
 	defer iter.Stop()

--- a/lib/gcpspanner/baseline_status_count_test.go
+++ b/lib/gcpspanner/baseline_status_count_test.go
@@ -102,13 +102,19 @@ func TestListBaselineStatusCounts_ExcludedFeatures(t *testing.T) {
 	ctx := context.Background()
 	loadDataForListBaselineStatusCounts(ctx, t)
 
-	// Exclude "FeatureB" and "FeatureE"
-	excludedFeatures := []string{"FeatureB", "FeatureE"}
-	for _, featureKey := range excludedFeatures {
-		err := spannerClient.InsertExcludedFeatureKey(ctx, featureKey)
-		if err != nil {
-			t.Fatalf("Failed to insert excluded feature key: %v", err)
-		}
+	// Exclude "FeatureB"
+	err := spannerClient.InsertExcludedFeatureKey(ctx, "FeatureB")
+	if err != nil {
+		t.Fatalf("Failed to insert excluded feature key: %v", err)
+	}
+
+	// Discourage FeatureE
+	err = spannerClient.UpsertFeatureDiscouragedDetails(ctx, "FeatureE", FeatureDiscouragedDetails{
+		AccordingTo:  nil,
+		Alternatives: nil,
+	})
+	if err != nil {
+		t.Fatalf("UpsertFeatureDiscouragedDetails failed: %v", err)
 	}
 
 	startAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/lib/gcpspanner/browser_feature_count.go
+++ b/lib/gcpspanner/browser_feature_count.go
@@ -54,13 +54,13 @@ func (c *Client) ListBrowserFeatureCountMetric(
 
 	txn := c.ReadOnlyTransaction()
 	defer txn.Close()
-	// 1. Get excluded feature IDs
-	excludedFeatureIDs, err := c.getFeatureIDsForEachExcludedFeatureKey(ctx, txn)
+	// 1. Get ignored feature IDs
+	ignoredFeatureIDs, err := c.getIgnoredFeatureIDsForStats(ctx, txn)
 	if err != nil {
 		return nil, err
 	}
 	// 2. Calculate initial cumulative count
-	cumulativeCount, err := c.getInitialBrowserFeatureCount(ctx, txn, parsedToken, browser, startAt, excludedFeatureIDs)
+	cumulativeCount, err := c.getInitialBrowserFeatureCount(ctx, txn, parsedToken, browser, startAt, ignoredFeatureIDs)
 	if err != nil {
 		return nil, errors.Join(ErrInternalQueryFailure, err)
 	}
@@ -72,7 +72,7 @@ func (c *Client) ListBrowserFeatureCountMetric(
 		endAt,
 		pageSize,
 		parsedToken,
-		excludedFeatureIDs,
+		ignoredFeatureIDs,
 	)
 	it := txn.Query(ctx, stmt)
 	defer it.Stop()

--- a/lib/gcpspanner/browser_feature_count_test.go
+++ b/lib/gcpspanner/browser_feature_count_test.go
@@ -100,23 +100,25 @@ func TestListBrowserFeatureCountMetric(t *testing.T) {
 	// We should change this in the future. Be careful.
 	// In the meantime, be careful with the order of the test cases.
 	testCases := []struct {
-		testName                    string
-		browser                     string
-		startAt                     time.Time
-		endAt                       time.Time
-		pageSize                    int
-		excludedFeatureKeysToInsert []string
-		inputCursor                 *string
-		expectedResult              *BrowserFeatureCountResultPage
+		testName                       string
+		browser                        string
+		startAt                        time.Time
+		endAt                          time.Time
+		pageSize                       int
+		excludedFeatureKeysToInsert    []string
+		discouragedFeatureKeysToInsert []string
+		inputCursor                    *string
+		expectedResult                 *BrowserFeatureCountResultPage
 	}{
 		{
-			testName:                    "Test 1a. First Page",
-			browser:                     "fooBrowser",
-			startAt:                     time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC),
-			endAt:                       time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC),
-			excludedFeatureKeysToInsert: nil,
-			pageSize:                    2,
-			inputCursor:                 nil,
+			testName:                       "Test 1a. First Page",
+			browser:                        "fooBrowser",
+			startAt:                        time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC),
+			endAt:                          time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC),
+			excludedFeatureKeysToInsert:    nil,
+			discouragedFeatureKeysToInsert: nil,
+			pageSize:                       2,
+			inputCursor:                    nil,
 			expectedResult: &BrowserFeatureCountResultPage{
 				NextPageToken: valuePtr(encodeBrowserFeatureCountCursor(
 					time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC), 2)),
@@ -133,12 +135,13 @@ func TestListBrowserFeatureCountMetric(t *testing.T) {
 			},
 		},
 		{
-			testName:                    "Test 1b. Second Page",
-			browser:                     "fooBrowser",
-			startAt:                     time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC),
-			endAt:                       time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC),
-			excludedFeatureKeysToInsert: nil,
-			pageSize:                    3,
+			testName:                       "Test 1b. Second Page",
+			browser:                        "fooBrowser",
+			startAt:                        time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC),
+			endAt:                          time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC),
+			excludedFeatureKeysToInsert:    nil,
+			discouragedFeatureKeysToInsert: nil,
+			pageSize:                       3,
 			inputCursor: valuePtr(encodeBrowserFeatureCountCursor(
 				time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC), 2)),
 			expectedResult: &BrowserFeatureCountResultPage{
@@ -152,13 +155,14 @@ func TestListBrowserFeatureCountMetric(t *testing.T) {
 			},
 		},
 		{
-			testName:                    "Test 2. Get the point but still count all the features beforehand.",
-			browser:                     "fooBrowser",
-			startAt:                     time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
-			endAt:                       time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC),
-			excludedFeatureKeysToInsert: nil,
-			pageSize:                    100,
-			inputCursor:                 nil,
+			testName:                       "Test 2. Get the point but still count all the features beforehand.",
+			browser:                        "fooBrowser",
+			startAt:                        time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+			endAt:                          time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC),
+			excludedFeatureKeysToInsert:    nil,
+			discouragedFeatureKeysToInsert: nil,
+			pageSize:                       100,
+			inputCursor:                    nil,
 			expectedResult: &BrowserFeatureCountResultPage{
 				NextPageToken: nil,
 				Metrics: []BrowserFeatureCountMetric{
@@ -173,13 +177,14 @@ func TestListBrowserFeatureCountMetric(t *testing.T) {
 		// (`barBrowser` in this case) *has* releases within the specified date range but *does not have any new*
 		// `BrowserFeatureAvailabilities` entries for those releases within that range.
 		{
-			testName:                    "Test 3. No availabilities for one browser.",
-			browser:                     "barBrowser",
-			startAt:                     time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC),
-			endAt:                       time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC),
-			excludedFeatureKeysToInsert: nil,
-			pageSize:                    3,
-			inputCursor:                 nil,
+			testName:                       "Test 3. No availabilities for one browser.",
+			browser:                        "barBrowser",
+			startAt:                        time.Date(2023, 12, 1, 0, 0, 0, 0, time.UTC),
+			endAt:                          time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC),
+			excludedFeatureKeysToInsert:    nil,
+			discouragedFeatureKeysToInsert: nil,
+			pageSize:                       3,
+			inputCursor:                    nil,
 			expectedResult: &BrowserFeatureCountResultPage{
 				NextPageToken: nil,
 				Metrics: []BrowserFeatureCountMetric{
@@ -203,6 +208,8 @@ func TestListBrowserFeatureCountMetric(t *testing.T) {
 			pageSize:                    3,
 			inputCursor:                 nil,
 			excludedFeatureKeysToInsert: []string{"FeatureY", "FeatureZ"},
+			// Have overlap between excludedFeatureKeysToInsert and discouragedFeatureKeysToInsert
+			discouragedFeatureKeysToInsert: []string{"FeatureZ"},
 			expectedResult: &BrowserFeatureCountResultPage{
 				NextPageToken: valuePtr(encodeBrowserFeatureCountCursor(
 					time.Date(2024, 4, 5, 0, 0, 0, 0, time.UTC), 1)),
@@ -213,11 +220,11 @@ func TestListBrowserFeatureCountMetric(t *testing.T) {
 					},
 					{
 						ReleaseDate:  time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC),
-						FeatureCount: 1, // FeatureY excluded
+						FeatureCount: 1, // FeatureY excluded / discouraged
 					},
 					{
 						ReleaseDate:  time.Date(2024, 4, 5, 0, 0, 0, 0, time.UTC),
-						FeatureCount: 1, // FeatureY and FeatureZ excluded
+						FeatureCount: 1, // FeatureY and FeatureZ excluded / discouraged
 					},
 				},
 			},
@@ -233,6 +240,17 @@ func TestListBrowserFeatureCountMetric(t *testing.T) {
 			for _, featureKey := range tc.excludedFeatureKeysToInsert {
 				if err := spannerClient.InsertExcludedFeatureKey(ctx, featureKey); err != nil {
 					t.Fatalf("Failed to insert excluded feature key: %v", err)
+				}
+			}
+
+			// Insert discouraged feature keys into the FeatureDiscouragedDetails table
+			for _, featureKey := range tc.discouragedFeatureKeysToInsert {
+				if err := spannerClient.UpsertFeatureDiscouragedDetails(
+					ctx, featureKey, FeatureDiscouragedDetails{
+						AccordingTo:  nil,
+						Alternatives: nil,
+					}); err != nil {
+					t.Fatalf("Failed to insert feature discouraged details: %v", err)
 				}
 			}
 

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -2625,3 +2625,13 @@ func (c *Client) ClearExcludedFeatureKeys(ctx context.Context) error {
 
 	return err
 }
+
+func (c *Client) ClearFeatureDiscouragedDetails(ctx context.Context) error {
+	_, err := c.ReadWriteTransaction(ctx, func(_ context.Context, txn *spanner.ReadWriteTransaction) error {
+		mutation := spanner.Delete(featureDiscouragedDetailsTable, spanner.AllKeys())
+
+		return txn.BufferWrite([]*spanner.Mutation{mutation})
+	})
+
+	return err
+}

--- a/lib/gcpspanner/missing_one_implementation.go
+++ b/lib/gcpspanner/missing_one_implementation.go
@@ -270,8 +270,8 @@ func (c *Client) ListMissingOneImplCounts(
 	txn := c.ReadOnlyTransaction()
 	defer txn.Close()
 
-	// Get excluded feature IDs
-	excludedFeatureIDs, err := c.getFeatureIDsForEachExcludedFeatureKey(ctx, txn)
+	// Get ignored feature IDs
+	ignoredFeatureIDs, err := c.getIgnoredFeatureIDsForStats(ctx, txn)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +283,7 @@ func (c *Client) ListMissingOneImplCounts(
 		startAt,
 		endAt,
 		pageSize,
-		excludedFeatureIDs,
+		ignoredFeatureIDs,
 		c.missingOneImplQuery,
 	)
 

--- a/lib/gcpspanner/missing_one_implementation_test.go
+++ b/lib/gcpspanner/missing_one_implementation_test.go
@@ -664,13 +664,25 @@ func testMissingOneImplSuite(
 	})
 
 	//nolint:dupl // WONTFIX - False positive. The counts are different.
-	t.Run("with excluded features", func(t *testing.T) {
-		// Exclude Feature X and Feature Z
-		excludedFeatures := []string{"FeatureX", "FeatureZ"}
+	t.Run("with excluded/discouraged features", func(t *testing.T) {
+		// Exclude Feature X
+		excludedFeatures := []string{"FeatureX"}
 		for _, featureKey := range excludedFeatures {
 			err := spannerClient.InsertExcludedFeatureKey(ctx, featureKey)
 			if err != nil {
 				t.Fatalf("Failed to insert excluded feature key: %v", err)
+			}
+		}
+
+		// Discourage FeatureZ
+		discouragedFeatures := []string{"FeatureZ"}
+		for _, featureKey := range discouragedFeatures {
+			err := spannerClient.UpsertFeatureDiscouragedDetails(ctx, featureKey, FeatureDiscouragedDetails{
+				AccordingTo:  nil,
+				Alternatives: nil,
+			})
+			if err != nil {
+				t.Fatalf("Failed to upsert feature discouraged details: %v", err)
 			}
 		}
 
@@ -683,9 +695,9 @@ func testMissingOneImplSuite(
 				Metrics: []MissingOneImplCount{
 					// fooBrowser 113 release
 					// Currently supported features:
-					// fooBrowser after excluding FeatureX and FeatureZ: FeatureY, FeatureW
-					// barBrowser after excluding FeatureX and FeatureZ: FeatureY, FeatureW
-					// bazBrowser after excluding FeatureX and FeatureZ: FeatureY
+					// fooBrowser after excluding/discouraging FeatureX and FeatureZ: FeatureY, FeatureW
+					// barBrowser after excluding/discouraging FeatureX and FeatureZ: FeatureY, FeatureW
+					// bazBrowser after excluding/discouraging FeatureX and FeatureZ: FeatureY
 					// Missing in on for bazBrowser: FeatureW
 					{
 						EventReleaseDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC),
@@ -693,9 +705,9 @@ func testMissingOneImplSuite(
 					},
 					// barBrowser 115 AND bazBrowser 17 release
 					// Currently supported features:
-					// fooBrowser after excluding FeatureX and FeatureZ: FeatureY
-					// barBrowser after excluding FeatureX and FeatureZ: FeatureY, FeatureW
-					// bazBrowser after excluding FeatureX and FeatureZ: FeatureY
+					// fooBrowser after excluding/discouraging FeatureX and FeatureZ: FeatureY
+					// barBrowser after excluding/discouraging FeatureX and FeatureZ: FeatureY, FeatureW
+					// bazBrowser after excluding/discouraging FeatureX and FeatureZ: FeatureY
 					// Missing in on for bazBrowser: None
 					{
 						EventReleaseDate: time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
@@ -703,9 +715,9 @@ func testMissingOneImplSuite(
 					},
 					// barBrowser 114 release
 					// Currently supported features:
-					// fooBrowser after excluding FeatureX and FeatureZ: FeatureY
-					// barBrowser after excluding FeatureX and FeatureZ: FeatureY
-					// bazBrowser after excluding FeatureX and FeatureZ: FeatureY
+					// fooBrowser after excluding/discouraging FeatureX and FeatureZ: FeatureY
+					// barBrowser after excluding/discouraging FeatureX and FeatureZ: FeatureY
+					// bazBrowser after excluding/discouraging FeatureX and FeatureZ: FeatureY
 					// Missing in on for bazBrowser: None
 					{
 						EventReleaseDate: time.Date(2024, 3, 28, 0, 0, 0, 0, time.UTC),
@@ -713,9 +725,9 @@ func testMissingOneImplSuite(
 					},
 					// fooBrowser 112 release
 					// Currently supported features:
-					// fooBrowser after excluding FeatureX and FeatureZ: FeatureY
-					// barBrowser after excluding FeatureX and FeatureZ: None
-					// bazBrowser after excluding FeatureX and FeatureZ: FeatureY
+					// fooBrowser after excluding/discouraging FeatureX and FeatureZ: FeatureY
+					// barBrowser after excluding/discouraging FeatureX and FeatureZ: None
+					// bazBrowser after excluding/discouraging FeatureX and FeatureZ: FeatureY
 					// Missing in on for bazBrowser: None
 					{
 						EventReleaseDate: time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC),
@@ -723,9 +735,9 @@ func testMissingOneImplSuite(
 					},
 					// bazBrowser 16.5 release
 					// Currently supported features:
-					// fooBrowser after excluding FeatureX and FeatureZ: None
-					// barBrowser after excluding FeatureX and FeatureZ: None
-					// bazBrowser after excluding FeatureX and FeatureZ: FeatureY
+					// fooBrowser after excluding/discouraging FeatureX and FeatureZ: None
+					// barBrowser after excluding/discouraging FeatureX and FeatureZ: None
+					// bazBrowser after excluding/discouraging FeatureX and FeatureZ: FeatureY
 					// Missing in on for bazBrowser: None
 					{
 						EventReleaseDate: time.Date(2024, 3, 5, 0, 0, 0, 0, time.UTC),
@@ -733,9 +745,9 @@ func testMissingOneImplSuite(
 					},
 					// fooBrowser 111 release
 					// Currently supported features:
-					// fooBrowser after excluding FeatureX and FeatureZ: None
-					// barBrowser after excluding FeatureX and FeatureZ: None
-					// bazBrowser after excluding FeatureX and FeatureZ: None
+					// fooBrowser after excluding/discouraging FeatureX and FeatureZ: None
+					// barBrowser after excluding/discouraging FeatureX and FeatureZ: None
+					// bazBrowser after excluding/discouraging FeatureX and FeatureZ: None
 					// Missing in on for bazBrowser: None
 					{
 						EventReleaseDate: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
@@ -743,9 +755,9 @@ func testMissingOneImplSuite(
 					},
 					// bazBrowser 16.4 release
 					// Currently supported features:
-					// fooBrowser after excluding FeatureX and FeatureZ: None
-					// barBrowser after excluding FeatureX and FeatureZ: None
-					// bazBrowser after excluding FeatureX and FeatureZ: None
+					// fooBrowser after excluding/discouraging FeatureX and FeatureZ: None
+					// barBrowser after excluding/discouraging FeatureX and FeatureZ: None
+					// bazBrowser after excluding/discouraging FeatureX and FeatureZ: None
 					// Missing in on for bazBrowser: None
 					{
 						EventReleaseDate: time.Date(2024, 1, 25, 0, 0, 0, 0, time.UTC),
@@ -753,9 +765,9 @@ func testMissingOneImplSuite(
 					},
 					// barBrowser 113 release
 					// Currently supported features:
-					// fooBrowser after excluding FeatureX and FeatureZ: None
-					// barBrowser after excluding FeatureX and FeatureZ: None
-					// bazBrowser after excluding FeatureX and FeatureZ: None
+					// fooBrowser after excluding/discouraging FeatureX and FeatureZ: None
+					// barBrowser after excluding/discouraging FeatureX and FeatureZ: None
+					// bazBrowser after excluding/discouraging FeatureX and FeatureZ: None
 					// Missing in on for bazBrowser: None
 					{
 						EventReleaseDate: time.Date(2024, 1, 20, 0, 0, 0, 0, time.UTC),
@@ -763,9 +775,9 @@ func testMissingOneImplSuite(
 					},
 					// fooBrowser 110 release
 					// Currently supported features:
-					// fooBrowser after excluding FeatureX and FeatureZ: None
-					// barBrowser after excluding FeatureX and FeatureZ: None
-					// bazBrowser after excluding FeatureX and FeatureZ: None
+					// fooBrowser after excluding/discouraging FeatureX and FeatureZ: None
+					// barBrowser after excluding/discouraging FeatureX and FeatureZ: None
+					// bazBrowser after excluding/discouraging FeatureX and FeatureZ: None
 					// Missing in on for bazBrowser: None
 					{
 						EventReleaseDate: time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC),
@@ -773,7 +785,7 @@ func testMissingOneImplSuite(
 					},
 				},
 			}
-			// Assert with excluded features
+			// Assert with excluded/discouraged features
 			assertListMissingOneImplCounts(
 				ctx,
 				t,
@@ -787,10 +799,15 @@ func testMissingOneImplSuite(
 			)
 		})
 
-		// Clear the excluded features after the test
+		// Clear the excluded and discouraged features after the test
 		err := spannerClient.ClearExcludedFeatureKeys(ctx)
 		if err != nil {
 			t.Fatalf("Failed to clear excluded feature keys: %v", err)
+		}
+
+		err = spannerClient.ClearFeatureDiscouragedDetails(ctx)
+		if err != nil {
+			t.Fatalf("Failed to clear feature discouraged details: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
This change modifies all of the spanner calls used on the stats page.

It adds a new getAllDiscouragedFeatureIDs method which is similar to [getFeatureIDsForEachExcludedFeatureKey](https://github.com/GoogleChrome/webstatus.dev/blob/88b65fb0b5645ddc0b0b90ca46bfe9ab85e314db/lib/gcpspanner/excluded_feature_keys.go#L25-L52)

getFeatureIDsForEachExcludedFeatureKey and getAllDiscouragedFeatureIDs are both now called in a common method named getIgnoredFeatureIDsForStats that is used in each spanner query for the stats page.

This change comes from last week's feedback to ignore discouraged features.

Builds on #1211 