### PR TITLE
UI adjustments for MissingOneImplFeatureList

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
@@ -229,16 +229,14 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
       '#missing-one-implementation-list-header',
     );
     expect(header).to.exist;
-    // Note: \n before chrome due to a complaint from lint in the html.
-    expect(header!.textContent?.trim()).to.contain(
-      'The missing feature IDs on 2024-01-01 for\n        Chrome: 4 features',
-    );
-
-    const anchor = header!.querySelector('a');
-    expect(anchor).to.exist;
-    expect(anchor?.getAttribute('href')).to.equal(
-      '/?q=id%3Acss+OR+id%3Ahtml+OR+id%3Ajs+OR+id%3Abluetooth',
-    );
+    const expectedHeader = `
+      <div slot="header" id="missing-one-implementation-list-header">
+        The missing feature IDs on 2024-01-01 for
+        Chrome:
+        <a target="_blank" href="/?q=id%3Acss+OR+id%3Ahtml+OR+id%3Ajs+OR+id%3Abluetooth">4 features</a>
+      </div>
+    `;
+    expect(header).dom.to.equal(expectedHeader);
 
     const table = el.shadowRoot!.querySelector('.missing-features-table');
     expect(table).to.exist;
@@ -288,10 +286,13 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
       '#missing-one-implementation-list-header',
     );
     expect(header).to.exist;
-    // Note: \n before chrome due to a complaint from lint in the html.
-    expect(header!.textContent?.trim()).to.contain(
-      'No missing features for on 2024-01-01 for\n        Chrome',
-    );
+    const expectedHeader = `
+      <div slot="header" id="missing-one-implementation-list-header">
+        No missing features for on 2024-01-01 for
+        Chrome
+      </div>
+    `;
+    expect(header).dom.to.equal(expectedHeader);
 
     const table = el.shadowRoot!.querySelector('.missing-features-table');
     expect(table).to.not.exist;

--- a/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
@@ -231,7 +231,7 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
     expect(header).to.exist;
     // Note: \n before chrome due to a complaint from lint in the html.
     expect(header!.textContent?.trim()).to.contain(
-      'The missing feature IDs on 2024-01-01 for\n          chrome',
+      'The missing feature IDs on 2024-01-01 for\n        Chrome: 4 features',
     );
 
     const anchor = header!.querySelector('a');
@@ -290,7 +290,7 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
     expect(header).to.exist;
     // Note: \n before chrome due to a complaint from lint in the html.
     expect(header!.textContent?.trim()).to.contain(
-      'No missing features for on 2024-01-01 for\n        chrome',
+      'No missing features for on 2024-01-01 for\n        Chrome',
     );
 
     const table = el.shadowRoot!.querySelector('.missing-features-table');

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -167,7 +167,7 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
           );
         this.missingFeaturesList = features;
         this.selectedDate = targetDate.toISOString().substring(0, 10);
-        this.selectedBrowser = targetBrowser;
+        this.selectedBrowser = label;
         this.updateFeatureListHref(features);
         return features;
       },
@@ -187,16 +187,18 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
     if (this.missingFeaturesList.length === 0) {
       return html`<div slot="header" id="${this.getPanelID()}-list-header">
         No missing features for on ${this.selectedDate} for
-        ${this.selectedBrowser}:
+        ${this.selectedBrowser}
       </div> `;
     }
 
     return html`
       <div slot="header" id="${this.getPanelID()}-list-header">
-        <a href="${this.featureListHref}" target="_blank">
-          The missing feature IDs on ${this.selectedDate} for
-          ${this.selectedBrowser}
-        </a>
+        The missing feature IDs on ${this.selectedDate} for
+        ${this.selectedBrowser}: <a
+          href="${this.featureListHref}"
+          target="_blank"
+          >${this.missingFeaturesList.length} features</a
+        >
       </div>
       ${this.renderMissingFeaturesTable()}
     `;
@@ -225,7 +227,9 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
           const feature_id = this.missingFeaturesList[featureIndex].feature_id;
           cells.push(
             html` <td>
-              <a href="/features/${feature_id}">${feature_id}</a>
+              <a href="/features/${feature_id}" style="padding-right: 1em;"
+                >${feature_id}</a
+              >
             </td>`,
           );
         } else {

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -191,6 +191,7 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
       </div> `;
     }
 
+    // prettier-ignore
     return html`
       <div slot="header" id="${this.getPanelID()}-list-header">
         The missing feature IDs on ${this.selectedDate} for

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -59,6 +59,9 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
           overflow-x: auto;
           white-space: nowrap;
         }
+        .missing-feature-id-link {
+          padding-right: 1em;
+        }
       `,
     ];
   }
@@ -191,13 +194,11 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
       </div> `;
     }
 
-    // prettier-ignore
     return html`
       <div slot="header" id="${this.getPanelID()}-list-header">
         The missing feature IDs on ${this.selectedDate} for
-        ${this.selectedBrowser}: <a
-          href="${this.featureListHref}"
-          target="_blank"
+        ${this.selectedBrowser}:
+        <a href="${this.featureListHref}" target="_blank"
           >${this.missingFeaturesList.length} features</a
         >
       </div>
@@ -228,7 +229,7 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
           const feature_id = this.missingFeaturesList[featureIndex].feature_id;
           cells.push(
             html` <td>
-              <a href="/features/${feature_id}" style="padding-right: 1em;"
+              <a href="/features/${feature_id}" class="missing-feature-id-link"
                 >${feature_id}</a
               >
             </td>`,


### PR DESCRIPTION
Fix #1301. A list of UI adjustments:
- Make the header more distinguishable, with a new format of `Missing only in Chrome on 2023-12-10: <a ..>12 features</a>`
- Add 1em padding-right for the text contentinside of the table
- Use browser labels for the header, mentioned [here](https://github.com/GoogleChrome/webstatus.dev/pull/1298#issuecomment-2741276226)

![Screenshot 2025-03-21 11 34 59 AM](https://github.com/user-attachments/assets/7a742c9c-e8d5-4c90-b1bd-f004b5cd6485)
