### PR TITLE
chore: Fix golangci-lint upgrade

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,38 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: "2"
 linters:
-  # Disable all linters enabled by default.
-  # See: https://golangci-lint.run/usage/linters
-  disable-all: true
-  # Enabling specified linters.
-  # See: https://github.com/web-platform-tests/wpt.fyi/issues/2983
+  default: none
   enable:
-    - staticcheck
-    - errcheck
-    - gosimple
-    - govet
-    - typecheck
-    - unused
-    - ineffassign
     - containedctx
-    - dupl
+    - copyloopvar
     - dogsled
+    - dupl
+    - errcheck
     - errname
     - errorlint
     - exhaustive
     - exhaustruct
-    - copyloopvar
     - gochecknoglobals
     - gocognit
     - goconst
     - gocyclo
     - godot
-    - gofmt
     - goheader
     - gomoddirectives
     - gosec
+    - govet
     - importas
+    - ineffassign
     - ireturn
     - lll
     - misspell
@@ -55,27 +47,32 @@ linters:
     - noctx
     - prealloc
     - revive
+    - staticcheck
     - unparam
+    - unused
     - usestdlibvars
-issues:
-  #   max-issues-per-linter: 0
-  #   max-same-issues: 0
-  exclude-dirs:
-    - lib/gen
-linters-settings:
-  #   exhaustruct:
-  #     # List of regular expressions to exclude struct packages and names from check.
-  #     # We exclude third-party structs with entirely optional (omitempty) fields.
-  #     exclude:
-  #       - 'github\.com/google/go-github/v65/github\.CheckRunOutput'
-  #       - 'github\.com/google/go-github/v65/github\.ListCheckRunsOptions'
-  #       - 'github\.com/google/go-github/v65/github\.ListOptions'
-  #       - 'github\.com/golang-jwt/jwt\.StandardClaims'
-  #       - 'net/http\.Client'
-  gomoddirectives:
-    # Allow local `replace` directives. Default is false.
-    replace-local: true
-run:
-  # Locally, it won't take this long. This is to prevent CI from failing in
-  # case of a bad run.
-  timeout: 5m
+  settings:
+    gomoddirectives:
+      replace-local: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - lib/gen
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - lib/gen
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "2"
+version: '2'
 linters:
   default: none
   enable:

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ golint-version:
 lint: go-lint node-lint tf-lint shell-lint style-lint dockerfile-lint
 
 go-lint: golint-version go-workspace-setup
-	go list -f '{{.Dir}}/...' -m | xargs -t golangci-lint run --go=$$(go version | awk '{print $$3}' | cut -c 3-)
+	go list -f '{{.Dir}}/...' -m | xargs -t golangci-lint run
 
 node-lint: node-install
 	npm run lint -w frontend

--- a/lib/gcpspanner/browser_feature_support_event.go
+++ b/lib/gcpspanner/browser_feature_support_event.go
@@ -100,7 +100,7 @@ func calculateBrowserSupportEvents(
 
 // PrecalculateBrowserFeatureSupportEvents populates the BrowserFeatureSupportEvents table with pre-calculated data.
 func (c *Client) PrecalculateBrowserFeatureSupportEvents(ctx context.Context, startAt, endAt time.Time) error {
-	txn := c.Client.ReadOnlyTransaction()
+	txn := c.ReadOnlyTransaction()
 	// 1. Fetch all BrowserFeatureAvailabilities
 	availabilities, err := c.fetchAllBrowserAvailabilitiesWithTransaction(ctx, txn)
 	if err != nil {

--- a/lib/gcpspanner/feature_search_query.go
+++ b/lib/gcpspanner/feature_search_query.go
@@ -229,10 +229,15 @@ func (b *FeatureSearchFilterBuilder) handleIdentifierAvailableBrowserDateTerm(no
 	}
 	var browserNode, dateNode *searchtypes.SearchNode
 	for idx := range node.Children {
-		if node.Children[idx].Term.Identifier == searchtypes.IdentifierAvailableOn {
+		term := node.Children[idx].Term
+		if term.Identifier == searchtypes.IdentifierAvailableOn {
 			browserNode = node.Children[idx]
-		} else if node.Children[idx].Term.Identifier == searchtypes.IdentifierAvailableDate {
+
+			continue
+		} else if term.Identifier == searchtypes.IdentifierAvailableDate {
 			dateNode = node.Children[idx]
+
+			continue
 		}
 	}
 	if browserNode == nil || dateNode == nil {

--- a/util/cmd/load_fake_data/main.go
+++ b/util/cmd/load_fake_data/main.go
@@ -655,13 +655,16 @@ func generateChromiumHistogramMetrics(
 		for currDate.Before(time.Date(2020, time.December, 1, 0, 0, 0, 0, time.UTC)) {
 			var usage *big.Rat
 			var modifier = r.Intn(4)
-			if modifier == 0 {
+
+			switch modifier {
+			case 0:
 				usage = big.NewRat(0, 1) // explicitly zero usage.
-			} else if modifier == 1 {
+			case 1:
 				usage = big.NewRat(1, 100000) // very tiny amount (<0.1%).
-			} else {
+			default:
 				usage = big.NewRat(r.Int63n(10000), 10000) // Generate usage between 0-100%
 			}
+
 			err := client.UpsertDailyChromiumHistogramMetric(
 				ctx,
 				metricdatatypes.WebDXFeatureEnum,

--- a/workflows/steps/services/bcd_consumer/pkg/data/parser_test.go
+++ b/workflows/steps/services/bcd_consumer/pkg/data/parser_test.go
@@ -124,7 +124,7 @@ func TestParse(t *testing.T) {
 				t.Errorf("unable to parse file err %s", err.Error())
 			}
 
-			if len(result.BrowserData.Browsers) == 0 {
+			if len(result.Browsers) == 0 {
 				t.Error("unexpected empty map")
 			}
 		})

--- a/workflows/steps/services/bcd_consumer/pkg/workflow/bcd_filter_data.go
+++ b/workflows/steps/services/bcd_consumer/pkg/workflow/bcd_filter_data.go
@@ -75,7 +75,7 @@ func (f BCDDataFilter) FilterData(
 	}
 	var ret []bcdconsumertypes.BrowserRelease
 	for _, browser := range filteredBrowsers {
-		browserData, found := in.BrowserData.Browsers[browser]
+		browserData, found := in.Browsers[browser]
 		if !found {
 			return nil, errors.Join(ErrMissingBrowser, fmt.Errorf("unable to find browser %s", browser))
 		}

--- a/workflows/steps/services/common/repo_downloader/pkg/gh/download.go
+++ b/workflows/steps/services/common/repo_downloader/pkg/gh/download.go
@@ -63,7 +63,7 @@ func (d *Downloader) Download(
 	}
 
 	statusCode := resp.StatusCode
-	if !(statusCode >= 200 && statusCode <= 299) {
+	if statusCode < 200 || statusCode > 299 {
 		err := fmt.Errorf("bad status code:%d, unable to download wpt-metadata", statusCode)
 		resp.Body.Close()
 


### PR DESCRIPTION
Fixes: #1316

Our CI process installs the latest golangci-lint. And they just released a new major version.

Luckily, they have a migrate guide and command. The command auto generated the changes to .golangci.yaml. No manual changes to .golangci.yaml were made (Except running make license-fix).

The rest of the changes fix the issues found in #1316