### PR TITLE
Add url helper for search_id for saved searches

### DIFF
--- a/frontend/src/static/js/utils/test/urls.test.ts
+++ b/frontend/src/static/js/utils/test/urls.test.ts
@@ -23,6 +23,7 @@ import {
   formatFeaturePageUrl,
   getWPTMetricView,
   getColumnOptions,
+  getSearchID,
 } from '../urls.js';
 
 describe('getSearchQuery', () => {
@@ -112,6 +113,23 @@ describe('getWPTMetricView', () => {
   });
 });
 
+describe('getSearchID', () => {
+  it('returns empty string when there was no search_id= param', () => {
+    const cs = getSearchID({search: ''});
+    assert.equal(cs, '');
+  });
+
+  it('returns empty string when the search_id= param has no value', () => {
+    const cs = getSearchID({search: '?search_id='});
+    assert.equal(cs, '');
+  });
+
+  it('returns the string when the search_id= param was set', () => {
+    const cs = getSearchID({search: '?search_id=fake_uuid'});
+    assert.equal(cs, 'fake_uuid');
+  });
+});
+
 describe('formatOverviewPageUrl', () => {
   it('returns a plain URL when no location is passed', () => {
     const url = formatOverviewPageUrl();
@@ -183,6 +201,11 @@ describe('formatOverviewPageUrl', () => {
       {column_options: []},
     );
     assert.equal(url, '/?q=css');
+  });
+
+  it('returns a URL with navigational params when search_id param is set', () => {
+    const url = formatOverviewPageUrl({search: ''}, {search_id: 'fake_uuid'});
+    assert.equal(url, '/?search_id=fake_uuid');
   });
 });
 

--- a/frontend/src/static/js/utils/urls.ts
+++ b/frontend/src/static/js/utils/urls.ts
@@ -47,6 +47,10 @@ export function getFeaturesLaggingFlag(location: {search: string}): boolean {
   return Boolean(getQueryParam(location.search, 'show_features_lagging'));
 }
 
+export function getSearchID(location: {search: string}): string {
+  return getQueryParam(location.search, 'search_id');
+}
+
 export interface DateRange {
   start?: Date;
   end?: Date;
@@ -80,6 +84,7 @@ type QueryStringOverrides = {
   wpt_metric_view?: string;
   dateRange?: DateRange;
   column_options?: string[];
+  search_id?: string;
 };
 
 /* Given the router location object, return a query string with
@@ -148,6 +153,12 @@ function getContextualQueryStringParams(
     // format endDate as yyyy-mm-dd
     const endDate = dateRange.end.toISOString().split('T')[0];
     searchParams.set('endDate', endDate);
+  }
+
+  const searchID =
+    'search_id' in overrides ? overrides.search_id : getSearchID(location);
+  if (searchID) {
+    searchParams.set('search_id', searchID);
   }
 
   return searchParams.toString() ? '?' + searchParams.toString() : '';


### PR DESCRIPTION
Also modify getContextualQueryStringParams so that users are able to send saved searches urls by setting search_id in the query parameter