### PR TITLE
Create a new generated npm workspace for typescript ANTLR generated code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ frontend/.postinstall
 lib/gen/*/*/*.go
 lib/gen/*/*/*.ts
 lib/gen/featuresearch/**
+lib/gen/antlrv4/ts-antlrv4/antlr/**
 
 # Ignore coverage files
 coverage

--- a/Makefile
+++ b/Makefile
@@ -247,11 +247,17 @@ node-test: playwright-install
 ################################
 # ANTLR
 ################################
-antlr-gen: clean-antlr
+antlr-gen: clean-antlr antlr-gen-go antlr-gen-ts
+
+antlr-gen-go:
 	java -jar /usr/local/lib/antlr-$${ANTLR4_VERSION}-complete.jar -Dlanguage=Go -o lib/gen/featuresearch/parser -visitor -no-listener antlr/FeatureSearch.g4
+
+antlr-gen-ts:
+	java -jar /usr/local/lib/antlr-$${ANTLR4_VERSION}-complete.jar -Dlanguage=TypeScript -o lib/gen/antlrv4/ts-antlrv4 -visitor antlr/FeatureSearch.g4
 
 clean-antlr:
 	rm -rf lib/gen/featuresearch/parser
+	rm -rf lib/gen/antlrv4/ts-antlrv4/antlr
 
 ################################
 # License

--- a/lib/gen/antlrv4/ts-antlrv4/package.json
+++ b/lib/gen/antlrv4/ts-antlrv4/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@webstatus.dev/ts-antlrv4",
+  "version": "1.0.0",
+  "description": "TypeScript ANTLR4 generated code for webstatus.dev",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "antlr4": "^4.13.1"
+  },
+  "devDependencies": {
+    "@types/antlr4": "^4.9.3",
+    "typescript": "^5.0.0",
+    "rimraf": "^5.0.0"
+  }
+}

--- a/lib/gen/antlrv4/ts-antlrv4/tsconfig.json
+++ b/lib/gen/antlrv4/ts-antlrv4/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "antlr/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "workspaces": [
         "frontend",
-        "lib/gen/openapi/ts-webstatus.dev-backend-types"
+        "lib/gen/openapi/ts-webstatus.dev-backend-types",
+        "lib/gen/antlrv4/ts-antlrv4"
       ],
       "devDependencies": {
         "@playwright/test": "^1.50.1",
@@ -781,6 +782,122 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "lib/gen/antlrv4/ts-antlrv4": {
+      "name": "@webstatus.dev/ts-antlrv4",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "antlr4": "^4.13.1"
+      },
+      "devDependencies": {
+        "@types/antlr4": "^4.9.3",
+        "rimraf": "^5.0.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "lib/gen/antlrv4/ts-antlrv4/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "lib/gen/antlrv4/ts-antlrv4/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "lib/gen/antlrv4/ts-antlrv4/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "lib/gen/antlrv4/ts-antlrv4/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "lib/gen/antlrv4/ts-antlrv4/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "lib/gen/antlrv4/ts-antlrv4/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "lib/gen/antlrv4/ts-antlrv4/node_modules/rimraf": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2236,6 +2353,17 @@
         "lit-html": "^2.0.0 || ^3.0.0"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
@@ -2930,6 +3058,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/antlr4": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/antlr4/-/antlr4-4.11.6.tgz",
+      "integrity": "sha512-YtxtT6vYfLK6jC55zC4Pb2YwV6Z8exn4DbDlQgoSEc6VqlFZloi6bgm0AqZns/7U4XQCAVMhv/+vnGcfyCkPfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__code-frame": {
       "version": "7.0.6",
@@ -3798,6 +3933,10 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@webstatus.dev/ts-antlrv4": {
+      "resolved": "lib/gen/antlrv4/ts-antlrv4",
+      "link": true
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3949,6 +4088,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/antlr4": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.2.tgz",
+      "integrity": "sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/arg": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "license": "Apache-2.0",
   "workspaces": [
     "frontend",
-    "lib/gen/openapi/ts-webstatus.dev-backend-types"
+    "lib/gen/openapi/ts-webstatus.dev-backend-types",
+    "lib/gen/antlrv4/ts-antlrv4"
   ],
   "devDependencies": {
     "@playwright/test": "^1.50.1",


### PR DESCRIPTION
## Context

As described in #716, we're looking for opportunities to do some client side search query validation or autocompletion, so we need to be able to get ANTLR generated code from the typescript side. This PR will unlock #717 and #718

## Changes
- Updated the `Makefile` so that it generates TypeScript code to `lib/gen/antlrv4/ts-antlrv4` along with Go code generation
- Updated the overall `package.json` file to include the new workspace - `lib/gen/antlrv4/ts-antlrv4`
- Added `package.json` and `tsconfig.json` to ts-antlrv4 so that it can later be imported into frontend code as well as get compiled.
- Updated `.gitignore` to exclude generated ANTLR files

Screenshot with generated typescript code:

<img width="300" alt="ts-antlrv4" src="https://github.com/user-attachments/assets/5b1c49e7-3e9e-45f7-b3b4-a8f2f732ceee" />


With the changes, we should be able to import the package to frontend with:

package.json (frontend):
```json
"dependencies": {
  "@webstatus.dev/ts-antlrv4": "file:../lib/gen/antlrv4/ts-antlrv4"
}
```

any ts file (frontend):
```ts
import { FeatureSearchLexer } from '@webstatus.dev/ts-antlrv4'
```