### PR TITLE
HTTP Server: remove user saved search

### DIFF
--- a/backend/pkg/httpserver/remove_saved_search.go
+++ b/backend/pkg/httpserver/remove_saved_search.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/httpmiddlewares"
+)
+
+// RemoveSavedSearch implements backend.StrictServerInterface.
+// nolint: ireturn // Name generated from openapi
+func (s *Server) RemoveSavedSearch(
+	ctx context.Context, request backend.RemoveSavedSearchRequestObject) (
+	backend.RemoveSavedSearchResponseObject, error) {
+	// At this point, the user should be authenticated and in the context.
+	// If for some reason the user is not in the context, it is a library or
+	// internal issue and not an user issue. Return 500 error in that case.
+	user, found := httpmiddlewares.AuthenticatedUserFromContext(ctx)
+	if !found {
+		slog.ErrorContext(ctx, "user not found in context. middleware malfunction")
+
+		return backend.RemoveSavedSearch500JSONResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "internal server error",
+		}, nil
+	}
+
+	err := s.wptMetricsStorer.DeleteUserSavedSearch(ctx, user.ID, request.SearchId)
+	if err != nil {
+		if errors.Is(err, backendtypes.ErrEntityDoesNotExist) {
+			return backend.RemoveSavedSearch404JSONResponse{
+				Code:    http.StatusNotFound,
+				Message: "saved search not found",
+			}, nil
+		} else if errors.Is(err, backendtypes.ErrUserNotAuthorizedForAction) {
+			return backend.RemoveSavedSearch403JSONResponse{
+				Code:    http.StatusForbidden,
+				Message: "forbidden",
+			}, nil
+		}
+
+		slog.ErrorContext(ctx, "unknown error deleting saved search", "error", err)
+
+		return backend.RemoveSavedSearch500JSONResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "unable to delete saved search",
+		}, nil
+	}
+
+	return backend.RemoveSavedSearch204Response{}, nil
+}

--- a/backend/pkg/httpserver/remove_saved_search_test.go
+++ b/backend/pkg/httpserver/remove_saved_search_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
+)
+
+func TestRemoveSavedSearch(t *testing.T) {
+	testUser := &auth.User{
+		ID: "testID1",
+	}
+	testCases := []struct {
+		name                 string
+		cfg                  *MockDeleteUserSavedSearchConfig
+		authMiddlewareOption testServerOption
+		request              *http.Request
+		expectedResponse     *http.Response
+	}{
+		{
+			name: "success",
+			cfg: &MockDeleteUserSavedSearchConfig{
+				expectedSavedSearchID: "saved-search-id",
+				expectedUserID:        "testID1",
+				err:                   nil,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodDelete,
+				"/v1/saved-searches/saved-search-id",
+				nil,
+			),
+			// nolint:exhaustruct // WONTFIX - only for test purposes
+			expectedResponse: &http.Response{
+				StatusCode: http.StatusNoContent,
+				// For no content, the openapi library currently just returns an
+				// empty string and empty headers
+				Body:   io.NopCloser(strings.NewReader("")),
+				Header: make(http.Header),
+			},
+		},
+		{
+			name: "not found",
+			cfg: &MockDeleteUserSavedSearchConfig{
+				expectedSavedSearchID: "saved-search-id",
+				expectedUserID:        "testID1",
+				err:                   backendtypes.ErrEntityDoesNotExist,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodDelete,
+				"/v1/saved-searches/saved-search-id",
+				nil,
+			),
+			// nolint:exhaustruct // WONTFIX - only for test purposes
+			expectedResponse: testJSONResponse(404,
+				`{
+					"code":404,
+					"message":"saved search not found"
+				}`,
+			),
+		},
+		{
+			name: "not authorized",
+			cfg: &MockDeleteUserSavedSearchConfig{
+				expectedSavedSearchID: "saved-search-id",
+				expectedUserID:        "testID1",
+				err:                   backendtypes.ErrUserNotAuthorizedForAction,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodDelete,
+				"/v1/saved-searches/saved-search-id",
+				nil,
+			),
+			// nolint:exhaustruct // WONTFIX - only for test purposes
+			expectedResponse: testJSONResponse(403,
+				`{
+					"code":403,
+					"message":"forbidden"
+				}`,
+			),
+		},
+		{
+			name: "general error",
+			cfg: &MockDeleteUserSavedSearchConfig{
+				expectedSavedSearchID: "saved-search-id",
+				expectedUserID:        "testID1",
+				err:                   errTest,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodDelete,
+				"/v1/saved-searches/saved-search-id",
+				nil,
+			),
+			// nolint:exhaustruct // WONTFIX - only for test purposes
+			expectedResponse: testJSONResponse(500,
+				`{
+					"code":500,
+					"message":"unable to delete saved search"
+				}`,
+			),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint:exhaustruct // WONTFIX
+			mockStorer := &MockWPTMetricsStorer{
+				deleteUserSavedSearchCfg: tc.cfg,
+				t:                        t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
+				operationResponseCaches: nil}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+				[]testServerOption{tc.authMiddlewareOption}...)
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -107,23 +107,13 @@ type WPTMetricsStorer interface {
 	) (*backend.BaselineStatusMetricsPage, error)
 	CreateUserSavedSearch(ctx context.Context, userID string,
 		savedSearch backend.SavedSearch) (*backend.SavedSearchResponse, error)
+	DeleteUserSavedSearch(ctx context.Context, userID, savedSearchID string) error
 }
 
 type Server struct {
 	metadataStorer          WebFeatureMetadataStorer
 	wptMetricsStorer        WPTMetricsStorer
 	operationResponseCaches *operationResponseCaches
-}
-
-// RemoveSavedSearch implements backend.StrictServerInterface.
-// nolint: revive, ireturn // Name generated from openapi
-func (s *Server) RemoveSavedSearch(
-	ctx context.Context, request backend.RemoveSavedSearchRequestObject) (
-	backend.RemoveSavedSearchResponseObject, error) {
-	return backend.RemoveSavedSearch400JSONResponse{
-		Code:    http.StatusBadRequest,
-		Message: "TODO",
-	}, nil
 }
 
 // UpdateSavedSearch implements backend.StrictServerInterface.

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -888,6 +888,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found (saved search does not exist)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
         '500':
           description: Internal Service Error
           content:


### PR DESCRIPTION
This change implements the http handler for removing a user saved search.

After calling the adapter layer (which is implemented in #1264), we:
- Check the error type to distinguish between:
  - A missing saved search
  - A saved search that the user does not have access to delete
  - A generic error

Other changes:
- Modify the test helper when comparing No content responses.