### PR TITLE
Refactor: Precise control over data fetching and task execution

### DIFF
--- a/frontend/src/static/js/components/webstatus-login.ts
+++ b/frontend/src/static/js/components/webstatus-login.ts
@@ -34,10 +34,10 @@ export class WebstatusLogin extends LitElement {
 
   @consume({context: firebaseUserContext, subscribe: true})
   @state()
-  user?: User;
+  user: User | null | undefined;
 
   handleLogInClick(authConfig: AuthConfig) {
-    if (this.user === undefined) {
+    if (this.user === undefined || this.user === null) {
       authConfig.signIn().catch(async error => {
         await toast(
           `Failed to login: ${error.message ?? 'unknown'}`,
@@ -97,7 +97,7 @@ export class WebstatusLogin extends LitElement {
     }
 
     // Unauthenticated user.
-    if (this.user === undefined) {
+    if (this.user === undefined || this.user === null) {
       return this.renderLoginButton(this.firebaseAuthConfig);
     }
 

--- a/frontend/src/static/js/contexts/app-bookmark-info-context.ts
+++ b/frontend/src/static/js/contexts/app-bookmark-info-context.ts
@@ -106,6 +106,8 @@ export const bookmarkHelpers = {
     location?: {search: string},
   ): boolean => {
     return (
+      info?.userSavedSearchBookmarkTask === undefined ||
+      info?.userSavedSearchBookmarkTask?.status === TaskStatus.INITIAL ||
       info?.userSavedSearchBookmarkTask?.status === TaskStatus.PENDING ||
       info?.currentLocation?.search !== location?.search
     );

--- a/frontend/src/static/js/contexts/firebase-user-context.ts
+++ b/frontend/src/static/js/contexts/firebase-user-context.ts
@@ -19,6 +19,9 @@ import {createContext} from '@lit/context';
 import type {User} from 'firebase/auth';
 export type {User} from 'firebase/auth';
 
-export const firebaseUserContext = createContext<User | undefined>(
+// User means there is an authenticated user
+// null means no authenticated user is active
+// undefined means a decision has not been made yet about the current user.
+export const firebaseUserContext = createContext<User | null | undefined>(
   'firebase-user',
 );

--- a/frontend/src/static/js/contexts/test/app-bookmark-info-context.test.ts
+++ b/frontend/src/static/js/contexts/test/app-bookmark-info-context.test.ts
@@ -50,7 +50,12 @@ describe('app-bookmark-info-context', () => {
       });
 
       it('should return the currentGlobalBookmark if userSavedSearchBookmarkTask is not complete', () => {
-        const info: AppBookmarkInfo = {
+        const expectedData = {
+          query: 'global',
+          name: 'Global Bookmark',
+        };
+        // Pending state
+        const pendingInfo: AppBookmarkInfo = {
           currentGlobalBookmark: {
             query: 'global',
             name: 'Global Bookmark',
@@ -61,10 +66,35 @@ describe('app-bookmark-info-context', () => {
             error: undefined,
           },
         };
-        expect(bookmarkHelpers.getCurrentBookmark(info)).to.deep.equal({
-          query: 'global',
-          name: 'Global Bookmark',
-        });
+        expect(bookmarkHelpers.getCurrentBookmark(pendingInfo)).to.deep.equal(
+          expectedData,
+        );
+        // Initial state
+        const initialInfo: AppBookmarkInfo = {
+          currentGlobalBookmark: {
+            query: 'global',
+            name: 'Global Bookmark',
+          },
+          userSavedSearchBookmarkTask: {
+            status: TaskStatus.INITIAL,
+            data: undefined,
+            error: undefined,
+          },
+        };
+        expect(bookmarkHelpers.getCurrentBookmark(initialInfo)).to.deep.equal(
+          expectedData,
+        );
+        // Undefined state
+        const undefinedInfo: AppBookmarkInfo = {
+          currentGlobalBookmark: {
+            query: 'global',
+            name: 'Global Bookmark',
+          },
+          userSavedSearchBookmarkTask: undefined,
+        };
+        expect(bookmarkHelpers.getCurrentBookmark(undefinedInfo)).to.deep.equal(
+          expectedData,
+        );
       });
 
       it('should return undefined if no bookmark is found', () => {
@@ -96,17 +126,37 @@ describe('app-bookmark-info-context', () => {
       });
 
       it('should return the query from the location if bookmark info is loading', () => {
-        const info: AppBookmarkInfo = {
+        const location = {search: '?q=test'};
+        const expectedQuery = 'test';
+        // Pending
+        const pendingInfo: AppBookmarkInfo = {
           userSavedSearchBookmarkTask: {
             status: TaskStatus.PENDING,
             data: undefined,
             error: undefined,
           },
         };
-        const location = {search: '?q=test'};
-        expect(bookmarkHelpers.getCurrentQuery(info, location)).to.equal(
-          'test',
+        expect(bookmarkHelpers.getCurrentQuery(pendingInfo, location)).to.equal(
+          expectedQuery,
         );
+        // Initial
+        const initialInfo: AppBookmarkInfo = {
+          userSavedSearchBookmarkTask: {
+            status: TaskStatus.INITIAL,
+            data: undefined,
+            error: undefined,
+          },
+        };
+        expect(bookmarkHelpers.getCurrentQuery(initialInfo, location)).to.equal(
+          expectedQuery,
+        );
+        // Undefined
+        const undefinedInfo: AppBookmarkInfo = {
+          userSavedSearchBookmarkTask: undefined,
+        };
+        expect(
+          bookmarkHelpers.getCurrentQuery(undefinedInfo, location),
+        ).to.equal(expectedQuery);
       });
 
       it('should return the query from the userSavedSearchBookmarkTask if available and complete', () => {
@@ -144,6 +194,11 @@ describe('app-bookmark-info-context', () => {
             query: 'global',
             name: 'Global Bookmark',
           },
+          userSavedSearchBookmarkTask: {
+            status: TaskStatus.COMPLETE,
+            data: undefined,
+            error: undefined,
+          },
         };
         expect(bookmarkHelpers.getCurrentQuery(info)).to.equal('global');
       });
@@ -168,15 +223,33 @@ describe('app-bookmark-info-context', () => {
     });
 
     describe('isBusyLoadingBookmarkInfo', () => {
-      it('should return true if userSavedSearchBookmarkTask is pending', () => {
-        const info: AppBookmarkInfo = {
+      it('should return true if userSavedSearchBookmarkTask is pending/initial/undefined', () => {
+        const pendingInfo: AppBookmarkInfo = {
           userSavedSearchBookmarkTask: {
             status: TaskStatus.PENDING,
             data: undefined,
             error: undefined,
           },
         };
-        expect(bookmarkHelpers.isBusyLoadingBookmarkInfo(info)).to.equal(true);
+        expect(bookmarkHelpers.isBusyLoadingBookmarkInfo(pendingInfo)).to.equal(
+          true,
+        );
+        const initialInfo: AppBookmarkInfo = {
+          userSavedSearchBookmarkTask: {
+            status: TaskStatus.INITIAL,
+            data: undefined,
+            error: undefined,
+          },
+        };
+        expect(bookmarkHelpers.isBusyLoadingBookmarkInfo(initialInfo)).to.equal(
+          true,
+        );
+        const undefinedInfo: AppBookmarkInfo = {
+          userSavedSearchBookmarkTask: undefined,
+        };
+        expect(
+          bookmarkHelpers.isBusyLoadingBookmarkInfo(undefinedInfo),
+        ).to.equal(true);
       });
 
       it('should return true if currentLocation search is different from location search', () => {
@@ -200,10 +273,6 @@ describe('app-bookmark-info-context', () => {
         expect(
           bookmarkHelpers.isBusyLoadingBookmarkInfo(info, location),
         ).to.equal(false);
-      });
-
-      it('should return false if no info is provided', () => {
-        expect(bookmarkHelpers.isBusyLoadingBookmarkInfo()).to.equal(false);
       });
     });
   });

--- a/frontend/src/static/js/services/test/webstatus-firebase-auth-service.test.ts
+++ b/frontend/src/static/js/services/test/webstatus-firebase-auth-service.test.ts
@@ -162,7 +162,7 @@ describe('webstatus-firebase-auth-service', () => {
     class FakeChildElement extends LitElement {
       @consume({context: firebaseUserContext, subscribe: true})
       @property({attribute: false})
-      user?: User;
+      user: User | null | undefined;
     }
     const root = document.createElement('div');
     document.body.appendChild(root);

--- a/frontend/src/static/js/services/webstatus-firebase-auth-service.ts
+++ b/frontend/src/static/js/services/webstatus-firebase-auth-service.ts
@@ -52,7 +52,7 @@ export class WebstatusFirebaseAuthService extends ServiceElement {
   firebaseAuthConfig?: AuthConfig;
 
   @provide({context: firebaseUserContext})
-  user?: User;
+  user: User | null | undefined;
 
   // Useful for testing
   authInitializer: (app: FirebaseApp | undefined) => Auth = getAuth;
@@ -85,7 +85,7 @@ export class WebstatusFirebaseAuthService extends ServiceElement {
       // 1. The user first logs in
       // 2. Resuming a session
       this.firebaseAuthConfig.auth.onAuthStateChanged(user => {
-        this.user = user ? user : undefined;
+        this.user = user ? user : null;
       });
     }
   }

--- a/frontend/src/static/js/utils/task-tracker.ts
+++ b/frontend/src/static/js/utils/task-tracker.ts
@@ -31,12 +31,3 @@ export interface TaskTracker<T, E> {
   /** Stores the result data of the completed task, or undefined if not complete or in error state. */
   data: T | undefined;
 }
-
-/**
- * Represents an error that occurs when a task is not ready to execute.
- */
-export class TaskNotReadyError extends Error {
-  constructor() {
-    super('Task not ready');
-  }
-}

--- a/frontend/src/static/js/utils/urls.ts
+++ b/frontend/src/static/js/utils/urls.ts
@@ -75,7 +75,7 @@ export function getPageSize(location: {search: string}): number {
   return Math.min(100, Math.max(num, 1));
 }
 
-type QueryStringOverrides = {
+export type QueryStringOverrides = {
   q?: string;
   start?: number;
   num?: number;


### PR DESCRIPTION
Background:

This PR refactors data fetching in two components by disabling `autoRun` for Lit Tasks. An issue was observed in Firefox in PR #1330 where tasks were being triggered multiple times. The previous error handling using `TaskNotReadyError` and checks for duplicate tasks was insufficient. Lit Task aborts a currently pending task if a new one is triggered. This led to scenarios in Firefox where the initial task could be aborted, and subsequent tasks might return errors, preventing successful data retrieval.

This tries to simplify things by turning off autoRun and leveraging the willUpdate lit lifecycle method to precisely run a task. This also allows us to not have to do checks on the task's arguments within the task itself since we control when the task exactly triggers.

Main changes:
- **`OverviewPage`:** The `loadingTask` is no longer set to `autoRun: true`. Instead, it is manually triggered in `willUpdate` based on changes to relevant properties and bookmark loading status. The `TaskNotReadyError` and related logic have been removed.
- **`webstatus-bookmarks-service`:**
    - The `loadingUserSavedBookmarkByIDTask` is no longer set to `autoRun: true` and is triggered in `willUpdate`.
    - The task now returns an object containing both the bookmark data and the current search query.

Other changes:
- **`webstatus-firebase-auth-service`:** Updated the type of the `user` state to `User | null | undefined`. This is useful for noting whether some data about the user has been loaded successfully or not vs no decision about the user has been made.
- Removed some redundant tests. Changed some tests to use sinon stubs
- Added some more coverage too.

Other notes:
- These tasks don't use the .render() method. They instead control what happens in the onError/onComplete callbacks. I am not saying we need to also change the other tasks that currently use .render() to something like this. Those are currently working. But something to consider if they dependency chain for those tasks become more complicated.

This is a split up of #1330