### PR TITLE
HTTP Layer for Update Saved Search

### DIFF
--- a/backend/pkg/httpserver/create_saved_search.go
+++ b/backend/pkg/httpserver/create_saved_search.go
@@ -99,12 +99,16 @@ func validateSavedSearchQuery(query *string, fieldErrors *fieldValidationErrors)
 // validateSavedSearchDescription checks the validity of the saved search description.
 // Description is optional, so nil is allowed. Validation only occurs if non-nil.
 func validateSavedSearchDescription(description *string, fieldErrors *fieldValidationErrors) {
+	// If description is nil, it's considered valid (optional field).
+	if description == nil {
+		return
+	}
+
 	// If description is provided (non-nil), validate its length.
-	if description != nil && (len(*description) < savedSearchNameDescriptionMinLength ||
-		len(*description) > savedSearchNameDescriptionMaxLength) {
+	if len(*description) < savedSearchNameDescriptionMinLength ||
+		len(*description) > savedSearchNameDescriptionMaxLength {
 		fieldErrors.addFieldError("description", errSavedSearchInvalidDescriptionLength)
 	}
-	// If description is nil, it's considered valid (optional field).
 }
 
 func validateSavedSearch(input *backend.SavedSearch) *fieldValidationErrors {

--- a/backend/pkg/httpserver/create_saved_search.go
+++ b/backend/pkg/httpserver/create_saved_search.go
@@ -86,14 +86,17 @@ func validateSavedSearchQuery(query *string, fieldErrors *fieldValidationErrors)
 
 	if len(*query) < savedSearchQueryMinLength || len(*query) > savedSearchQueryMaxLength {
 		fieldErrors.addFieldError("query", errSavedSearchInvalidQueryLength)
-	} else {
-		// Only parse if length is okay
-		parser := searchtypes.FeaturesSearchQueryParser{}
-		_, err := parser.Parse(*query)
-		if err != nil {
-			fieldErrors.addFieldError("query", errQueryDoesNotMatchGrammar)
-		}
+
+		return
 	}
+
+	// Only parse if length is okay
+	parser := searchtypes.FeaturesSearchQueryParser{}
+	_, err := parser.Parse(*query)
+	if err != nil {
+		fieldErrors.addFieldError("query", errQueryDoesNotMatchGrammar)
+	}
+
 }
 
 // validateSavedSearchDescription checks the validity of the saved search description.

--- a/backend/pkg/httpserver/create_saved_search_test.go
+++ b/backend/pkg/httpserver/create_saved_search_test.go
@@ -194,6 +194,26 @@ func TestCreateSavedSearch(t *testing.T) {
 				}`),
 		},
 		{
+			name:                            "missing body creation error",
+			mockCreateUserSavedSearchConfig: nil,
+			authMiddlewareOption:            withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/saved-searches",
+				strings.NewReader(`{}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"name":"name must be between 1 and 32 characters long",
+						"query":"query must be between 1 and 256 characters long"
+					},
+					"message":"input validation errors"
+				}`,
+			),
+		},
+		{
 			name: "general creation error",
 			mockCreateUserSavedSearchConfig: &MockCreateUserSavedSearchConfig{
 				expectedSavedSearch: backend.SavedSearch{

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -123,24 +123,18 @@ type WPTMetricsStorer interface {
 		pageSize int,
 		pageToken *string,
 	) (*backend.UserSavedSearchPage, error)
+	UpdateUserSavedSearch(
+		ctx context.Context,
+		savedSearchID string,
+		userID string,
+		savedSearch *backend.SavedSearchUpdateRequest,
+	) (*backend.SavedSearchResponse, error)
 }
 
 type Server struct {
 	metadataStorer          WebFeatureMetadataStorer
 	wptMetricsStorer        WPTMetricsStorer
 	operationResponseCaches *operationResponseCaches
-}
-
-// UpdateSavedSearch implements backend.StrictServerInterface.
-// nolint: revive, ireturn // Name generated from openapi
-func (s *Server) UpdateSavedSearch(
-	ctx context.Context, request backend.UpdateSavedSearchRequestObject) (
-	backend.UpdateSavedSearchResponseObject, error) {
-	return backend.UpdateSavedSearch400JSONResponse{
-		Code:    http.StatusBadRequest,
-		Message: "TODO",
-		Errors:  nil,
-	}, nil
 }
 
 // GetUserSavedSearchBookmark implements backend.StrictServerInterface.

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -193,6 +193,14 @@ type MockListUserSavedSeachesConfig struct {
 	err               error
 }
 
+type MockUpdateUserSavedSearchConfig struct {
+	expectedSavedSearchID string
+	expectedUserID        string
+	expectedUpdateRequest *backend.SavedSearchUpdateRequest
+	output                *backend.SavedSearchResponse
+	err                   error
+}
+
 type MockWPTMetricsStorer struct {
 	featureCfg                                        *MockListMetricsForFeatureIDBrowserAndChannelConfig
 	aggregateCfg                                      *MockListMetricsOverTimeWithAggregatedTotalsConfig
@@ -208,6 +216,7 @@ type MockWPTMetricsStorer struct {
 	deleteUserSavedSearchCfg                          *MockDeleteUserSavedSearchConfig
 	getSavedSearchCfg                                 *MockGetSavedSearchConfig
 	listUserSavedSearchesCfg                          *MockListUserSavedSeachesConfig
+	updateUserSavedSearchCfg                          *MockUpdateUserSavedSearchConfig
 	t                                                 *testing.T
 	callCountListMissingOneImplCounts                 int
 	callCountListMissingOneImplFeatures               int
@@ -222,6 +231,7 @@ type MockWPTMetricsStorer struct {
 	callCountDeleteUserSavedSearch                    int
 	callCountGetSavedSearch                           int
 	callCountListUserSavedSearches                    int
+	callCountUpdateUserSavedSearch                    int
 }
 
 func (m *MockWPTMetricsStorer) GetIDFromFeatureKey(
@@ -492,6 +502,29 @@ func (m *MockWPTMetricsStorer) DeleteUserSavedSearch(
 	}
 
 	return m.deleteUserSavedSearchCfg.err
+}
+
+func (m *MockWPTMetricsStorer) UpdateUserSavedSearch(
+	_ context.Context,
+	savedSearchID string,
+	userID string,
+	req *backend.SavedSearchUpdateRequest,
+) (*backend.SavedSearchResponse, error) {
+	m.callCountUpdateUserSavedSearch++
+
+	if savedSearchID != m.updateUserSavedSearchCfg.expectedSavedSearchID ||
+		userID != m.updateUserSavedSearchCfg.expectedUserID ||
+		!reflect.DeepEqual(req, m.updateUserSavedSearchCfg.expectedUpdateRequest) {
+		m.t.Errorf("Incorrect arguments. Expected: ( %s %s %v ), Got: { %s %s %v}",
+			m.updateUserSavedSearchCfg.expectedSavedSearchID,
+			m.updateUserSavedSearchCfg.expectedUserID,
+			m.updateUserSavedSearchCfg.expectedUpdateRequest,
+			savedSearchID,
+			userID,
+			req)
+	}
+
+	return m.updateUserSavedSearchCfg.output, m.updateUserSavedSearchCfg.err
 }
 
 func (m *MockWPTMetricsStorer) ListUserSavedSearches(

--- a/backend/pkg/httpserver/update_saved_search.go
+++ b/backend/pkg/httpserver/update_saved_search.go
@@ -1,0 +1,132 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/httpmiddlewares"
+)
+
+// validateSavedSearchUpdate handles validation when updating an existing SavedSearch.
+func validateSavedSearchUpdate(input *backend.UpdateSavedSearchJSONRequestBody) *fieldValidationErrors {
+	activeMasks := make(map[backend.SavedSearchUpdateRequestUpdateMask]bool)
+	var invalidMasks []string
+
+	fieldErrors := &fieldValidationErrors{fieldErrorMap: nil}
+
+	if len(input.UpdateMask) == 0 {
+		fieldErrors.addFieldError("update_mask", errors.New("update_mask must be set"))
+
+		return fieldErrors
+	}
+
+	for _, mask := range input.UpdateMask {
+		switch mask {
+		case
+			backend.SavedSearchUpdateRequestMaskName,
+			backend.SavedSearchUpdateRequestMaskQuery,
+			backend.SavedSearchUpdateRequestMaskDescription:
+			activeMasks[mask] = true
+		default:
+			invalidMasks = append(invalidMasks, string(mask))
+		}
+	}
+
+	if len(invalidMasks) > 0 {
+		fieldErrors.addFieldError("update_mask", errors.New("invalid update_mask values: "+
+			strings.Join(invalidMasks, ", "),
+		))
+
+		return fieldErrors
+	}
+
+	// Validate Name only if it's in the update mask
+	if activeMasks[backend.SavedSearchUpdateRequestMaskName] {
+		validateSavedSearchName(input.Name, fieldErrors)
+	}
+
+	// Validate Query only if it's in the update mask
+	if activeMasks[backend.SavedSearchUpdateRequestMaskQuery] {
+		// Original logic also checked for nil before length/parsing.
+		validateSavedSearchQuery(input.Query, fieldErrors)
+	}
+
+	// Validate Description only if it's in the update mask
+	if activeMasks[backend.SavedSearchUpdateRequestMaskDescription] {
+		validateSavedSearchDescription(input.Description, fieldErrors)
+	}
+
+	if fieldErrors.hasErrors() {
+		return fieldErrors
+	}
+
+	return nil
+}
+
+// UpdateSavedSearch implements backend.StrictServerInterface.
+// nolint: ireturn // Name generated from openapi
+func (s *Server) UpdateSavedSearch(
+	ctx context.Context, request backend.UpdateSavedSearchRequestObject) (
+	backend.UpdateSavedSearchResponseObject, error) {
+	// At this point, the user should be authenticated and in the context.
+	// If for some reason the user is not in the context, it is a library or
+	// internal issue and not an user issue. Return 500 error in that case.
+	user, found := httpmiddlewares.AuthenticatedUserFromContext(ctx)
+	if !found {
+		slog.ErrorContext(ctx, "user not found in context. middleware malfunction")
+
+		return backend.UpdateSavedSearch500JSONResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "internal server error",
+		}, nil
+	}
+	validationErr := validateSavedSearchUpdate(request.Body)
+	if validationErr != nil {
+		return backend.UpdateSavedSearch400JSONResponse{
+			Code:    http.StatusBadRequest,
+			Message: "input validation errors",
+			Errors:  validationErr.fieldErrorMap,
+		}, nil
+	}
+	output, err := s.wptMetricsStorer.UpdateUserSavedSearch(ctx, request.SearchId, user.ID, request.Body)
+	if err != nil {
+		if errors.Is(err, backendtypes.ErrUserNotAuthorizedForAction) {
+			return backend.UpdateSavedSearch403JSONResponse{
+				Code:    http.StatusForbidden,
+				Message: "forbidden",
+			}, nil
+		} else if errors.Is(err, backendtypes.ErrEntityDoesNotExist) {
+			return backend.UpdateSavedSearch404JSONResponse{
+				Code:    http.StatusNotFound,
+				Message: "saved search not found",
+			}, nil
+		}
+		slog.ErrorContext(ctx, "unable to update user saved search", "error", err)
+
+		return backend.UpdateSavedSearch500JSONResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "unable to update user saved search",
+		}, nil
+	}
+
+	return backend.UpdateSavedSearch200JSONResponse(*output), nil
+}

--- a/backend/pkg/httpserver/update_saved_search_test.go
+++ b/backend/pkg/httpserver/update_saved_search_test.go
@@ -1,0 +1,363 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestUpdateSavedSearch(t *testing.T) {
+	testUser := &auth.User{
+		ID: "testID1",
+	}
+	// Common Request Bodies and Mock Settings
+	updateAllFieldsRequestBody := `{
+			"query": "name:\"test\"",
+			"name" : "test name",
+			"description": "test description",
+			"update_mask": ["name", "query", "description"]
+	}`
+	updateAllFieldsExpectedRequest := &backend.SavedSearchUpdateRequest{
+		Name:        valuePtr("test name"),
+		Query:       valuePtr(`name:"test"`),
+		Description: valuePtr("test description"),
+		UpdateMask: []backend.SavedSearchUpdateRequestUpdateMask{
+			backend.SavedSearchUpdateRequestMaskName,
+			backend.SavedSearchUpdateRequestMaskQuery,
+			backend.SavedSearchUpdateRequestMaskDescription,
+		},
+	}
+	updateAllFieldsClearDescriptionExpectedRequest := &backend.SavedSearchUpdateRequest{
+		Name:        valuePtr("test name"),
+		Query:       valuePtr(`name:"test"`),
+		Description: nil,
+		UpdateMask: []backend.SavedSearchUpdateRequestUpdateMask{
+			backend.SavedSearchUpdateRequestMaskName,
+			backend.SavedSearchUpdateRequestMaskQuery,
+			backend.SavedSearchUpdateRequestMaskDescription,
+		},
+	}
+	testCases := []struct {
+		name                 string
+		cfg                  *MockUpdateUserSavedSearchConfig
+		authMiddlewareOption testServerOption
+		request              *http.Request
+		expectedResponse     *http.Response
+	}{
+		{
+			name:                 "missing body update error",
+			cfg:                  nil,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/saved-searches/saved-search-id",
+				strings.NewReader(`{}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{"code":400,"errors":{"update_mask":"update_mask must be set"},"message":"input validation errors"}`,
+			),
+		},
+		{
+			name:                 "empty update mask error",
+			cfg:                  nil,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/saved-searches/saved-search-id",
+				strings.NewReader(`{"update_mask": []}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{"code":400,"errors":{"update_mask":"update_mask must be set"},"message":"input validation errors"}`,
+			),
+		},
+		{
+			name:                 "update with invalid masks error",
+			cfg:                  nil,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/saved-searches/saved-search-id",
+				strings.NewReader(`{"update_mask": ["query", "foo"]}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{"update_mask":"invalid update_mask values: foo"},"message":"input validation errors"
+				}`,
+			),
+		},
+		{
+			name:                 "missing fields, all update masks set, update error",
+			cfg:                  nil,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/saved-searches/saved-search-id",
+				strings.NewReader(`{
+					"update_mask": ["name", "query", "description"]
+				}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"name":"name must be between 1 and 32 characters long",
+						"query":"query must be between 1 and 256 characters long"
+					},
+					"message":"input validation errors"
+				}`,
+			),
+		},
+		{
+			name: "forbidden error",
+			cfg: &MockUpdateUserSavedSearchConfig{
+				expectedSavedSearchID: "saved-search-id",
+				expectedUserID:        "testID1",
+				expectedUpdateRequest: updateAllFieldsExpectedRequest,
+				output:                nil,
+				err:                   backendtypes.ErrUserNotAuthorizedForAction,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/saved-searches/saved-search-id",
+				strings.NewReader(updateAllFieldsRequestBody),
+			),
+			expectedResponse: testJSONResponse(403,
+				`{
+					"code":403,
+					"message":"forbidden"
+				}`,
+			),
+		},
+		{
+			name: "forbidden error",
+			cfg: &MockUpdateUserSavedSearchConfig{
+				expectedSavedSearchID: "saved-search-id",
+				expectedUserID:        "testID1",
+				expectedUpdateRequest: updateAllFieldsExpectedRequest,
+				output:                nil,
+				err:                   backendtypes.ErrEntityDoesNotExist,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/saved-searches/saved-search-id",
+				strings.NewReader(updateAllFieldsRequestBody),
+			),
+			expectedResponse: testJSONResponse(404,
+				`{
+					"code":404,
+					"message":"saved search not found"
+				}`,
+			),
+		},
+		{
+			name: "general error",
+			cfg: &MockUpdateUserSavedSearchConfig{
+				expectedSavedSearchID: "saved-search-id",
+				expectedUserID:        "testID1",
+				expectedUpdateRequest: updateAllFieldsExpectedRequest,
+				output:                nil,
+				err:                   errTest,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/saved-searches/saved-search-id",
+				strings.NewReader(updateAllFieldsRequestBody),
+			),
+			expectedResponse: testJSONResponse(500,
+				`{
+					"code":500,
+					"message":"unable to update user saved search"
+				}`,
+			),
+		},
+		{
+			name: "success all fields",
+			cfg: &MockUpdateUserSavedSearchConfig{
+				expectedSavedSearchID: "saved-search-id",
+				expectedUserID:        "testID1",
+				expectedUpdateRequest: updateAllFieldsExpectedRequest,
+				output: &backend.SavedSearchResponse{
+					Id:          "saved-search-id",
+					Name:        "test name",
+					Query:       `name:"test"`,
+					Description: valuePtr("test description"),
+					Permissions: &backend.UserSavedSearchPermissions{
+						Role: valuePtr(backend.SavedSearchOwner),
+					},
+					BookmarkStatus: &backend.UserSavedSearchBookmark{
+						Status: backend.BookmarkActive,
+					},
+					CreatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+				err: nil,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/saved-searches/saved-search-id",
+				strings.NewReader(updateAllFieldsRequestBody),
+			),
+			expectedResponse: testJSONResponse(200,
+				`{
+					"bookmark_status":{
+					   "status":"bookmark_active"
+					},
+					"created_at":"2000-01-01T00:00:00Z",
+					"description":"test description",
+					"id":"saved-search-id",
+					"name":"test name",
+					"permissions":{
+					   "role":"saved_search_owner"
+					},
+					"query":"name:\"test\"",
+					"updated_at":"2000-01-01T00:00:00Z"
+				}`,
+			),
+		},
+		{
+			name: "success, all fields, clear description with explicit null",
+			cfg: &MockUpdateUserSavedSearchConfig{
+				expectedSavedSearchID: "saved-search-id",
+				expectedUserID:        "testID1",
+				expectedUpdateRequest: updateAllFieldsClearDescriptionExpectedRequest,
+				output: &backend.SavedSearchResponse{
+					Id:          "saved-search-id",
+					Name:        "test name",
+					Query:       `name:"test"`,
+					Description: nil,
+					Permissions: &backend.UserSavedSearchPermissions{
+						Role: valuePtr(backend.SavedSearchOwner),
+					},
+					BookmarkStatus: &backend.UserSavedSearchBookmark{
+						Status: backend.BookmarkActive,
+					},
+					CreatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+				err: nil,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/saved-searches/saved-search-id",
+				strings.NewReader(
+					`{
+						"query": "name:\"test\"",
+						"name" : "test name",
+						"description": null,
+						"update_mask": ["name", "query", "description"]
+					}`,
+				),
+			),
+			expectedResponse: testJSONResponse(200,
+				`{
+					"bookmark_status":{
+					   "status":"bookmark_active"
+					},
+					"created_at":"2000-01-01T00:00:00Z",
+					"id":"saved-search-id",
+					"name":"test name",
+					"permissions":{
+					   "role":"saved_search_owner"
+					},
+					"query":"name:\"test\"",
+					"updated_at":"2000-01-01T00:00:00Z"
+				}`,
+			),
+		},
+		{
+			name: "success, all fields, clear description with implicit null",
+			cfg: &MockUpdateUserSavedSearchConfig{
+				expectedSavedSearchID: "saved-search-id",
+				expectedUserID:        "testID1",
+				expectedUpdateRequest: updateAllFieldsClearDescriptionExpectedRequest,
+				output: &backend.SavedSearchResponse{
+					Id:          "saved-search-id",
+					Name:        "test name",
+					Query:       `name:"test"`,
+					Description: nil,
+					Permissions: &backend.UserSavedSearchPermissions{
+						Role: valuePtr(backend.SavedSearchOwner),
+					},
+					BookmarkStatus: &backend.UserSavedSearchBookmark{
+						Status: backend.BookmarkActive,
+					},
+					CreatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+				err: nil,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/saved-searches/saved-search-id",
+				strings.NewReader(
+					`{
+						"query": "name:\"test\"",
+						"name" : "test name",
+						"update_mask": ["name", "query", "description"]
+					}`,
+				),
+			),
+			expectedResponse: testJSONResponse(200,
+				`{
+					"bookmark_status":{
+					   "status":"bookmark_active"
+					},
+					"created_at":"2000-01-01T00:00:00Z",
+					"id":"saved-search-id",
+					"name":"test name",
+					"permissions":{
+					   "role":"saved_search_owner"
+					},
+					"query":"name:\"test\"",
+					"updated_at":"2000-01-01T00:00:00Z"
+				}`,
+			),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint:exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				updateUserSavedSearchCfg: tc.cfg,
+				t:                        t,
+			}
+			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
+				operationResponseCaches: nil}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+				[]testServerOption{tc.authMiddlewareOption}...)
+		})
+	}
+}

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -840,6 +840,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
         '500':
           description: Internal Service Error
           content:


### PR DESCRIPTION
This adds the HTTP layer for the update saved search operation.

Validation changes:
- Refactor the validation logic of SavedSearches so that CreateSavedSearch and UpdateSavedSearch
  can both use the same logic.
- The update saved search validation contains additional checks for the update_mask passed in.

Other changes:
- Add 404 case for update saved search in the openapi document