### PR TITLE
Spanner logic to delete a single user saved search

### DIFF
--- a/lib/gcpspanner/client.go
+++ b/lib/gcpspanner/client.go
@@ -612,8 +612,10 @@ func (c *entityWriter[M, ExternalStruct, SpannerStruct, ExternalKey]) updateWith
 
 // removableEntityMapper extends writeableEntityMapper with the ability to remove an entity.
 type removableEntityMapper[ExternalStruct any, SpannerStruct any, ExternalKey any] interface {
-	writeableEntityMapper[ExternalStruct, SpannerStruct, ExternalKey]
+	readableEntityMapper[ExternalStruct, SpannerStruct, ExternalKey]
+	GetKey(ExternalStruct) ExternalKey
 	DeleteKey(ExternalKey) spanner.Key
+	Table() string
 }
 
 // entityRemover is a basic client for removing any row from the database.

--- a/lib/gcpspanner/delete_user_saved_search.go
+++ b/lib/gcpspanner/delete_user_saved_search.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"log/slog"
+
+	"cloud.google.com/go/spanner"
+)
+
+// removeUserSavedSearchMapper implements removableEntityMapper.
+type removeUserSavedSearchMapper struct{}
+
+func (m removeUserSavedSearchMapper) Table() string { return savedSearchesTable }
+
+func (m removeUserSavedSearchMapper) GetKey(in DeleteUserSavedSearchRequest) removeUserSavedSearchMapperKey {
+	return removeUserSavedSearchMapperKey{
+		ID:     in.SavedSearchID,
+		UserID: in.RequestingUserID,
+	}
+}
+
+type removeUserSavedSearchMapperKey struct {
+	ID     string
+	UserID string
+}
+
+func (m removeUserSavedSearchMapper) SelectOne(key removeUserSavedSearchMapperKey) spanner.Statement {
+	return authenticatedUserSavedSearchMapper{}.SelectOne(
+		authenticatedUserSavedSearchMapperKey(key))
+}
+
+func (m removeUserSavedSearchMapper) DeleteKey(key removeUserSavedSearchMapperKey) spanner.Key {
+	return spanner.Key{key.ID}
+}
+
+// DeleteUserSavedSearchRequest contains the request parameters for DeleteUserSavedSearch.
+type DeleteUserSavedSearchRequest struct {
+	RequestingUserID string
+	SavedSearchID    string
+}
+
+// DeleteUserSavedSearch deletes a user's saved search.
+func (c *Client) DeleteUserSavedSearch(ctx context.Context, req DeleteUserSavedSearchRequest) error {
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		// 1. Check if the user has permission to delete (OWNER role)
+		err := c.checkForSavedSearchRole(ctx, txn, SavedSearchOwner, req.RequestingUserID, req.SavedSearchID)
+		if err != nil {
+			return err
+		}
+
+		// 2. Read and update the existing saved search
+		err = newEntityRemover[removeUserSavedSearchMapper, UserSavedSearch](c).removeWithTransaction(ctx, txn, req)
+		if err != nil {
+			slog.ErrorContext(ctx, "failed to update the saved search", "error", err)
+
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lib/gcpspanner/delete_user_saved_search_test.go
+++ b/lib/gcpspanner/delete_user_saved_search_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+)
+
+func TestDeleteUserSavedSearch(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+
+	savedSearchID, err := spannerClient.CreateNewUserSavedSearch(ctx, CreateUserSavedSearchRequest{
+		Name:        "my little search",
+		Query:       "group:css",
+		OwnerUserID: "userID1",
+		Description: valuePtr("desc"),
+	})
+	if err != nil {
+		t.Errorf("expected nil error. received %s", err)
+	}
+	if savedSearchID == nil {
+		t.Error("expected non-nil id.")
+	}
+
+	t.Run("non owner cannot delete search", func(t *testing.T) {
+		err := spannerClient.DeleteUserSavedSearch(ctx, DeleteUserSavedSearchRequest{
+			SavedSearchID:    *savedSearchID,
+			RequestingUserID: "userID2",
+		})
+		if !errors.Is(err, ErrMissingRequiredRole) {
+			t.Errorf("expected ErrMissingRequiredRole. received %s", err)
+		}
+
+		expectedSavedSearch := &UserSavedSearch{
+			IsBookmarked: nil,
+			Role:         nil,
+			SavedSearch: SavedSearch{
+				ID:          *savedSearchID,
+				Name:        "my little search",
+				Query:       "group:css",
+				Scope:       "USER_PUBLIC",
+				AuthorID:    "userID1",
+				Description: valuePtr("desc"),
+				// Don't actually compare the last two values.
+				CreatedAt: spanner.CommitTimestamp,
+				UpdatedAt: spanner.CommitTimestamp,
+			},
+		}
+		actual, err := spannerClient.GetUserSavedSearch(ctx, *savedSearchID, nil)
+		if err != nil {
+			t.Errorf("expected nil error. received %s", err)
+		}
+		if !userSavedSearchEquality(expectedSavedSearch, actual) {
+			t.Errorf("different saved searches\nexpected: %+v\nreceived: %v", expectedSavedSearch, actual)
+		}
+	})
+
+	t.Run("owner can delete search", func(t *testing.T) {
+		err := spannerClient.DeleteUserSavedSearch(ctx, DeleteUserSavedSearchRequest{
+			SavedSearchID:    *savedSearchID,
+			RequestingUserID: "userID1",
+		})
+		if !errors.Is(err, nil) {
+			t.Errorf("expected nil error. received %s", err)
+		}
+		_, err = spannerClient.GetUserSavedSearch(ctx, *savedSearchID, nil)
+		if !errors.Is(err, ErrQueryReturnedNoResults) {
+			t.Errorf("expected ErrQueryReturnedNoResults. received %s", err)
+		}
+	})
+}

--- a/lib/gcpspanner/user_search_bookmarks.go
+++ b/lib/gcpspanner/user_search_bookmarks.go
@@ -79,5 +79,5 @@ func (c *Client) AddUserSearchBookmark(ctx context.Context, req UserSavedSearchB
 }
 
 func (c *Client) DeleteUserSearchBookmark(ctx context.Context, req UserSavedSearchBookmark) error {
-	return newEntityRemover[userSavedSearchBookmarkMapper](c).remove(ctx, req)
+	return newEntityRemover[userSavedSearchBookmarkMapper, UserSavedSearchBookmark](c).remove(ctx, req)
 }


### PR DESCRIPTION
This change adds the logic to delete a single saved search.

This change adds removeUserSavedSearchMapper which implements the removableEntityMapper interface.

Prior the deletion, it does a role check for the user id.

Other changes:
- Slight changes to removableEntityMapper interface

Fixes #805