### PR TITLE
Add plumbing between spanner & http for missing one implementation

### DIFF
--- a/backend/pkg/httpserver/list_missing_one_implementation_features.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_features.go
@@ -16,20 +16,53 @@ package httpserver
 
 import (
 	"context"
-	"net/http"
+	"errors"
+	"log/slog"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
 // ListMissingOneImplementationFeatures implements backend.StrictServerInterface.
 // nolint: ireturn // Signature generated from openapi
 func (s *Server) ListMissingOneImplementationFeatures(
-	_ context.Context,
-	_ backend.ListMissingOneImplementationFeaturesRequestObject) (
+	ctx context.Context,
+	request backend.ListMissingOneImplementationFeaturesRequestObject) (
 	backend.ListMissingOneImplementationFeaturesResponseObject, error) {
+	otherBrowsers := make([]string, len(request.Params.Browser))
+	for i := 0; i < len(request.Params.Browser); i++ {
+		otherBrowsers[i] = string(request.Params.Browser[i])
+	}
+	page, err := s.wptMetricsStorer.ListMissingOneImplementationFeatures(
+		ctx,
+		string(request.Browser),
+		otherBrowsers,
+		request.Date.Time,
+		getPageSizeOrDefault(request.Params.PageSize),
+		request.Params.PageToken,
+	)
+	if err != nil {
+		if errors.Is(err, backendtypes.ErrInvalidPageToken) {
+			slog.WarnContext(ctx, "invalid page token", "token", request.Params.PageToken, "error", err)
 
-	return backend.ListMissingOneImplementationFeatures400JSONResponse{
-		Code:    http.StatusBadRequest,
-		Message: "TODO",
-	}, nil
+			return backend.ListMissingOneImplementationFeatures400JSONResponse{
+				Code:    400,
+				Message: "invalid page token",
+			}, nil
+		}
+
+		slog.ErrorContext(ctx, "unable to get missing one implementation feature list", "error", err)
+
+		return backend.ListMissingOneImplementationFeatures500JSONResponse{
+			Code:    500,
+			Message: "unable to get missing one implementation feature list",
+		}, nil
+	}
+
+	resp := backend.ListMissingOneImplementationFeatures200JSONResponse{
+		Metadata: page.Metadata,
+		Data:     page.Data,
+	}
+
+	return resp, nil
 }

--- a/backend/pkg/httpserver/list_missing_one_implementation_features_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_features_test.go
@@ -13,3 +13,190 @@
 // limitations under the License.
 
 package httpserver
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+func TestListMissingOneImplementationFeatures(t *testing.T) {
+	foo := "foo"
+	bar := "bar"
+	testCases := []struct {
+		name              string
+		mockConfig        MockListMissingOneImplFeaturesConfig
+		expectedCallCount int // For the mock method
+		request           backend.ListMissingOneImplementationFeaturesRequestObject
+		expectedResponse  backend.ListMissingOneImplementationFeaturesResponseObject
+		expectedError     error
+	}{
+		{
+			name: "Success Case - no optional params - use defaults",
+			mockConfig: MockListMissingOneImplFeaturesConfig{
+				expectedTargetBrowser: "chrome",
+				expectedOtherBrowsers: []string{"edge", "firefox", "safari"},
+				expectedtargetDate:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:      100,
+				expectedPageToken:     nil,
+				pageToken:             nil,
+				err:                   nil,
+				page: &backend.MissingOneImplFeaturesPage{
+					Metadata: &backend.PageMetadata{
+						NextPageToken: nil,
+					},
+					Data: []backend.MissingOneImplFeature{
+						{
+							FeatureId: &foo,
+						},
+						{
+							FeatureId: &bar,
+						},
+					},
+				},
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListMissingOneImplementationFeatures200JSONResponse{
+				Data: []backend.MissingOneImplFeature{
+					{
+						FeatureId: &foo,
+					},
+					{
+						FeatureId: &bar,
+					},
+				},
+				Metadata: &backend.PageMetadata{
+					NextPageToken: nil,
+				},
+			},
+			request: backend.ListMissingOneImplementationFeaturesRequestObject{
+				Params: backend.ListMissingOneImplementationFeaturesParams{
+					PageToken: nil,
+					PageSize:  nil,
+					Browser: []backend.SupportedBrowsers{
+						backend.Edge, backend.Firefox, backend.Safari,
+					},
+				},
+				Browser: backend.Chrome,
+				Date:    openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success Case - include optional params",
+			mockConfig: MockListMissingOneImplFeaturesConfig{
+				expectedTargetBrowser: "chrome",
+				expectedOtherBrowsers: []string{"edge", "firefox", "safari"},
+				expectedtargetDate:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:      50,
+				expectedPageToken:     inputPageToken,
+				err:                   nil,
+				page: &backend.MissingOneImplFeaturesPage{
+					Metadata: &backend.PageMetadata{
+						NextPageToken: nextPageToken,
+					},
+					Data: []backend.MissingOneImplFeature{
+						{
+							FeatureId: &foo,
+						},
+						{
+							FeatureId: &bar,
+						},
+					},
+				},
+				pageToken: nextPageToken,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListMissingOneImplementationFeatures200JSONResponse{
+				Metadata: &backend.PageMetadata{
+					NextPageToken: nextPageToken,
+				},
+				Data: []backend.MissingOneImplFeature{
+					{
+						FeatureId: &foo,
+					},
+					{
+						FeatureId: &bar,
+					},
+				},
+			},
+			request: backend.ListMissingOneImplementationFeaturesRequestObject{
+				Params: backend.ListMissingOneImplementationFeaturesParams{
+					PageToken: inputPageToken,
+					PageSize:  valuePtr[int](50),
+					Browser: []backend.SupportedBrowsers{
+						backend.Edge, backend.Firefox, backend.Safari,
+					},
+				},
+				Browser: backend.Chrome,
+				Date:    openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "500 case",
+			mockConfig: MockListMissingOneImplFeaturesConfig{
+				expectedTargetBrowser: "chrome",
+				expectedOtherBrowsers: []string{"edge", "firefox", "safari"},
+				expectedtargetDate:    time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedPageSize:      100,
+				expectedPageToken:     nil,
+				page:                  nil,
+				pageToken:             nil,
+				err:                   errTest,
+			},
+			expectedCallCount: 1,
+			expectedResponse: backend.ListMissingOneImplementationFeatures500JSONResponse{
+				Code:    500,
+				Message: "unable to get missing one implementation feature list",
+			},
+			request: backend.ListMissingOneImplementationFeaturesRequestObject{
+				Params: backend.ListMissingOneImplementationFeaturesParams{
+					PageToken: nil,
+					PageSize:  nil,
+					Browser: []backend.SupportedBrowsers{
+						backend.Edge, backend.Firefox, backend.Safari,
+					},
+				},
+				Browser: backend.Chrome,
+				Date:    openapi_types.Date{Time: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// nolint: exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				listMissingOneImplFeaturesCfg: &tc.mockConfig,
+				t:                             t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil}
+
+			// Call the function under test
+			resp, err := myServer.ListMissingOneImplementationFeatures(context.Background(), tc.request)
+
+			// Assertions
+			if mockStorer.callCountListMissingOneImplFeatures != tc.expectedCallCount {
+				t.Errorf("Incorrect call count: expected %d, got %d",
+					tc.expectedCallCount,
+					mockStorer.callCountListMissingOneImplFeatures)
+			}
+
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(tc.expectedResponse, resp) {
+				t.Errorf("Unexpected response: %v", resp)
+			}
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -98,6 +98,14 @@ type WPTMetricsStorer interface {
 		pageSize int,
 		pageToken *string,
 	) (*backend.BrowserReleaseFeatureMetricsPage, error)
+	ListMissingOneImplementationFeatures(
+		ctx context.Context,
+		targetBrowser string,
+		otherBrowsers []string,
+		targetDate time.Time,
+		pageSize int,
+		pageToken *string,
+	) (*backend.MissingOneImplFeaturesPage, error)
 	ListBaselineStatusCounts(
 		ctx context.Context,
 		startAt time.Time,

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -144,6 +144,17 @@ type MockListMissingOneImplCountsConfig struct {
 	err                   error
 }
 
+type MockListMissingOneImplFeaturesConfig struct {
+	expectedTargetBrowser string
+	expectedOtherBrowsers []string
+	expectedtargetDate    time.Time
+	expectedPageSize      int
+	expectedPageToken     *string
+	pageToken             *string
+	page                  *backend.MissingOneImplFeaturesPage
+	err                   error
+}
+
 type MockListBaselineStatusCountsConfig struct {
 	expectedStartAt   time.Time
 	expectedEndAt     time.Time
@@ -173,6 +184,7 @@ type MockWPTMetricsStorer struct {
 	featuresSearchCfg                                 *MockFeaturesSearchConfig
 	listBrowserFeatureCountMetricCfg                  *MockListBrowserFeatureCountMetricConfig
 	listMissingOneImplCountCfg                        *MockListMissingOneImplCountsConfig
+	listMissingOneImplFeaturesCfg                     *MockListMissingOneImplFeaturesConfig
 	listBaselineStatusCountsCfg                       *MockListBaselineStatusCountsConfig
 	listChromiumDailyUsageStatsCfg                    *MockListChromiumDailyUsageStatsConfig
 	getFeatureByIDConfig                              *MockGetFeatureByIDConfig
@@ -181,6 +193,7 @@ type MockWPTMetricsStorer struct {
 	deleteUserSavedSearchCfg                          *MockDeleteUserSavedSearchConfig
 	t                                                 *testing.T
 	callCountListMissingOneImplCounts                 int
+	callCountListMissingOneImplFeatures               int
 	callCountListBaselineStatusCounts                 int
 	callCountListBrowserFeatureCountMetric            int
 	callCountFeaturesSearch                           int
@@ -367,6 +380,29 @@ func (m *MockWPTMetricsStorer) ListMissingOneImplCounts(
 	}
 
 	return m.listMissingOneImplCountCfg.page, m.listMissingOneImplCountCfg.err
+}
+
+func (m *MockWPTMetricsStorer) ListMissingOneImplementationFeatures(
+	_ context.Context,
+	targetBrowser string,
+	otherBrowsers []string,
+	targetDate time.Time,
+	pageSize int,
+	pageToken *string,
+) (*backend.MissingOneImplFeaturesPage, error) {
+	m.callCountListMissingOneImplFeatures++
+
+	if targetBrowser != m.listMissingOneImplFeaturesCfg.expectedTargetBrowser ||
+		!slices.Equal(otherBrowsers, m.listMissingOneImplFeaturesCfg.expectedOtherBrowsers) ||
+		!targetDate.Equal(m.listMissingOneImplFeaturesCfg.expectedtargetDate) ||
+		pageSize != m.listMissingOneImplFeaturesCfg.expectedPageSize ||
+		!reflect.DeepEqual(pageToken, m.listMissingOneImplFeaturesCfg.expectedPageToken) {
+
+		m.t.Errorf("Incorrect arguments. Expected: %v, Got: { %v, %s, %s, %d %v }",
+			m.listMissingOneImplFeaturesCfg, targetBrowser, otherBrowsers, targetDate, pageSize, pageToken)
+	}
+
+	return m.listMissingOneImplFeaturesCfg.page, m.listMissingOneImplFeaturesCfg.err
 }
 
 func (m *MockWPTMetricsStorer) ListBaselineStatusCounts(

--- a/lib/gcpspanner/missing_one_implementation_feature_list.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list.go
@@ -142,7 +142,7 @@ func buildMissingOneImplFeatureListTemplate(
 	return stmt
 }
 
-func (c *Client) MissingOneImplFeatureList(
+func (c *Client) ListMissingOneImplementationFeatures(
 	ctx context.Context,
 	targetBrowser string,
 	otherBrowsers []string,

--- a/lib/gcpspanner/missing_one_implementation_feature_list_test.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list_test.go
@@ -131,7 +131,7 @@ func loadDataForListMissingOneImplFeatureList(ctx context.Context, t *testing.T,
 func assertMissingOneImplFeatureList(ctx context.Context, t *testing.T, targetDate time.Time,
 	targetBrowser string, otherBrowsers []string, expectedPage *MissingOneImplFeatureListPage, token *string,
 	pageSize int) {
-	result, err := spannerClient.MissingOneImplFeatureList(
+	result, err := spannerClient.ListMissingOneImplementationFeatures(
 		ctx,
 		targetBrowser,
 		otherBrowsers,

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -79,6 +79,11 @@ type mockListMissingOneImplCountsConfig struct {
 	returnedError error
 }
 
+type mockListMissingOneImplFeaturesConfig struct {
+	result        *gcpspanner.MissingOneImplFeatureListPage
+	returnedError error
+}
+
 type mockCreateNewUserSavedSearchConfig struct {
 	expectedNewSearch gcpspanner.CreateUserSavedSearchRequest
 	result            *string
@@ -107,6 +112,7 @@ type mockBackendSpannerClient struct {
 	mockGetIDByFeaturesIDCfg             mockGetIDByFeaturesIDConfig
 	mockListBrowserFeatureCountMetricCfg mockListBrowserFeatureCountMetricConfig
 	mockListMissingOneImplCountsCfg      mockListMissingOneImplCountsConfig
+	mockListMissingOneImplFeaturesCfg    mockListMissingOneImplFeaturesConfig
 	mockListBaselineStatusCountsCfg      mockListBaselineStatusCountsConfig
 	mockCreateNewUserSavedSearchCfg      *mockCreateNewUserSavedSearchConfig
 	mockGetUserSavedSearchCfg            *mockGetUserSavedSearchConfig
@@ -279,6 +285,26 @@ func (c mockBackendSpannerClient) ListMissingOneImplCounts(
 	}
 
 	return c.mockListMissingOneImplCountsCfg.result, c.mockListMissingOneImplCountsCfg.returnedError
+}
+
+func (c mockBackendSpannerClient) ListMissingOneImplementationFeatures(
+	ctx context.Context,
+	targetBrowser string,
+	otherBrowsers []string,
+	targetDate time.Time,
+	pageSize int,
+	pageToken *string,
+) (*gcpspanner.MissingOneImplFeatureListPage, error) {
+	if ctx != context.Background() ||
+		targetBrowser != "mybrowser" ||
+		!slices.Equal(otherBrowsers, []string{"browser1", "browser2"}) ||
+		!targetDate.Equal(testStart) ||
+		pageSize != 100 ||
+		pageToken != nonNilInputPageToken {
+		c.t.Error("unexpected input to mock")
+	}
+
+	return c.mockListMissingOneImplFeaturesCfg.result, c.mockListMissingOneImplFeaturesCfg.returnedError
 }
 
 // ListBaselineStatusCounts implements BackendSpannerClient.
@@ -697,6 +723,92 @@ func TestListMissingOneImplCounts(t *testing.T) {
 				[]string{"browser1", "browser2"},
 				testStart,
 				testEnd,
+				100,
+				nonNilInputPageToken)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Error("unexpected error")
+			}
+
+			if !reflect.DeepEqual(page, tc.expectedPage) {
+				t.Error("unexpected metrics")
+			}
+		})
+	}
+}
+
+func TestListMissingOneImplementationFeatures(t *testing.T) {
+	featureOne := "foo"
+	featureTwo := "bar"
+	// nolint:dupl // WONTFIX
+	testCases := []struct {
+		name         string
+		cfg          mockListMissingOneImplFeaturesConfig
+		expectedPage *backend.MissingOneImplFeaturesPage
+		expectedErr  error
+	}{
+		{
+			name: "success",
+			cfg: mockListMissingOneImplFeaturesConfig{
+				result: &gcpspanner.MissingOneImplFeatureListPage{
+					NextPageToken: nonNilNextPageToken,
+					FeatureList: []gcpspanner.MissingOneImplFeature{
+						{
+							WebFeatureID: featureOne,
+						},
+						{
+							WebFeatureID: featureTwo,
+						},
+					},
+				},
+				returnedError: nil,
+			},
+			expectedPage: &backend.MissingOneImplFeaturesPage{
+				Metadata: &backend.PageMetadata{
+					NextPageToken: nonNilNextPageToken,
+				},
+				Data: []backend.MissingOneImplFeature{
+					{
+						FeatureId: &featureOne,
+					},
+					{
+						FeatureId: &featureTwo,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "failure",
+			cfg: mockListMissingOneImplFeaturesConfig{
+				result:        nil,
+				returnedError: errTest,
+			},
+			expectedPage: nil,
+			expectedErr:  errTest,
+		},
+		{
+			name: "invalid cursor",
+			cfg: mockListMissingOneImplFeaturesConfig{
+				result:        nil,
+				returnedError: gcpspanner.ErrInvalidCursorFormat,
+			},
+			expectedPage: nil,
+			expectedErr:  backendtypes.ErrInvalidPageToken,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint: exhaustruct
+			mock := mockBackendSpannerClient{
+				t:                                 t,
+				mockListMissingOneImplFeaturesCfg: tc.cfg,
+			}
+			backend := NewBackend(mock)
+			page, err := backend.ListMissingOneImplementationFeatures(
+				context.Background(),
+				"mybrowser",
+				[]string{"browser1", "browser2"},
+				testStart,
 				100,
 				nonNilInputPageToken)
 			if !errors.Is(err, tc.expectedErr) {


### PR DESCRIPTION
This change adds the spanner adapter conversion layer for the missing one implementation feature list endpoint. This change is inspired from https://github.com/GoogleChrome/webstatus.dev/pull/904