### PR TITLE
Allow Updates of Browser Feature Availabilities

### DIFF
--- a/lib/gcpspanner/browser_feature_count_test.go
+++ b/lib/gcpspanner/browser_feature_count_test.go
@@ -82,7 +82,7 @@ func loadDataForListBrowserFeatureCountMetric(ctx context.Context, t *testing.T,
 		}, // Available from barBrowser 81
 	}
 	for _, availability := range browserFeatureAvailabilities {
-		err := client.InsertBrowserFeatureAvailability(ctx,
+		err := client.UpsertBrowserFeatureAvailability(ctx,
 			availability.FeatureKey, availability.BrowserFeatureAvailability)
 		if err != nil {
 			t.Errorf("unexpected error during insert. %s", err.Error())

--- a/lib/gcpspanner/browser_feature_support_event_test.go
+++ b/lib/gcpspanner/browser_feature_support_event_test.go
@@ -81,7 +81,7 @@ func setupTablesForPrecalculateBrowserFeatureSupportEvents(
 		},
 	}
 	for _, availability := range availabilities {
-		err := spannerClient.InsertBrowserFeatureAvailability(ctx, availability.WebFeatureKey,
+		err := spannerClient.UpsertBrowserFeatureAvailability(ctx, availability.WebFeatureKey,
 			availability.BrowserFeatureAvailability)
 		if err != nil {
 			t.Fatalf("Failed to insert BrowserFeatureAvailability: %v", err)

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -155,7 +155,7 @@ func setupRequiredTablesForFeaturesSearch(ctx context.Context,
 		},
 	}
 	for _, availability := range sampleBrowserAvailabilities {
-		err := client.InsertBrowserFeatureAvailability(ctx, availability.FeatureKey, availability.BrowserFeatureAvailability)
+		err := client.UpsertBrowserFeatureAvailability(ctx, availability.FeatureKey, availability.BrowserFeatureAvailability)
 		if err != nil {
 			t.Errorf("unexpected error during insert of availabilities. %s", err.Error())
 		}

--- a/lib/gcpspanner/missing_one_implementation_feature_list_test.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list_test.go
@@ -114,7 +114,7 @@ func loadDataForListMissingOneImplFeatureList(ctx context.Context, t *testing.T,
 		}, // Available from bazBrowser 16.5
 	}
 	for _, availability := range browserFeatureAvailabilities {
-		err := client.InsertBrowserFeatureAvailability(ctx,
+		err := client.UpsertBrowserFeatureAvailability(ctx,
 			availability.FeatureKey, availability.BrowserFeatureAvailability)
 		if err != nil {
 			t.Errorf("unexpected error during insert. %s", err.Error())

--- a/lib/gcpspanner/missing_one_implementation_test.go
+++ b/lib/gcpspanner/missing_one_implementation_test.go
@@ -112,7 +112,7 @@ func loadDataForListMissingOneImplCounts(ctx context.Context, t *testing.T, clie
 		}, // Available from bazBrowser 16.5
 	}
 	for _, availability := range browserFeatureAvailabilities {
-		err := client.InsertBrowserFeatureAvailability(ctx,
+		err := client.UpsertBrowserFeatureAvailability(ctx,
 			availability.FeatureKey, availability.BrowserFeatureAvailability)
 		if err != nil {
 			t.Errorf("unexpected error during insert. %s", err.Error())

--- a/lib/gcpspanner/spanneradapters/web_features_consumer.go
+++ b/lib/gcpspanner/spanneradapters/web_features_consumer.go
@@ -27,7 +27,7 @@ import (
 type WebFeatureSpannerClient interface {
 	UpsertWebFeature(ctx context.Context, feature gcpspanner.WebFeature) (*string, error)
 	UpsertFeatureBaselineStatus(ctx context.Context, featureID string, status gcpspanner.FeatureBaselineStatus) error
-	InsertBrowserFeatureAvailability(
+	UpsertBrowserFeatureAvailability(
 		ctx context.Context,
 		featureID string,
 		featureAvailability gcpspanner.BrowserFeatureAvailability) error
@@ -81,7 +81,7 @@ func (c *WebFeaturesConsumer) InsertWebFeatures(
 		// Read the browser support data.
 		fba := extractBrowserAvailability(featureData)
 		for _, browserAvailability := range fba {
-			err := c.client.InsertBrowserFeatureAvailability(ctx, featureID, browserAvailability)
+			err := c.client.UpsertBrowserFeatureAvailability(ctx, featureID, browserAvailability)
 			if err != nil {
 				slog.ErrorContext(ctx, "unable to insert BrowserFeatureAvailability",
 					"browserName", browserAvailability.BrowserName,

--- a/lib/gcpspanner/spanneradapters/web_features_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/web_features_consumer_test.go
@@ -206,7 +206,7 @@ type mockUpsertFeatureBaselineStatusConfig struct {
 	expectedCount  int
 }
 
-type mockInsertBrowserFeatureAvailabilityConfig struct {
+type mockUpsertBrowserFeatureAvailabilityConfig struct {
 	expectedInputs          map[string][]gcpspanner.BrowserFeatureAvailability
 	outputs                 map[string][]error
 	expectedCountPerFeature map[string]int
@@ -236,7 +236,7 @@ type mockWebFeatureSpannerClient struct {
 	upsertFeatureBaselineStatusCount                int
 	mockUpsertFeatureBaselineStatusCfg              mockUpsertFeatureBaselineStatusConfig
 	insertBrowserFeatureAvailabilityCountPerFeature map[string]int
-	mockInsertBrowserFeatureAvailabilityCfg         mockInsertBrowserFeatureAvailabilityConfig
+	mockUpsertBrowserFeatureAvailabilityCfg         mockUpsertBrowserFeatureAvailabilityConfig
 	mockUpsertFeatureSpecCfg                        mockUpsertFeatureSpecConfig
 	upsertFeatureSpecCount                          int
 	mockPrecalculateBrowserFeatureSupportEventsCfg  mockPrecalculateBrowserFeatureSupportEventsConfig
@@ -305,21 +305,21 @@ func (c *mockWebFeatureSpannerClient) UpsertFeatureSpec(
 	return c.mockUpsertFeatureSpecCfg.outputs[featureID]
 }
 
-func (c *mockWebFeatureSpannerClient) InsertBrowserFeatureAvailability(
+func (c *mockWebFeatureSpannerClient) UpsertBrowserFeatureAvailability(
 	_ context.Context, featureID string, featureAvailability gcpspanner.BrowserFeatureAvailability) error {
 	expectedCountForFeature := c.insertBrowserFeatureAvailabilityCountPerFeature[featureID]
-	if len(c.mockInsertBrowserFeatureAvailabilityCfg.expectedInputs[featureID]) <=
+	if len(c.mockUpsertBrowserFeatureAvailabilityCfg.expectedInputs[featureID]) <=
 		expectedCountForFeature {
-		c.t.Fatal("no more expected input for InsertBrowserFeatureAvailability")
+		c.t.Fatal("no more expected input for UpsertBrowserFeatureAvailability")
 	}
-	if len(c.mockInsertBrowserFeatureAvailabilityCfg.outputs[featureID]) <=
+	if len(c.mockUpsertBrowserFeatureAvailabilityCfg.outputs[featureID]) <=
 		expectedCountForFeature {
-		c.t.Fatal("no more configured outputs for InsertBrowserFeatureAvailability")
+		c.t.Fatal("no more configured outputs for UpsertBrowserFeatureAvailability")
 	}
 
 	idx := expectedCountForFeature
 
-	expectedInputs, found := c.mockInsertBrowserFeatureAvailabilityCfg.expectedInputs[featureID]
+	expectedInputs, found := c.mockUpsertBrowserFeatureAvailabilityCfg.expectedInputs[featureID]
 	if !found {
 		c.t.Errorf("unexpected input %v", featureAvailability)
 	}
@@ -331,7 +331,7 @@ func (c *mockWebFeatureSpannerClient) InsertBrowserFeatureAvailability(
 	}
 	c.insertBrowserFeatureAvailabilityCountPerFeature[featureID]++
 
-	return c.mockInsertBrowserFeatureAvailabilityCfg.outputs[featureID][idx]
+	return c.mockUpsertBrowserFeatureAvailabilityCfg.outputs[featureID][idx]
 }
 
 func (c *mockWebFeatureSpannerClient) PrecalculateBrowserFeatureSupportEvents(_ context.Context,
@@ -371,7 +371,7 @@ func newMockmockWebFeatureSpannerClient(
 	t *testing.T,
 	mockUpsertWebFeatureCfg mockUpsertWebFeatureConfig,
 	mockUpsertFeatureBaselineStatusCfg mockUpsertFeatureBaselineStatusConfig,
-	mockInsertBrowserFeatureAvailabilityCfg mockInsertBrowserFeatureAvailabilityConfig,
+	mockUpsertBrowserFeatureAvailabilityCfg mockUpsertBrowserFeatureAvailabilityConfig,
 	mockUpsertFeatureSpecCfg mockUpsertFeatureSpecConfig,
 	mocmockPrecalculateBrowserFeatureSupportEventsCfg mockPrecalculateBrowserFeatureSupportEventsConfig,
 	mockUpsertFeatureDiscouragedDetailsCfg mockUpsertFeatureDiscouragedDetailsConfig,
@@ -380,7 +380,7 @@ func newMockmockWebFeatureSpannerClient(
 		t:                                       t,
 		mockUpsertWebFeatureCfg:                 mockUpsertWebFeatureCfg,
 		mockUpsertFeatureBaselineStatusCfg:      mockUpsertFeatureBaselineStatusCfg,
-		mockInsertBrowserFeatureAvailabilityCfg: mockInsertBrowserFeatureAvailabilityCfg,
+		mockUpsertBrowserFeatureAvailabilityCfg: mockUpsertBrowserFeatureAvailabilityCfg,
 		mockUpsertFeatureSpecCfg:                mockUpsertFeatureSpecCfg,
 		upsertWebFeatureCount:                   0,
 		upsertFeatureBaselineStatusCount:        0,
@@ -412,7 +412,7 @@ func TestInsertWebFeatures(t *testing.T) {
 		name                                           string
 		mockUpsertWebFeatureCfg                        mockUpsertWebFeatureConfig
 		mockUpsertFeatureBaselineStatusCfg             mockUpsertFeatureBaselineStatusConfig
-		mockInsertBrowserFeatureAvailabilityCfg        mockInsertBrowserFeatureAvailabilityConfig
+		mockUpsertBrowserFeatureAvailabilityCfg        mockUpsertBrowserFeatureAvailabilityConfig
 		mockUpsertFeatureSpecCfg                       mockUpsertFeatureSpecConfig
 		mockPrecalculateBrowserFeatureSupportEventsCfg mockPrecalculateBrowserFeatureSupportEventsConfig
 		mockUpsertFeatureDiscouragedDetailsCfg         mockUpsertFeatureDiscouragedDetailsConfig
@@ -461,7 +461,7 @@ func TestInsertWebFeatures(t *testing.T) {
 				},
 				expectedCount: 2,
 			},
-			mockInsertBrowserFeatureAvailabilityCfg: mockInsertBrowserFeatureAvailabilityConfig{
+			mockUpsertBrowserFeatureAvailabilityCfg: mockUpsertBrowserFeatureAvailabilityConfig{
 				expectedInputs: map[string][]gcpspanner.BrowserFeatureAvailability{
 					"feature1": {
 						{
@@ -628,7 +628,7 @@ func TestInsertWebFeatures(t *testing.T) {
 				outputs:        nil,
 				expectedCount:  0,
 			},
-			mockInsertBrowserFeatureAvailabilityCfg: mockInsertBrowserFeatureAvailabilityConfig{
+			mockUpsertBrowserFeatureAvailabilityCfg: mockUpsertBrowserFeatureAvailabilityConfig{
 				expectedInputs:          map[string][]gcpspanner.BrowserFeatureAvailability{},
 				outputs:                 map[string][]error{},
 				expectedCountPerFeature: map[string]int{},
@@ -710,7 +710,7 @@ func TestInsertWebFeatures(t *testing.T) {
 				},
 				expectedCount: 1,
 			},
-			mockInsertBrowserFeatureAvailabilityCfg: mockInsertBrowserFeatureAvailabilityConfig{
+			mockUpsertBrowserFeatureAvailabilityCfg: mockUpsertBrowserFeatureAvailabilityConfig{
 				expectedInputs:          map[string][]gcpspanner.BrowserFeatureAvailability{},
 				outputs:                 map[string][]error{},
 				expectedCountPerFeature: map[string]int{},
@@ -763,7 +763,7 @@ func TestInsertWebFeatures(t *testing.T) {
 			expectedError: ErrBaselineStatusTest,
 		},
 		{
-			name: "InsertBrowserFeatureAvailability error",
+			name: "UpsertBrowserFeatureAvailability error",
 			mockUpsertWebFeatureCfg: mockUpsertWebFeatureConfig{
 				expectedInputs: map[string]gcpspanner.WebFeature{
 					"feature1": {
@@ -792,7 +792,7 @@ func TestInsertWebFeatures(t *testing.T) {
 				},
 				expectedCount: 1,
 			},
-			mockInsertBrowserFeatureAvailabilityCfg: mockInsertBrowserFeatureAvailabilityConfig{
+			mockUpsertBrowserFeatureAvailabilityCfg: mockUpsertBrowserFeatureAvailabilityConfig{
 				expectedInputs: map[string][]gcpspanner.BrowserFeatureAvailability{
 					"feature1": {
 						{
@@ -885,7 +885,7 @@ func TestInsertWebFeatures(t *testing.T) {
 				},
 				expectedCount: 1,
 			},
-			mockInsertBrowserFeatureAvailabilityCfg: mockInsertBrowserFeatureAvailabilityConfig{
+			mockUpsertBrowserFeatureAvailabilityCfg: mockUpsertBrowserFeatureAvailabilityConfig{
 				expectedInputs: map[string][]gcpspanner.BrowserFeatureAvailability{
 					"feature1": {
 						{
@@ -1014,7 +1014,7 @@ func TestInsertWebFeatures(t *testing.T) {
 				},
 				expectedCount: 2,
 			},
-			mockInsertBrowserFeatureAvailabilityCfg: mockInsertBrowserFeatureAvailabilityConfig{
+			mockUpsertBrowserFeatureAvailabilityCfg: mockUpsertBrowserFeatureAvailabilityConfig{
 				expectedInputs: map[string][]gcpspanner.BrowserFeatureAvailability{
 					"feature1": {
 						{
@@ -1159,7 +1159,7 @@ func TestInsertWebFeatures(t *testing.T) {
 				t,
 				tc.mockUpsertWebFeatureCfg,
 				tc.mockUpsertFeatureBaselineStatusCfg,
-				tc.mockInsertBrowserFeatureAvailabilityCfg,
+				tc.mockUpsertBrowserFeatureAvailabilityCfg,
 				tc.mockUpsertFeatureSpecCfg,
 				tc.mockPrecalculateBrowserFeatureSupportEventsCfg,
 				tc.mockUpsertFeatureDiscouragedDetailsCfg,
@@ -1194,9 +1194,9 @@ func TestInsertWebFeatures(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(mockClient.insertBrowserFeatureAvailabilityCountPerFeature,
-				tc.mockInsertBrowserFeatureAvailabilityCfg.expectedCountPerFeature) {
-				t.Errorf("Unexpected call counts for InsertBrowserFeatureAvailability. Expected: %v, Got: %v",
-					tc.mockInsertBrowserFeatureAvailabilityCfg.expectedCountPerFeature,
+				tc.mockUpsertBrowserFeatureAvailabilityCfg.expectedCountPerFeature) {
+				t.Errorf("Unexpected call counts for UpsertBrowserFeatureAvailability. Expected: %v, Got: %v",
+					tc.mockUpsertBrowserFeatureAvailabilityCfg.expectedCountPerFeature,
 					mockClient.insertBrowserFeatureAvailabilityCountPerFeature)
 			}
 

--- a/util/cmd/load_fake_data/main.go
+++ b/util/cmd/load_fake_data/main.go
@@ -240,7 +240,7 @@ func generateFeatureAvailability(
 	// Insert the availabilities into Spanner
 	for _, browser := range browsers {
 		for featureKey, releaseNumber := range featureAvailability[browser] {
-			err := client.InsertBrowserFeatureAvailability(
+			err := client.UpsertBrowserFeatureAvailability(
 				ctx,
 				featureKey,
 				gcpspanner.BrowserFeatureAvailability{


### PR DESCRIPTION
## Overview

Modified InsertBrowserFeatureAvailability to UpsertBrowserFeatureAvailability to support updates.

To support this, I added a new entityUniqueWriter struct for this. Take a look at the constraint info section for more information as to why.

## Database Constraint Note

Due to the unique index on `(WebFeatureID, BrowserName)` in the `BrowserFeatureAvailabilities` table, updates are handled via a "delete then insert" pattern. The `entityUniqueWriter` is used to implement this behavior.

We were able to use most of the existing mapper functionality when using the entityUniqueWriter. I got rid of the Merge method because we aren't really doing merges in this case. And I also implemented the DeleteKey method to extract the keys to delete the row before inserting the new one.