### PR TITLE
Add service for loading user bookmarks

### DIFF
--- a/frontend/src/static/js/api/client.ts
+++ b/frontend/src/static/js/api/client.ts
@@ -51,6 +51,7 @@ type PageablePath =
   | '/v1/features'
   | '/v1/features/{feature_id}/stats/wpt/browsers/{browser}/channels/{channel}/{metric_view}'
   | '/v1/stats/features/browsers/{browser}/feature_counts'
+  | '/v1/users/me/saved-searches'
   | '/v1/stats/baseline_status/low_date_feature_counts';
 
 type SuccessResponsePageableData<
@@ -348,6 +349,26 @@ export class APIClient {
       {params: {query: queryParams}},
       this.createOffsetPaginationTokenForGetFeatures,
     );
+  }
+
+  // Get all saved searches for a user
+  public async getAllUserSavedSearches(
+    token: string,
+  ): Promise<SavedSearchResponse[]> {
+    type SavedSearchResponsePage = SuccessResponsePageableData<
+      components['schemas']['SavedSearchResponse'][],
+      ParamsOption<'/v1/users/me/saved-searches'>,
+      'application/json',
+      '/v1/users/me/saved-searches'
+    >;
+    return this.getAllPagesOfData<
+      '/v1/users/me/saved-searches',
+      SavedSearchResponsePage
+    >('/v1/users/me/saved-searches', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
   }
 
   public async *getFeatureStatsByBrowserAndChannel(

--- a/frontend/web-test-runner.config.mjs
+++ b/frontend/web-test-runner.config.mjs
@@ -23,6 +23,7 @@ const filteredLogs = [
   'WebstatusFormDateRangePicker: minimumDate, maximumDate, startDate, and endDate are required properties.',
   // Unknown errors print to console for users to send us.
   'Saved Search Unknown Test Error',
+  'User Saved Searches Unknown Test Error',
 ];
 
 export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({


### PR DESCRIPTION
This PR adds a new task in the frontend to support loading a user's saved bookmarks. This is the pre-req step for displaying these bookmarks in the sidebar (next PR).

Main changes:
- **`app-bookmark-info-context`:**
    - Added a new `TaskTracker` property, `userSavedSearchBookmarksTask`, to the `AppBookmarkInfo` interface. This will hold the status and data of the user's bookmarks loading task.
    - Updated the `isBusyLoadingBookmarkInfo` helper to consider the loading state of the `userSavedSearchBookmarksTask`.
    - Introduced new error classes: `UserSavedSearchesInternalError` and `UserSavedSearchesUnknownError` to handle errors specific to fetching the user's bookmark list.
- **`webstatus-bookmarks-service`:**
    - Added a new `loadingUserSavedBookmarksTask` (Lit Task) to fetch all of the current user's saved searches from the backend.
    - This task is triggered in the `willUpdate` lifecycle method when the `apiClient` and `user` properties are available. For the `user`, it is okay if there is an actual User object (means the user has been detected) or null (no user detected after trying. Different from undefined)
    - The results of the task are stored in the `userSavedSearchBookmarksTask` within the `appBookmarkInfo` context.

This is a split up of #1330 

Depends on #1334 