### PR TITLE
Use K_REVISION for SPA bundle

### DIFF
--- a/frontend/manifests/pod.yaml
+++ b/frontend/manifests/pod.yaml
@@ -42,6 +42,8 @@ spec:
           value: local
         - name: FIREBASE_APP_AUTH_DOMAIN
           value: local
+        - name: K_REVISION
+          value: local
       resources:
         limits:
           cpu: 250m

--- a/frontend/scripts/setup_server.sh
+++ b/frontend/scripts/setup_server.sh
@@ -16,6 +16,8 @@
 INDEX_HTML="/usr/share/nginx/html/index.html"
 TMP_INDEX_HTML="/tmp/index.html"
 OLD_INDEX_HTML="/tmp/old-index.html"
+# shellcheck disable=SC2155 # Used by index.html
+export WEBSTATUS_VERSION="$(echo "$K_REVISION" | basenc --base64url)"
 envsubst < "${INDEX_HTML}" > "${TMP_INDEX_HTML}"
 cp "${INDEX_HTML}" "${OLD_INDEX_HTML}"
 cp "${TMP_INDEX_HTML}" "${INDEX_HTML}"

--- a/frontend/src/static/index.html
+++ b/frontend/src/static/index.html
@@ -71,7 +71,7 @@
 
       gtag('config', '$GOOGLE_ANALYTICS_ID');
     </script>
-    <script src="/public/js/index.js"></script>
+    <script src="/public/js/index.js?v=$WEBSTATUS_VERSION"></script>
     <webstatus-app
       settings='{
         "apiUrl": "$API_URL",

--- a/images/nodejs_service.Dockerfile
+++ b/images/nodejs_service.Dockerfile
@@ -55,6 +55,9 @@ COPY --from=builder /work/${service_dir}/scripts/setup_server.sh /docker-entrypo
 
 FROM nginx:1.27.4-alpine-slim AS static
 
+# Install coreutils to install basenc
+RUN apk add coreutils
+
 ARG service_dir
 COPY --from=builder /work/${service_dir}/nginx.conf /etc/nginx/nginx.conf
 COPY --from=production /work/${service_dir}/dist/static /usr/share/nginx/html


### PR DESCRIPTION
This should allow browsers to request a new bundle after a deployment

Cloud run environment provides [K_REVISION](https://cloud.google.com/run/docs/container-contract#:~:text=hello%2Dworld-,K_REVISION,-The%20name%20of)

So we can use that as an unique ID. We base 64 url encode it so that it is safe for browsers.

Also, set the local environment up with a fake value so that it replicates production.