### PR TITLE
Refactor: move vocab, adding types, simplify appBookmarkInfo usage

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-overview-content.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-overview-content.test.ts
@@ -14,35 +14,9 @@
  * limitations under the License.
  */
 
-import {provide} from '@lit/context';
-import {LitElement, TemplateResult, html} from 'lit';
-import {customElement, property} from 'lit/decorators.js';
-import {
-  appSettingsContext,
-  AppSettings,
-} from '../../contexts/settings-context.js';
 import {WebstatusOverviewContent} from '../webstatus-overview-content.js';
 import '../webstatus-overview-content.js';
 import {expect} from '@open-wc/testing';
-import {
-  AppBookmarkInfo,
-  appBookmarkInfoContext,
-} from '../../contexts/app-bookmark-info-context.js';
-
-@customElement('fake-parent-element')
-class FakeParentElement extends LitElement {
-  @provide({context: appSettingsContext})
-  @property({type: Object})
-  settings!: AppSettings;
-
-  @provide({context: appBookmarkInfoContext})
-  @property({type: Object})
-  appBookmarkInfo: AppBookmarkInfo = {};
-
-  render(): TemplateResult {
-    return html`<slot></slot>`;
-  }
-}
 
 describe('webstatus-overview-content', () => {
   describe('RenderBookmarkUI', () => {
@@ -54,20 +28,15 @@ describe('webstatus-overview-content', () => {
     it('should display the bookmark title and description when query is matched', async () => {
       container = document.createElement('div');
       container.innerHTML = `
-        <fake-parent-element>
           <webstatus-overview-content>
           </webstatus-overview-content>
-        </fake-parent-element>
       `;
-      const parent: FakeParentElement = container.querySelector(
-        'fake-parent-element',
-      ) as FakeParentElement;
       const element: WebstatusOverviewContent = container.querySelector(
         'webstatus-overview-content',
       ) as WebstatusOverviewContent;
       // Set location to one of the globalBookmarks.
       element.location = {search: '?q=test_query_1'};
-      parent.appBookmarkInfo = {
+      element.appBookmarkInfo = {
         globalBookmarks: [
           {
             name: 'Test Bookmark 1',
@@ -87,7 +56,6 @@ describe('webstatus-overview-content', () => {
         },
       };
       document.body.appendChild(container);
-      await parent.updateComplete;
       await element.updateComplete;
 
       const title = element?.shadowRoot?.querySelector('#overview-title');
@@ -103,20 +71,15 @@ describe('webstatus-overview-content', () => {
     it('should not display description UI when it is empty', async () => {
       container = document.createElement('div');
       container.innerHTML = `
-        <fake-parent-element>
           <webstatus-overview-content>
           </webstatus-overview-content>
-        </fake-parent-element>
       `;
-      const parent: FakeParentElement = container.querySelector(
-        'fake-parent-element',
-      ) as FakeParentElement;
       const element: WebstatusOverviewContent = container.querySelector(
         'webstatus-overview-content',
       ) as WebstatusOverviewContent;
       // Set location to one of the globalBookmarks.
       element.location = {search: '?q=test_query_1'};
-      parent.appBookmarkInfo = {
+      element.appBookmarkInfo = {
         globalBookmarks: [
           {
             name: 'Test Bookmark 1',
@@ -129,7 +92,6 @@ describe('webstatus-overview-content', () => {
         },
       };
       document.body.appendChild(container);
-      await parent.updateComplete;
       await element.updateComplete;
 
       const title = element?.shadowRoot?.querySelector('#overview-title');

--- a/frontend/src/static/js/components/webstatus-overview-content.ts
+++ b/frontend/src/static/js/components/webstatus-overview-content.ts
@@ -23,7 +23,7 @@ import {
   nothing,
 } from 'lit';
 import {TaskStatus} from '@lit/task';
-import {customElement, property, state} from 'lit/decorators.js';
+import {customElement, property} from 'lit/decorators.js';
 import {type components} from 'webstatus.dev-backend';
 
 import './webstatus-overview-filters.js';
@@ -34,10 +34,8 @@ import {TaskTracker} from '../utils/task-tracker.js';
 import {ApiError} from '../api/errors.js';
 import {
   AppBookmarkInfo,
-  appBookmarkInfoContext,
   bookmarkHelpers,
 } from '../contexts/app-bookmark-info-context.js';
-import {consume} from '@lit/context';
 
 @customElement('webstatus-overview-content')
 export class WebstatusOverviewContent extends LitElement {
@@ -51,8 +49,7 @@ export class WebstatusOverviewContent extends LitElement {
   @property({type: Object})
   location!: {search: string}; // Set by parent.
 
-  @consume({context: appBookmarkInfoContext, subscribe: true})
-  @state()
+  @property({type: Object})
   appBookmarkInfo?: AppBookmarkInfo;
 
   static get styles(): CSSResultGroup {
@@ -111,6 +108,7 @@ export class WebstatusOverviewContent extends LitElement {
         <br />
         <webstatus-overview-filters
           .location=${this.location}
+          .appBookmarkInfo=${this.appBookmarkInfo}
         ></webstatus-overview-filters>
         <br />
 

--- a/frontend/src/static/js/components/webstatus-overview-filters.ts
+++ b/frontend/src/static/js/components/webstatus-overview-filters.ts
@@ -61,96 +61,17 @@ import {CSVUtils} from '../utils/csv.js';
 import {Toast} from '../utils/toast.js';
 import {navigateToUrl} from '../utils/app-router.js';
 import {
-  appBookmarkInfoContext,
   AppBookmarkInfo,
   bookmarkHelpers,
 } from '../contexts/app-bookmark-info-context.js';
+import {VOCABULARY} from '../utils/constants.js';
 
 const WEBSTATUS_FEATURE_OVERVIEW_CSV_FILENAME =
   'webstatus-feature-overview.csv';
 
-const VOCABULARY = [
-  {
-    name: 'available_date:chrome:2023-01-01..2024-01-01',
-    doc: 'Became available on Chrome between the given dates',
-  },
-  {
-    name: 'available_date:edge:2023-01-01..2024-01-01',
-    doc: 'Became available on Edge between the given dates',
-  },
-  {
-    name: 'available_date:firefox:2023-01-01..2024-01-01',
-    doc: 'Became available on Firefox between the given dates',
-  },
-  {
-    name: 'available_date:safari:2023-01-01..2024-01-01',
-    doc: 'Became available on Safari between the given dates',
-  },
-  {
-    name: 'available_on:chrome',
-    doc: 'Features available on Chrome',
-  },
-  {
-    name: 'available_on:edge',
-    doc: 'Features available on Edge',
-  },
-  {
-    name: 'available_on:firefox',
-    doc: 'Features available on Firefox',
-  },
-  {
-    name: 'available_on:safari',
-    doc: 'Features available on Safari',
-  },
-  {
-    name: 'baseline_date:2023-01-01..2024-01-01',
-    doc: 'Reached baseline between the given dates',
-  },
-  {
-    name: 'baseline_status:limited',
-    doc: 'Features that are not yet in baseline',
-  },
-  {
-    name: 'baseline_status:newly',
-    doc: 'Features newly added to baseline',
-  },
-  {
-    name: 'baseline_status:widely',
-    doc: 'Features in baseline and widely available',
-  },
-  {
-    name: 'group:',
-    doc: 'Features in a group or its descendants. E.g., group:css',
-  },
-  {
-    name: 'snapshot:',
-    doc: 'Features in a snapshot. E.g., snapshot:ecmascript-5',
-  },
-  {
-    name: 'name:',
-    doc: 'Find by substring of the name. E.g., name:grid',
-  },
-  {
-    name: 'name:"a substring"',
-    doc: 'Find by substring of the name. E.g., name:"CSS Grid"',
-  },
-  {
-    name: 'id:',
-    doc: 'Find by its feature identifier . E.g., id:html',
-  },
-  {
-    name: 'OR',
-    doc: 'Combine query terms with a logical-OR',
-  },
-  {
-    name: '-',
-    doc: 'Negate search term with a leading minus',
-  },
-];
-
 @customElement('webstatus-overview-filters')
 export class WebstatusOverviewFilters extends LitElement {
-  typeaheadRef = createRef();
+  typeaheadRef = createRef<WebstatusTypeahead>();
   @consume({context: apiClientContext})
   @state()
   apiClient?: APIClient;
@@ -158,8 +79,7 @@ export class WebstatusOverviewFilters extends LitElement {
   @property({type: Object})
   location!: {search: string};
 
-  @consume({context: appBookmarkInfoContext, subscribe: true})
-  @state()
+  @property({type: Object})
   appBookmarkInfo?: AppBookmarkInfo;
 
   _activeQuery: string = '';
@@ -253,13 +173,13 @@ export class WebstatusOverviewFilters extends LitElement {
     if (e.key === '/' && !inInputContext) {
       e.preventDefault();
       e.stopPropagation();
-      (this.typeaheadRef?.value as WebstatusTypeahead).focus();
+      this.typeaheadRef?.value?.focus();
     }
   };
 
   gotoFilterQueryString(): void {
     const newUrl = formatOverviewPageUrl(this.location, {
-      q: (this.typeaheadRef.value as WebstatusTypeahead).value,
+      q: this.typeaheadRef.value?.value,
       start: 0,
     });
     navigateToUrl(newUrl);

--- a/frontend/src/static/js/components/webstatus-overview-page.ts
+++ b/frontend/src/static/js/components/webstatus-overview-page.ts
@@ -173,6 +173,7 @@ export class OverviewPage extends LitElement {
       <webstatus-overview-content
         .location=${this.location}
         .taskTracker=${this.taskTracker}
+        .appBookmarkInfo=${this.appBookmarkInfo}
       >
       </webstatus-overview-content>
     `;

--- a/frontend/src/static/js/components/webstatus-typeahead.ts
+++ b/frontend/src/static/js/components/webstatus-typeahead.ts
@@ -55,8 +55,8 @@ interface VocabularyItem {
 
 @customElement('webstatus-typeahead')
 export class WebstatusTypeahead extends LitElement {
-  slDropdownRef = createRef();
-  slInputRef = createRef();
+  slDropdownRef = createRef<WebstatusTypeaheadDropdown>();
+  slInputRef = createRef<SlInput>();
 
   @property()
   value: string;
@@ -122,30 +122,27 @@ export class WebstatusTypeahead extends LitElement {
     if (event) {
       event.stopPropagation();
     }
-    const slInput: SlInput = this.slInputRef.value as SlInput;
-    this.value = slInput.value;
+    this.value = this.slInputRef.value!.value;
   }
 
   async hide() {
-    await (this.slDropdownRef.value as SlDropdown).hide();
+    await this.slDropdownRef.value?.hide();
   }
 
   async show() {
-    await (this.slDropdownRef.value as SlDropdown).show();
+    await this.slDropdownRef.value?.show();
   }
 
   focus() {
-    const slInput: SlInput = this.slInputRef.value as SlInput;
-    slInput?.focus();
+    this.slInputRef.value?.focus();
   }
 
   blur() {
-    const slInput: SlInput = this.slInputRef.value as SlInput;
-    slInput?.blur();
+    this.slInputRef.value?.blur();
   }
 
   findPrefix() {
-    const inputEl = (this.slInputRef.value as SlInput).input;
+    const inputEl = this.slInputRef.value!.input;
     const wholeStr = inputEl!.value;
     const caret = inputEl.selectionStart;
     if (caret === null || caret !== inputEl.selectionEnd) {
@@ -180,14 +177,14 @@ export class WebstatusTypeahead extends LitElement {
 
   async handleCandidateSelected(e: {detail: {item: SlMenuItem}}) {
     const candidateValue = e.detail!.item!.value;
-    const inputEl = (this.slInputRef.value as SlInput).input;
+    const inputEl = this.slInputRef.value!.input;
     const wholeStr = inputEl.value;
     // Don't add a space after the completed value: let the user type it.
     const newWholeStr =
       wholeStr.substring(0, this.chunkStart) +
       candidateValue +
       wholeStr.substring(this.chunkEnd, wholeStr.length);
-    (this.slInputRef.value as SlInput).value = newWholeStr;
+    this.slInputRef.value!.value = newWholeStr;
     this.reflectValue();
     // Wait for the sl-input to propagate its new value to its <input> before
     // setting or accessing the text selection.
@@ -211,7 +208,7 @@ export class WebstatusTypeahead extends LitElement {
   // on keyDown so that the handler is run before the dropdown keyDown is run.
   handleInputFieldKeyDown(event: KeyboardEvent) {
     if (event.key === 'Enter') {
-      const slDropdown = this.slDropdownRef.value as WebstatusTypeaheadDropdown;
+      const slDropdown = this.slDropdownRef.value!;
       if (!slDropdown.open || !slDropdown.getCurrentItem()) {
         this._fireEvent('sl-change', this);
         event.stopPropagation();
@@ -243,7 +240,7 @@ export class WebstatusTypeahead extends LitElement {
     this.candidates = this.vocabulary.filter(c =>
       this.shouldShowCandidate(c, this.prefix),
     );
-    const slDropdown = this.slDropdownRef.value as SlDropdown;
+    const slDropdown = this.slDropdownRef.value!;
     if (
       this.candidates.length > 0 &&
       !this.wasDismissed &&

--- a/frontend/src/static/js/utils/constants.ts
+++ b/frontend/src/static/js/utils/constants.ts
@@ -94,3 +94,82 @@ export const DEFAULT_BOOKMARKS: Bookmark[] = [
     override_num_param: 25,
   },
 ];
+
+export const VOCABULARY = [
+  {
+    name: 'available_date:chrome:2023-01-01..2024-01-01',
+    doc: 'Became available on Chrome between the given dates',
+  },
+  {
+    name: 'available_date:edge:2023-01-01..2024-01-01',
+    doc: 'Became available on Edge between the given dates',
+  },
+  {
+    name: 'available_date:firefox:2023-01-01..2024-01-01',
+    doc: 'Became available on Firefox between the given dates',
+  },
+  {
+    name: 'available_date:safari:2023-01-01..2024-01-01',
+    doc: 'Became available on Safari between the given dates',
+  },
+  {
+    name: 'available_on:chrome',
+    doc: 'Features available on Chrome',
+  },
+  {
+    name: 'available_on:edge',
+    doc: 'Features available on Edge',
+  },
+  {
+    name: 'available_on:firefox',
+    doc: 'Features available on Firefox',
+  },
+  {
+    name: 'available_on:safari',
+    doc: 'Features available on Safari',
+  },
+  {
+    name: 'baseline_date:2023-01-01..2024-01-01',
+    doc: 'Reached baseline between the given dates',
+  },
+  {
+    name: 'baseline_status:limited',
+    doc: 'Features that are not yet in baseline',
+  },
+  {
+    name: 'baseline_status:newly',
+    doc: 'Features newly added to baseline',
+  },
+  {
+    name: 'baseline_status:widely',
+    doc: 'Features in baseline and widely available',
+  },
+  {
+    name: 'group:',
+    doc: 'Features in a group or its descendants. E.g., group:css',
+  },
+  {
+    name: 'snapshot:',
+    doc: 'Features in a snapshot. E.g., snapshot:ecmascript-5',
+  },
+  {
+    name: 'name:',
+    doc: 'Find by substring of the name. E.g., name:grid',
+  },
+  {
+    name: 'name:"a substring"',
+    doc: 'Find by substring of the name. E.g., name:"CSS Grid"',
+  },
+  {
+    name: 'id:',
+    doc: 'Find by its feature identifier . E.g., id:html',
+  },
+  {
+    name: 'OR',
+    doc: 'Combine query terms with a logical-OR',
+  },
+  {
+    name: '-',
+    doc: 'Negate search term with a leading minus',
+  },
+];


### PR DESCRIPTION
This change is a small refactor to a few small parts I saw while doing #1364

1. Move the vocabulary to the constants file.
  - In the future, it will be used in other places, so I moved it to the constants file
2. Adding some types so we don't have to do type assertions
  - It also points out that the ref can be of type `T | undefined`. For now, assume that it is always defined like before. We can revisit later if needed.
3. Previously, multiple components were subscribed to the appBookmarkInfo context. But really, we could just have one component subscribe and pass it down. That's what that change does.