### PR TITLE
Store and reuse selection in between draws

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-gchart.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-gchart.test.ts
@@ -63,6 +63,8 @@ describe('webstatus-gchart', () => {
       'webstatus-gchart',
     ) as WebstatusGChart;
 
+    component.currentSelection = [{row: 0, column: 1}];
+
     await loaderComponent.updateComplete;
     await loaderComponent.waitForGChartsLibraryLoaded();
     await component.updateComplete;
@@ -77,8 +79,10 @@ describe('webstatus-gchart', () => {
   });
 
   it('redraws the chart on resize', async () => {
-    // Spy on the chartWrapper.draw method (make sure chartWrapper is initialized)
+    // Spy on the chartWrapper.draw and setSelection methods (make sure chartWrapper is initialized)
     const drawSpy = sinon.spy(component.chartWrapper!, 'draw');
+    const mockChart = sinon.createStubInstance(google.visualization.LineChart);
+    sinon.stub(component.chartWrapper!, 'getChart').returns(mockChart);
 
     // Simulate a resize
     const resizeObserverCallback = mockResizeObserver.args[0][0];
@@ -90,6 +94,7 @@ describe('webstatus-gchart', () => {
 
     // Assert that chartWrapper.draw was called
     assert.isTrue(drawSpy.calledOnce);
+    assert.isTrue(mockChart.setSelection.calledOnceWith([{row: 0, column: 1}]));
   });
 
   describe('Selection events', () => {


### PR DESCRIPTION
When the gchart redraws (either from resizing the window or the parent encompassing component redraws it), it drops the selected data points.

This change fixes that.

This was originally reported in the description in #1242