### PR TITLE
Add POST as an allowed method to CORS policy

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -147,7 +147,7 @@ func main() {
 			//nolint: exhaustruct // No need to use every option of 3rd party struct.
 			cors.Options{
 				AllowedOrigins:   []string{allowedOrigin, "http://*"},
-				AllowedMethods:   []string{"GET", "OPTIONS", "PATCH", "DELETE", "PUT"},
+				AllowedMethods:   []string{"GET", "OPTIONS", "PATCH", "DELETE", "PUT", "POST"},
 				AllowedHeaders:   []string{"Authorization"},
 				AllowCredentials: true, // Remove after UbP
 				MaxAge:           300,  // Maximum value not ignored by any of major browsers


### PR DESCRIPTION
This is needed by [this](https://github.com/GoogleChrome/webstatus.dev/blob/497c3bacf20ffe44b28da835217ec3eba48573cf/openapi/backend/openapi.yaml#L684-L695)

Split up of #1364