### PR TITLE
Adjust backend permissions for spanner

### DIFF
--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -180,7 +180,7 @@ resource "google_project_iam_member" "gcp_datastore_user" {
 }
 
 resource "google_project_iam_member" "gcp_spanner_user" {
-  role     = "roles/spanner.databaseReader"
+  role     = "roles/spanner.databaseUser"
   provider = google.internal_project
   project  = var.datastore_info.project_id
   member   = google_service_account.backend.member


### PR DESCRIPTION
Previously, it was set to [databaseReader](https://cloud.google.com/spanner/docs/iam#spanner.databaseReader). This change sets it to [databaseUser](https://cloud.google.com/spanner/docs/iam#spanner.databaseUser).

In the future, we should explore [fine grained access](https://cloud.google.com/spanner/docs/fgac-about) for per table access.

This is needed for the user saved searches work so the backend machine user can write to the database. 