### PR TITLE
Add an empty token check in missing_one_implementation_feature_list

### DIFF
--- a/lib/gcpspanner/missing_one_implementation_feature_list.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list.go
@@ -131,6 +131,7 @@ func buildMissingOneImplFeatureListTemplate(
 
 	tmplData := missingOneImplFeatureListTemplateData{
 		OtherBrowsersParamNames: otherBrowsersParamNames,
+		Offset:                  0,
 		ExcludedFeatureFilter:   excludedFeatureFilter,
 	}
 

--- a/lib/gcpspanner/missing_one_implementation_feature_list.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list.go
@@ -131,8 +131,11 @@ func buildMissingOneImplFeatureListTemplate(
 
 	tmplData := missingOneImplFeatureListTemplateData{
 		OtherBrowsersParamNames: otherBrowsersParamNames,
-		Offset:                  cursor.Offset,
 		ExcludedFeatureFilter:   excludedFeatureFilter,
+	}
+
+	if cursor != nil {
+		tmplData.Offset = cursor.Offset
 	}
 
 	sql := missingOneImplFeatureListTemplate.Execute(tmplData)

--- a/lib/gcpspanner/missing_one_implementation_feature_list_test.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list_test.go
@@ -329,6 +329,35 @@ func testMissingOneImplFeatureListSuite(
 			)
 		})
 
+		t.Run("simple query without a token", func(t *testing.T) {
+			expectedResult := &MissingOneImplFeatureListPage{
+				NextPageToken: nil,
+				FeatureList: []MissingOneImplFeature{
+					// fooBrowser 113 release
+					// Currently supported features:
+					// fooBrowser: FeatureX, FeatureZ, FeatureY, FeatureW
+					// barBrowser: FeatureX, FeatureZ, FeatureY, FeatureW
+					// bazBrowser: FeatureX, FeatureY
+					// Missing in on for bazBrowser: FeatureW, FeatureZ
+					{
+						WebFeatureID: "FeatureZ",
+					},
+					{
+						WebFeatureID: "FeatureW",
+					},
+				},
+			}
+			assertMissingOneImplFeatureList(
+				ctx,
+				t,
+				targetDate,
+				targetBrowser,
+				otherBrowsers,
+				expectedResult,
+				nil,
+				pageSize,
+			)
+		})
 	})
 
 	t.Run("with excluded/discouraged features", func(t *testing.T) {


### PR DESCRIPTION
Fix the nil pointer issue when a token is empty and the cursor is nil. It causes a `invalid memory address or nil pointer dereference` in staging testing