### PR TITLE
fixup: Add missing bearerAuth security requirement for bookmark endpoints

### DIFF
--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -612,6 +612,8 @@ paths:
     put:
       summary: Add bookmark status for a particular saved search.
       operationId: putUserSavedSearchBookmark
+      security:
+        - bearerAuth: []
       responses:
         '200':
           description: OK
@@ -648,6 +650,8 @@ paths:
     delete:
       summary: Remove bookmark status for a particular saved search.
       operationId: removeUserSavedSearchBookmark
+      security:
+        - bearerAuth: []
       responses:
         '204':
           description: No Content


### PR DESCRIPTION
This change adds the bearerAuth security requirement to the bookmark endpoints. Other endpoints have it but I missed these two. Without this change, those endpoints will get a 500 response code because it could not find the security requirement.

This comes from the split up of #1364