### PR TITLE
Add missing frontend client code & remove extra route

### DIFF
--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -137,17 +137,6 @@ type Server struct {
 	operationResponseCaches *operationResponseCaches
 }
 
-// GetUserSavedSearchBookmark implements backend.StrictServerInterface.
-// nolint: revive, ireturn // Name generated from openapi
-func (s *Server) GetUserSavedSearchBookmark(
-	ctx context.Context, request backend.GetUserSavedSearchBookmarkRequestObject) (
-	backend.GetUserSavedSearchBookmarkResponseObject, error) {
-	return backend.GetUserSavedSearchBookmark400JSONResponse{
-		Code:    http.StatusBadRequest,
-		Message: "TODO",
-	}, nil
-}
-
 // PutUserSavedSearchBookmark implements backend.StrictServerInterface.
 // nolint: revive, ireturn // Name generated from openapi
 func (s *Server) PutUserSavedSearchBookmark(

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -761,15 +761,6 @@ func (m *mockServerInterface) GetSavedSearch(ctx context.Context, _ backend.GetS
 	panic("unimplemented")
 }
 
-// GetUserSavedSearchBookmark implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
-func (m *mockServerInterface) GetUserSavedSearchBookmark(ctx context.Context,
-	_ backend.GetUserSavedSearchBookmarkRequestObject) (backend.GetUserSavedSearchBookmarkResponseObject, error) {
-	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
-	m.callCount++
-	panic("unimplemented")
-}
-
 // ListAggregatedFeatureSupport implements backend.StrictServerInterface.
 // nolint: ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListAggregatedFeatureSupport(ctx context.Context,

--- a/frontend/src/static/js/api/client.ts
+++ b/frontend/src/static/js/api/client.ts
@@ -72,6 +72,13 @@ type PageMetadataWithTotal = components['schemas']['PageMetadataWithTotal'];
 
 type ManualOffsetPagination = (offset: number) => string;
 
+export type UpdateSavedSearchInput = {
+  id: string;
+  name?: string;
+  description?: string | null;
+  query?: string;
+};
+
 /**
  * Iterable list of browsers we have data for.
  * This is the same as the items in the BrowsersParameter enum,
@@ -614,6 +621,143 @@ export class APIClient {
       throw createAPIError(error);
     }
 
+    return response.data;
+  }
+
+  public async removeSavedSearchByID(searchID: string, token: string) {
+    const options = {
+      ...temporaryFetchOptions,
+      params: {
+        path: {
+          search_id: searchID,
+        },
+      },
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    };
+    const response = await this.client.DELETE(
+      '/v1/saved-searches/{search_id}',
+      options,
+    );
+    const error = response.error;
+    if (error !== undefined) {
+      throw createAPIError(error);
+    }
+
+    return response.data;
+  }
+
+  public async putUserSavedSearchBookmark(searchID: string, token: string) {
+    const options = {
+      ...temporaryFetchOptions,
+      params: {
+        path: {
+          search_id: searchID,
+        },
+      },
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    };
+    const response = await this.client.PUT(
+      '/v1/users/me/saved-searches/{search_id}/bookmark_status',
+      options,
+    );
+    const error = response.error;
+    if (error !== undefined) {
+      throw createAPIError(error);
+    }
+
+    return response.data;
+  }
+
+  public async removeUserSavedSearchBookmark(searchID: string, token: string) {
+    const options = {
+      ...temporaryFetchOptions,
+      params: {
+        path: {
+          search_id: searchID,
+        },
+      },
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    };
+    const response = await this.client.DELETE(
+      '/v1/users/me/saved-searches/{search_id}/bookmark_status',
+      options,
+    );
+    const error = response.error;
+    if (error !== undefined) {
+      throw createAPIError(error);
+    }
+
+    return response.data;
+  }
+
+  public async createSavedSearch(
+    token: string,
+    savedSearch: components['schemas']['SavedSearch'],
+  ): Promise<components['schemas']['SavedSearchResponse']> {
+    const options: FetchOptions<
+      FilterKeys<paths['/v1/saved-searches'], 'post'>
+    > = {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      body: savedSearch,
+      credentials: temporaryFetchOptions.credentials,
+    };
+    const response = await this.client.POST('/v1/saved-searches', options);
+    const error = response.error;
+    if (error !== undefined) {
+      throw createAPIError(error);
+    }
+    return response.data;
+  }
+
+  public async updateSavedSearch(
+    savedSearch: UpdateSavedSearchInput,
+    token: string,
+  ): Promise<components['schemas']['SavedSearchResponse']> {
+    const req: components['schemas']['SavedSearchUpdateRequest'] = {
+      update_mask: [],
+    };
+    if (savedSearch.name !== undefined) {
+      req.update_mask.push('name');
+      req.name = savedSearch.name;
+    }
+    if (savedSearch.description !== undefined) {
+      req.update_mask.push('description');
+      req.description = savedSearch.description;
+    }
+    if (savedSearch.query !== undefined) {
+      req.update_mask.push('query');
+      req.query = savedSearch.query;
+    }
+    const options: FetchOptions<
+      FilterKeys<paths['/v1/saved-searches/{search_id}'], 'patch'>
+    > = {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      params: {
+        path: {
+          search_id: savedSearch.id,
+        },
+      },
+      body: req,
+      credentials: temporaryFetchOptions.credentials,
+    };
+    const response = await this.client.PATCH(
+      '/v1/saved-searches/{search_id}',
+      options,
+    );
+    const error = response.error;
+    if (error !== undefined) {
+      throw createAPIError(error);
+    }
     return response.data;
   }
 }

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -615,10 +615,6 @@ paths:
       responses:
         '200':
           description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UserSavedSearchBookmark'
         '400':
           description: Bad Input
           content:

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -609,48 +609,6 @@ paths:
         required: true
         schema:
           type: string
-    get:
-      summary: Get a user's bookmark status
-      operationId: getUserSavedSearchBookmark
-      security:
-        - bearerAuth: []
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UserSavedSearchBookmark'
-        '400':
-          description: Bad Input
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BasicErrorModel'
-        '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BasicErrorModel'
-        '403':
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BasicErrorModel'
-        '404':
-          description: Not Found (saved search does not exist)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BasicErrorModel'
-        '500':
-          description: Internal Service Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BasicErrorModel'
     put:
       summary: Add bookmark status for a particular saved search.
       operationId: putUserSavedSearchBookmark


### PR DESCRIPTION
Change 1:
- This change adds the rest of the client code to call the remaining openapi methods for saved searches and bookmarks.
- You will see that for the update saved search, it handles the update mask and allows the description to be set to null which will clear it out

Change 2:
- Remove the extra route to get the bookmark status. Instead, the user will use the existing getSavedSearch/listUserSavedSearches (while authenticated) which will contain the user's bookmark status. When we list out the bookmarks for the side bar, we already have the status in that response. No need to get it again.

Change 3:
- Remove the response body for the 200 response for the put request for bookmark status since the user will be getting that from the getSavedSearch/listUserSavedSearches operations