### PR TITLE
HTTP Server: create user saved search

### DIFF
--- a/backend/pkg/httpserver/create_saved_search.go
+++ b/backend/pkg/httpserver/create_saved_search.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/httpmiddlewares"
+)
+
+const (
+	savedSearchNameMaxLength            = 32
+	savedSearchNameMinLength            = 1
+	savedSearchNameDescriptionMaxLength = 1024
+	savedSearchNameDescriptionMinLength = 1
+	savedSearchQueryMaxLength           = 256
+	savedSearchQueryMinLength           = 1
+)
+
+var (
+	errSavedSearchInvalidNameLength = fmt.Errorf("name must be between %d and %d characters long",
+		savedSearchNameMinLength, savedSearchNameMaxLength)
+	errSavedSearchInvalidQueryLength = fmt.Errorf("query must be between %d and %d characters long",
+		savedSearchQueryMinLength, savedSearchQueryMaxLength)
+	errSavedSearchInvalidDescriptionLength = fmt.Errorf("description must be between %d and %d characters long",
+		savedSearchNameDescriptionMinLength, savedSearchNameDescriptionMaxLength)
+	errQueryDoesNotMatchGrammar = errors.New("query does not match grammar")
+)
+
+type fieldValidationErrors struct {
+	fieldErrorMap map[string]string
+}
+
+func (f *fieldValidationErrors) addFieldError(field string, err error) {
+	if f.fieldErrorMap == nil {
+		f.fieldErrorMap = make(map[string]string)
+	}
+	f.fieldErrorMap[field] = err.Error()
+}
+
+func (f fieldValidationErrors) hasErrors() bool {
+	return len(f.fieldErrorMap) > 0
+}
+
+func validateSavedSearch(input *backend.SavedSearch) *fieldValidationErrors {
+	fieldErrors := &fieldValidationErrors{fieldErrorMap: nil}
+
+	if len(input.Name) < savedSearchNameMinLength || len(input.Name) > savedSearchNameMaxLength {
+		fieldErrors.addFieldError("name", errSavedSearchInvalidNameLength)
+	}
+
+	if len(input.Query) < savedSearchQueryMinLength || len(input.Query) > savedSearchQueryMaxLength {
+		fieldErrors.addFieldError("query", errSavedSearchInvalidQueryLength)
+	} else {
+		parser := searchtypes.FeaturesSearchQueryParser{}
+		_, err := parser.Parse(input.Query)
+		if err != nil {
+			fieldErrors.addFieldError("query", errQueryDoesNotMatchGrammar)
+		}
+
+	}
+
+	if input.Description != nil && (len(*input.Description) < savedSearchNameDescriptionMinLength ||
+		len(*input.Description) > savedSearchNameDescriptionMaxLength) {
+		fieldErrors.addFieldError("description", errSavedSearchInvalidDescriptionLength)
+	}
+	if fieldErrors.hasErrors() {
+		return fieldErrors
+	}
+
+	return nil
+}
+
+// CreateSavedSearch implements backend.StrictServerInterface.
+// nolint: ireturn // Name generated from openapi
+func (s *Server) CreateSavedSearch(ctx context.Context, request backend.CreateSavedSearchRequestObject) (
+	backend.CreateSavedSearchResponseObject, error) {
+	// At this point, the user should be authenticated and in the context.
+	// If for some reason the user is not in the context, it is a library or
+	// internal issue and not an user issue. Return 500 error in that case.
+	user, found := httpmiddlewares.AuthenticatedUserFromContext(ctx)
+	if !found {
+		slog.ErrorContext(ctx, "user not found in context. middleware malfunction")
+
+		return backend.CreateSavedSearch500JSONResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "internal server error",
+		}, nil
+	}
+
+	validationErr := validateSavedSearch(request.Body)
+	if validationErr != nil {
+		return backend.CreateSavedSearch400JSONResponse{
+			Code:    http.StatusBadRequest,
+			Message: "input validation errors",
+			Errors:  validationErr.fieldErrorMap,
+		}, nil
+	}
+
+	output, err := s.wptMetricsStorer.CreateUserSavedSearch(ctx, user.ID, *request.Body)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to create user saved search", "error", err)
+
+		return backend.CreateSavedSearch500JSONResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "unable to create user saved search",
+		}, nil
+	}
+
+	return backend.CreateSavedSearch201JSONResponse(*output), nil
+}

--- a/backend/pkg/httpserver/create_saved_search_test.go
+++ b/backend/pkg/httpserver/create_saved_search_test.go
@@ -1,0 +1,285 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func createStringOfNLength(n int) string {
+	s := ""
+	for i := 0; i < n; i++ {
+		s += "a"
+	}
+
+	return s
+}
+
+func TestCreateSavedSearch(t *testing.T) {
+	testUser := &auth.User{
+		ID: "testID1",
+	}
+	testCases := []struct {
+		name                            string
+		mockCreateUserSavedSearchConfig *MockCreateUserSavedSearchConfig
+		authMiddlewareOption            testServerOption
+		request                         *http.Request
+		expectedResponse                *http.Response
+	}{
+		{
+			name:                            "name is 33 characters long, missing query",
+			mockCreateUserSavedSearchConfig: nil,
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/saved-searches",
+				strings.NewReader(`{"name": "`+createStringOfNLength(33)+`"}`),
+			),
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"name":"name must be between 1 and 32 characters long",
+						"query":"query must be between 1 and 256 characters long"
+					},
+					"message":"input validation errors"
+				}`),
+		},
+		{
+			name:                            "name is empty",
+			mockCreateUserSavedSearchConfig: nil,
+			authMiddlewareOption:            withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/saved-searches",
+				strings.NewReader(`{"name" : "", "query" : "test query"}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"name":"name must be between 1 and 32 characters long"
+					},
+					"message":"input validation errors"
+				}`),
+		},
+		{
+			name:                            "name is missing",
+			mockCreateUserSavedSearchConfig: nil,
+			authMiddlewareOption:            withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/saved-searches",
+				strings.NewReader(`{"query" : "test query"}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"name":"name must be between 1 and 32 characters long"
+					},
+					"message":"input validation errors"
+				}`),
+		},
+		{
+			name:                            "query is empty",
+			mockCreateUserSavedSearchConfig: nil,
+			authMiddlewareOption:            withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/saved-searches",
+				strings.NewReader(`{"query" : "", "name" : "test name"}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"query":"query must be between 1 and 256 characters long"
+					},
+					"message":"input validation errors"
+				}`),
+		},
+		{
+			name:                            "query is 257 characters long",
+			mockCreateUserSavedSearchConfig: nil,
+			authMiddlewareOption:            withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/saved-searches",
+				strings.NewReader(`{"query": "`+createStringOfNLength(257)+`", "name" : "test name"}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"query":"query must be between 1 and 256 characters long"
+					},
+					"message":"input validation errors"
+				}`),
+		},
+		{
+			name:                            "description is empty",
+			mockCreateUserSavedSearchConfig: nil,
+			authMiddlewareOption:            withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/saved-searches",
+				strings.NewReader(`{"query": "test query", "name" : "test name", "description": ""}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"description":"description must be between 1 and 1024 characters long"
+					},
+					"message":"input validation errors"
+				}`),
+		},
+		{
+			name:                            "description is 1025 characters long",
+			mockCreateUserSavedSearchConfig: nil,
+			authMiddlewareOption:            withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/saved-searches",
+				strings.NewReader(`{"query": "test query", "name" : "test name", "description": "`+
+					createStringOfNLength(1025)+`"}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"description":"description must be between 1 and 1024 characters long"
+					},
+					"message":"input validation errors"
+				}`),
+		},
+		{
+			name:                            "query has bad syntax",
+			mockCreateUserSavedSearchConfig: nil,
+			authMiddlewareOption:            withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/saved-searches",
+				strings.NewReader(`{"query": "name:", "name" : "test name"}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"query":"query does not match grammar"
+					},
+					"message":"input validation errors"
+				}`),
+		},
+		{
+			name: "successful with name and query",
+			mockCreateUserSavedSearchConfig: &MockCreateUserSavedSearchConfig{
+				expectedSavedSearch: backend.SavedSearch{
+					Name:        "test name",
+					Query:       `name:"test"`,
+					Description: nil,
+				},
+				expectedUserID: "testID1",
+				output: &backend.SavedSearchResponse{
+					Id:          "searchID1",
+					Name:        "test name",
+					Query:       `name:"test"`,
+					Description: nil,
+					CreatedAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+				err: nil,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/saved-searches",
+				strings.NewReader(`{"query": "name:\"test\"", "name" : "test name"}`),
+			),
+			expectedResponse: testJSONResponse(201,
+				`{
+					"created_at":"2000-01-01T00:00:00Z",
+					"id":"searchID1",
+					"name":"test name",
+					"query":"name:\"test\"",
+					"updated_at":"2000-01-01T00:00:00Z"
+				}`,
+			),
+		},
+		{
+			name: "successful with name, query and description",
+			mockCreateUserSavedSearchConfig: &MockCreateUserSavedSearchConfig{
+				expectedSavedSearch: backend.SavedSearch{
+					Name:        "test name",
+					Query:       `name:"test"`,
+					Description: valuePtr("test description"),
+				},
+				expectedUserID: "testID1",
+				output: &backend.SavedSearchResponse{
+					Id:          "searchID1",
+					Name:        "test name",
+					Query:       `name:"test"`,
+					Description: valuePtr("test description"),
+					CreatedAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt:   time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+				err: nil,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/saved-searches",
+				strings.NewReader(
+					`{
+						"query": "name:\"test\"",
+						"name" : "test name",
+						"description": "test description"
+					}`,
+				),
+			),
+			expectedResponse: testJSONResponse(201,
+				`{
+					"created_at":"2000-01-01T00:00:00Z",
+					"id":"searchID1",
+					"name":"test name",
+					"description" : "test description",
+					"query":"name:\"test\"",
+					"updated_at":"2000-01-01T00:00:00Z"
+				}`,
+			),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint:exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				createUserSavedSearchCfg: tc.mockCreateUserSavedSearchConfig,
+				t:                        t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
+				operationResponseCaches: nil}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+				[]testServerOption{tc.authMiddlewareOption}...)
+		})
+	}
+}

--- a/backend/pkg/httpserver/middlewares_test.go
+++ b/backend/pkg/httpserver/middlewares_test.go
@@ -140,3 +140,14 @@ func TestAuthScopePresentWhenSecurityConfigured(t *testing.T) {
 func TestAuthScopeAbsentWhenSecurityNotConfigured(t *testing.T) {
 	testAuthScope(t, "/v1/features", http.MethodGet, false, nil)
 }
+
+func mockAuthMiddleware(u *auth.User) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if u != nil {
+				r = r.WithContext(httpmiddlewares.AuthenticatedUserToContext(r.Context(), u))
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -105,6 +105,8 @@ type WPTMetricsStorer interface {
 		pageSize int,
 		pageToken *string,
 	) (*backend.BaselineStatusMetricsPage, error)
+	CreateUserSavedSearch(ctx context.Context, userID string,
+		savedSearch backend.SavedSearch) (*backend.SavedSearchResponse, error)
 }
 
 type Server struct {
@@ -130,16 +132,6 @@ func (s *Server) UpdateSavedSearch(
 	ctx context.Context, request backend.UpdateSavedSearchRequestObject) (
 	backend.UpdateSavedSearchResponseObject, error) {
 	return backend.UpdateSavedSearch400JSONResponse{
-		Code:    http.StatusBadRequest,
-		Message: "TODO",
-	}, nil
-}
-
-// CreateSavedSearch implements backend.StrictServerInterface.
-// nolint: revive, ireturn // Name generated from openapi
-func (s *Server) CreateSavedSearch(ctx context.Context, request backend.CreateSavedSearchRequestObject) (
-	backend.CreateSavedSearchResponseObject, error) {
-	return backend.CreateSavedSearch400JSONResponse{
 		Code:    http.StatusBadRequest,
 		Message: "TODO",
 	}, nil

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -773,7 +773,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasicErrorModel'
+                $ref: '#/components/schemas/ExtendedErrorModel'
         '401':
           description: Unauthorized
           content:
@@ -1231,12 +1231,15 @@ components:
         name:
           type: string
           minLength: 1
+          maxLength: 32
         description:
           type: string
           minLength: 1
+          maxLength: 1024
         query:
           type: string
           minLength: 1
+          maxLength: 256
       required:
         - name
         - query
@@ -1342,10 +1345,12 @@ components:
         - $ref: '#/components/schemas/BasicErrorModel'
         - type: object
           required:
-            - rootCause
+            - errors
           properties:
-            rootCause:
-              type: string
+            errors:
+              type: object
+              additionalProperties:
+                type: string
     MissingOneImplFeature: # Schema for a single feature object
       type: object
       properties:


### PR DESCRIPTION
This change implements the http handler for creating a user saved search.

Prior to calling the adapter layer (which is implemented in #1245), we:
- Get the user from the context (which should be at this point)
- Validate the input
  - If the input is invalid, return ExtendedErrorModel which has the fields with problems
- Calls the adapter layer to create the saved search.

Other changes:
- Slight changes to ExtendedErrorModel
- Make the create saved search endpoint's 400 error use ExtendedErrorModel (the first endpoint to use ExtendedErrorModel)
- Add some max length limits to input fields