### PR TITLE
chore: npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -817,9 +817,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.7.tgz",
-      "integrity": "sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
There was a moderate severity being reported when running npm install.

Dependabot did not catch it even after manually running it.

Here's the report:
```
npm audit report

@babel/runtime  <7.26.10
Severity: moderate
Babel has inefficient RexExp complexity in generated code with .replace when transpiling named capturing groups - https://github.com/advisories/GHSA-968p-4wvh-cqc8
```

I don't think it impacts us but since npm automatically fixed it after running `npm audit fix`, I figured I might as well push this.