### PR TITLE
refactor: use undefined instead of null for TaskTracker

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-overview-table.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-overview-table.test.ts
@@ -63,7 +63,7 @@ describe('webstatus-overview-table', () => {
     ApiError
   > = {
     status: TaskStatus.COMPLETE,
-    error: null,
+    error: undefined,
     data: page,
   };
   it('renders with no data', async () => {
@@ -169,7 +169,7 @@ describe('webstatus-overview-table', () => {
       ApiError
     > = {
       status: TaskStatus.COMPLETE,
-      error: null,
+      error: undefined,
       data: cssPage,
     };
     const location = {search: `?q=${cssQuery}`};

--- a/frontend/src/static/js/components/webstatus-overview-content.ts
+++ b/frontend/src/static/js/components/webstatus-overview-content.ts
@@ -44,8 +44,8 @@ export class WebstatusOverviewContent extends LitElement {
   @property({type: Object})
   taskTracker: TaskTracker<components['schemas']['FeaturePage'], ApiError> = {
     status: TaskStatus.INITIAL, // Initial state
-    error: null,
-    data: null,
+    error: undefined,
+    data: undefined,
   };
 
   @property({type: Object})

--- a/frontend/src/static/js/components/webstatus-overview-page.ts
+++ b/frontend/src/static/js/components/webstatus-overview-page.ts
@@ -50,8 +50,8 @@ export class OverviewPage extends LitElement {
   @state()
   taskTracker: TaskTracker<components['schemas']['FeaturePage'], ApiError> = {
     status: TaskStatus.INITIAL, // Initial state
-    error: null,
-    data: null,
+    error: undefined,
+    data: undefined,
   };
 
   @property({type: Object})
@@ -73,8 +73,8 @@ export class OverviewPage extends LitElement {
           // Reset taskTracker here due to a Task data cache issue.
           this.taskTracker = {
             status: TaskStatus.INITIAL,
-            error: null,
-            data: null,
+            error: undefined,
+            data: undefined,
           };
           this.currentLocation = this.location;
           return this._fetchFeatures(apiClient, routerLocation);
@@ -84,7 +84,7 @@ export class OverviewPage extends LitElement {
       onComplete: page => {
         this.taskTracker = {
           status: TaskStatus.COMPLETE,
-          error: null,
+          error: undefined,
           data: page,
         };
       },
@@ -93,7 +93,7 @@ export class OverviewPage extends LitElement {
           this.taskTracker = {
             status: TaskStatus.ERROR,
             error: error,
-            data: null,
+            data: undefined,
           };
           await toast(`${error.message}`, 'danger', 'exclamation-triangle');
         } else {
@@ -101,7 +101,7 @@ export class OverviewPage extends LitElement {
           this.taskTracker = {
             status: TaskStatus.ERROR,
             error: new UnknownError('unknown error fetching features'),
-            data: null,
+            data: undefined,
           };
         }
       },

--- a/frontend/src/static/js/components/webstatus-overview-table.ts
+++ b/frontend/src/static/js/components/webstatus-overview-table.ts
@@ -46,8 +46,8 @@ export class WebstatusOverviewTable extends LitElement {
   @property({type: Object})
   taskTracker: TaskTracker<components['schemas']['FeaturePage'], ApiError> = {
     status: TaskStatus.INITIAL, // Initial state
-    error: null,
-    data: null,
+    error: undefined,
+    data: undefined,
   };
 
   @property({type: Object})

--- a/frontend/src/static/js/utils/task-tracker.ts
+++ b/frontend/src/static/js/utils/task-tracker.ts
@@ -25,9 +25,9 @@ export interface TaskTracker<T, E> {
   /** Status of the task */
   status: TaskStatus;
 
-  /** Stores the error object if an error occurred, or null if no error. */
-  error: E | Error | null;
+  /** Stores the error object if an error occurred, or undefined if no error. */
+  error: E | Error | undefined;
 
-  /** Stores the result data of the completed task, or null if not complete or in error state. */
-  data: T | null;
+  /** Stores the result data of the completed task, or undefined if not complete or in error state. */
+  data: T | undefined;
 }


### PR DESCRIPTION
Right now, the task tracker uses null for missing values. We should instead use undefined.