### PR TITLE
Add user saved bookmark info to app-bookmark-info-context

### DIFF
--- a/frontend/src/static/js/api/client.ts
+++ b/frontend/src/static/js/api/client.ts
@@ -152,6 +152,7 @@ export type MissingOneImplFeaturesPage =
   components['schemas']['MissingOneImplFeaturesPage'];
 export type MissingOneImplFeaturesList =
   components['schemas']['MissingOneImplFeature'][];
+export type SavedSearchResponse = components['schemas']['SavedSearchResponse'];
 
 // TODO. Remove once not behind UbP
 const temporaryFetchOptions: FetchOptions<unknown> = {
@@ -563,5 +564,35 @@ export class APIClient {
     } while (nextPageToken !== undefined);
 
     return allFeatures;
+  }
+
+  public async getSavedSearchByID(
+    searchID: string,
+    token?: string,
+  ): Promise<SavedSearchResponse> {
+    const options = {
+      ...temporaryFetchOptions,
+      params: {
+        path: {
+          search_id: searchID,
+        },
+      },
+    };
+    // If the token is there, add it to the options
+    if (token) {
+      options.headers = {
+        Authorization: `Bearer ${token}`,
+      };
+    }
+    const response = await this.client.GET(
+      '/v1/saved-searches/{search_id}',
+      options,
+    );
+    const error = response.error;
+    if (error !== undefined) {
+      throw createAPIError(error);
+    }
+
+    return response.data;
   }
 }

--- a/frontend/src/static/js/components/webstatus-overview-content.ts
+++ b/frontend/src/static/js/components/webstatus-overview-content.ts
@@ -35,7 +35,7 @@ import {ApiError} from '../api/errors.js';
 import {
   AppBookmarkInfo,
   appBookmarkInfoContext,
-  getCurrentBookmark,
+  bookmarkHelpers,
 } from '../contexts/app-bookmark-info-context.js';
 import {consume} from '@lit/context';
 
@@ -91,7 +91,10 @@ export class WebstatusOverviewContent extends LitElement {
   }
 
   render(): TemplateResult {
-    const bookmark = getCurrentBookmark(this.appBookmarkInfo, this.location);
+    const bookmark = bookmarkHelpers.getCurrentBookmark(
+      this.appBookmarkInfo,
+      this.location,
+    );
     const pageTitle = bookmark ? bookmark.name : 'Features overview';
     const pageDescription = bookmark?.description;
     return html`

--- a/frontend/src/static/js/components/webstatus-sidebar-menu.ts
+++ b/frontend/src/static/js/components/webstatus-sidebar-menu.ts
@@ -40,7 +40,7 @@ import {consume} from '@lit/context';
 import {
   AppBookmarkInfo,
   appBookmarkInfoContext,
-  getCurrentBookmark,
+  bookmarkHelpers,
 } from '../contexts/app-bookmark-info-context.js';
 
 // Map from sl-tree-item ids to paths.
@@ -147,8 +147,10 @@ export class WebstatusSidebarMenu extends LitElement {
     this.highlightNavigationItem(this.getNavTree());
     // Check if activeBookmarkQuery needs to be updated
     const newActiveBookmarkQuery =
-      getCurrentBookmark(this.appBookmarkInfo, this.getLocation())?.query ||
-      null;
+      bookmarkHelpers.getCurrentBookmark(
+        this.appBookmarkInfo,
+        this.getLocation(),
+      )?.query || null;
 
     this.activeBookmarkQuery = newActiveBookmarkQuery;
     this.requestUpdate();
@@ -230,11 +232,17 @@ export class WebstatusSidebarMenu extends LitElement {
         q: bookmark.query,
         start: 0,
         num: bookmark.override_num_param,
+        // If the user is on a saved search and clicks on a global bookmark,
+        // we should clear the search id parameter.
+        search_id: '',
       });
     } else {
       bookmarkUrl = formatOverviewPageUrl(currentURL, {
         q: bookmark.query,
         start: 0,
+        // If the user is on a saved search and clicks on a global bookmark,
+        // we should clear the search id parameter.
+        search_id: '',
       });
     }
     // The bookmark should only be active when the path is the FEATURES path

--- a/frontend/src/static/js/contexts/app-bookmark-info-context.ts
+++ b/frontend/src/static/js/contexts/app-bookmark-info-context.ts
@@ -16,27 +16,147 @@
 
 import {createContext} from '@lit/context';
 import {Bookmark} from '../utils/constants.js';
+import {TaskTracker} from '../utils/task-tracker.js';
+import {TaskStatus} from '@lit/task';
+import {getSearchID, getSearchQuery} from '../utils/urls.js';
 
 export interface AppBookmarkInfo {
   globalBookmarks?: Bookmark[];
   currentGlobalBookmark?: Bookmark;
+  userSavedSearchBookmarkTask?: TaskTracker<Bookmark, SavedSearchError>;
+  currentLocation?: {search: string};
 }
 
 export const appBookmarkInfoContext =
   createContext<AppBookmarkInfo>('app-bookmark-info');
 
+export const bookmarkHelpers = {
+  /**
+   * Returns the current bookmark based on the provided AppBookmarkInfo and location.
+   *
+   * @param {AppBookmarkInfo?} info  - The AppBookmarkInfo object.
+   * @param {{search: string}?} location - The location object containing the search parameters.
+   */
+  getCurrentBookmark(
+    info?: AppBookmarkInfo,
+    location?: {search: string},
+  ): Bookmark | undefined {
+    const searchID = getSearchID(location ?? {search: ''});
+    if (
+      // There's a chance that the context has not been updated so we should check the search ID in the location.
+      searchID &&
+      info?.userSavedSearchBookmarkTask?.status === TaskStatus.COMPLETE &&
+      info?.userSavedSearchBookmarkTask.data
+    ) {
+      return info.userSavedSearchBookmarkTask.data;
+    }
+
+    return info?.currentGlobalBookmark;
+  },
+
+  /**
+   * Returns the current query based on the provided AppBookmarkInfo and location.
+   *
+   * This function determines the active query string by considering both global
+   * and user-saved bookmarks, as well as the current location's search parameters.
+   *
+   * - If a user-saved bookmark is active (indicated by a matching `search_id` in
+   *   the location), its query is used unless the location's `q` parameter is
+   *   different, which indicates the user is editing the query.
+   * - If a global bookmark is active, its query is used.
+   * - If no bookmark is active, the query from the location's `q` parameter is used.
+   * - If the bookmark information is still loading, the query from the location's `q` parameter is used.
+   *
+   * @param {AppBookmarkInfo?} info - The AppBookmarkInfo object.
+   * @param {{search: string}?} location - The location object containing the search parameters.
+   * @returns {string} The current query string.
+   */
+  getCurrentQuery: (
+    info?: AppBookmarkInfo,
+    location?: {search: string},
+  ): string => {
+    const q = getSearchQuery(location ?? {search: ''});
+    if (bookmarkHelpers.isBusyLoadingBookmarkInfo(info, location)) {
+      return q;
+    }
+    const bookmark = bookmarkHelpers.getCurrentBookmark(info, location);
+    // User saved bookmarks can be edited. And those have IDs
+    if (bookmark !== undefined && bookmark.id !== undefined) {
+      // If there's a bookmark, prioritize its query unless q is different.
+      // If they are different, this could mean we are trying to edit.
+      return q !== bookmark.query && q !== '' ? q : bookmark.query;
+    } else if (bookmark !== undefined && bookmark.id === undefined) {
+      // If there's a global bookmark, use its query.
+      return bookmark.query;
+    }
+
+    return q;
+  },
+
+  /**
+   * Checks if the bookmark information is currently being loaded or if the
+   * current location has changed.
+   *
+   * @param {AppBookmarkInfo?} info - The AppBookmarkInfo object.
+   * @param {{search: string}?} location - The location object containing the search parameters.
+   * @returns {boolean} True if the bookmark info is loading or the location has changed, false otherwise.
+   */
+  isBusyLoadingBookmarkInfo: (
+    info?: AppBookmarkInfo,
+    location?: {search: string},
+  ): boolean => {
+    return (
+      info?.userSavedSearchBookmarkTask?.status === TaskStatus.PENDING ||
+      info?.currentLocation?.search !== location?.search
+    );
+  },
+};
+
 /**
- * Returns the current bookmark based on the provided AppBookmarkInfo and location.
- * Currently, it only returns the current global bookmark.
- * In the future, it can be extended to return other bookmarks based on the search parameters.
- *
- * @param {AppBookmarkInfo?} info  - The AppBookmarkInfo object.
- * @param {{search: string}?} _ - The location object containing the search parameters.
- *          Currently not used, but reserved for future use.
+ * Represents an error related to saved searches.
  */
-export function getCurrentBookmark(
-  info?: AppBookmarkInfo,
-  _?: {search: string},
-): Bookmark | undefined {
-  return info?.currentGlobalBookmark;
+export type SavedSearchError = Error & {message: string};
+
+/**
+ * Represents an error when a saved search is not found.
+ */
+export class SavedSearchNotFoundError extends Error {
+  /**
+   * Creates a new SavedSearchNotFoundError.
+   * @param {string} id - The ID of the saved search that was not found.
+   */
+  constructor(id: string) {
+    super(`Saved search with id ${id} not found`);
+  }
+}
+
+/**
+ * Represents an internal error that occurred while fetching a saved search.
+ */
+export class SavedSearchInternalError extends Error {
+  /**
+   * Creates a new SavedSearchInternalError.
+   * @param {string} id - The ID of the saved search that caused the error.
+   * @param {string} msg - The error message.
+   */
+  constructor(id: string, msg: string) {
+    super(`Error fetching saved search ID ${id}: ${msg}`);
+  }
+}
+
+/**
+ * Represents an unknown error that occurred while fetching a saved search.
+ */
+export class SavedSearchUnknownError extends Error {
+  /**
+   * Creates a new SavedSearchUnknownError.
+   * @param {string} id - The ID of the saved search that caused the error.
+   * @param {unknown} err - The unknown error.
+   */
+  constructor(id: string, err: unknown) {
+    super(
+      `Unknown error fetching saved search ID ${id}. Check console for details.`,
+    );
+    console.error(err);
+  }
 }

--- a/frontend/src/static/js/contexts/test/app-bookmark-info-context.test.ts
+++ b/frontend/src/static/js/contexts/test/app-bookmark-info-context.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  bookmarkHelpers,
+  SavedSearchNotFoundError,
+  SavedSearchInternalError,
+  SavedSearchUnknownError,
+  AppBookmarkInfo,
+} from '../app-bookmark-info-context.js';
+import {TaskStatus} from '@lit/task';
+import {expect} from '@open-wc/testing';
+import sinon from 'sinon';
+
+describe('app-bookmark-info-context', () => {
+  describe('bookmarkHelpers', () => {
+    describe('getCurrentBookmark', () => {
+      it('should return undefined if no info is provided', () => {
+        expect(bookmarkHelpers.getCurrentBookmark()).to.be.undefined;
+      });
+
+      it('should return the userSavedSearchBookmarkTask data if available and complete', () => {
+        const info: AppBookmarkInfo = {
+          userSavedSearchBookmarkTask: {
+            status: TaskStatus.COMPLETE,
+            data: {query: 'test', name: 'Test Bookmark', id: '123'},
+            error: undefined,
+          },
+        };
+        expect(
+          bookmarkHelpers.getCurrentBookmark(info, {search: '?search_id=123'}),
+        ).to.deep.equal({
+          query: 'test',
+          name: 'Test Bookmark',
+          id: '123',
+        });
+      });
+
+      it('should return the currentGlobalBookmark if userSavedSearchBookmarkTask is not complete', () => {
+        const info: AppBookmarkInfo = {
+          currentGlobalBookmark: {
+            query: 'global',
+            name: 'Global Bookmark',
+          },
+          userSavedSearchBookmarkTask: {
+            status: TaskStatus.PENDING,
+            data: undefined,
+            error: undefined,
+          },
+        };
+        expect(bookmarkHelpers.getCurrentBookmark(info)).to.deep.equal({
+          query: 'global',
+          name: 'Global Bookmark',
+        });
+      });
+
+      it('should return undefined if no bookmark is found', () => {
+        const info: AppBookmarkInfo = {};
+        expect(bookmarkHelpers.getCurrentBookmark(info)).to.be.undefined;
+      });
+
+      it('should handle a location with a search ID', () => {
+        const info: AppBookmarkInfo = {
+          userSavedSearchBookmarkTask: {
+            status: TaskStatus.COMPLETE,
+            data: {query: 'test', name: 'Test Bookmark', id: '123'},
+            error: undefined,
+          },
+        };
+        const location = {search: '?search_id=123'};
+        expect(
+          bookmarkHelpers.getCurrentBookmark(info, location),
+        ).to.deep.equal({query: 'test', name: 'Test Bookmark', id: '123'});
+      });
+    });
+
+    describe('getCurrentQuery', () => {
+      it('should return the query from the location if info is undefined', () => {
+        const location = {search: '?q=test'};
+        expect(bookmarkHelpers.getCurrentQuery(undefined, location)).to.equal(
+          'test',
+        );
+      });
+
+      it('should return the query from the location if bookmark info is loading', () => {
+        const info: AppBookmarkInfo = {
+          userSavedSearchBookmarkTask: {
+            status: TaskStatus.PENDING,
+            data: undefined,
+            error: undefined,
+          },
+        };
+        const location = {search: '?q=test'};
+        expect(bookmarkHelpers.getCurrentQuery(info, location)).to.equal(
+          'test',
+        );
+      });
+
+      it('should return the query from the userSavedSearchBookmarkTask if available and complete', () => {
+        const info: AppBookmarkInfo = {
+          userSavedSearchBookmarkTask: {
+            status: TaskStatus.COMPLETE,
+            data: {query: 'test', name: 'Test Bookmark', id: '123'},
+            error: undefined,
+          },
+        };
+        const isBusyStub = sinon.stub(
+          bookmarkHelpers,
+          'isBusyLoadingBookmarkInfo',
+        );
+        isBusyStub.returns(false);
+        const getCurrentBookmarkStub = sinon.stub(
+          bookmarkHelpers,
+          'getCurrentBookmark',
+        );
+        getCurrentBookmarkStub.returns({
+          query: 'test',
+          name: 'Test Bookmark',
+          id: '123',
+        });
+        expect(
+          bookmarkHelpers.getCurrentQuery(info, {search: '?search_id=123'}),
+        ).to.equal('test');
+        getCurrentBookmarkStub.restore();
+        isBusyStub.restore();
+      });
+
+      it('should return the query from the currentGlobalBookmark if available', () => {
+        const info: AppBookmarkInfo = {
+          currentGlobalBookmark: {
+            query: 'global',
+            name: 'Global Bookmark',
+          },
+        };
+        expect(bookmarkHelpers.getCurrentQuery(info)).to.equal('global');
+      });
+
+      it('should return an empty string if no query is found', () => {
+        expect(bookmarkHelpers.getCurrentQuery()).to.equal('');
+      });
+
+      it('should prioritize q parameter over bookmark query if different', () => {
+        const info: AppBookmarkInfo = {
+          userSavedSearchBookmarkTask: {
+            status: TaskStatus.COMPLETE,
+            data: {query: 'test', name: 'Test Bookmark', id: '123'},
+            error: undefined,
+          },
+        };
+        const location = {search: '?q=edited'};
+        expect(bookmarkHelpers.getCurrentQuery(info, location)).to.equal(
+          'edited',
+        );
+      });
+    });
+
+    describe('isBusyLoadingBookmarkInfo', () => {
+      it('should return true if userSavedSearchBookmarkTask is pending', () => {
+        const info: AppBookmarkInfo = {
+          userSavedSearchBookmarkTask: {
+            status: TaskStatus.PENDING,
+            data: undefined,
+            error: undefined,
+          },
+        };
+        expect(bookmarkHelpers.isBusyLoadingBookmarkInfo(info)).to.equal(true);
+      });
+
+      it('should return true if currentLocation search is different from location search', () => {
+        const info: AppBookmarkInfo = {currentLocation: {search: '?q=old'}};
+        const location = {search: '?q=new'};
+        expect(
+          bookmarkHelpers.isBusyLoadingBookmarkInfo(info, location),
+        ).to.equal(true);
+      });
+
+      it('should return false if userSavedSearchBookmarkTask is complete and locations match', () => {
+        const info: AppBookmarkInfo = {
+          userSavedSearchBookmarkTask: {
+            status: TaskStatus.COMPLETE,
+            data: undefined,
+            error: undefined,
+          },
+          currentLocation: {search: '?q=test'},
+        };
+        const location = {search: '?q=test'};
+        expect(
+          bookmarkHelpers.isBusyLoadingBookmarkInfo(info, location),
+        ).to.equal(false);
+      });
+
+      it('should return false if no info is provided', () => {
+        expect(bookmarkHelpers.isBusyLoadingBookmarkInfo()).to.equal(false);
+      });
+    });
+  });
+
+  describe('Error Classes', () => {
+    it('SavedSearchNotFoundError should create correct error message', () => {
+      const error = new SavedSearchNotFoundError('123');
+      expect(error.message).to.equal('Saved search with id 123 not found');
+    });
+
+    it('SavedSearchInternalError should create correct error message', () => {
+      const error = new SavedSearchInternalError('123', 'Server Error');
+      expect(error.message).to.equal(
+        'Error fetching saved search ID 123: Server Error',
+      );
+    });
+
+    it('SavedSearchUnknownError should create correct error message and log error to console', () => {
+      const error = new SavedSearchUnknownError(
+        '123',
+        new Error('Saved Search Unknown Test Error'),
+      );
+      expect(error.message).to.equal(
+        'Unknown error fetching saved search ID 123. Check console for details.',
+      );
+    });
+  });
+});

--- a/frontend/src/static/js/utils/constants.ts
+++ b/frontend/src/static/js/utils/constants.ts
@@ -32,6 +32,8 @@ export interface Bookmark {
   is_ordered?: boolean;
   // Override the num parameter value, if provided.
   override_num_param?: number;
+  // Server side id for bookmark
+  id?: string;
 }
 
 export const DEFAULT_BOOKMARKS: Bookmark[] = [

--- a/frontend/web-test-runner.config.mjs
+++ b/frontend/web-test-runner.config.mjs
@@ -21,6 +21,8 @@ const filteredLogs = [
   'Element sl-tree-item scheduled an update',
   // From the date range picker
   'WebstatusFormDateRangePicker: minimumDate, maximumDate, startDate, and endDate are required properties.',
+  // Unknown errors print to console for users to send us.
+  'Saved Search Unknown Test Error',
 ];
 
 export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({


### PR DESCRIPTION
Why: This is the pre-work for the changes to come to frontend/src/static/js/services/webstatus-bookmarks-service.ts for loading a saved search id from the query parameter.

This change adds two new fields to the context:
- userSavedSearchBookmarkTask: TaskTracker with information about the optional saved search bookmark being loaded when search_id query parameter is provided.
- currentLocation: A snapshot of the location information that applies to the info in the context. We will use this to let us know if our data is outdated.

This change also reorganizes the existing helpers into `bookmarkHelpers`. This will be useful for stubing. Because previously, we would run into this [issue](https://sinonjs.org/how-to/stub-dependency/)

There are two new helpers added:
- getCurrentQuery: A useful helper that lets the UI component know which query it should really use.
- isBusyLoadingBookmarkInfo: Let's the UI know that things aren't ready yet

Also, added some custom errors that we will be using in a future PR (this is a split up of https://github.com/GoogleChrome/webstatus.dev/compare/jcscottiii/ui-searches-v4.9?expand=1) The errors provided a central place to get error messages for each type of error. In a future PR, we will show a toast for these messages. I added a catch all error `SavedSearchUnknownError` that does print to console on purpose, thus the adjustment to frontend/web-test-runner.config.mjs to filter it our for tests

Other changes:
- Adjust existing code to use the bookmarkHelpers container
- Add api client call to getSavedSearchByID
- Add id to bookmark interface