### PR TITLE
Add adapter logic to handle bookmark operations

### DIFF
--- a/lib/gcpspanner/spanneradapters/backendtypes/types.go
+++ b/lib/gcpspanner/spanneradapters/backendtypes/types.go
@@ -26,6 +26,10 @@ var (
 	// number of allowed saved searches.
 	ErrUserMaxSavedSearches = errors.New("user has reached the maximum number of allowed saved searches")
 
+	// ErrUserMaxBookmarks indicates the user has reached the maximum
+	// number of allowed bookmarks.
+	ErrUserMaxBookmarks = errors.New("user has reached the maximum number of allowed bookmarks")
+
 	// ErrUserNotAuthorizedForAction indicates the user is not authorized to execute the requested action.
 	ErrUserNotAuthorizedForAction = errors.New("user not authorized to execute action")
 


### PR DESCRIPTION
This change adds the adapter logic for the [putUserSavedSearchBookmark](https://github.com/GoogleChrome/webstatus.dev/blob/80e7bccea843ad8d02dd9a662c89143d650c06a8/openapi/backend/openapi.yaml#L656) and [removeUserSavedSearchBookmark](https://github.com/GoogleChrome/webstatus.dev/blob/80e7bccea843ad8d02dd9a662c89143d650c06a8/openapi/backend/openapi.yaml#L696) operations.

PutUserSavedSearchBookmark handles converting the errors from spanner for 1) bookmark limit exceeded and 2) entity does not exist to errors that the http layer will use to return the appropriate status code

RemoveUserSavedSearchBookmark handles converting the errors from spanner for 1) saved search owner cannot delete bookmark and 2) entity does not exist to errors that the http layer will use to return the appropriate status code