### PR TITLE
Bug Fix: handle non existent data field in paginated data

### DIFF
--- a/e2e/tests/overview-page.spec.ts
+++ b/e2e/tests/overview-page.spec.ts
@@ -15,7 +15,11 @@
  */
 
 import {test, expect, Request} from '@playwright/test';
-import {gotoOverviewPageUrl, getOverviewPageFeatureCount} from './utils';
+import {
+  gotoOverviewPageUrl,
+  getOverviewPageFeatureCount,
+  loginAsUser,
+} from './utils';
 
 test('matches the screenshot', async ({page}) => {
   await gotoOverviewPageUrl(page, 'http://localhost:5555/');
@@ -256,6 +260,22 @@ test('Typing slash focuses on searchbox', async ({page}) => {
   // The slash focuses on the searchbox.
   // Later characters, including slashes, go in the searchbox.
   await expect(searchbox).toHaveAttribute('value', 'def/ghi');
+});
+
+test('newly logged in user should see no errors (toasts or in console)', async ({
+  page,
+}) => {
+  const errors: string[] = [];
+
+  page.on('console', msg => {
+    if (msg.type() === 'error') {
+      errors.push(msg.text());
+    }
+  });
+  await loginAsUser(page, 'fresh user');
+  await gotoOverviewPageUrl(page, 'http://localhost:5555/');
+  await expect(page.locator('.toast')).toHaveCount(0);
+  expect(errors).toEqual([]);
 });
 
 test.describe('saved searches', () => {

--- a/e2e/tests/overview-page.spec.ts
+++ b/e2e/tests/overview-page.spec.ts
@@ -262,20 +262,10 @@ test('Typing slash focuses on searchbox', async ({page}) => {
   await expect(searchbox).toHaveAttribute('value', 'def/ghi');
 });
 
-test('newly logged in user should see no errors (toasts or in console)', async ({
-  page,
-}) => {
-  const errors: string[] = [];
-
-  page.on('console', msg => {
-    if (msg.type() === 'error') {
-      errors.push(msg.text());
-    }
-  });
+test('newly logged in user should see no errors (toasts)', async ({page}) => {
   await loginAsUser(page, 'fresh user');
   await gotoOverviewPageUrl(page, 'http://localhost:5555/');
   await expect(page.locator('.toast')).toHaveCount(0);
-  expect(errors).toEqual([]);
 });
 
 test.describe('saved searches', () => {

--- a/frontend/src/static/js/api/client.ts
+++ b/frontend/src/static/js/api/client.ts
@@ -269,7 +269,7 @@ export class APIClient {
       );
 
       nextPageToken = page?.metadata?.next_page_token;
-      allData.push(...page.data);
+      allData.push(...(page.data ?? []));
       offset += (page.data || []).length;
     } while (nextPageToken !== undefined);
 

--- a/util/cmd/load_test_users/main.go
+++ b/util/cmd/load_test_users/main.go
@@ -116,9 +116,10 @@ func getUsers() []User {
 			EmailVerified: true,
 			UserID:        "abcdedf1234567892",
 		},
+		// This user should have no data and should be used to replicate the experience of a newly logged in user.
 		{
-			Name:          "test user 3",
-			Email:         "test.user.3@example.com",
+			Name:          "fresh user",
+			Email:         "fresh.user@example.com",
 			EmailVerified: true,
 			UserID:        "abcdedf1234567893",
 		},


### PR DESCRIPTION
The new `list user saved searches` returns no `data` field in the page if there is none. That list method uses a helper method that does the iteration for us. But previous routes always had a data field in the object

A logged in user will get this error in the console:

```
TypeError: a.data is not iterable (cannot read property undefined)
```

As well as see a toast like this:


![image](https://github.com/user-attachments/assets/4e81f188-6c80-401b-b912-1713f62fa164)


This solves that

---
Long term, we should decide if we should provide the data field for all paginated routes. Even if  there is no data.
