### PR TITLE
Add dataFetchStartDate and dataFetchEndDate variables

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-feature-usage-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-feature-usage-chart-panel.test.ts
@@ -61,6 +61,14 @@ describe('WebstatusFeatureUsageChartPanel', () => {
     expect(header!.textContent).to.contain('Feature Usage');
   });
 
+  it('uses the correct dataFetchStartDate and dataFetchEndDate', async () => {
+    // Start date should use the default dataFetchStartDateOffsetMsec and dataFetchEndDateOffsetMsec
+    // Default dataFetchStartDateOffsetMsec is 30 days
+    // Default dataFetchEndDateOffsetMsec is 0 days
+    expect(el.dataFetchStartDate).to.deep.equal(new Date('2023-12-02'));
+    expect(el.dataFetchEndDate).to.deep.equal(new Date('2024-01-31'));
+  });
+
   it('calls _fetchAndAggregateData with correct configurations', async () => {
     expect(fetchAndAggregateDataStub).to.have.been.calledOnce;
     const [fetchFunctionConfigs, additionalSeriesConfigs] =

--- a/frontend/src/static/js/components/test/webstatus-feature-wpt-progress-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-feature-wpt-progress-chart-panel.test.ts
@@ -60,6 +60,14 @@ describe('WebstatusFeatureWPTProgressChartPanel', () => {
     expect(header!.textContent).to.contain('Implementation progress');
   });
 
+  it('uses the correct dataFetchStartDate and dataFetchEndDate', async () => {
+    // Start date should use the default dataFetchStartDateOffsetMsec and dataFetchEndDateOffsetMsec
+    // Default dataFetchStartDateOffsetMsec is 30 days
+    // Default dataFetchEndDateOffsetMsec is 0 days
+    expect(el.dataFetchStartDate).to.deep.equal(new Date('2023-12-02'));
+    expect(el.dataFetchEndDate).to.deep.equal(new Date('2024-01-31'));
+  });
+
   it('calls _fetchAndAggregateData with correct configurations', async () => {
     expect(fetchAndAggregateDataStub).to.have.been.calledOnce;
     const [fetchFunctionConfigs, additionalSeriesConfigs] =

--- a/frontend/src/static/js/components/test/webstatus-stats-global-feature-count-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-global-feature-count-chart-panel.test.ts
@@ -69,6 +69,14 @@ describe('WebstatusStatsGlobalFeatureCountChartPanel', () => {
     expect(header!.textContent).to.contain('Global feature support');
   });
 
+  it('uses the correct dataFetchStartDate and dataFetchEndDate', async () => {
+    // Start date should use the overridden dataFetchStartDateOffsetMsec and default dataFetchEndDateOffsetMsec
+    // Default dataFetchStartDateOffsetMsec is 500 days
+    // Default dataFetchEndDateOffsetMsec is 0 days
+    expect(el.dataFetchStartDate).to.deep.equal(new Date('2022-08-19'));
+    expect(el.dataFetchEndDate).to.deep.equal(new Date('2024-01-31'));
+  });
+
   it('calls _fetchAndAggregateData with correct arguments', async () => {
     expect(fetchAndAggregateDataStub).to.have.been.calledOnce;
     const [fetchFunctionConfigs, additionalSeriesConfigs] =

--- a/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
@@ -68,6 +68,14 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
     );
   });
 
+  it('uses the correct dataFetchStartDate and dataFetchEndDate', async () => {
+    // Start date should use the default dataFetchStartDateOffsetMsec and dataFetchEndDateOffsetMsec
+    // Default dataFetchStartDateOffsetMsec is 30 days
+    // Default dataFetchEndDateOffsetMsec is 0 days
+    expect(el.dataFetchStartDate).to.deep.equal(new Date('2023-12-02'));
+    expect(el.dataFetchEndDate).to.deep.equal(new Date('2024-01-31'));
+  });
+
   it('calls _fetchAndAggregateData with correct configurations', async () => {
     expect(fetchAndAggregateDataStub).to.have.been.calledOnce;
     const [fetchFunctionConfigs] = fetchAndAggregateDataStub.getCall(0).args;

--- a/frontend/src/static/js/components/webstatus-feature-usage-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-feature-usage-chart-panel.ts
@@ -31,7 +31,11 @@ export class WebstatusFeatureUsageChartPanel extends WebstatusLineChartPanel {
   createLoadingTask(): Task {
     return new Task(this, {
       args: () =>
-        [this.startDate, this.endDate, this.featureId] as [Date, Date, string],
+        [this.dataFetchStartDate, this.dataFetchEndDate, this.featureId] as [
+          Date,
+          Date,
+          string,
+        ],
       task: async ([startDate, endDate, featureId]: [Date, Date, string]) => {
         if (
           featureId === undefined ||

--- a/frontend/src/static/js/components/webstatus-feature-wpt-progress-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-feature-wpt-progress-chart-panel.ts
@@ -94,7 +94,11 @@ export class WebstatusFeatureWPTProgressChartPanel extends WebstatusLineChartPan
   createLoadingTask(): Task {
     return new Task(this, {
       args: () =>
-        [this.startDate, this.endDate, this.featureId] as [Date, Date, string],
+        [this.dataFetchStartDate, this.dataFetchEndDate, this.featureId] as [
+          Date,
+          Date,
+          string,
+        ],
       task: async ([startDate, endDate, featureId]: [Date, Date, string]) => {
         if (
           featureId === undefined ||

--- a/frontend/src/static/js/components/webstatus-line-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-line-chart-panel.ts
@@ -17,6 +17,7 @@
 import {
   CSSResultGroup,
   LitElement,
+  PropertyValueMap,
   TemplateResult,
   css,
   html,
@@ -115,12 +116,44 @@ export interface FetchFunctionConfig<T> {
  */
 export abstract class WebstatusLineChartPanel extends LitElement {
   /**
+   * The start date used to fetch data.
+   * Currently, we fetch more data so that the chart has more data.
+   * It is calculated by adding dataFetchStartDateOffsetMsec to startDate
+   * @property
+   * @type {Date}
+   */
+  dataFetchStartDate!: Date;
+
+  /**
+   * The number of milliseconds to offset the start date when fetching data.
+   * Implementers of the class can change this value as needed.
+   * By default, go back 1 month.
+   * @type {number}
+   */
+  dataFetchStartDateOffsetMsec: number = -1000 * 60 * 60 * 24 * 30;
+
+  /**
    * The start date for the data to be displayed in the chart.
    * @property
    * @type {Date}
    */
   @property({type: Object})
   startDate!: Date;
+
+  /**
+   * The end date used to fetch data.
+   * @property
+   * @type {Date}
+   */
+  dataFetchEndDate!: Date;
+
+  /**
+   * The number of milliseconds to offset the end date when fetching data.
+   * Implementers of the class can change this value as needed.
+   * By default, set to 0.
+   * @type {number}
+   */
+  dataFetchEndDateOffsetMsec: number = 0;
 
   /**
    * The end date for the data to be displayed in the chart.
@@ -209,6 +242,19 @@ export abstract class WebstatusLineChartPanel extends LitElement {
   constructor() {
     super();
     this._task = this.createLoadingTask();
+  }
+
+  protected willUpdate(changedProperties: PropertyValueMap<this>) {
+    if (changedProperties.has('startDate')) {
+      this.dataFetchStartDate = new Date(
+        this.startDate.getTime() + this.dataFetchStartDateOffsetMsec,
+      );
+    }
+    if (changedProperties.has('endDate')) {
+      this.dataFetchEndDate = new Date(
+        this.endDate.getTime() + this.dataFetchEndDateOffsetMsec,
+      );
+    }
   }
 
   static get styles(): CSSResultGroup {

--- a/frontend/src/static/js/components/webstatus-stats-global-feature-count-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-global-feature-count-chart-panel.ts
@@ -32,6 +32,10 @@ import {customElement, state} from 'lit/decorators.js';
 
 @customElement('webstatus-stats-global-feature-chart-panel')
 export class WebstatusStatsGlobalFeatureCountChartPanel extends WebstatusLineChartPanel {
+  // Worst case there are 470 days between releases for Edge
+  // https://github.com/mdn/browser-compat-data/blob/92d6876b420b0e6e69eb61256ed04827c9889063/browsers/edge.json#L53-L66
+  // Set offset to -500 days.
+  override dataFetchStartDateOffsetMsec: number = -500 * 24 * 60 * 60 * 1000;
   getDisplayDataChartOptionsInput(): {
     seriesColors: string[];
     vAxisTitle: string;
@@ -68,7 +72,8 @@ export class WebstatusStatsGlobalFeatureCountChartPanel extends WebstatusLineCha
 
   createLoadingTask(): Task {
     return new Task(this, {
-      args: () => [this.startDate, this.endDate] as [Date, Date],
+      args: () =>
+        [this.dataFetchStartDate, this.dataFetchEndDate] as [Date, Date],
       task: async ([startDate, endDate]: [Date, Date]) => {
         await this._fetchAndAggregateData([
           ...this._createFetchFunctionConfigs(startDate, endDate),

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -58,7 +58,8 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
 
   createLoadingTask(): Task {
     return new Task(this, {
-      args: () => [this.startDate, this.endDate] as [Date, Date],
+      args: () =>
+        [this.dataFetchStartDate, this.dataFetchEndDate] as [Date, Date],
       task: async ([startDate, endDate]: [Date, Date]) => {
         await this._fetchAndAggregateData(
           this._createFetchFunctionConfigs(


### PR DESCRIPTION
These variables are used for the actual fetching of the data.

This will help us gather more data so that the lines don't end unexpectedly if there are no data points right at the beginning.

These variables are calculated during the willUpdate [callback](https://lit.dev/docs/components/properties/#:~:text=To%20compute%20values%20from%20existing%20properties%2C%20we%20recommend%20using%20the%20willUpdate%20callback%2C%20which%20allows%20you%20to%20set%20values)

They are calculated from dataFetchStartDateOffsetMsec and dataFetchEndDateOffsetMsec

Each data panel can override those values as needed. For example, the global feature chart on the stats page has dataFetchStartDateOffsetMsec set to 500 days because there's are two data points where there are >400 days in between them.

The default for dataFetchStartDateOffsetMsec is 30 days.