### PR TITLE
Adjust header size and margin in MissOneImplf feature list

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
@@ -231,9 +231,11 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
     expect(header).to.exist;
     const expectedHeader = `
       <div slot="header" id="missing-one-implementation-list-header">
-        The missing feature IDs on 2024-01-01 for
-        Chrome:
-        <a href="/?q=id%3Acss+OR+id%3Ahtml+OR+id%3Ajs+OR+id%3Abluetooth">4 features</a>
+        <h3>
+          The missing feature IDs on 2024-01-01 for
+          Chrome:
+          <a href="/?q=id%3Acss+OR+id%3Ahtml+OR+id%3Ajs+OR+id%3Abluetooth">4 features</a>
+        </h3>
       </div>
     `;
     expect(header).dom.to.equal(expectedHeader);
@@ -288,8 +290,10 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
     expect(header).to.exist;
     const expectedHeader = `
       <div slot="header" id="missing-one-implementation-list-header">
-        No missing features for on 2024-01-01 for
-        Chrome
+        <h3>
+          No missing features for on 2024-01-01 for
+          Chrome
+        </h3>
       </div>
     `;
     expect(header).dom.to.equal(expectedHeader);

--- a/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
@@ -231,11 +231,8 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
     expect(header).to.exist;
     const expectedHeader = `
       <div slot="header" id="missing-one-implementation-list-header">
-        <h3>
-          The missing feature IDs on 2024-01-01 for
-          Chrome:
-          <a href="/?q=id%3Acss+OR+id%3Ahtml+OR+id%3Ajs+OR+id%3Abluetooth">4 features</a>
-        </h3>
+        Missing feature IDs on 2024-01-01 for Chrome:
+        <a href="/?q=id%3Acss+OR+id%3Ahtml+OR+id%3Ajs+OR+id%3Abluetooth">4 features</a>
       </div>
     `;
     expect(header).dom.to.equal(expectedHeader);
@@ -290,10 +287,8 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
     expect(header).to.exist;
     const expectedHeader = `
       <div slot="header" id="missing-one-implementation-list-header">
-        <h3>
-          No missing features for on 2024-01-01 for
-          Chrome
-        </h3>
+        No missing features for on 2024-01-01 for
+        Chrome
       </div>
     `;
     expect(header).dom.to.equal(expectedHeader);

--- a/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
@@ -231,7 +231,7 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
     expect(header).to.exist;
     const expectedHeader = `
       <div slot="header" id="missing-one-implementation-list-header">
-        Missing feature IDs on 2024-01-01 for Chrome:
+        Missing features on 2024-01-01 for Chrome:
         <a href="/?q=id%3Acss+OR+id%3Ahtml+OR+id%3Ajs+OR+id%3Abluetooth">4 features</a>
       </div>
     `;

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -56,6 +56,7 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
         }
         #missing-one-implementation-list-header {
           margin-bottom: 1em;
+          font-size: large;
         }
         .missing-features-table {
           width: 100%;
@@ -192,22 +193,17 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
   pointSelectedTaskRenderOnSuccess(): TemplateResult {
     if (this.missingFeaturesList.length === 0) {
       return html`<div slot="header" id="${this.getPanelID()}-list-header">
-        <h3>
-          No missing features for on ${this.selectedDate} for
-          ${this.selectedBrowser}
-        </h3>
+        No missing features for on ${this.selectedDate} for
+        ${this.selectedBrowser}
       </div> `;
     }
 
     return html`
       <div slot="header" id="${this.getPanelID()}-list-header">
-        <h3>
-          The missing feature IDs on ${this.selectedDate} for
-          ${this.selectedBrowser}:
-          <a href="${this.featureListHref}"
-            >${this.missingFeaturesList.length} features</a
-          >
-        </h3>
+        Missing feature IDs on ${this.selectedDate} for ${this.selectedBrowser}:
+        <a href="${this.featureListHref}"
+          >${this.missingFeaturesList.length} features</a
+        >
       </div>
       ${this.renderMissingFeaturesTable()}
     `;

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -54,6 +54,9 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
         #missing-one-implementation-datapoint-details-complete {
           display: block;
         }
+        #missing-one-implementation-list-header {
+          margin-bottom: 1em;
+        }
         .missing-features-table {
           width: 100%;
           overflow-x: auto;
@@ -189,18 +192,22 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
   pointSelectedTaskRenderOnSuccess(): TemplateResult {
     if (this.missingFeaturesList.length === 0) {
       return html`<div slot="header" id="${this.getPanelID()}-list-header">
-        No missing features for on ${this.selectedDate} for
-        ${this.selectedBrowser}
+        <h3>
+          No missing features for on ${this.selectedDate} for
+          ${this.selectedBrowser}
+        </h3>
       </div> `;
     }
 
     return html`
       <div slot="header" id="${this.getPanelID()}-list-header">
-        The missing feature IDs on ${this.selectedDate} for
-        ${this.selectedBrowser}:
-        <a href="${this.featureListHref}"
-          >${this.missingFeaturesList.length} features</a
-        >
+        <h3>
+          The missing feature IDs on ${this.selectedDate} for
+          ${this.selectedBrowser}:
+          <a href="${this.featureListHref}"
+            >${this.missingFeaturesList.length} features</a
+          >
+        </h3>
       </div>
       ${this.renderMissingFeaturesTable()}
     `;

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -200,7 +200,7 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
 
     return html`
       <div slot="header" id="${this.getPanelID()}-list-header">
-        Missing feature IDs on ${this.selectedDate} for ${this.selectedBrowser}:
+        Missing features on ${this.selectedDate} for ${this.selectedBrowser}:
         <a href="${this.featureListHref}"
           >${this.missingFeaturesList.length} features</a
         >


### PR DESCRIPTION
Fix #1322. Use `<h3>` for header and add 1em margin to the bottom.

![Screenshot 2025-03-25 11 16 28 AM](https://github.com/user-attachments/assets/95f9cce8-b20d-4991-b43e-427a0f651813)
