### PR TITLE
Increase the length of the Links column

### DIFF
--- a/infra/storage/spanner/migrations/000015.sql
+++ b/infra/storage/spanner/migrations/000015.sql
@@ -1,0 +1,15 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE FeatureSpecs ALTER COLUMN Links ARRAY<STRING(MAX)>;


### PR DESCRIPTION
The web features workflow started to fail due to this error:

```
unable to insert FeatureSpec links=[https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-additional-properties-of-the-string.prototype-object] featureID=html-wrapper-methods error="internal spanner query failure\nspanner: code = \"FailedPrecondition\", desc = \"New value exceeds the maximum size limit for elements in this column in this database: FeatureSpecs.Links, size: 143, limit: 128.\"
```

This change modifies the Links column from Array(String(128)) to Array(String(MAX))