### PR TITLE
Handle exclusions specified in the ExcludedFeatureKeys table

### DIFF
--- a/lib/gcpspanner/missing_one_implementation_feature_list_test.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list_test.go
@@ -369,7 +369,7 @@ func testMissingOneImplFeatureListSuite(
 					// fooBrowser: FeatureX, FeatureZ, FeatureY, FeatureW
 					// barBrowser: FeatureX, FeatureZ, FeatureY, FeatureW
 					// bazBrowser: FeatureX, FeatureY
-					// Missing in on for bazBrowser: FeatureW, FeatureZ
+					// Missing in on for bazBrowser: FeatureW (FeatureZ is excluded/discouraged)
 					{
 						WebFeatureID: "FeatureW",
 					},

--- a/lib/gcpspanner/missing_one_implementation_feature_list_test.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list_test.go
@@ -353,6 +353,7 @@ func testMissingOneImplFeatureListSuite(
 			}
 		}
 
+		// nolint:goconst // WONTFIX
 		t.Run("simple query", func(t *testing.T) {
 			targetBrowser := "bazBrowser"
 			otherBrowsers := []string{"fooBrowser", "barBrowser"}


### PR DESCRIPTION
Fix #1109. Handle exclusions specified in the `FeatureDiscouragedDetails` and `ExcludedFeatureKeys` table