### PR TITLE
Add anchor link to overview page with feature ID list

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
@@ -183,7 +183,13 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
     expect(header).to.exist;
     // Note: \n before chrome due to a complaint from lint in the html.
     expect(header!.textContent?.trim()).to.contain(
-      'The missing feature IDs on 2024-01-01 for\n        chrome',
+      'The missing feature IDs on 2024-01-01 for\n          chrome',
+    );
+
+    const anchor = header!.querySelector('a');
+    expect(anchor).to.exist;
+    expect(anchor?.getAttribute('href')).to.equal(
+      '/?q=id%3Acss+OR+id%3Ahtml+OR+id%3Ajs+OR+id%3Abluetooth',
     );
 
     const table = el.shadowRoot!.querySelector('.missing-features-table');

--- a/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
@@ -207,6 +207,48 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
     );
   });
 
+  it('renders empty features footer', async () => {
+    apiClientStub.getMissingOneImplementationFeatures.resolves([]);
+    const chart = el.shadowRoot!.querySelector(
+      '#missing-one-implementation-chart',
+    )!;
+
+    const chartClickEvent: ChartSelectPointEvent = new CustomEvent(
+      'point-selected',
+      {
+        detail: {
+          label: 'Chromium',
+          timestamp: new Date('2024-01-01'),
+          value: 123,
+        },
+        bubbles: true,
+      },
+    );
+    // Simulate point-selected event on the chart component
+    chart.dispatchEvent(chartClickEvent);
+    await el.updateComplete;
+
+    // Assert that the task and renderer are set (no need to wait for the event)
+    expect(el._pointSelectedTask).to.exist;
+    await el._pointSelectedTask?.taskComplete;
+    await el.updateComplete;
+
+    expect(el._renderCustomPointSelectedSuccess).to.exist;
+    await el.updateComplete;
+
+    const header = el.shadowRoot!.querySelector(
+      '#missing-one-implementation-list-header',
+    );
+    expect(header).to.exist;
+    // Note: \n before chrome due to a complaint from lint in the html.
+    expect(header!.textContent?.trim()).to.contain(
+      'No missing features for on 2024-01-01 for\n        chrome',
+    );
+
+    const table = el.shadowRoot!.querySelector('.missing-features-table');
+    expect(table).to.not.exist;
+  });
+
   it('assert correct getMissingOneImplementationFeatures calls', async () => {
     apiClientStub.getMissingOneImplementationFeatures.resolves([
       {

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -115,15 +115,16 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
   }
 
   updateFeatureListHref(featureList: MissingOneImplFeaturesList) {
-    if (!featureList.length) {
+    if (featureList.length === 0) {
       this.featureListHref = '';
+      return;
     }
     let query = 'id:' + featureList[0].feature_id;
     for (let i = 1; i < featureList.length; i++) {
       query += ' OR id:' + featureList[i].feature_id;
     }
 
-    this.featureListHref = formatOverviewPageUrl({search: '?q=' + query});
+    this.featureListHref = formatOverviewPageUrl({search: ''}, {q: query});
   }
 
   /**
@@ -172,9 +173,16 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
    * @returns {TemplateResult} The rendered content for the success state.
    */
   pointSelectedTaskRenderOnSuccess(): TemplateResult {
+    if (this.missingFeaturesList.length === 0) {
+      return html`<div slot="header" id="${this.getPanelID()}-list-header">
+        No missing features for on ${this.selectedDate} for
+        ${this.selectedBrowser}:
+      </div> `;
+    }
+
     return html`
       <div slot="header" id="${this.getPanelID()}-list-header">
-        <a href="${this.featureListHref}">
+        <a href="${this.featureListHref}" target="_blank">
           The missing feature IDs on ${this.selectedDate} for
           ${this.selectedBrowser}:
         </a>

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -184,7 +184,7 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
       <div slot="header" id="${this.getPanelID()}-list-header">
         <a href="${this.featureListHref}" target="_blank">
           The missing feature IDs on ${this.selectedDate} for
-          ${this.selectedBrowser}:
+          ${this.selectedBrowser}
         </a>
       </div>
       ${this.renderMissingFeaturesTable()}

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -30,6 +30,7 @@ import {
 } from '../api/client.js';
 import {ChartSelectPointEvent} from './webstatus-gchart.js';
 import {customElement, state} from 'lit/decorators.js';
+import {formatOverviewPageUrl} from '../utils/urls.js';
 
 @customElement('webstatus-stats-missing-one-impl-chart-panel')
 export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPanel {
@@ -39,6 +40,7 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
   missingFeaturesList: MissingOneImplFeaturesList = [];
   selectedBrowser: string = '';
   selectedDate: string = '';
+  featureListHref: string = '';
 
   static get styles() {
     return [
@@ -112,6 +114,18 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
     };
   }
 
+  updateFeatureListHref(featureList: MissingOneImplFeaturesList) {
+    if (!featureList.length) {
+      this.featureListHref = '';
+    }
+    let query = 'id:' + featureList[0].feature_id;
+    for (let i = 1; i < featureList.length; i++) {
+      query += ' OR id:' + featureList[i].feature_id;
+    }
+
+    this.featureListHref = formatOverviewPageUrl({search: '?q=' + query});
+  }
+
   /**
    * Creates a task and a renderer for handling point-selected events.
    * Overrides createPointSelectedTask() in the parent class when an point is
@@ -142,6 +156,7 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
         this.missingFeaturesList = features;
         this.selectedDate = targetDate.toISOString().substring(0, 10);
         this.selectedBrowser = targetBrowser;
+        this.updateFeatureListHref(features);
         return features;
       },
       args: () => [targetDate, targetBrowser],
@@ -159,8 +174,10 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
   pointSelectedTaskRenderOnSuccess(): TemplateResult {
     return html`
       <div slot="header" id="${this.getPanelID()}-list-header">
-        The missing feature IDs on ${this.selectedDate} for
-        ${this.selectedBrowser}:
+        <a href="${this.featureListHref}">
+          The missing feature IDs on ${this.selectedDate} for
+          ${this.selectedBrowser}:
+        </a>
       </div>
       ${this.renderMissingFeaturesTable()}
     `;


### PR DESCRIPTION
A follow-up request for #1111. Add an anchor link to overview page that shows the same set of feature IDs in MissingOneImplementationFeatureList.

Staging testing note:
Test it with max numbers of feature list, 80~