### PR TITLE
Add adapter logic that calls spanner to delete user saved search

### DIFF
--- a/lib/gcpspanner/delete_user_saved_search_test.go
+++ b/lib/gcpspanner/delete_user_saved_search_test.go
@@ -85,4 +85,14 @@ func TestDeleteUserSavedSearch(t *testing.T) {
 			t.Errorf("expected ErrQueryReturnedNoResults. received %s", err)
 		}
 	})
+
+	t.Run("non existent search returns ErrQueryReturnedNoResults", func(t *testing.T) {
+		err := spannerClient.DeleteUserSavedSearch(ctx, DeleteUserSavedSearchRequest{
+			RequestingUserID: "userID1",
+			SavedSearchID:    "bad-id",
+		})
+		if !errors.Is(err, ErrQueryReturnedNoResults) {
+			t.Errorf("expected ErrQueryReturnedNoResults. received %s", err)
+		}
+	})
 }

--- a/lib/gcpspanner/spanneradapters/backendtypes/types.go
+++ b/lib/gcpspanner/spanneradapters/backendtypes/types.go
@@ -25,4 +25,10 @@ var (
 	// ErrUserMaxSavedSearches indicates the user has reached the maximum
 	// number of allowed saved searches.
 	ErrUserMaxSavedSearches = errors.New("user has reached the maximum number of allowed saved searches")
+
+	// ErrUserNotAuthorizedForAction indicates the user is not authorized to execute the requested action.
+	ErrUserNotAuthorizedForAction = errors.New("user not authorized to execute action")
+
+	// ErrEntityDoesNotExist indicates the entity does not exist.
+	ErrEntityDoesNotExist = errors.New("entity does not exist")
 )


### PR DESCRIPTION
This is the layer between the httpserver and spanner.

It parses out the error if the:
- The user does not have access, or
- The entity does not exist

Other changes
- Modify the spanner logic to check if the entity exists in the same transaction