### PR TITLE
refactor: Add bookmarks context

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-overview-content.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-overview-content.test.ts
@@ -23,13 +23,21 @@ import {
 } from '../../contexts/settings-context.js';
 import {WebstatusOverviewContent} from '../webstatus-overview-content.js';
 import '../webstatus-overview-content.js';
-import {assert, expect} from '@open-wc/testing';
+import {expect} from '@open-wc/testing';
+import {
+  AppBookmarkInfo,
+  appBookmarkInfoContext,
+} from '../../contexts/app-bookmark-info-context.js';
 
 @customElement('fake-parent-element')
 class FakeParentElement extends LitElement {
   @provide({context: appSettingsContext})
   @property({type: Object})
   settings!: AppSettings;
+
+  @provide({context: appBookmarkInfoContext})
+  @property({type: Object})
+  appBookmarkInfo: AppBookmarkInfo = {};
 
   render(): TemplateResult {
     return html`<slot></slot>`;
@@ -57,25 +65,30 @@ describe('webstatus-overview-content', () => {
       const element: WebstatusOverviewContent = container.querySelector(
         'webstatus-overview-content',
       ) as WebstatusOverviewContent;
-      // Set location to one of the DEFAULT_BOOKMARKS.
+      // Set location to one of the globalBookmarks.
       element.location = {search: '?q=test_query_1'};
-      element.bookmarks = [
-        {
+      parent.appBookmarkInfo = {
+        globalBookmarks: [
+          {
+            name: 'Test Bookmark 1',
+            query: 'test_query_1',
+            description: 'test description1',
+          },
+          {
+            name: 'Test Bookmark 2',
+            query: 'test_query_2',
+            description: 'test description2',
+          },
+        ],
+        currentGlobalBookmark: {
           name: 'Test Bookmark 1',
           query: 'test_query_1',
           description: 'test description1',
         },
-        {
-          name: 'Test Bookmark 2',
-          query: 'test_query_2',
-          description: 'test description2',
-        },
-      ];
+      };
       document.body.appendChild(container);
       await parent.updateComplete;
       await element.updateComplete;
-
-      assert.exists(element.getBookmarkFromQuery());
 
       const title = element?.shadowRoot?.querySelector('#overview-title');
       expect(title).to.exist;
@@ -101,19 +114,23 @@ describe('webstatus-overview-content', () => {
       const element: WebstatusOverviewContent = container.querySelector(
         'webstatus-overview-content',
       ) as WebstatusOverviewContent;
-      // Set location to one of the DEFAULT_BOOKMARKS.
+      // Set location to one of the globalBookmarks.
       element.location = {search: '?q=test_query_1'};
-      element.bookmarks = [
-        {
+      parent.appBookmarkInfo = {
+        globalBookmarks: [
+          {
+            name: 'Test Bookmark 1',
+            query: 'test_query_1',
+          },
+        ],
+        currentGlobalBookmark: {
           name: 'Test Bookmark 1',
           query: 'test_query_1',
         },
-      ];
+      };
       document.body.appendChild(container);
       await parent.updateComplete;
       await element.updateComplete;
-
-      assert.exists(element.getBookmarkFromQuery());
 
       const title = element?.shadowRoot?.querySelector('#overview-title');
       expect(title).to.exist;

--- a/frontend/src/static/js/components/test/webstatus-sidebar-menu.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-sidebar-menu.test.ts
@@ -20,6 +20,13 @@ import {WebstatusSidebarMenu} from '../webstatus-sidebar-menu.js';
 import {SlTreeItem} from '@shoelace-style/shoelace';
 import '../webstatus-sidebar-menu.js';
 import {Bookmark} from '../../utils/constants.js';
+import {customElement, property} from 'lit/decorators.js';
+import {provide} from '@lit/context';
+import {LitElement, TemplateResult} from 'lit';
+import {
+  AppBookmarkInfo,
+  appBookmarkInfoContext,
+} from '../../contexts/app-bookmark-info-context.js';
 
 const testBookmarks: Bookmark[] = [
   {
@@ -33,13 +40,48 @@ const testBookmarks: Bookmark[] = [
     description: 'test description2',
   },
 ];
+
+@customElement('fake-bookmark-parent-element')
+class FakeBookmarkParentElement extends LitElement {
+  @provide({context: appBookmarkInfoContext})
+  @property({type: Object})
+  appBookmarkInfo: AppBookmarkInfo = {
+    globalBookmarks: testBookmarks,
+    currentGlobalBookmark: undefined,
+  };
+
+  render(): TemplateResult {
+    return html`<slot></slot>`;
+  }
+}
+
+function createTestContainer(): HTMLElement {
+  const container = document.createElement('div');
+  container.innerHTML = `
+  <fake-bookmark-parent-element>
+    <webstatus-sidebar-menu>
+    </webstatus-sidebar-menu>
+  </fake-bookmark-parent-element>
+`;
+  return container;
+}
+
 describe('webstatus-sidebar-menu', () => {
   let el: WebstatusSidebarMenu;
+  let parent: FakeBookmarkParentElement;
+  let container: HTMLElement;
 
   beforeEach(async () => {
-    el = await fixture<WebstatusSidebarMenu>(
-      '<webstatus-sidebar-menu></webstatus-sidebar-menu>',
-    );
+    container = createTestContainer();
+
+    parent = container.querySelector<FakeBookmarkParentElement>(
+      'fake-bookmark-parent-element',
+    )!;
+    el = container.querySelector<WebstatusSidebarMenu>(
+      'webstatus-sidebar-menu',
+    )!;
+    expect(parent).to.exist;
+    expect(el).to.exist;
 
     // Mock router utility functions and initial location
     el.getLocation = sinon.stub().returns({
@@ -47,15 +89,14 @@ describe('webstatus-sidebar-menu', () => {
       href: 'http://localhost/',
     });
     el.navigate = sinon.stub();
-
-    // Set up test bookmarks
-    el.setBookmarks(testBookmarks);
+    document.body.appendChild(container);
 
     await el.updateComplete; // Wait for the component to update with the new bookmarks
   });
 
   afterEach(() => {
     sinon.restore();
+    document.body.removeChild(container);
   });
 
   it('renders the correct structure with features and statistics sections', async () => {
@@ -86,14 +127,21 @@ describe('webstatus-sidebar-menu', () => {
   it('updates the active bookmark query when the URL changes', async () => {
     // Set mock location to match a test bookmark
     (el.getLocation as sinon.SinonStub).returns({
-      search: `?q=${el.bookmarks[1].query}`,
-      href: `http://localhost/?q=${el.bookmarks[1].query}`,
+      search: `?q=${el.appBookmarkInfo?.globalBookmarks?.[1].query}`,
+      href: `http://localhost/?q=${el.appBookmarkInfo?.globalBookmarks?.[1].query}`,
     });
+    parent.appBookmarkInfo = {
+      globalBookmarks: testBookmarks,
+      currentGlobalBookmark: testBookmarks[1],
+    };
 
     el.updateActiveStatus();
+    await parent.updateComplete;
     await el.updateComplete;
     expect(el.getLocation as sinon.SinonStub).to.be.called;
-    expect(el.getActiveBookmarkQuery()).to.equal(el.bookmarks[1].query);
+    expect(el.getActiveBookmarkQuery()).to.equal(
+      el.appBookmarkInfo?.globalBookmarks?.[1].query,
+    );
   });
 
   it('correctly handles bookmark clicks', async () => {
@@ -110,8 +158,8 @@ describe('webstatus-sidebar-menu', () => {
     expect(el.getActiveBookmarkQuery()).to.be.null;
 
     (el.getLocation as sinon.SinonStub).returns({
-      search: `?q=${el.bookmarks[0].query}`,
-      href: `http://localhost/?q=${el.bookmarks[0].query}`,
+      search: `?q=${el.appBookmarkInfo?.globalBookmarks?.[0].query}`,
+      href: `http://localhost/?q=${el.appBookmarkInfo?.globalBookmarks?.[0].query}`,
     });
 
     // Stub the click method to prevent default behavior
@@ -119,6 +167,11 @@ describe('webstatus-sidebar-menu', () => {
 
     // Click the anchor
     bookmarkAnchor.click();
+    parent.appBookmarkInfo = {
+      globalBookmarks: testBookmarks,
+      currentGlobalBookmark: testBookmarks[0],
+    };
+    await parent.updateComplete;
     await el.updateComplete;
 
     // Simulate popstate event.
@@ -130,7 +183,9 @@ describe('webstatus-sidebar-menu', () => {
 
     // Assertions
     expect(clickStub.calledOnce).to.be.true;
-    expect(el.getActiveBookmarkQuery()).to.equal(el.bookmarks[0].query);
+    expect(el.getActiveBookmarkQuery()).to.equal(
+      el.appBookmarkInfo?.globalBookmarks?.[0].query,
+    );
 
     const bookmarkItems = el.shadowRoot
       ?.querySelector('sl-tree')
@@ -165,7 +220,10 @@ describe('webstatus-sidebar-menu', () => {
       <webstatus-sidebar-menu
         .getLocation=${getCurrentLocationStub}
         .navigate=${navigateToUrlStub}
-        .bookmarks=${testBookmarks}
+        .appBookmarkInfo=${{
+          globalBookmarks: testBookmarks,
+          currentGlobalBookmark: testBookmarks[0],
+        }}
       ></webstatus-sidebar-menu>
     `);
 

--- a/frontend/src/static/js/components/test/webstatus-sidebar-menu.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-sidebar-menu.test.ts
@@ -165,20 +165,13 @@ describe('webstatus-sidebar-menu', () => {
     // Stub the click method to prevent default behavior
     const clickStub = sinon.stub(bookmarkAnchor, 'click');
 
-    // Click the anchor
+    // Click the anchor. The parent element handles updating the currentGlobalBookmark
     bookmarkAnchor.click();
     parent.appBookmarkInfo = {
       globalBookmarks: testBookmarks,
       currentGlobalBookmark: testBookmarks[0],
     };
     await parent.updateComplete;
-    await el.updateComplete;
-
-    // Simulate popstate event.
-    const popStateEvent = new PopStateEvent('popstate', {
-      state: {},
-    });
-    window.dispatchEvent(popStateEvent);
     await el.updateComplete;
 
     // Assertions

--- a/frontend/src/static/js/components/webstatus-overview-content.ts
+++ b/frontend/src/static/js/components/webstatus-overview-content.ts
@@ -32,8 +32,11 @@ import './webstatus-overview-pagination.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {TaskTracker} from '../utils/task-tracker.js';
 import {ApiError} from '../api/errors.js';
-import {getSearchQuery} from '../utils/urls.js';
-import {DEFAULT_BOOKMARKS, Bookmark} from '../utils/constants.js';
+import {
+  AppBookmarkInfo,
+  appBookmarkInfoContext,
+} from '../contexts/app-bookmark-info-context.js';
+import {consume} from '@lit/context';
 
 @customElement('webstatus-overview-content')
 export class WebstatusOverviewContent extends LitElement {
@@ -47,8 +50,9 @@ export class WebstatusOverviewContent extends LitElement {
   @property({type: Object})
   location!: {search: string}; // Set by parent.
 
+  @consume({context: appBookmarkInfoContext, subscribe: true})
   @state()
-  bookmarks: Bookmark[] = DEFAULT_BOOKMARKS;
+  appBookmarkInfo?: AppBookmarkInfo;
 
   static get styles(): CSSResultGroup {
     return [
@@ -69,11 +73,6 @@ export class WebstatusOverviewContent extends LitElement {
     ];
   }
 
-  getBookmarkFromQuery(): Bookmark | undefined {
-    const currentQuery = getSearchQuery(this.location);
-    return this.bookmarks.find(bookmark => bookmark.query === currentQuery);
-  }
-
   renderCount(): TemplateResult {
     switch (this.taskTracker.status) {
       case TaskStatus.INITIAL:
@@ -91,7 +90,7 @@ export class WebstatusOverviewContent extends LitElement {
   }
 
   render(): TemplateResult {
-    const bookmark = this.getBookmarkFromQuery();
+    const bookmark = this.appBookmarkInfo?.currentGlobalBookmark;
     const pageTitle = bookmark ? bookmark.name : 'Features overview';
     const pageDescription = bookmark?.description;
     return html`
@@ -114,7 +113,7 @@ export class WebstatusOverviewContent extends LitElement {
         <webstatus-overview-table
           .location=${this.location}
           .taskTracker=${this.taskTracker}
-          .bookmark=${this.getBookmarkFromQuery()}
+          .bookmark=${bookmark}
         >
         </webstatus-overview-table>
         <webstatus-overview-pagination

--- a/frontend/src/static/js/components/webstatus-overview-content.ts
+++ b/frontend/src/static/js/components/webstatus-overview-content.ts
@@ -35,6 +35,7 @@ import {ApiError} from '../api/errors.js';
 import {
   AppBookmarkInfo,
   appBookmarkInfoContext,
+  getCurrentBookmark,
 } from '../contexts/app-bookmark-info-context.js';
 import {consume} from '@lit/context';
 
@@ -90,7 +91,7 @@ export class WebstatusOverviewContent extends LitElement {
   }
 
   render(): TemplateResult {
-    const bookmark = this.appBookmarkInfo?.currentGlobalBookmark;
+    const bookmark = getCurrentBookmark(this.appBookmarkInfo, this.location);
     const pageTitle = bookmark ? bookmark.name : 'Features overview';
     const pageDescription = bookmark?.description;
     return html`

--- a/frontend/src/static/js/components/webstatus-services-container.ts
+++ b/frontend/src/static/js/components/webstatus-services-container.ts
@@ -22,6 +22,7 @@ import '../services/webstatus-firebase-app-service.js';
 import '../services/webstatus-firebase-auth-service.js';
 import '../services/webstatus-gcharts-loader-service.js';
 import '../services/webstatus-api-client-service.js';
+import '../services/webstatus-bookmarks-service.js';
 
 /**
  * WebstatusServiceContainer: Centralized container for web status services.
@@ -55,7 +56,9 @@ export class WebstatusServicesContainer extends LitElement {
               <webstatus-firebase-auth-service
                 .settings="${this.settings.firebase.auth}"
               >
-                <slot></slot>
+                <webstatus-bookmarks-service>
+                  <slot></slot>
+                </webstatus-bookmarks-service>
               </webstatus-firebase-auth-service>
             </webstatus-firebase-app-service>
           </webstatus-api-client-service>

--- a/frontend/src/static/js/components/webstatus-sidebar-menu.ts
+++ b/frontend/src/static/js/components/webstatus-sidebar-menu.ts
@@ -20,6 +20,7 @@ import {
   type TemplateResult,
   css,
   html,
+  PropertyValueMap,
 } from 'lit';
 import {customElement, state} from 'lit/decorators.js';
 import {SlTree, SlTreeItem} from '@shoelace-style/shoelace';
@@ -39,6 +40,7 @@ import {consume} from '@lit/context';
 import {
   AppBookmarkInfo,
   appBookmarkInfoContext,
+  getCurrentBookmark,
 } from '../contexts/app-bookmark-info-context.js';
 
 // Map from sl-tree-item ids to paths.
@@ -115,7 +117,6 @@ export class WebstatusSidebarMenu extends LitElement {
 
   constructor() {
     super();
-    window.addEventListener('popstate', this.handlePopState.bind(this));
   }
 
   connectedCallback(): void {
@@ -127,7 +128,7 @@ export class WebstatusSidebarMenu extends LitElement {
     super.disconnectedCallback();
   }
 
-  private handlePopState() {
+  private handleBookmarkInfoUpdate() {
     this.updateActiveStatus();
   }
 
@@ -146,7 +147,8 @@ export class WebstatusSidebarMenu extends LitElement {
     this.highlightNavigationItem(this.getNavTree());
     // Check if activeBookmarkQuery needs to be updated
     const newActiveBookmarkQuery =
-      this.appBookmarkInfo?.currentGlobalBookmark?.query || null;
+      getCurrentBookmark(this.appBookmarkInfo, this.getLocation())?.query ||
+      null;
 
     this.activeBookmarkQuery = newActiveBookmarkQuery;
     this.requestUpdate();
@@ -178,6 +180,12 @@ export class WebstatusSidebarMenu extends LitElement {
       if (itemToSelect) {
         itemToSelect.selected = true;
       }
+    }
+  }
+
+  protected willUpdate(changedProperties: PropertyValueMap<this>): void {
+    if (changedProperties.has('appBookmarkInfo')) {
+      this.handleBookmarkInfoUpdate();
     }
   }
 

--- a/frontend/src/static/js/contexts/app-bookmark-info-context.ts
+++ b/frontend/src/static/js/contexts/app-bookmark-info-context.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createContext} from '@lit/context';
+import {Bookmark} from '../utils/constants.js';
+
+export interface AppBookmarkInfo {
+  globalBookmarks?: Bookmark[];
+  currentGlobalBookmark?: Bookmark;
+}
+
+export const appBookmarkInfoContext =
+  createContext<AppBookmarkInfo>('app-bookmark-info');

--- a/frontend/src/static/js/contexts/app-bookmark-info-context.ts
+++ b/frontend/src/static/js/contexts/app-bookmark-info-context.ts
@@ -26,7 +26,6 @@ export const appBookmarkInfoContext =
   createContext<AppBookmarkInfo>('app-bookmark-info');
 
 /**
- * /**
  * Returns the current bookmark based on the provided AppBookmarkInfo and location.
  * Currently, it only returns the current global bookmark.
  * In the future, it can be extended to return other bookmarks based on the search parameters.

--- a/frontend/src/static/js/contexts/app-bookmark-info-context.ts
+++ b/frontend/src/static/js/contexts/app-bookmark-info-context.ts
@@ -24,3 +24,20 @@ export interface AppBookmarkInfo {
 
 export const appBookmarkInfoContext =
   createContext<AppBookmarkInfo>('app-bookmark-info');
+
+/**
+ * /**
+ * Returns the current bookmark based on the provided AppBookmarkInfo and location.
+ * Currently, it only returns the current global bookmark.
+ * In the future, it can be extended to return other bookmarks based on the search parameters.
+ *
+ * @param {AppBookmarkInfo?} info  - The AppBookmarkInfo object.
+ * @param {{search: string}?} _ - The location object containing the search parameters.
+ *          Currently not used, but reserved for future use.
+ */
+export function getCurrentBookmark(
+  info?: AppBookmarkInfo,
+  _?: {search: string},
+): Bookmark | undefined {
+  return info?.currentGlobalBookmark;
+}

--- a/frontend/src/static/js/services/test/webstatus-bookmarks-service.test.ts
+++ b/frontend/src/static/js/services/test/webstatus-bookmarks-service.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {LitElement, html} from 'lit';
+import {customElement, state} from 'lit/decorators.js';
+import {consume} from '@lit/context';
+import {
+  AppBookmarkInfo,
+  appBookmarkInfoContext,
+} from '../../contexts/app-bookmark-info-context.js';
+import {WebstatusBookmarksService} from '../webstatus-bookmarks-service.js';
+import {fixture, expect} from '@open-wc/testing';
+import '../webstatus-bookmarks-service.js';
+import {DEFAULT_BOOKMARKS} from '../../utils/constants.js';
+
+@customElement('test-bookmark-consumer')
+class TestBookmarkConsumer extends LitElement {
+  @consume({context: appBookmarkInfoContext, subscribe: true})
+  @state()
+  appBookmarkInfo?: AppBookmarkInfo;
+
+  render() {
+    return html`<div>${this.appBookmarkInfo?.globalBookmarks?.length}</div>`;
+  }
+}
+
+describe('webstatus-bookmarks-service', () => {
+  it('can be added to the page with the defaults', async () => {
+    const component = await fixture<WebstatusBookmarksService>(
+      html`<webstatus-bookmarks-service> </webstatus-bookmarks-service>`,
+    );
+    expect(component).to.exist;
+    const expectedInfo: AppBookmarkInfo = {
+      globalBookmarks: DEFAULT_BOOKMARKS,
+      currentGlobalBookmark: undefined,
+    };
+    expect(component!.appBookmarkInfo).to.deep.equal(expectedInfo);
+  });
+  it('provides appBookmarkInfo to consuming components', async () => {
+    const el = await fixture<WebstatusBookmarksService>(html`
+      <webstatus-bookmarks-service>
+        <test-bookmark-consumer></test-bookmark-consumer>
+      </webstatus-bookmarks-service>
+    `);
+    const expectedInfo: AppBookmarkInfo = {
+      globalBookmarks: DEFAULT_BOOKMARKS,
+      currentGlobalBookmark: undefined,
+    };
+    const consumer = el.querySelector<TestBookmarkConsumer>(
+      'test-bookmark-consumer',
+    );
+    el.getLocation = () => {
+      return {search: '', href: ''};
+    };
+    expect(el).to.exist;
+    expect(consumer).to.exist;
+    expect(el.appBookmarkInfo).to.deep.equal(expectedInfo);
+  });
+
+  it('updates appBookmarkInfo on popstate event', async () => {
+    const el = await fixture<WebstatusBookmarksService>(html`
+      <webstatus-bookmarks-service>
+        <test-bookmark-consumer></test-bookmark-consumer>
+      </webstatus-bookmarks-service>
+    `);
+    const consumer = el.querySelector<TestBookmarkConsumer>(
+      'test-bookmark-consumer',
+    );
+    el._globalBookmarks = [
+      {
+        name: 'Test Bookmark 1',
+        query: 'test_query_1',
+      },
+    ];
+    el.appBookmarkInfo = {
+      globalBookmarks: [
+        {
+          name: 'Test Bookmark 1',
+          query: 'test_query_1',
+        },
+      ],
+      currentGlobalBookmark: undefined,
+    };
+    await el.updateComplete;
+    await consumer!.updateComplete;
+
+    // Initial state
+    expect(consumer!.appBookmarkInfo).to.deep.equal({
+      globalBookmarks: [
+        {
+          name: 'Test Bookmark 1',
+          query: 'test_query_1',
+        },
+      ],
+      currentGlobalBookmark: undefined,
+    });
+
+    // Simulate popstate event with a query
+    el.getLocation = () => {
+      return {search: '?q=test_query_1', href: '?q=test_query_1'};
+    };
+    const popStateEvent = new PopStateEvent('popstate', {
+      state: {},
+    });
+    window.dispatchEvent(popStateEvent);
+    await el.updateComplete;
+    await consumer!.updateComplete;
+
+    // Updated state
+    expect(consumer!.appBookmarkInfo).to.deep.equal({
+      globalBookmarks: [
+        {
+          name: 'Test Bookmark 1',
+          query: 'test_query_1',
+        },
+      ],
+      currentGlobalBookmark: {
+        name: 'Test Bookmark 1',
+        query: 'test_query_1',
+      },
+    });
+  });
+});

--- a/frontend/src/static/js/services/webstatus-bookmarks-service.ts
+++ b/frontend/src/static/js/services/webstatus-bookmarks-service.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {customElement} from 'lit/decorators.js';
+import {ServiceElement} from './service-element.js';
+import {provide} from '@lit/context';
+import {
+  AppBookmarkInfo,
+  appBookmarkInfoContext,
+} from '../contexts/app-bookmark-info-context.js';
+import {Bookmark, DEFAULT_BOOKMARKS} from '../utils/constants.js';
+import {getSearchQuery} from '../utils/urls.js';
+import {AppLocation, getCurrentLocation} from '../utils/app-router.js';
+
+interface GetLocationFunction {
+  (): AppLocation;
+}
+
+@customElement('webstatus-bookmarks-service')
+export class WebstatusBookmarksService extends ServiceElement {
+  @provide({context: appBookmarkInfoContext})
+  appBookmarkInfo: AppBookmarkInfo = {};
+
+  _globalBookmarks: Bookmark[];
+  _currentGlobalBookmark?: Bookmark;
+  currentLocation?: AppLocation;
+
+  // Helper for testing.
+  getLocation: GetLocationFunction = getCurrentLocation;
+
+  constructor() {
+    super();
+    this.currentLocation = this.getLocation();
+    this._globalBookmarks = DEFAULT_BOOKMARKS;
+    this._currentGlobalBookmark = this.findCurrentBookmarkByQuery(
+      this._globalBookmarks,
+    );
+
+    window.addEventListener('popstate', this.handlePopState.bind(this));
+  }
+
+  private handlePopState() {
+    const location = this.getLocation();
+    this.currentLocation = location;
+    this._currentGlobalBookmark = this.findCurrentBookmarkByQuery(
+      this.appBookmarkInfo.globalBookmarks,
+    );
+    this.refreshAppBookmarkInfo();
+  }
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.refreshAppBookmarkInfo();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+  }
+
+  findCurrentBookmarkByQuery(bookmarks?: Bookmark[]): Bookmark | undefined {
+    const currentQuery = getSearchQuery(this.currentLocation ?? {search: ''});
+    return bookmarks?.find(bookmark => bookmark.query === currentQuery);
+  }
+
+  // Assign the appBookmarkInfo object to trigger a refresh of subscribed contexts
+  refreshAppBookmarkInfo() {
+    this.appBookmarkInfo = {
+      globalBookmarks: this._globalBookmarks,
+      currentGlobalBookmark: this._currentGlobalBookmark,
+    };
+  }
+}

--- a/frontend/src/static/js/utils/app-router.ts
+++ b/frontend/src/static/js/utils/app-router.ts
@@ -68,5 +68,7 @@ export const navigateToUrl = (url: string, event?: MouseEvent) => {
 };
 
 export const getCurrentLocation = (): AppLocation => {
-  return window.location;
+  // Return a copy of the location object to avoid modifying the original and
+  // to have more control over when our copy is updated.
+  return {...window.location};
 };


### PR DESCRIPTION
Currently, the code relies on the `DEFAULT_BOOKMARKS` constant to get the current list of bookmarks.

However, this leads to a problem where we can't have a dynamic list of bookmarks.

This is a refactoring that moves that information to a central location: webstatus-bookmarks-service.

Any child component can subscribe to that context to get updates.

Then in the future, we can have a process that can update the bookmark info.

Also there were multiple components figuring out the current bookmark. The service figures it out and publishes that information too.

This refactor is part of the changes needed for Saved Searches (in which some bookmarks will be coming from the server.)