### PR TITLE
Add adapter logic to update saved search

### DIFF
--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -139,6 +139,7 @@ func (s *Server) UpdateSavedSearch(
 	return backend.UpdateSavedSearch400JSONResponse{
 		Code:    http.StatusBadRequest,
 		Message: "TODO",
+		Errors:  nil,
 	}, nil
 }
 

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -1250,7 +1250,7 @@ components:
         update_mask:
           type: array
           description: >
-            A list of fields to update.  Required. Allowed values are: `name`, `description`, `query`.
+            A list of fields to update. Required. Allowed values are: `name`, `description`, `query`.
           items:
             type: string
             enum:

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -827,7 +827,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasicErrorModel'
+                $ref: '#/components/schemas/ExtendedErrorModel'
         '401':
           description: Unauthorized
           content:
@@ -1237,16 +1237,36 @@ components:
       description: |
         Represents the data required to update a saved search.
         Only the fields that need to be modified need to be included in the request.
+        To clear a field, include the field in `update_mask` and set the corresponding value to an empty string.
       properties:
         name:
           type: string
           minLength: 1
         description:
           type: string
-          minLength: 1
         query:
           type: string
           minLength: 1
+        update_mask:
+          type: array
+          description: >
+            A list of fields to update.  Required. Allowed values are: `name`, `description`, `query`.
+          items:
+            type: string
+            enum:
+              - name
+              - description
+              - query
+            # Custom field used by https://github.com/oapi-codegen/oapi-codegen
+            # Otherwise, the constant name will be Name, Description and Query
+            x-enumNames:
+              - SavedSearchUpdateRequestMaskName
+              - SavedSearchUpdateRequestMaskDescription
+              - SavedSearchUpdateRequestMaskQuery
+          minItems: 1
+          uniqueItems: true
+      required:
+        - update_mask
     UserSavedSearchBookmarkStatus:
       type: string
       description: |

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -1237,13 +1237,16 @@ components:
       description: |
         Represents the data required to update a saved search.
         Only the fields that need to be modified need to be included in the request.
-        To clear a field, include the field in `update_mask` and set the corresponding value to an empty string.
+        To clear a field, include the field in `update_mask` and set the corresponding value to null.
+        Only fields with nullable set to true can be cleared.
       properties:
         name:
           type: string
           minLength: 1
         description:
           type: string
+          nullable: true
+          minLength: 1
         query:
           type: string
           minLength: 1


### PR DESCRIPTION
Also updated the openapi document to follow AIP-134 for this PATCH method https://google.aip.dev/134

This means adding an update_mask to the request.

This allows us to selectively update each field.

The adapter logic looks at the update_mask and converts it to the Optionally type in the gcpspanner layer

The validation of the request will happen in the http layer which will happen in the next PR.