### PR TITLE
Keep navigation within the tab in MissOneImpl Chart

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
@@ -233,7 +233,7 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
       <div slot="header" id="missing-one-implementation-list-header">
         The missing feature IDs on 2024-01-01 for
         Chrome:
-        <a target="_blank" href="/?q=id%3Acss+OR+id%3Ahtml+OR+id%3Ajs+OR+id%3Abluetooth">4 features</a>
+        <a href="/?q=id%3Acss+OR+id%3Ahtml+OR+id%3Ajs+OR+id%3Abluetooth">4 features</a>
       </div>
     `;
     expect(header).dom.to.equal(expectedHeader);

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -198,7 +198,7 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
       <div slot="header" id="${this.getPanelID()}-list-header">
         The missing feature IDs on ${this.selectedDate} for
         ${this.selectedBrowser}:
-        <a href="${this.featureListHref}" target="_blank"
+        <a href="${this.featureListHref}"
           >${this.missingFeaturesList.length} features</a
         >
       </div>


### PR DESCRIPTION
Address comments in https://github.com/GoogleChrome/webstatus.dev/pull/1298#discussion_r2004559219.  This PR removes the `target="_blank` and keep the navigation within the tab. 