### PR TITLE
Add the server code to get saved searches

### DIFF
--- a/backend/pkg/httpserver/get_saved_search_test.go
+++ b/backend/pkg/httpserver/get_saved_search_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestGetSavedSearch(t *testing.T) {
+	// testUser := &auth.User{
+	// 	ID: "getSavedSearchUser",
+	// }
+	testCases := []struct {
+		name                 string
+		cfg                  *MockGetSavedSearchConfig
+		authMiddlewareOption testServerOption
+		request              *http.Request
+		expectedResponse     *http.Response
+	}{
+		{
+			name: "success unauthenticated",
+			cfg: &MockGetSavedSearchConfig{
+				expectedSavedSearchID: "saved-search-id",
+				expectedUserID:        nil,
+				output: &backend.SavedSearchResponse{
+					Id:             "saved-search-id",
+					CreatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					Name:           "test search",
+					Query:          "test query",
+					Description:    valuePtr("test description"),
+					BookmarkStatus: nil,
+					Permissions:    nil,
+				},
+				err: nil,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(nil)),
+			request: httptest.NewRequest(http.MethodGet, "/v1/saved-searches/saved-search-id",
+				nil),
+			expectedResponse: testJSONResponse(200, `
+			{
+				"created_at":"2000-01-01T00:00:00Z",
+				"description":"test description",
+				"id":"saved-search-id",
+				"name":"test search",
+				"query":"test query",
+				"updated_at":"2000-01-01T00:00:00Z"
+			}`),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint:exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				getSavedSearchCfg: tc.cfg,
+				t:                 t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
+				operationResponseCaches: nil}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+				[]testServerOption{tc.authMiddlewareOption}...)
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -108,6 +108,7 @@ type WPTMetricsStorer interface {
 	CreateUserSavedSearch(ctx context.Context, userID string,
 		savedSearch backend.SavedSearch) (*backend.SavedSearchResponse, error)
 	DeleteUserSavedSearch(ctx context.Context, userID, savedSearchID string) error
+	GetSavedSearch(ctx context.Context, savedSearchID string, userID *string) (*backend.SavedSearchResponse, error)
 }
 
 type Server struct {

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -167,6 +167,13 @@ type MockDeleteUserSavedSearchConfig struct {
 	err                   error
 }
 
+type MockGetSavedSearchConfig struct {
+	expectedSavedSearchID string
+	expectedUserID        *string
+	output                *backend.SavedSearchResponse
+	err                   error
+}
+
 type MockWPTMetricsStorer struct {
 	featureCfg                                        *MockListMetricsForFeatureIDBrowserAndChannelConfig
 	aggregateCfg                                      *MockListMetricsOverTimeWithAggregatedTotalsConfig
@@ -179,6 +186,7 @@ type MockWPTMetricsStorer struct {
 	getIDFromFeatureKeyConfig                         *MockGetIDFromFeatureKeyConfig
 	createUserSavedSearchCfg                          *MockCreateUserSavedSearchConfig
 	deleteUserSavedSearchCfg                          *MockDeleteUserSavedSearchConfig
+	getSavedSearchCfg                                 *MockGetSavedSearchConfig
 	t                                                 *testing.T
 	callCountListMissingOneImplCounts                 int
 	callCountListBaselineStatusCounts                 int
@@ -190,6 +198,7 @@ type MockWPTMetricsStorer struct {
 	callCountGetFeature                               int
 	callCountCreateUserSavedSearch                    int
 	callCountDeleteUserSavedSearch                    int
+	callCountGetSavedSearch                           int
 }
 
 func (m *MockWPTMetricsStorer) GetIDFromFeatureKey(
@@ -404,6 +413,22 @@ func (m *MockWPTMetricsStorer) CreateUserSavedSearch(
 	}
 
 	return m.createUserSavedSearchCfg.output, m.createUserSavedSearchCfg.err
+}
+
+func (m *MockWPTMetricsStorer) GetSavedSearch(
+	_ context.Context,
+	savedSearchID string,
+	userID *string) (*backend.SavedSearchResponse, error) {
+	m.callCountGetSavedSearch++
+
+	if savedSearchID != m.getSavedSearchCfg.expectedSavedSearchID ||
+		!reflect.DeepEqual(userID, m.getSavedSearchCfg.expectedUserID) {
+		m.t.Errorf("Incorrect arguments. Expected: { %s %v }, Got: { %s %v }",
+			m.getSavedSearchCfg.expectedSavedSearchID, m.getSavedSearchCfg.expectedUserID,
+			savedSearchID, userID)
+	}
+
+	return m.getSavedSearchCfg.output, m.getSavedSearchCfg.err
 }
 
 func (m *MockWPTMetricsStorer) DeleteUserSavedSearch(


### PR DESCRIPTION
This calls the adapter code to get a saved search.

It allows for both unauthenticated and authenticated requests

If the call is authenticated, it gets extra information for the saved search regarding the relationship of the user to the saved search