### PR TITLE
Add task that automatically loads a search bookmark when search_id is present

### DIFF
--- a/frontend/src/static/js/services/test/webstatus-bookmarks-service.test.ts
+++ b/frontend/src/static/js/services/test/webstatus-bookmarks-service.test.ts
@@ -18,12 +18,21 @@ import {customElement, state} from 'lit/decorators.js';
 import {consume} from '@lit/context';
 import {
   AppBookmarkInfo,
+  SavedSearchInternalError,
+  SavedSearchNotFoundError,
+  SavedSearchUnknownError,
   appBookmarkInfoContext,
 } from '../../contexts/app-bookmark-info-context.js';
 import {WebstatusBookmarksService} from '../webstatus-bookmarks-service.js';
-import {fixture, expect} from '@open-wc/testing';
+import {fixture, expect, waitUntil} from '@open-wc/testing';
 import '../webstatus-bookmarks-service.js';
 import {DEFAULT_BOOKMARKS} from '../../utils/constants.js';
+import {APIClient} from '../../api/client.js';
+import {SinonStubbedInstance} from 'sinon';
+import {TaskStatus} from '@lit/task';
+import sinon from 'sinon';
+import {NotFoundError, ApiError} from '../../api/errors.js';
+import {Toast} from '../../utils/toast.js';
 
 @customElement('test-bookmark-consumer')
 class TestBookmarkConsumer extends LitElement {
@@ -37,16 +46,24 @@ class TestBookmarkConsumer extends LitElement {
 }
 
 describe('webstatus-bookmarks-service', () => {
+  let toastStub: SinonStubbedInstance<Toast>;
+  beforeEach(() => {
+    toastStub = sinon.stub(Toast.prototype);
+  });
+  afterEach(() => {
+    sinon.restore();
+  });
   it('can be added to the page with the defaults', async () => {
     const component = await fixture<WebstatusBookmarksService>(
       html`<webstatus-bookmarks-service> </webstatus-bookmarks-service>`,
     );
     expect(component).to.exist;
-    const expectedInfo: AppBookmarkInfo = {
-      globalBookmarks: DEFAULT_BOOKMARKS,
-      currentGlobalBookmark: undefined,
-    };
-    expect(component!.appBookmarkInfo).to.deep.equal(expectedInfo);
+    expect(component!.appBookmarkInfo.globalBookmarks).to.deep.equal(
+      DEFAULT_BOOKMARKS,
+    );
+    expect(component!.appBookmarkInfo.currentGlobalBookmark).to.deep.equal(
+      undefined,
+    );
   });
   it('provides appBookmarkInfo to consuming components', async () => {
     const el = await fixture<WebstatusBookmarksService>(html`
@@ -54,19 +71,20 @@ describe('webstatus-bookmarks-service', () => {
         <test-bookmark-consumer></test-bookmark-consumer>
       </webstatus-bookmarks-service>
     `);
-    const expectedInfo: AppBookmarkInfo = {
-      globalBookmarks: DEFAULT_BOOKMARKS,
-      currentGlobalBookmark: undefined,
-    };
     const consumer = el.querySelector<TestBookmarkConsumer>(
       'test-bookmark-consumer',
     );
     el.getLocation = () => {
-      return {search: '', href: ''};
+      return {search: '', href: '', pathname: ''};
     };
     expect(el).to.exist;
     expect(consumer).to.exist;
-    expect(el.appBookmarkInfo).to.deep.equal(expectedInfo);
+    expect(consumer!.appBookmarkInfo!.globalBookmarks).to.deep.equal(
+      DEFAULT_BOOKMARKS,
+    );
+    expect(consumer!.appBookmarkInfo!.currentGlobalBookmark).to.deep.equal(
+      undefined,
+    );
   });
 
   it('updates appBookmarkInfo on popstate event', async () => {
@@ -109,7 +127,7 @@ describe('webstatus-bookmarks-service', () => {
 
     // Simulate popstate event with a query
     el.getLocation = () => {
-      return {search: '?q=test_query_1', href: '?q=test_query_1'};
+      return {search: '?q=test_query_1', href: '?q=test_query_1', pathname: ''};
     };
     const popStateEvent = new PopStateEvent('popstate', {
       state: {},
@@ -119,17 +137,284 @@ describe('webstatus-bookmarks-service', () => {
     await consumer!.updateComplete;
 
     // Updated state
-    expect(consumer!.appBookmarkInfo).to.deep.equal({
-      globalBookmarks: [
-        {
-          name: 'Test Bookmark 1',
-          query: 'test_query_1',
-        },
-      ],
-      currentGlobalBookmark: {
+    expect(consumer!.appBookmarkInfo!.globalBookmarks).to.deep.equal([
+      {
         name: 'Test Bookmark 1',
         query: 'test_query_1',
       },
+    ]);
+    expect(consumer!.appBookmarkInfo!.currentGlobalBookmark).to.deep.equal({
+      name: 'Test Bookmark 1',
+      query: 'test_query_1',
     });
+  });
+  describe('loadingUserSavedBookmarkByIDTask', () => {
+    let apiClientStub: SinonStubbedInstance<APIClient>;
+
+    beforeEach(async () => {
+      apiClientStub = sinon.stub(new APIClient(''));
+    });
+
+    it('should handle NotFoundError', async () => {
+      apiClientStub = sinon.stub(new APIClient(''));
+      apiClientStub.getSavedSearchByID.rejects(new NotFoundError(''));
+      const service = await fixture<WebstatusBookmarksService>(
+        html`<webstatus-bookmarks-service
+          .apiClient=${apiClientStub}
+          .getSearchID=${() => 'test'}
+          .getLocation=${() => {
+            return {
+              search: '?search_id=test',
+              href: '?search_id=test',
+              pathname: '',
+            };
+          }}
+        ></webstatus-bookmarks-service>`,
+      );
+
+      await waitUntil(
+        () =>
+          service.appBookmarkInfo.userSavedSearchBookmarkTask?.status !==
+          TaskStatus.PENDING,
+      );
+      expect(
+        service.appBookmarkInfo.userSavedSearchBookmarkTask?.error,
+      ).to.be.instanceOf(SavedSearchNotFoundError);
+      expect(toastStub.toast).to.have.been.calledOnceWithExactly(
+        'Saved search with id test not found',
+        'danger',
+        'exclamation-triangle',
+      );
+    });
+
+    it('should handle ApiError', async () => {
+      apiClientStub.getSavedSearchByID.rejects(
+        new ApiError('Something went wrong', 500),
+      );
+      const service = await fixture<WebstatusBookmarksService>(
+        html`<webstatus-bookmarks-service
+          .apiClient=${apiClientStub}
+          .getSearchID=${() => 'test'}
+          .getLocation=${() => {
+            return {
+              search: '?search_id=test',
+              href: '?search_id=test',
+              pathname: '',
+            };
+          }}
+        ></webstatus-bookmarks-service>`,
+      );
+      await waitUntil(
+        () =>
+          service.appBookmarkInfo.userSavedSearchBookmarkTask?.status !==
+          TaskStatus.PENDING,
+      );
+      expect(
+        service.appBookmarkInfo.userSavedSearchBookmarkTask?.error,
+      ).to.be.instanceOf(SavedSearchInternalError);
+      expect(toastStub.toast).to.have.been.calledOnceWithExactly(
+        'Error fetching saved search ID test: Something went wrong',
+        'danger',
+        'exclamation-triangle',
+      );
+    });
+
+    it('should handle unknown errors', async () => {
+      apiClientStub.getSavedSearchByID.rejects(
+        new Error('Saved Search Unknown Test Error'),
+      );
+      const service = await fixture<WebstatusBookmarksService>(
+        html`<webstatus-bookmarks-service
+          .apiClient=${apiClientStub}
+          .getSearchID=${() => 'test'}
+          .getLocation=${() => {
+            return {
+              search: '?search_id=test',
+              href: '?search_id=test',
+              pathname: '',
+            };
+          }}
+        ></webstatus-bookmarks-service>`,
+      );
+      await waitUntil(
+        () =>
+          service.appBookmarkInfo.userSavedSearchBookmarkTask?.status !==
+          TaskStatus.PENDING,
+      );
+      expect(
+        service.appBookmarkInfo.userSavedSearchBookmarkTask?.error,
+      ).to.be.instanceOf(SavedSearchUnknownError);
+      expect(toastStub.toast).to.have.been.calledOnceWithExactly(
+        'Unknown error fetching saved search ID test. Check console for details.',
+        'danger',
+        'exclamation-triangle',
+      );
+    });
+
+    it.skip('should complete successfully if searchID is not found', async () => {
+      apiClientStub.getSavedSearchByID.resolves(undefined);
+      const service = await fixture<WebstatusBookmarksService>(
+        html`<webstatus-bookmarks-service
+          .apiClient=${apiClientStub}
+          .getSearchID=${() => 'test'}
+          .getLocation=${() => {
+            return {
+              search: '?search_id=test',
+              href: '?search_id=test',
+              pathname: '',
+            };
+          }}
+        ></webstatus-bookmarks-service>`,
+      );
+      await waitUntil(
+        () =>
+          service.appBookmarkInfo.userSavedSearchBookmarkTask?.status !==
+          TaskStatus.PENDING,
+      );
+      expect(
+        service.appBookmarkInfo.userSavedSearchBookmarkTask?.status,
+      ).to.equal(TaskStatus.COMPLETE);
+      expect(service.appBookmarkInfo.userSavedSearchBookmarkTask?.data).to.be
+        .undefined;
+    });
+
+    it('should complete successfully with bookmark data', async () => {
+      const mockBookmark = {
+        id: '123',
+        query: 'test',
+        name: 'Test Bookmark',
+        description: 'Test Description',
+        created_at: '2023-08-13',
+        updated_at: '2023-08-13',
+      };
+      apiClientStub.getSavedSearchByID.resolves(mockBookmark);
+      const service = await fixture<WebstatusBookmarksService>(
+        html`<webstatus-bookmarks-service
+          .apiClient=${apiClientStub}
+          .getSearchID=${() => 'test'}
+          .getLocation=${() => {
+            return {
+              search: '?search_id=test',
+              href: '?search_id=test',
+              pathname: '',
+            };
+          }}
+        ></webstatus-bookmarks-service>`,
+      );
+      await waitUntil(
+        () =>
+          service.appBookmarkInfo.userSavedSearchBookmarkTask?.status !==
+          TaskStatus.PENDING,
+      );
+      expect(
+        service.appBookmarkInfo.userSavedSearchBookmarkTask?.status,
+      ).to.equal(TaskStatus.COMPLETE);
+      expect(
+        service.appBookmarkInfo.userSavedSearchBookmarkTask?.data,
+      ).to.deep.equal(mockBookmark);
+    });
+  });
+
+  describe('findCurrentBookmarkByQuery', () => {
+    it('should return undefined for empty bookmarks', () => {
+      const service = new WebstatusBookmarksService();
+      expect(service.findCurrentBookmarkByQuery()).to.be.undefined;
+    });
+
+    it('should find a matching bookmark', () => {
+      const service = new WebstatusBookmarksService();
+      service._currentLocation = {
+        search: '?q=test',
+        href: '?q=test',
+        pathname: '',
+      };
+      const bookmarks = [{query: 'test', name: 'Test'}];
+      expect(service.findCurrentBookmarkByQuery(bookmarks)).to.deep.equal({
+        query: 'test',
+        name: 'Test',
+      });
+    });
+
+    it('should return undefined if no bookmark matches', () => {
+      const service = new WebstatusBookmarksService();
+      service._currentLocation = {
+        search: '?q=test',
+        href: '?q=test',
+        pathname: '',
+      };
+      const bookmarks = [{query: 'other', name: 'Other'}];
+      expect(service.findCurrentBookmarkByQuery(bookmarks)).to.be.undefined;
+    });
+  });
+
+  it('should refresh appBookmarkInfo correctly', () => {
+    const service = new WebstatusBookmarksService();
+    service._globalBookmarks = [{query: 'global', name: 'Global'}];
+    service._currentGlobalBookmark = {query: 'global', name: 'Global'};
+    service._userSavedBookmarkByIDTaskTracker = {
+      status: TaskStatus.COMPLETE,
+      data: {query: 'saved', name: 'Saved'},
+      error: undefined,
+    };
+    service._currentLocation = {
+      search: '?q=test',
+      href: '?q=test',
+      pathname: '',
+    };
+    service.refreshAppBookmarkInfo();
+    expect(service.appBookmarkInfo).to.deep.equal({
+      globalBookmarks: [{query: 'global', name: 'Global'}],
+      currentGlobalBookmark: {query: 'global', name: 'Global'},
+      userSavedSearchBookmarkTask: {
+        status: TaskStatus.COMPLETE,
+        data: {query: 'saved', name: 'Saved'},
+        error: undefined,
+      },
+      currentLocation: {search: '?q=test', href: '?q=test', pathname: ''},
+    });
+  });
+
+  it('should handle apiClient.getSavedSearchByID rejection in loadingUserSavedBookmarkByIDTask', async () => {
+    const apiClient = new APIClient('');
+    const getSavedSearchByIDStub = sinon.stub(apiClient, 'getSavedSearchByID');
+    getSavedSearchByIDStub.rejects(
+      new Error('Saved Search Unknown Test Error'),
+    );
+    const service = await fixture<WebstatusBookmarksService>(
+      html`<webstatus-bookmarks-service
+        .apiClient=${apiClient}
+        .getSearchID=${() => 'test'}
+        .getLocation=${() => {
+          return {
+            search: '?search_id=test',
+            href: '?search_id=test',
+            pathname: '',
+          };
+        }}
+      ></webstatus-bookmarks-service>`,
+    );
+    await waitUntil(
+      () =>
+        service.appBookmarkInfo.userSavedSearchBookmarkTask?.status !==
+        TaskStatus.PENDING,
+    );
+    expect(
+      service.appBookmarkInfo.userSavedSearchBookmarkTask?.error,
+    ).to.be.instanceOf(SavedSearchUnknownError);
+    expect(toastStub.toast).to.have.been.calledOnceWithExactly(
+      'Unknown error fetching saved search ID test. Check console for details.',
+      'danger',
+      'exclamation-triangle',
+    );
+    getSavedSearchByIDStub.restore();
+  });
+
+  it('getLocation should return the current location', () => {
+    const service = new WebstatusBookmarksService();
+    const location = service.getLocation();
+    expect(location).to.be.an('object');
+    expect(location).to.have.property('search');
+    expect(location).to.have.property('href');
+    expect(location).to.have.property('pathname');
   });
 });

--- a/frontend/src/static/js/utils/app-router.ts
+++ b/frontend/src/static/js/utils/app-router.ts
@@ -47,6 +47,7 @@ export const initRouter = async (element: HTMLElement): Promise<Router> => {
 export interface AppLocation {
   search: string;
   href: string;
+  pathname: string;
 }
 
 export const navigateToUrl = (url: string, event?: MouseEvent) => {


### PR DESCRIPTION
Depends on #1327 

Modified the WebstatusBookmarksService to have a new task loadingUserSavedBookmarkByIDTask. This task is automatically triggered by changes to the location, api client and user (for sign in and sign out so that we can get role information too when calling getSavedSearchByID by providing a token)

Upon completion it updates _userSavedBookmarkByIDTaskTracker (which is used in refreshAppBookmarkInfo like the other internal properties).

If it errors, it will show a toast using the custom error messages from #1327 as well as update the page url to remove the faulty search_id

Other changes:
- Renamed changedLocation to _changedLocation to be consistent with the other internal properties
- Add pathname to AppLocation because it is needed by updatePageUrl