### PR TITLE
Support pagination for missing one implementation feature IDs query

### DIFF
--- a/lib/gcpspanner/missing_one_implementation_feature_list.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list.go
@@ -40,6 +40,24 @@ type MissingOneImplFeatureListPage struct {
 	FeatureList   []MissingOneImplFeature
 }
 
+// missingOneImplFeatureListCursor: Represents a point for resuming queries based on the
+// numerical offset from the start of the result set. Useful for pagination.
+type missingOneImplFeatureListCursor struct {
+	Offset int `json:"offset"`
+}
+
+// decodemissingOneImplFeatureListCursor provides a wrapper around the generic decodeCursor.
+func decodemissingOneImplFeatureListCursor(cursor string) (*missingOneImplFeatureListCursor, error) {
+	return decodeCursor[missingOneImplFeatureListCursor](cursor)
+}
+
+// encodemissingOneImplFeatureListCursor provides a wrapper around the generic encodeCursor.
+func encodemissingOneImplFeatureListCursor(offset int) string {
+	return encodeCursor(missingOneImplFeatureListCursor{
+		Offset: offset,
+	})
+}
+
 // MissingOneImplFeature contains information regarding the list of features implemented in all other browsers but not
 // in the target browser.
 type MissingOneImplFeature struct {
@@ -69,16 +87,23 @@ AND
 {{ end }}
 1=1
 ORDER BY KEY ASC
+LIMIT @limit
+{{ if .Offset }}
+OFFSET {{ .Offset }}
+{{ end }}
 `
 
 type missingOneImplFeatureListTemplateData struct {
 	OtherBrowsersParamNames []string
+	Offset                  int
 }
 
 func buildMissingOneImplFeatureListTemplate(
 	targetBrowser string,
 	otherBrowsers []string,
 	targetDate time.Time,
+	cursor *missingOneImplFeatureListCursor,
+	pageSize int,
 ) spanner.Statement {
 	params := map[string]interface{}{}
 	allBrowsers := make([]string, len(otherBrowsers)+1)
@@ -93,9 +118,11 @@ func buildMissingOneImplFeatureListTemplate(
 	}
 
 	params["targetDate"] = targetDate
+	params["limit"] = pageSize
 
 	tmplData := missingOneImplFeatureListTemplateData{
 		OtherBrowsersParamNames: otherBrowsersParamNames,
+		Offset:                  cursor.Offset,
 	}
 
 	sql := missingOneImplFeatureListTemplate.Execute(tmplData)
@@ -110,7 +137,18 @@ func (c *Client) MissingOneImplFeatureList(
 	targetBrowser string,
 	otherBrowsers []string,
 	targetDate time.Time,
+	pageSize int,
+	pageToken *string,
 ) (*MissingOneImplFeatureListPage, error) {
+	var cursor *missingOneImplFeatureListCursor
+	var err error
+	if pageToken != nil {
+		cursor, err = decodemissingOneImplFeatureListCursor(*pageToken)
+		if err != nil {
+			return nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+	}
+
 	txn := c.ReadOnlyTransaction()
 	defer txn.Close()
 
@@ -118,6 +156,8 @@ func (c *Client) MissingOneImplFeatureList(
 		targetBrowser,
 		otherBrowsers,
 		targetDate,
+		cursor,
+		pageSize,
 	)
 
 	it := txn.Query(ctx, stmt)
@@ -142,6 +182,15 @@ func (c *Client) MissingOneImplFeatureList(
 	page := MissingOneImplFeatureListPage{
 		FeatureList:   results,
 		NextPageToken: nil,
+	}
+
+	if len(results) == pageSize {
+		previousOffset := 0
+		if cursor != nil {
+			previousOffset = cursor.Offset
+		}
+		token := encodemissingOneImplFeatureListCursor(previousOffset + pageSize)
+		page.NextPageToken = &token
 	}
 
 	return &page, nil

--- a/lib/gcpspanner/missing_one_implementation_feature_list.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list.go
@@ -46,13 +46,13 @@ type missingOneImplFeatureListCursor struct {
 	Offset int `json:"offset"`
 }
 
-// decodemissingOneImplFeatureListCursor provides a wrapper around the generic decodeCursor.
-func decodemissingOneImplFeatureListCursor(cursor string) (*missingOneImplFeatureListCursor, error) {
+// decodeMissingOneImplFeatureListCursor provides a wrapper around the generic decodeCursor.
+func decodeMissingOneImplFeatureListCursor(cursor string) (*missingOneImplFeatureListCursor, error) {
 	return decodeCursor[missingOneImplFeatureListCursor](cursor)
 }
 
-// encodemissingOneImplFeatureListCursor provides a wrapper around the generic encodeCursor.
-func encodemissingOneImplFeatureListCursor(offset int) string {
+// encodeMissingOneImplFeatureListCursor provides a wrapper around the generic encodeCursor.
+func encodeMissingOneImplFeatureListCursor(offset int) string {
 	return encodeCursor(missingOneImplFeatureListCursor{
 		Offset: offset,
 	})
@@ -143,7 +143,7 @@ func (c *Client) MissingOneImplFeatureList(
 	var cursor *missingOneImplFeatureListCursor
 	var err error
 	if pageToken != nil {
-		cursor, err = decodemissingOneImplFeatureListCursor(*pageToken)
+		cursor, err = decodeMissingOneImplFeatureListCursor(*pageToken)
 		if err != nil {
 			return nil, errors.Join(ErrInternalQueryFailure, err)
 		}
@@ -189,7 +189,7 @@ func (c *Client) MissingOneImplFeatureList(
 		if cursor != nil {
 			previousOffset = cursor.Offset
 		}
-		token := encodemissingOneImplFeatureListCursor(previousOffset + pageSize)
+		token := encodeMissingOneImplFeatureListCursor(previousOffset + pageSize)
 		page.NextPageToken = &token
 	}
 

--- a/lib/gcpspanner/missing_one_implementation_feature_list_test.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list_test.go
@@ -161,7 +161,7 @@ func testMissingOneImplFeatureListSuite(
 		}
 		targetDate := time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC)
 		pageSize := 25
-		token := encodemissingOneImplFeatureListCursor(0)
+		token := encodeMissingOneImplFeatureListCursor(0)
 
 		t.Run("simple successful query", func(t *testing.T) {
 			expectedResult := &MissingOneImplFeatureListPage{
@@ -246,7 +246,7 @@ func testMissingOneImplFeatureListSuite(
 		})
 
 		t.Run("simple successful query with pagination", func(t *testing.T) {
-			pageToken := encodemissingOneImplFeatureListCursor(1)
+			pageToken := encodeMissingOneImplFeatureListCursor(1)
 			expectedResult := &MissingOneImplFeatureListPage{
 				NextPageToken: nil,
 				FeatureList: []MissingOneImplFeature{
@@ -275,7 +275,7 @@ func testMissingOneImplFeatureListSuite(
 
 		t.Run("Return a page token with page size 1", func(t *testing.T) {
 			onePerPage := 1
-			returnToken := encodemissingOneImplFeatureListCursor(1)
+			returnToken := encodeMissingOneImplFeatureListCursor(1)
 			expectedResult := &MissingOneImplFeatureListPage{
 				NextPageToken: &returnToken,
 				FeatureList: []MissingOneImplFeature{
@@ -301,7 +301,7 @@ func testMissingOneImplFeatureListSuite(
 				onePerPage,
 			)
 
-			pageTwoToken := encodemissingOneImplFeatureListCursor(2)
+			pageTwoToken := encodeMissingOneImplFeatureListCursor(2)
 			expectedResultPageTwo := &MissingOneImplFeatureListPage{
 				NextPageToken: &pageTwoToken,
 				FeatureList: []MissingOneImplFeature{

--- a/lib/gcpspanner/missing_one_implementation_feature_list_test.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list_test.go
@@ -127,6 +127,7 @@ func loadDataForListMissingOneImplFeatureList(ctx context.Context, t *testing.T,
 	}
 }
 
+// nolint:unparam // WONTFIX
 func assertMissingOneImplFeatureList(ctx context.Context, t *testing.T, targetDate time.Time,
 	targetBrowser string, otherBrowsers []string, expectedPage *MissingOneImplFeatureListPage, token *string,
 	pageSize int) {


### PR DESCRIPTION
#1109. Support pagination to handle potentially large numbers of feature IDs. Implement the cursor through an `Offset`  from the start of the result set.