### PR TITLE
Allow overview-page components to use appBookmarkInfoContext to automatically load public user saved searches

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-overview-filters.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-overview-filters.test.ts
@@ -30,6 +30,51 @@ import {Toast} from '../../utils/toast.js';
 import {WebstatusOverviewFilters} from '../webstatus-overview-filters.js';
 import {APIClient} from '../../api/client.js';
 
+import {stub} from 'sinon'; // Make sure you have sinon installed
+import {bookmarkHelpers} from '../../contexts/app-bookmark-info-context.js';
+
+it('should correctly update _activeQuery based on getCurrentQuery return value', async () => {
+  const apiClient = new APIClient('');
+  const location = {search: ''};
+
+  const getCurrentQueryStub = stub(bookmarkHelpers, 'getCurrentQuery');
+
+  // Test case 1: Empty query
+  getCurrentQueryStub.returns('');
+  let filterComponent = await fixture<WebstatusOverviewFilters>(
+    html`<webstatus-overview-filters
+      .location=${location}
+      .apiClient=${apiClient}
+    ></webstatus-overview-filters>`,
+  );
+  await elementUpdated(filterComponent);
+  expect(filterComponent._activeQuery).to.eq('');
+
+  // Test case 2: A specific query
+  getCurrentQueryStub.returns('my-test-query');
+  filterComponent = await fixture<WebstatusOverviewFilters>(
+    html`<webstatus-overview-filters
+      .location=${location}
+      .apiClient=${apiClient}
+    ></webstatus-overview-filters>`,
+  );
+  await elementUpdated(filterComponent);
+  expect(filterComponent._activeQuery).to.eq('my-test-query');
+
+  // Test case 3: Another query
+  getCurrentQueryStub.returns('another-test-query');
+  filterComponent = await fixture<WebstatusOverviewFilters>(
+    html`<webstatus-overview-filters
+      .location=${location}
+      .apiClient=${apiClient}
+    ></webstatus-overview-filters>`,
+  );
+  await elementUpdated(filterComponent);
+  expect(filterComponent._activeQuery).to.eq('another-test-query');
+
+  getCurrentQueryStub.restore();
+});
+
 describe('downloadCSV', () => {
   it('should display an error toast when the CSVUtils.downloadCSV function throws an error', async () => {
     const apiClient = new APIClient(''); // TODO Can probably stub allFeaturesFetecher instead.

--- a/frontend/src/static/js/utils/task-tracker.ts
+++ b/frontend/src/static/js/utils/task-tracker.ts
@@ -31,3 +31,12 @@ export interface TaskTracker<T, E> {
   /** Stores the result data of the completed task, or undefined if not complete or in error state. */
   data: T | undefined;
 }
+
+/**
+ * Represents an error that occurs when a task is not ready to execute.
+ */
+export class TaskNotReadyError extends Error {
+  constructor() {
+    super('Task not ready');
+  }
+}


### PR DESCRIPTION
Depends on #1328 

This change subscribes various overview page components to appBookmarkInfoContext so that it can get bookmark info.

I also introduced a new Error for TaskTracker: TaskNotReadyError We need this error so that the call to getFeatures waits until we have gotten the information from user saved searches API.

You will see the changes in webstatus-overview-page.ts that use that new error.

Future PR TODO:
- When it comes to editing and creating these bookmarks, we will probably move around some of these components (Which might simplify the number of components subscribed to appBookmarkInfoContext). In the meantime, I did not add too many unit tests but instead added some e2e tests in playwright to help give some coverage. The playwright tests use the fake data populated [here](https://github.com/GoogleChrome/webstatus.dev/blob/c04fbfd0887f4d56494051f7fa4da3bef41b8c77/util/cmd/load_fake_data/main.go#L399-L425).