### PR TITLE
Spanner query for missing one implementation feature IDs 

### DIFF
--- a/lib/gcpspanner/missing_one_implementation_feature_list.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list.go
@@ -68,6 +68,7 @@ EXISTS (
 AND
 {{ end }}
 1=1
+ORDER BY KEY ASC
 `
 
 type missingOneImplFeatureListTemplateData struct {

--- a/lib/gcpspanner/missing_one_implementation_feature_list.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func init() {
+	missingOneImplFeatureListTemplate = NewQueryTemplate(missingOneImplFeatureListRawTemplate)
+}
+
+// nolint: gochecknoglobals // WONTFIX. Compile the template once at startup. Startup fails if invalid.
+var (
+	// missingOneImplFeatureListTemplate is the compiled version of missingOneImplFeatureListRawTemplate.
+	missingOneImplFeatureListTemplate BaseQueryTemplate
+)
+
+// MissingOneImplFeatureListPage contains the details for the missing one implementation feature list request.
+type MissingOneImplFeatureListPage struct {
+	NextPageToken *string
+	FeatureList   []MissingOneImplFeature
+}
+
+// MissingOneImplFeature contains information regarding the list of features implemented in all other browsers but not
+// in the target browser.
+type MissingOneImplFeature struct {
+	WebFeatureID string `spanner:"KEY"`
+}
+
+const missingOneImplFeatureListRawTemplate = `
+SELECT wf.FeatureKey as KEY
+FROM WebFeatures wf
+WHERE wf.ID IN (
+    SELECT bfse.WebFeatureID
+    FROM BrowserFeatureSupportEvents bfse
+    WHERE bfse.TargetBrowserName = @targetBrowserParam
+      AND bfse.EventReleaseDate = @targetDate
+      AND bfse.SupportStatus = 'unsupported'
+)
+AND {{ range $browserParamName := .OtherBrowsersParamNames }}
+EXISTS (
+    SELECT 1
+    FROM BrowserFeatureSupportEvents bfse_other
+    WHERE bfse_other.WebFeatureID = wf.ID
+      AND bfse_other.TargetBrowserName = @{{ $browserParamName }}
+      AND bfse_other.EventReleaseDate = @targetDate
+      AND bfse_other.SupportStatus = 'supported'
+)
+AND
+{{ end }}
+1=1
+`
+
+type missingOneImplFeatureListTemplateData struct {
+	OtherBrowsersParamNames []string
+}
+
+func buildMissingOneImplFeatureListTemplate(
+	targetBrowser string,
+	otherBrowsers []string,
+	targetDate time.Time,
+) spanner.Statement {
+	params := map[string]interface{}{}
+	allBrowsers := make([]string, len(otherBrowsers)+1)
+	copy(allBrowsers, otherBrowsers)
+	allBrowsers[len(allBrowsers)-1] = targetBrowser
+	params["targetBrowserParam"] = targetBrowser
+	otherBrowsersParamNames := make([]string, 0, len(otherBrowsers))
+	for i := range otherBrowsers {
+		paramName := fmt.Sprintf("otherBrowser%d", i)
+		params[paramName] = otherBrowsers[i]
+		otherBrowsersParamNames = append(otherBrowsersParamNames, paramName)
+	}
+
+	params["targetDate"] = targetDate
+
+	tmplData := missingOneImplFeatureListTemplateData{
+		OtherBrowsersParamNames: otherBrowsersParamNames,
+	}
+
+	sql := missingOneImplFeatureListTemplate.Execute(tmplData)
+	stmt := spanner.NewStatement(sql)
+	stmt.Params = params
+
+	return stmt
+}
+
+func (c *Client) MissingOneImplFeatureList(
+	ctx context.Context,
+	targetBrowser string,
+	otherBrowsers []string,
+	targetDate time.Time,
+) (*MissingOneImplFeatureListPage, error) {
+	txn := c.ReadOnlyTransaction()
+	defer txn.Close()
+
+	stmt := buildMissingOneImplFeatureListTemplate(
+		targetBrowser,
+		otherBrowsers,
+		targetDate,
+	)
+
+	it := txn.Query(ctx, stmt)
+	defer it.Stop()
+
+	var results []MissingOneImplFeature
+	for {
+		row, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		var result MissingOneImplFeature
+		if err := row.ToStruct(&result); err != nil {
+			return nil, err
+		}
+		results = append(results, MissingOneImplFeature{result.WebFeatureID})
+	}
+
+	page := MissingOneImplFeatureListPage{
+		FeatureList:   results,
+		NextPageToken: nil,
+	}
+
+	return &page, nil
+}

--- a/lib/gcpspanner/missing_one_implementation_feature_list_test.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list_test.go
@@ -150,7 +150,7 @@ func testMissingOneImplFeatureListSuite(
 	ctx context.Context,
 	t *testing.T,
 ) {
-	t.Run("bazBrowser ", func(t *testing.T) {
+	t.Run("bazBrowser", func(t *testing.T) {
 		const targetBrowser = "bazBrowser"
 		otherBrowsers := []string{
 			"fooBrowser",

--- a/lib/gcpspanner/missing_one_implementation_feature_list_test.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list_test.go
@@ -1,0 +1,249 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// nolint:dupl // WONTFIX - false positive
+func loadDataForListMissingOneImplFeatureList(ctx context.Context, t *testing.T, client *Client) {
+	webFeatures := []WebFeature{
+		{FeatureKey: "FeatureX", Name: "Cool API"},
+		{FeatureKey: "FeatureY", Name: "Super API"},
+		{FeatureKey: "FeatureZ", Name: "Neat API"},
+		{FeatureKey: "FeatureW", Name: "Amazing API"},
+	}
+	for _, feature := range webFeatures {
+		_, err := client.UpsertWebFeature(ctx, feature)
+		if err != nil {
+			t.Errorf("unexpected error during insert of features. %s", err.Error())
+		}
+	}
+
+	browserReleases := []BrowserRelease{
+		// fooBrowser Releases
+		{BrowserName: "fooBrowser", BrowserVersion: "110", ReleaseDate: time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC)},
+		{BrowserName: "fooBrowser", BrowserVersion: "111", ReleaseDate: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)},
+		{BrowserName: "fooBrowser", BrowserVersion: "112", ReleaseDate: time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)},
+		{BrowserName: "fooBrowser", BrowserVersion: "113", ReleaseDate: time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC)},
+
+		// barBrowser Releases
+		{BrowserName: "barBrowser", BrowserVersion: "113", ReleaseDate: time.Date(2024, 1, 20, 0, 0, 0, 0, time.UTC)},
+		{BrowserName: "barBrowser", BrowserVersion: "114", ReleaseDate: time.Date(2024, 3, 28, 0, 0, 0, 0, time.UTC)},
+		{BrowserName: "barBrowser", BrowserVersion: "115", ReleaseDate: time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)},
+
+		// bazBrowser Releases
+		{BrowserName: "bazBrowser", BrowserVersion: "16.4", ReleaseDate: time.Date(2024, 1, 25, 0, 0, 0, 0, time.UTC)},
+		{BrowserName: "bazBrowser", BrowserVersion: "16.5", ReleaseDate: time.Date(2024, 3, 5, 0, 0, 0, 0, time.UTC)},
+		{BrowserName: "bazBrowser", BrowserVersion: "17", ReleaseDate: time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)},
+	}
+	for _, release := range browserReleases {
+		err := client.InsertBrowserRelease(ctx, release)
+		if err != nil {
+			t.Errorf("unexpected error during insert of releases. %s", err.Error())
+		}
+	}
+
+	browserFeatureAvailabilities := []struct {
+		FeatureKey string
+		BrowserFeatureAvailability
+	}{
+		// fooBrowser Availabilities
+		{
+			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "fooBrowser", BrowserVersion: "111"},
+			FeatureKey:                 "FeatureX",
+		}, // Available from fooBrowser 111
+		{
+			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "fooBrowser", BrowserVersion: "112"},
+			FeatureKey:                 "FeatureY",
+		}, // Available from fooBrowser 112
+		{
+			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "fooBrowser", BrowserVersion: "112"},
+			FeatureKey:                 "FeatureZ",
+		}, // Available from fooBrowser 112
+		{
+			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "fooBrowser", BrowserVersion: "113"},
+			FeatureKey:                 "FeatureW",
+		}, // Available from fooBrowser 113
+
+		// barBrowser Availabilities
+		{
+			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "barBrowser", BrowserVersion: "113"},
+			FeatureKey:                 "FeatureX",
+		}, // Available from barBrowser 113
+		{
+			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "barBrowser", BrowserVersion: "113"},
+			FeatureKey:                 "FeatureZ",
+		}, // Available from barBrowser 113
+		{
+			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "barBrowser", BrowserVersion: "114"},
+			FeatureKey:                 "FeatureY",
+		}, // Available from barBrowser 114
+		{
+			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "barBrowser", BrowserVersion: "115"},
+			FeatureKey:                 "FeatureW",
+		}, // Available from barBrowser 115
+
+		// bazBrowser Availabilities
+		{
+			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "bazBrowser", BrowserVersion: "16.4"},
+			FeatureKey:                 "FeatureX",
+		}, // Available from bazBrowser 16.4
+		{
+			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "bazBrowser", BrowserVersion: "16.5"},
+			FeatureKey:                 "FeatureY",
+		}, // Available from bazBrowser 16.5
+	}
+	for _, availability := range browserFeatureAvailabilities {
+		err := client.InsertBrowserFeatureAvailability(ctx,
+			availability.FeatureKey, availability.BrowserFeatureAvailability)
+		if err != nil {
+			t.Errorf("unexpected error during insert. %s", err.Error())
+		}
+	}
+	err := spannerClient.PrecalculateBrowserFeatureSupportEvents(ctx,
+		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Errorf("unexpected error during pre-calculate. %s", err.Error())
+	}
+}
+
+func assertMissingOneImplFeatureList(ctx context.Context, t *testing.T, targetDate time.Time,
+	targetBrowser string, otherBrowsers []string, expectedPage *MissingOneImplFeatureListPage) {
+	result, err := spannerClient.MissingOneImplFeatureList(
+		ctx,
+		targetBrowser,
+		otherBrowsers,
+		targetDate,
+	)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(expectedPage.NextPageToken, result.NextPageToken) {
+		t.Errorf("unexpected result.\nExpected %+v\nReceived %+v", expectedPage, result)
+	}
+	if !assert.ElementsMatch(t, expectedPage.FeatureList, result.FeatureList) {
+		t.Errorf("unexpected result.\nExpected %+v\nReceived %+v", expectedPage, result)
+	}
+}
+
+func testMissingOneImplFeatureListSuite(
+	ctx context.Context,
+	t *testing.T,
+) {
+	t.Run("bazBrowser ", func(t *testing.T) {
+		const targetBrowser = "bazBrowser"
+		otherBrowsers := []string{
+			"fooBrowser",
+			"barBrowser",
+		}
+		targetDate := time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC)
+
+		t.Run("simple successful query", func(t *testing.T) {
+			expectedResult := &MissingOneImplFeatureListPage{
+				NextPageToken: nil,
+				FeatureList: []MissingOneImplFeature{
+					// fooBrowser 113 release
+					// Currently supported features:
+					// fooBrowser: FeatureX, FeatureZ, FeatureY, FeatureW
+					// barBrowser: FeatureX, FeatureZ, FeatureY, FeatureW
+					// bazBrowser: FeatureX, FeatureY
+					// Missing in on for bazBrowser: FeatureW, FeatureZ
+					{
+						WebFeatureID: "FeatureZ",
+					},
+					{
+						WebFeatureID: "FeatureW",
+					},
+				},
+			}
+			assertMissingOneImplFeatureList(
+				ctx,
+				t,
+				targetDate,
+				targetBrowser,
+				otherBrowsers,
+				expectedResult,
+			)
+		})
+
+		t.Run("empty query result", func(t *testing.T) {
+			emptyDate := time.Date(2024, 3, 5, 0, 0, 0, 0, time.UTC)
+			expectedResult := &MissingOneImplFeatureListPage{
+				NextPageToken: nil,
+				FeatureList:   []MissingOneImplFeature{},
+			}
+			assertMissingOneImplFeatureList(
+				ctx,
+				t,
+				emptyDate,
+				targetBrowser,
+				otherBrowsers,
+				expectedResult,
+			)
+		})
+
+		t.Run("simple query at a smaller subset of otherBrowsers", func(t *testing.T) {
+			subsetBrowsers := []string{
+				"barBrowser",
+			}
+
+			expectedResult := &MissingOneImplFeatureListPage{
+				NextPageToken: nil,
+				FeatureList: []MissingOneImplFeature{
+					// fooBrowser 113 release
+					// Currently supported features:
+					// fooBrowser: FeatureX, FeatureZ, FeatureY, FeatureW
+					// barBrowser: FeatureX, FeatureZ, FeatureY, FeatureW
+					// bazBrowser: FeatureX, FeatureY
+					// Missing in on for bazBrowser: FeatureW, FeatureZ
+					{
+						WebFeatureID: "FeatureZ",
+					},
+					{
+						WebFeatureID: "FeatureW",
+					},
+				},
+			}
+			assertMissingOneImplFeatureList(
+				ctx,
+				t,
+				targetDate,
+				targetBrowser,
+				subsetBrowsers,
+				expectedResult,
+			)
+		})
+	})
+}
+
+func TestListMissingOneImplFeatureList(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+
+	loadDataForListMissingOneImplFeatureList(ctx, t, spannerClient)
+	actualEvents := spannerClient.readAllBrowserFeatureSupportEvents(ctx, t)
+	slices.SortFunc(actualEvents, sortBrowserFeatureSupportEvents)
+	t.Run("MissingOneImplFeatureListQuery", func(t *testing.T) {
+		testMissingOneImplFeatureListSuite(ctx, t)
+	})
+}

--- a/lib/gcpspanner/missing_one_implementation_feature_list_test.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// nolint:dupl // WONTFIX - false positive
+// nolint:dupl // WONTFIX
 func loadDataForListMissingOneImplFeatureList(ctx context.Context, t *testing.T, client *Client) {
 	webFeatures := []WebFeature{
 		{FeatureKey: "FeatureX", Name: "Cool API"},

--- a/lib/gcpspanner/missing_one_implementation_test.go
+++ b/lib/gcpspanner/missing_one_implementation_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 )
 
+// nolint:dupl // WONTFIX
 func loadDataForListMissingOneImplCounts(ctx context.Context, t *testing.T, client *Client) {
 	webFeatures := []WebFeature{
 		{FeatureKey: "FeatureX", Name: "Cool API"},


### PR DESCRIPTION
A part of #1109. Implementing the Spanner logic to retrieve the list of feature IDs that are counted as "missing one implementation" for a target browser and target date. 

This change is similar to the implementation in https://github.com/GoogleChrome/webstatus.dev/blob/main/lib/gcpspanner/missing_one_implementation.go#L197, but with a simpler template. Unlike that implementation, both GCP and local emulator use the same template.

A simpler version is tested on the [Spanner studio](https://pantheon.corp.google.com/spanner/instances/staging-spanner/databases/staging-database/details/query?inv=1&invt=Abrs3g&project=webstatus-dev-internal-staging)
### Follow-up:
Handle potential exclusions specified in the ExcludedFeatureKeys table.
 support pagination to handle potentially large numbers of feature IDs.