### PR TITLE
Add checks for the number of bookmarks and prevent removal of owned searches

### DIFF
--- a/lib/gcpspanner/client.go
+++ b/lib/gcpspanner/client.go
@@ -121,10 +121,14 @@ func (w LocalBatchWriter) BatchWriteMutations(
 
 // searchConfig holds the application configuation for the saved search feature.
 type searchConfig struct {
+	// Max number saved searches per user.
 	maxOwnedSearchesPerUser uint32
+	// Max number of bookmarks per user (excluding the saved searches they own)
+	maxBookmarksPerUser uint32
 }
 
 const defaultMaxOwnedSearchesPerUser = 25
+const defaultMaxBookmarksPerUser = 25
 const defaultBatchSize = 10000
 const defaultBatchWriters = 8
 
@@ -193,7 +197,10 @@ func NewSpannerClient(projectID string, instanceID string, name string) (*Client
 		client,
 		GCPFeatureSearchBaseQuery{},
 		GCPMissingOneImplementationQuery{},
-		searchConfig{maxOwnedSearchesPerUser: defaultMaxOwnedSearchesPerUser},
+		searchConfig{
+			maxOwnedSearchesPerUser: defaultMaxOwnedSearchesPerUser,
+			maxBookmarksPerUser:     defaultMaxBookmarksPerUser,
+		},
 		bw,
 		defaultBatchSize,
 		defaultBatchWriters,
@@ -730,6 +737,7 @@ type entityRemover[
 }
 
 // remove performs an delete operation on an entity.
+// nolint: unused // TODO: Remove nolint directive once the method is used.
 func (c *entityRemover[M, ExternalStruct, SpannerStruct, ExternalKey]) remove(ctx context.Context,
 	input ExternalStruct) error {
 	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {

--- a/lib/gcpspanner/user_search_bookmarks_test.go
+++ b/lib/gcpspanner/user_search_bookmarks_test.go
@@ -16,14 +16,29 @@ package gcpspanner
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"cloud.google.com/go/spanner"
 )
 
+func assertUserSearchSearchWithBookmarkStatus(
+	ctx context.Context, t *testing.T, expectedSavedSearch *UserSavedSearch, savedSearchID *string, userID string) {
+	actual, err := spannerClient.GetUserSavedSearch(ctx, *savedSearchID, valuePtr(userID))
+	if err != nil {
+		t.Errorf("expected nil error. received %s", err)
+	}
+	if !userSavedSearchEquality(expectedSavedSearch, actual) {
+		t.Errorf("different saved searches\nexpected: %+v\nreceived: %v", expectedSavedSearch, actual)
+	}
+}
+
 func TestUserSearchBookmark(t *testing.T) {
 	restartDatabaseContainer(t)
 	ctx := context.Background()
+
+	// Reset the max bookmarks to 1.
+	spannerClient.searchCfg.maxBookmarksPerUser = 1
 
 	savedSearchID, err := spannerClient.CreateNewUserSavedSearch(ctx, CreateUserSavedSearchRequest{
 		Name:        "my little search",
@@ -38,10 +53,23 @@ func TestUserSearchBookmark(t *testing.T) {
 		t.Fatal("expected non-nil id.")
 	}
 
-	const testUser = "test-user"
+	savedSearchID2, err := spannerClient.CreateNewUserSavedSearch(ctx, CreateUserSavedSearchRequest{
+		Name:        "my big search",
+		Query:       "group:html",
+		OwnerUserID: "userID1",
+		Description: nil,
+	})
+	if err != nil {
+		t.Errorf("expected nil error. received %s", err)
+	}
+	if savedSearchID2 == nil {
+		t.Fatal("expected non-nil id.")
+	}
 
+	var testUserSavedSearchID *string
+	const testUser = "test-user"
 	// user initially does not have a bookmark
-	expectedSavedSearch := &UserSavedSearch{
+	expectedSavedSearchBeforeBookmark := &UserSavedSearch{
 		IsBookmarked: valuePtr(false),
 		Role:         nil,
 		SavedSearch: SavedSearch{
@@ -56,59 +84,106 @@ func TestUserSearchBookmark(t *testing.T) {
 			UpdatedAt: spanner.CommitTimestamp,
 		},
 	}
-	actual, err := spannerClient.GetUserSavedSearch(ctx, *savedSearchID, valuePtr(testUser))
-	if err != nil {
-		t.Errorf("expected nil error. received %s", err)
-	}
-	if !userSavedSearchEquality(expectedSavedSearch, actual) {
-		t.Errorf("different saved searches\nexpected: %+v\nreceived: %v", expectedSavedSearch, actual)
-	}
+	t.Run("the test user can see they don't have bookmark status", func(t *testing.T) {
+		assertUserSearchSearchWithBookmarkStatus(ctx, t, expectedSavedSearchBeforeBookmark, savedSearchID, testUser)
+	})
 
-	// user can successfully have a bookmark added
-	expectedSavedSearchAfter := &UserSavedSearch{
-		IsBookmarked: valuePtr(true),
-		Role:         nil,
-		SavedSearch: SavedSearch{
-			ID:          *savedSearchID,
-			Name:        "my little search",
-			Query:       "group:css",
-			Scope:       "USER_PUBLIC",
-			AuthorID:    "userID1",
+	t.Run("the test user can bookmark it", func(t *testing.T) {
+		// user can successfully have a bookmark added
+		expectedSavedSearchAfter := &UserSavedSearch{
+			IsBookmarked: valuePtr(true),
+			Role:         nil,
+			SavedSearch: SavedSearch{
+				ID:          *savedSearchID,
+				Name:        "my little search",
+				Query:       "group:css",
+				Scope:       "USER_PUBLIC",
+				AuthorID:    "userID1",
+				Description: nil,
+				// Don't actually compare the last two values.
+				CreatedAt: spanner.CommitTimestamp,
+				UpdatedAt: spanner.CommitTimestamp,
+			},
+		}
+		err = spannerClient.AddUserSearchBookmark(ctx, UserSavedSearchBookmark{
+			UserID:        testUser,
+			SavedSearchID: *savedSearchID,
+		})
+		if err != nil {
+			t.Errorf("expected nil error. received %s", err)
+		}
+
+		assertUserSearchSearchWithBookmarkStatus(ctx, t, expectedSavedSearchAfter, savedSearchID, testUser)
+	})
+
+	t.Run("the test user gets a limit error once it tries to bookmark too many", func(t *testing.T) {
+		err = spannerClient.AddUserSearchBookmark(ctx, UserSavedSearchBookmark{
+			UserID:        testUser,
+			SavedSearchID: *savedSearchID2,
+		})
+		if !errors.Is(err, ErrUserSearchBookmarkLimitExceeded) {
+			t.Errorf("expected ErrUserSearchBookmarkLimitExceeded error. received %s", err)
+		}
+	})
+
+	// Assuming they have not hit the saved search limit. (That is tested in create_user_saved_search_test.go)
+	t.Run("the test user can still make saved searches even after hitting the bookmark limit", func(t *testing.T) {
+		var err error
+		testUserSavedSearchID, err = spannerClient.CreateNewUserSavedSearch(ctx, CreateUserSavedSearchRequest{
+			Name:        "my really big search",
+			Query:       "group:html OR group:css",
+			OwnerUserID: testUser,
 			Description: nil,
-			// Don't actually compare the last two values.
-			CreatedAt: spanner.CommitTimestamp,
-			UpdatedAt: spanner.CommitTimestamp,
-		},
-	}
-	err = spannerClient.AddUserSearchBookmark(ctx, UserSavedSearchBookmark{
-		UserID:        testUser,
-		SavedSearchID: *savedSearchID,
+		})
+		if err != nil {
+			t.Errorf("expected nil error. received %s", err)
+		}
+		if testUserSavedSearchID == nil {
+			t.Fatal("expected non-nil id.")
+		}
 	})
-	if err != nil {
-		t.Errorf("expected nil error. received %s", err)
-	}
-	actual, err = spannerClient.GetUserSavedSearch(ctx, *savedSearchID, valuePtr(testUser))
-	if err != nil {
-		t.Errorf("expected nil error. received %s", err)
-	}
-	if !userSavedSearchEquality(expectedSavedSearchAfter, actual) {
-		t.Errorf("different saved searches\nexpected: %+v\nreceived: %v", expectedSavedSearchAfter, actual)
-	}
 
-	// user can successfully have a bookmark removed
-	err = spannerClient.DeleteUserSearchBookmark(ctx, UserSavedSearchBookmark{
-		UserID:        testUser,
-		SavedSearchID: *savedSearchID,
+	t.Run("the test user can remove a bookmark for a saved search they don't own", func(t *testing.T) {
+		err = spannerClient.DeleteUserSearchBookmark(ctx, UserSavedSearchBookmark{
+			UserID:        testUser,
+			SavedSearchID: *savedSearchID,
+		})
+		if err != nil {
+			t.Errorf("expected nil error. received %s", err)
+		}
+
+		assertUserSearchSearchWithBookmarkStatus(ctx, t, expectedSavedSearchBeforeBookmark, savedSearchID, testUser)
 	})
-	if err != nil {
-		t.Errorf("expected nil error. received %s", err)
-	}
-	actual, err = spannerClient.GetUserSavedSearch(ctx, *savedSearchID, valuePtr(testUser))
-	if err != nil {
-		t.Errorf("expected nil error. received %s", err)
-	}
-	if !userSavedSearchEquality(expectedSavedSearch, actual) {
-		t.Errorf("different saved searches\nexpected: %+v\nreceived: %v", expectedSavedSearch, actual)
-	}
 
+	t.Run("the test user gets ErrQueryReturnedNoResults when trying to remove bookmark that does not exist (anymore)",
+		func(t *testing.T) {
+			err = spannerClient.DeleteUserSearchBookmark(ctx, UserSavedSearchBookmark{
+				UserID:        testUser,
+				SavedSearchID: *savedSearchID,
+			})
+			if !errors.Is(err, ErrQueryReturnedNoResults) {
+				t.Errorf("expected ErrQueryReturnedNoResults error. received %s", err)
+			}
+		})
+
+	t.Run("the test user gets ErrQueryReturnedNoResults when trying to add a bookmark for search that does not exist",
+		func(t *testing.T) {
+			err = spannerClient.AddUserSearchBookmark(ctx, UserSavedSearchBookmark{
+				UserID:        testUser,
+				SavedSearchID: "fake-uuid",
+			})
+			if !errors.Is(err, ErrQueryReturnedNoResults) {
+				t.Errorf("expected ErrQueryReturnedNoResults error. received %s", err)
+			}
+		})
+
+	t.Run("the test user cannot remove a bookmark for a saved search they own", func(t *testing.T) {
+		err = spannerClient.DeleteUserSearchBookmark(ctx, UserSavedSearchBookmark{
+			UserID:        testUser,
+			SavedSearchID: *testUserSavedSearchID,
+		})
+		if !errors.Is(err, ErrOwnerCannotDeleteBookmark) {
+			t.Errorf("expected ErrOwnerCannotDeleteBookmark error. received %s", err)
+		}
+	})
 }


### PR DESCRIPTION
# Change 1: Limit number of bookmarks

We already have a limit for the number of saved searches a user can own.

This code adds a new configuration for the number of bookmarks they can have.

In addition to the 25 saved searches they can own, they also can bookmark 25 other saved searches that they don't own.


# Change 2: Prevent bookmark removal of owned searches

When a user creates a saved search, they are automatically bookmarked (Similar to [issue tracker](https://developers.google.com/issue-tracker/guides/work-with-hotlist#:~:text=Hotlists%20that%20you%20own%20are%20starred%20automatically)).

And in Issue Tracker, you can't remove the star if you are the admin. This change adds the same type of check.