### PR TITLE
Correct implemenation to implementaion

### DIFF
--- a/backend/pkg/httpserver/cache.go
+++ b/backend/pkg/httpserver/cache.go
@@ -139,9 +139,9 @@ type operationResponseCaches struct {
 		backend.ListAggregatedFeatureSupportRequestObject,
 		backend.ListAggregatedFeatureSupport200JSONResponse,
 	]
-	listMissingOneImplemenationCountsCache operationResponseCache[
-		backend.ListMissingOneImplemenationCountsRequestObject,
-		backend.ListMissingOneImplemenationCounts200JSONResponse,
+	ListMissingOneImplementationCountsCache operationResponseCache[
+		backend.ListMissingOneImplementationCountsRequestObject,
+		backend.ListMissingOneImplementationCounts200JSONResponse,
 	]
 	listAggregatedWPTMetricsCache operationResponseCache[
 		backend.ListAggregatedWPTMetricsRequestObject,
@@ -191,10 +191,10 @@ func initOperationResponseCaches(dataCacher RawBytesDataCacher,
 		]{cacher: dataCacher, operationID: "listAggregatedFeatureSupport",
 			overrideCacheOptions: routeCacheOptions.AggregatedFeatureStatsOptions},
 
-		listMissingOneImplemenationCountsCache: operationResponseCache[
-			backend.ListMissingOneImplemenationCountsRequestObject,
-			backend.ListMissingOneImplemenationCounts200JSONResponse,
-		]{cacher: dataCacher, operationID: "listMissingOneImplemenationCounts",
+		ListMissingOneImplementationCountsCache: operationResponseCache[
+			backend.ListMissingOneImplementationCountsRequestObject,
+			backend.ListMissingOneImplementationCounts200JSONResponse,
+		]{cacher: dataCacher, operationID: "ListMissingOneImplementationCounts",
 			overrideCacheOptions: routeCacheOptions.AggregatedFeatureStatsOptions},
 
 		listAggregatedWPTMetricsCache: operationResponseCache[

--- a/backend/pkg/httpserver/list_missing_one_implementation_counts.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_counts.go
@@ -23,14 +23,14 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-// ListMissingOneImplemenationCounts implements backend.StrictServerInterface.
+// ListMissingOneImplementationCounts implements backend.StrictServerInterface.
 // nolint: ireturn // Signature generated from openapi
-func (s *Server) ListMissingOneImplemenationCounts(
+func (s *Server) ListMissingOneImplementationCounts(
 	ctx context.Context,
-	request backend.ListMissingOneImplemenationCountsRequestObject) (
-	backend.ListMissingOneImplemenationCountsResponseObject, error) {
-	var cachedResponse backend.ListMissingOneImplemenationCounts200JSONResponse
-	found := s.operationResponseCaches.listMissingOneImplemenationCountsCache.Lookup(ctx, request, &cachedResponse)
+	request backend.ListMissingOneImplementationCountsRequestObject) (
+	backend.ListMissingOneImplementationCountsResponseObject, error) {
+	var cachedResponse backend.ListMissingOneImplementationCounts200JSONResponse
+	found := s.operationResponseCaches.ListMissingOneImplementationCountsCache.Lookup(ctx, request, &cachedResponse)
 	if found {
 		return cachedResponse, nil
 	}
@@ -51,7 +51,7 @@ func (s *Server) ListMissingOneImplemenationCounts(
 		if errors.Is(err, backendtypes.ErrInvalidPageToken) {
 			slog.WarnContext(ctx, "invalid page token", "token", request.Params.PageToken, "error", err)
 
-			return backend.ListMissingOneImplemenationCounts400JSONResponse{
+			return backend.ListMissingOneImplementationCounts400JSONResponse{
 				Code:    400,
 				Message: "invalid page token",
 			}, nil
@@ -59,17 +59,17 @@ func (s *Server) ListMissingOneImplemenationCounts(
 
 		slog.ErrorContext(ctx, "unable to get missing one implementation count", "error", err)
 
-		return backend.ListMissingOneImplemenationCounts500JSONResponse{
+		return backend.ListMissingOneImplementationCounts500JSONResponse{
 			Code:    500,
 			Message: "unable to get missing one implementation metrics",
 		}, nil
 	}
 
-	resp := backend.ListMissingOneImplemenationCounts200JSONResponse{
+	resp := backend.ListMissingOneImplementationCounts200JSONResponse{
 		Metadata: page.Metadata,
 		Data:     page.Data,
 	}
-	s.operationResponseCaches.listMissingOneImplemenationCountsCache.AttemptCache(ctx, request, &resp)
+	s.operationResponseCaches.ListMissingOneImplementationCountsCache.AttemptCache(ctx, request, &resp)
 
 	return resp, nil
 }

--- a/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-func TestListMissingOneImplemenationCounts(t *testing.T) {
+func TestListMissingOneImplementationCounts(t *testing.T) {
 	testCases := []struct {
 		name               string
 		mockConfig         *MockListMissingOneImplCountsConfig
@@ -64,7 +64,7 @@ func TestListMissingOneImplemenationCounts(t *testing.T) {
 			},
 			expectedGetCalls: []*ExpectedGetCall{
 				{
-					Key: `listMissingOneImplemenationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
+					Key: `ListMissingOneImplementationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
 						`"endAt":"2000-01-10","browser":["edge","firefox","safari"]}}`,
 					Value: nil,
 					Err:   cachetypes.ErrCachedDataNotFound,
@@ -72,7 +72,7 @@ func TestListMissingOneImplemenationCounts(t *testing.T) {
 			},
 			expectedCacheCalls: []*ExpectedCacheCall{
 				{
-					Key: `listMissingOneImplemenationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
+					Key: `ListMissingOneImplementationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
 						`"endAt":"2000-01-10","browser":["edge","firefox","safari"]}}`,
 					Value: []byte(
 						`{"data":[{"count":10,"timestamp":"2000-01-10T00:00:00Z"},` +
@@ -108,7 +108,7 @@ func TestListMissingOneImplemenationCounts(t *testing.T) {
 			mockConfig: nil,
 			expectedGetCalls: []*ExpectedGetCall{
 				{
-					Key: `listMissingOneImplemenationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
+					Key: `ListMissingOneImplementationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
 						`"endAt":"2000-01-10","browser":["edge","firefox","safari"]}}`,
 					Value: []byte(
 						`{"data":[{"count":10,"timestamp":"2000-01-10T00:00:00Z"},` +
@@ -169,7 +169,7 @@ func TestListMissingOneImplemenationCounts(t *testing.T) {
 			},
 			expectedGetCalls: []*ExpectedGetCall{
 				{
-					Key: `listMissingOneImplemenationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
+					Key: `ListMissingOneImplementationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
 						`"endAt":"2000-01-10","page_token":"input-token",` +
 						`"page_size":50,"browser":["edge","firefox","safari"]}}`,
 					Value: nil,
@@ -178,7 +178,7 @@ func TestListMissingOneImplemenationCounts(t *testing.T) {
 			},
 			expectedCacheCalls: []*ExpectedCacheCall{
 				{
-					Key: `listMissingOneImplemenationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
+					Key: `ListMissingOneImplementationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
 						`"endAt":"2000-01-10","page_token":"input-token",` +
 						`"page_size":50,"browser":["edge","firefox","safari"]}}`,
 					Value: []byte(
@@ -216,7 +216,7 @@ func TestListMissingOneImplemenationCounts(t *testing.T) {
 			mockConfig: nil,
 			expectedGetCalls: []*ExpectedGetCall{
 				{
-					Key: `listMissingOneImplemenationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
+					Key: `ListMissingOneImplementationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
 						`"endAt":"2000-01-10","page_token":"input-token",` +
 						`"page_size":50,"browser":["edge","firefox","safari"]}}`,
 					Value: []byte(
@@ -265,7 +265,7 @@ func TestListMissingOneImplemenationCounts(t *testing.T) {
 			},
 			expectedGetCalls: []*ExpectedGetCall{
 				{
-					Key: `listMissingOneImplemenationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
+					Key: `ListMissingOneImplementationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
 						`"endAt":"2000-01-10","browser":["edge","firefox","safari"]}}`,
 					Value: nil,
 					Err:   cachetypes.ErrCachedDataNotFound,
@@ -295,7 +295,7 @@ func TestListMissingOneImplemenationCounts(t *testing.T) {
 			},
 			expectedGetCalls: []*ExpectedGetCall{
 				{
-					Key: `listMissingOneImplemenationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
+					Key: `ListMissingOneImplementationCounts-{"browser":"chrome","Params":{"startAt":"2000-01-01",` +
 						`"endAt":"2000-01-10","page_token":"","browser":["edge","firefox","safari"]}}`,
 					Value: nil,
 					Err:   cachetypes.ErrCachedDataNotFound,

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -606,11 +606,11 @@ func (m *mockServerInterface) ListFeatures(ctx context.Context,
 	panic("unimplemented")
 }
 
-// ListMissingOneImplemenationCounts implements backend.StrictServerInterface.
+// ListMissingOneImplementationCounts implements backend.StrictServerInterface.
 // nolint: ireturn // WONTFIX - generated method signature
-func (m *mockServerInterface) ListMissingOneImplemenationCounts(ctx context.Context,
-	_ backend.ListMissingOneImplemenationCountsRequestObject) (
-	backend.ListMissingOneImplemenationCountsResponseObject, error) {
+func (m *mockServerInterface) ListMissingOneImplementationCounts(ctx context.Context,
+	_ backend.ListMissingOneImplementationCountsRequestObject) (
+	backend.ListMissingOneImplementationCountsResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
 	m.callCount++
 	panic("unimplemented")

--- a/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
@@ -259,7 +259,7 @@ describe('webstatus-feature-page', () => {
       hostElement = document.createElement('div');
     });
 
-    it('renders nothing when there is no implemenation', async () => {
+    it('renders nothing when there is no implementation', async () => {
       const browserImpl = undefined;
       const actual = element.renderBrowserImpl(browserImpl);
       render(actual, hostElement);

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -355,7 +355,7 @@ paths:
         comparison browsers but not supported by the specified target browser,
         as of each browser's (target browser or comparison browser) release
         date.
-      operationId: listMissingOneImplemenationCounts
+      operationId: listMissingOneImplementationCounts
       parameters:
         - $ref: '#/components/parameters/startAtParam'
         - $ref: '#/components/parameters/endAtParam'


### PR DESCRIPTION
Correct the typo `implemenation` to `implementaion` in MissingOneImplementationCounts