### PR TITLE
Override cache TTL + set higher ttl for stats page

### DIFF
--- a/backend/manifests/pod.yaml
+++ b/backend/manifests/pod.yaml
@@ -47,6 +47,8 @@ spec:
           value: '6379'
         - name: CACHE_TTL
           value: 5m # Short TTL locally
+        - name: AGGREGATED_FEATURE_STATS_TTL
+          value: 5m # Short TTL locally
         # FIREBASE_AUTH_EMULATOR_HOST is needed by the Admin SDK to skip verification
         - name: FIREBASE_AUTH_EMULATOR_HOST
           value: auth:9099

--- a/backend/pkg/httpserver/cache.go
+++ b/backend/pkg/httpserver/cache.go
@@ -29,8 +29,9 @@ import (
 // logical grouping and potential future deletion by prefix.  It also handles
 // JSON serialization/deserialization of keys and values.
 type operationResponseCache[Key any, Response any] struct {
-	cacher      RawBytesDataCacher
-	operationID string
+	cacher       RawBytesDataCacher
+	operationID  string
+	cacheOptions []cachetypes.CacheOption
 }
 
 func (c operationResponseCache[Key, Response]) key(key []byte) string {
@@ -67,7 +68,7 @@ func (c operationResponseCache[Key, Response]) AttemptCache(ctx context.Context,
 		return
 	}
 
-	err = c.cacher.Cache(ctx, c.key(jsonBytesKey), jsonBytesValue)
+	err = c.cacher.Cache(ctx, c.key(jsonBytesKey), jsonBytesValue, c.cacheOptions...)
 	if err != nil {
 		slog.ErrorContext(ctx, "encountered unexpected error when caching",
 			"error", err, "key", key, "operation", c.operationID)
@@ -156,51 +157,55 @@ type operationResponseCaches struct {
 // operationResponseCache instance within the operationResponseCaches struct.
 // While each cache instance uses the same underlying RawBytesDataCacher for storage,
 // they operate independently and are specialized for their respective API operations.
-func initOperationResponseCaches(dataCacher RawBytesDataCacher) *operationResponseCaches {
+func initOperationResponseCaches(dataCacher RawBytesDataCacher,
+	routeCacheOptions RouteCacheOptions) *operationResponseCaches {
 	return &operationResponseCaches{
 		getFeatureCache: operationResponseCache[
 			backend.GetFeatureRequestObject,
 			backend.GetFeature200JSONResponse,
-		]{cacher: dataCacher, operationID: "getFeature"},
+		]{cacher: dataCacher, operationID: "getFeature", cacheOptions: nil},
 
 		listFeaturesCache: operationResponseCache[
 			backend.ListFeaturesRequestObject,
 			backend.ListFeatures200JSONResponse,
-		]{cacher: dataCacher, operationID: "listFeatures"},
+		]{cacher: dataCacher, operationID: "listFeatures", cacheOptions: nil},
 
 		getFeatureMetadataCache: operationResponseCache[
 			backend.GetFeatureMetadataRequestObject,
 			backend.GetFeatureMetadata200JSONResponse,
-		]{cacher: dataCacher, operationID: "getFeatureMetadata"},
+		]{cacher: dataCacher, operationID: "getFeatureMetadata", cacheOptions: nil},
 
 		listFeatureWPTMetricsCache: operationResponseCache[
 			backend.ListFeatureWPTMetricsRequestObject,
 			backend.ListFeatureWPTMetrics200JSONResponse,
-		]{cacher: dataCacher, operationID: "listFeatureWPTMetrics"},
+		]{cacher: dataCacher, operationID: "listFeatureWPTMetrics", cacheOptions: nil},
 
 		listChromiumDailyUsageStatsCache: operationResponseCache[
 			backend.ListChromiumDailyUsageStatsRequestObject,
 			backend.ListChromiumDailyUsageStats200JSONResponse,
-		]{cacher: dataCacher, operationID: "listChromiumDailyUsageStats"},
+		]{cacher: dataCacher, operationID: "listChromiumDailyUsageStats", cacheOptions: nil},
 
 		listAggregatedFeatureSupportCache: operationResponseCache[
 			backend.ListAggregatedFeatureSupportRequestObject,
 			backend.ListAggregatedFeatureSupport200JSONResponse,
-		]{cacher: dataCacher, operationID: "listAggregatedFeatureSupport"},
+		]{cacher: dataCacher, operationID: "listAggregatedFeatureSupport",
+			cacheOptions: routeCacheOptions.AggregatedFeatureStatsOptions},
 
 		listMissingOneImplemenationCountsCache: operationResponseCache[
 			backend.ListMissingOneImplemenationCountsRequestObject,
 			backend.ListMissingOneImplemenationCounts200JSONResponse,
-		]{cacher: dataCacher, operationID: "listMissingOneImplemenationCounts"},
+		]{cacher: dataCacher, operationID: "listMissingOneImplemenationCounts",
+			cacheOptions: routeCacheOptions.AggregatedFeatureStatsOptions},
 
 		listAggregatedWPTMetricsCache: operationResponseCache[
 			backend.ListAggregatedWPTMetricsRequestObject,
 			backend.ListAggregatedWPTMetrics200JSONResponse,
-		]{cacher: dataCacher, operationID: "listAggregatedWPTMetrics"},
+		]{cacher: dataCacher, operationID: "listAggregatedWPTMetrics", cacheOptions: nil},
 
 		listAggregatedBaselineStatusCountsCache: operationResponseCache[
 			backend.ListAggregatedBaselineStatusCountsRequestObject,
 			backend.ListAggregatedBaselineStatusCounts200JSONResponse,
-		]{cacher: dataCacher, operationID: "listAggregatedBaselineStatusCounts"},
+		]{cacher: dataCacher, operationID: "listAggregatedBaselineStatusCounts",
+			cacheOptions: routeCacheOptions.AggregatedFeatureStatsOptions},
 	}
 }

--- a/backend/pkg/httpserver/cache_test.go
+++ b/backend/pkg/httpserver/cache_test.go
@@ -50,8 +50,13 @@ func NewMockRawBytesDataCacher(
 	}
 }
 
+func getDefaultCacheConfig() *cachetypes.CacheConfig {
+	return cachetypes.NewCacheConfig(0)
+}
+
 // Cache implements the Cache method of the RawBytesDataCacher interface.
-func (m *MockRawBytesDataCacher) Cache(_ context.Context, key string, value []byte) error {
+func (m *MockRawBytesDataCacher) Cache(_ context.Context, key string, value []byte,
+	options ...cachetypes.CacheOption) error {
 	if m.currentCacheCallIdx >= len(m.expectedCacheCalls) {
 		m.t.Errorf("unexpected call to Cache with key: %s", key)
 
@@ -66,9 +71,20 @@ func (m *MockRawBytesDataCacher) Cache(_ context.Context, key string, value []by
 		m.t.Errorf("expected Cache value: %v, got: %v", string(expectedCall.Value), string(value))
 	}
 
+	cacheCfg := getDefaultCacheConfig()
+
+	for _, opt := range options {
+		opt(cacheCfg)
+	}
+
+	if !reflect.DeepEqual(expectedCall.CacheCfg, cacheCfg) {
+		m.t.Errorf("expected Cache config: %v, got: %v", expectedCall.CacheCfg, cacheCfg)
+	}
+
 	m.actualCacheCalls = append(m.actualCacheCalls, &ActualCacheCall{
-		Key:   key,
-		Value: value,
+		Key:      key,
+		Value:    value,
+		CacheCfg: cacheCfg,
 	})
 	m.currentCacheCallIdx++
 
@@ -126,14 +142,16 @@ func (m *MockRawBytesDataCacher) AssertExpectations() {
 
 // ExpectedCacheCall represents an expected call to Cache.
 type ExpectedCacheCall struct {
-	Key   string
-	Value []byte
+	Key      string
+	Value    []byte
+	CacheCfg *cachetypes.CacheConfig
 }
 
 // ActualCacheCall represents an actual call made to Cache.
 type ActualCacheCall struct {
-	Key   string
-	Value []byte
+	Key      string
+	Value    []byte
+	CacheCfg *cachetypes.CacheConfig
 }
 
 // ExpectedGetCall represents an expected call to Get.
@@ -165,6 +183,7 @@ func TestOperationResponseCache_AttemptCache(t *testing.T) {
 		key                TestKey
 		value              *TestValue
 		expectedCacheCalls []*ExpectedCacheCall
+		cacheOptions       []cachetypes.CacheOption
 	}{
 		{
 			name: "Valid Cache Operation",
@@ -178,9 +197,32 @@ func TestOperationResponseCache_AttemptCache(t *testing.T) {
 			},
 			expectedCacheCalls: []*ExpectedCacheCall{
 				{
-					Key:   `customOperation-{"ID":"test-id","Param":"test-param"}`,
-					Value: []byte(`{"Name":"Test Item","Value":123}`),
+					Key:      `customOperation-{"ID":"test-id","Param":"test-param"}`,
+					Value:    []byte(`{"Name":"Test Item","Value":123}`),
+					CacheCfg: getDefaultCacheConfig(),
 				},
+			},
+			cacheOptions: nil,
+		},
+		{
+			name: "Valid Cache Operation with option",
+			key: TestKey{
+				ID:    "test-id",
+				Param: "test-param",
+			},
+			value: &TestValue{
+				Name:  "Test Item",
+				Value: 123,
+			},
+			expectedCacheCalls: []*ExpectedCacheCall{
+				{
+					Key:      `customOperation-{"ID":"test-id","Param":"test-param"}`,
+					Value:    []byte(`{"Name":"Test Item","Value":123}`),
+					CacheCfg: cachetypes.NewCacheConfig(10),
+				},
+			},
+			cacheOptions: []cachetypes.CacheOption{
+				cachetypes.WithTTL(10),
 			},
 		},
 		{
@@ -191,6 +233,7 @@ func TestOperationResponseCache_AttemptCache(t *testing.T) {
 			},
 			value:              nil,
 			expectedCacheCalls: []*ExpectedCacheCall{},
+			cacheOptions:       nil,
 		},
 	}
 
@@ -200,7 +243,7 @@ func TestOperationResponseCache_AttemptCache(t *testing.T) {
 			cache := operationResponseCache[
 				TestKey,
 				TestValue,
-			]{cacher: mockCacher, operationID: "customOperation"}
+			]{cacher: mockCacher, operationID: "customOperation", cacheOptions: tc.cacheOptions}
 
 			cache.AttemptCache(context.Background(), tc.key, tc.value)
 			mockCacher.AssertExpectations()
@@ -291,7 +334,7 @@ func TestOperationResponseCache_Lookup(t *testing.T) {
 			cache := operationResponseCache[
 				TestKey,
 				TestValue,
-			]{cacher: mockCacher, operationID: "customOperation"}
+			]{cacher: mockCacher, operationID: "customOperation", cacheOptions: nil}
 
 			var actualValue TestValue
 			result := cache.Lookup(context.Background(), tc.key, &actualValue)
@@ -304,5 +347,11 @@ func TestOperationResponseCache_Lookup(t *testing.T) {
 			}
 			mockCacher.AssertExpectations()
 		})
+	}
+}
+
+func getTestRouteCacheOptions() RouteCacheOptions {
+	return RouteCacheOptions{
+		AggregatedFeatureStatsOptions: nil,
 	}
 }

--- a/backend/pkg/httpserver/get_feature_metadata_test.go
+++ b/backend/pkg/httpserver/get_feature_metadata_test.go
@@ -112,7 +112,7 @@ func TestGetFeatureMetadata(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: mockMetadataStorer,
-				operationResponseCaches: initOperationResponseCaches(mockCacher)}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			mockCacher.AssertExpectations()
 			// TODO: Start tracking call count and assert call count.

--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -322,7 +322,7 @@ func TestGetFeature(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher)}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountGetFeature,
 				"GetFeature", mockCacher)

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -482,7 +482,7 @@ func TestListFeatures(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher)}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountFeaturesSearch,
 				"FeaturesSearch", mockCacher)

--- a/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
+++ b/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
@@ -295,7 +295,7 @@ func TestListAggregatedBaselineStatusCounts(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher)}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListBaselineStatusCounts,
 				"ListBaselineStatusCounts", mockCacher)

--- a/backend/pkg/httpserver/list_aggregated_feature_support_test.go
+++ b/backend/pkg/httpserver/list_aggregated_feature_support_test.go
@@ -303,7 +303,7 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher)}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListBrowserFeatureCountMetric,
 				"ListBrowserFeatureCountMetric", mockCacher)

--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
@@ -298,7 +298,7 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher)}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMetricsOverTimeWithAggregatedTotals,
 				"ListMetricsOverTimeWithAggregatedTotals", mockCacher)

--- a/backend/pkg/httpserver/list_chromium_usage_test.go
+++ b/backend/pkg/httpserver/list_chromium_usage_test.go
@@ -153,7 +153,7 @@ func TestListChromiumDailyUsageStats(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher)}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListChromiumDailyUsageStats,
 				"ListChromiumDailyUsageStats", mockCacher)

--- a/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
@@ -294,7 +294,7 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher)}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMetricsForFeatureIDBrowserAndChannel,
 				"ListMetricsForFeatureIDBrowserAndChannel", mockCacher)

--- a/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
@@ -318,7 +318,7 @@ func TestListMissingOneImplemenationCounts(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher)}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMissingOneImplCounts,
 				"ListMissingOneImplCounts", mockCacher)

--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -45,7 +45,10 @@ custom_ssl_certificates_for_backend  = []
 
 spanner_region_override = "nam-eur-asia1"
 
-cache_duration = "5m"
+backend_cache_settings = {
+  default_duration                  = "1h"
+  aggregated_feature_stats_duration = "3h"
+}
 
 backend_cors_allowed_origin = "https://*"
 

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -45,7 +45,10 @@ frontend_domains = ["website-webstatus-dev.corp.goog"]
 custom_ssl_certificates_for_frontend = ["ub-self-sign"]
 custom_ssl_certificates_for_backend  = ["ub-self-sign"]
 
-cache_duration = "5m"
+backend_cache_settings = {
+  default_duration                  = "5m"
+  aggregated_feature_stats_duration = "1h"
+}
 
 # Needed for UbP.
 backend_cors_allowed_origin = "https://website-webstatus-dev.corp.goog"

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -102,7 +102,11 @@ resource "google_cloud_run_v2_service" "service" {
       }
       env {
         name  = "CACHE_TTL"
-        value = var.cache_duration
+        value = var.cache_settings.default_duration
+      }
+      env {
+        name  = "AGGREGATED_FEATURE_STATS_TTL"
+        value = var.cache_settings.aggregated_feature_stats_duration
       }
       env {
         name  = "OTEL_EXPORTER_OTLP_ENDPOINT"

--- a/infra/backend/variables.tf
+++ b/infra/backend/variables.tf
@@ -75,8 +75,11 @@ variable "valkey_env_vars" {
   description = "Map of Valkey host and port per region"
 }
 
-variable "cache_duration" {
-  type = string
+variable "cache_settings" {
+  type = object({
+    default_duration                  = string
+    aggregated_feature_stats_duration = string
+  })
 }
 
 variable "cors_allowed_origin" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -113,7 +113,7 @@ module "backend" {
   domains                   = var.backend_domains
   custom_ssl_certificates   = var.custom_ssl_certificates_for_backend
   projects                  = var.projects
-  cache_duration            = var.cache_duration
+  cache_settings            = var.backend_cache_settings
   valkey_env_vars           = module.storage.valkey_env_vars
   cors_allowed_origin       = var.backend_cors_allowed_origin
   min_instance_count        = var.backend_min_instance_count

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -118,9 +118,12 @@ variable "backend_domains" {
   description = "List of domains for the backend"
 }
 
-variable "cache_duration" {
-  type        = string
-  description = "TTL for entries that are cached"
+variable "backend_cache_settings" {
+  type = object({
+    default_duration                  = string
+    aggregated_feature_stats_duration = string
+  })
+  description = "Various cache settings for backend"
 }
 
 variable "backend_cors_allowed_origin" {

--- a/lib/valkeycache/cache.go
+++ b/lib/valkeycache/cache.go
@@ -66,9 +66,18 @@ func (c *ValkeyDataCache[K, V]) Cache(
 	ctx context.Context,
 	key K,
 	in V,
+	options ...cachetypes.CacheOption,
 ) error {
+	// Build default config for cache operation
+	cacheCfg := cachetypes.NewCacheConfig(c.ttl)
+
+	// Apply options to config
+	for _, opt := range options {
+		opt(cacheCfg)
+	}
+
 	err := c.client.Do(ctx, c.client.B().Set().Key(c.cacheKey(key)).
-		Value(valkey.BinaryString(in)).Ex(c.ttl).Build()).Error()
+		Value(valkey.BinaryString(in)).Ex(cacheCfg.GetTTL()).Build()).Error()
 	if err != nil {
 		return err
 	}

--- a/lib/valkeycache/cache_test.go
+++ b/lib/valkeycache/cache_test.go
@@ -120,4 +120,41 @@ func TestValkeyDataCache(t *testing.T) {
 
 	})
 
+	t.Run("cache hit with custom ttl", func(t *testing.T) {
+		// Store result with custom ttl
+		err := cache.Cache(ctx, testKey1, testValue1, cachetypes.WithTTL(getDefatulTTL()*4))
+		if !errors.Is(err, nil) {
+			t.Errorf("invalid error storing value %v", err)
+		}
+
+		// Get result.
+		result, err := cache.Get(ctx, testKey1)
+		if !errors.Is(err, nil) {
+			t.Errorf("invalid error getting value %v", err)
+		}
+		if !reflect.DeepEqual(result, testValue1) {
+			t.Error("expected result")
+		}
+
+		// Wait normally and should still get the result
+		time.Sleep(getDefatulTTL() * 2)
+		result, err = cache.Get(ctx, testKey1)
+		if !errors.Is(err, nil) {
+			t.Errorf("invalid error getting value %v", err)
+		}
+		if !reflect.DeepEqual(result, testValue1) {
+			t.Error("expected result")
+		}
+
+		// Waiting again should allow the custom TTL to expire
+		time.Sleep(getDefatulTTL() * 4)
+		result, err = cache.Get(ctx, testKey1)
+		if !errors.Is(err, cachetypes.ErrCachedDataNotFound) {
+			t.Errorf("invalid error getting expired result %v", err)
+		}
+		if result != nil {
+			t.Error("expected null result")
+		}
+
+	})
 }


### PR DESCRIPTION
There's a default TTL use for all operations. This adds a new TTL for the stats page by allowing it to set a new option.