### PR TITLE
refactor: begin renaming bookmark to saved searches

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-overview-content.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-overview-content.test.ts
@@ -34,10 +34,10 @@ describe('webstatus-overview-content', () => {
       const element: WebstatusOverviewContent = container.querySelector(
         'webstatus-overview-content',
       ) as WebstatusOverviewContent;
-      // Set location to one of the globalBookmarks.
+      // Set location to one of the globalSavedSearches.
       element.location = {search: '?q=test_query_1'};
       element.appBookmarkInfo = {
-        globalBookmarks: [
+        globalSavedSearches: [
           {
             name: 'Test Bookmark 1',
             query: 'test_query_1',
@@ -49,7 +49,7 @@ describe('webstatus-overview-content', () => {
             description: 'test description2',
           },
         ],
-        currentGlobalBookmark: {
+        currentGlobalSavedSearch: {
           name: 'Test Bookmark 1',
           query: 'test_query_1',
           description: 'test description1',
@@ -77,16 +77,16 @@ describe('webstatus-overview-content', () => {
       const element: WebstatusOverviewContent = container.querySelector(
         'webstatus-overview-content',
       ) as WebstatusOverviewContent;
-      // Set location to one of the globalBookmarks.
+      // Set location to one of the globalSavedSearches.
       element.location = {search: '?q=test_query_1'};
       element.appBookmarkInfo = {
-        globalBookmarks: [
+        globalSavedSearches: [
           {
             name: 'Test Bookmark 1',
             query: 'test_query_1',
           },
         ],
-        currentGlobalBookmark: {
+        currentGlobalSavedSearch: {
           name: 'Test Bookmark 1',
           query: 'test_query_1',
         },

--- a/frontend/src/static/js/components/test/webstatus-overview-filters.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-overview-filters.test.ts
@@ -31,13 +31,13 @@ import {WebstatusOverviewFilters} from '../webstatus-overview-filters.js';
 import {APIClient} from '../../api/client.js';
 
 import {stub} from 'sinon'; // Make sure you have sinon installed
-import {bookmarkHelpers} from '../../contexts/app-bookmark-info-context.js';
+import {savedSearchHelpers} from '../../contexts/app-bookmark-info-context.js';
 
 it('should correctly update _activeQuery based on getCurrentQuery return value', async () => {
   const apiClient = new APIClient('');
   const location = {search: ''};
 
-  const getCurrentQueryStub = stub(bookmarkHelpers, 'getCurrentQuery');
+  const getCurrentQueryStub = stub(savedSearchHelpers, 'getCurrentQuery');
 
   // Test case 1: Empty query
   getCurrentQueryStub.returns('');

--- a/frontend/src/static/js/components/test/webstatus-overview-table.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-overview-table.test.ts
@@ -23,12 +23,12 @@ import {WebstatusOverviewTable} from '../webstatus-overview-table.js';
 import '../webstatus-overview-table.js';
 import {
   CurrentSavedSearch,
-  SavedSearchType,
+  SavedSearchScope,
 } from '../../contexts/app-bookmark-info-context.js';
 
 describe('webstatus-overview-table', () => {
   const orderedSavedSearch: CurrentSavedSearch = {
-    type: SavedSearchType.GlobalSavedSearch,
+    scope: SavedSearchScope.GlobalSavedSearch,
     value: {
       name: 'Ordered Bookmark 1',
       query: 'name:test3 OR id:test1 OR id:test2',
@@ -37,7 +37,7 @@ describe('webstatus-overview-table', () => {
     },
   };
   const defaultOrderSavedSearch: CurrentSavedSearch = {
-    type: SavedSearchType.GlobalSavedSearch,
+    scope: SavedSearchScope.GlobalSavedSearch,
     value: {
       name: 'No order Bookmark 2',
       query: 'id:nothing',
@@ -114,7 +114,7 @@ describe('webstatus-overview-table', () => {
     const cssQuery =
       'id:anchor-positioning OR id:container-queries OR id:has OR id:nesting OR id:view-transitions OR id:subgrid OR id:grid OR name:scrollbar OR id:scroll-driven-animations OR id:scope';
     const cssSavedSearch: CurrentSavedSearch = {
-      type: SavedSearchType.GlobalSavedSearch,
+      scope: SavedSearchScope.GlobalSavedSearch,
       value: {
         name: 'css',
         query: cssQuery,

--- a/frontend/src/static/js/components/test/webstatus-overview-table.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-overview-table.test.ts
@@ -21,19 +21,29 @@ import {ApiError} from '../../api/errors.js';
 import {TaskStatus} from '@lit/task';
 import {WebstatusOverviewTable} from '../webstatus-overview-table.js';
 import '../webstatus-overview-table.js';
+import {
+  CurrentSavedSearch,
+  SavedSearchType,
+} from '../../contexts/app-bookmark-info-context.js';
 
 describe('webstatus-overview-table', () => {
-  const orderedBookmark = {
-    name: 'Ordered Bookmark 1',
-    query: 'name:test3 OR id:test1 OR id:test2',
-    description: 'test description1',
-    is_ordered: true,
+  const orderedSavedSearch: CurrentSavedSearch = {
+    type: SavedSearchType.GlobalSavedSearch,
+    value: {
+      name: 'Ordered Bookmark 1',
+      query: 'name:test3 OR id:test1 OR id:test2',
+      description: 'test description1',
+      is_ordered: true,
+    },
   };
-  const defaultOrderBookmark = {
-    name: 'No order Bookmark 2',
-    query: 'id:nothing',
-    description: 'test description1',
-    is_ordered: false,
+  const defaultOrderSavedSearch: CurrentSavedSearch = {
+    type: SavedSearchType.GlobalSavedSearch,
+    value: {
+      name: 'No order Bookmark 2',
+      query: 'id:nothing',
+      description: 'test description1',
+      is_ordered: false,
+    },
   };
   const page = {
     data: [
@@ -82,7 +92,7 @@ describe('webstatus-overview-table', () => {
       await fixture<WebstatusOverviewTable>(
         html`<webstatus-overview-table
           .location=${location}
-          .bookmark=${orderedBookmark}
+          .savedSearch=${orderedSavedSearch}
           .taskTracker=${taskTracker}
         ></webstatus-overview-table>`,
       );
@@ -100,14 +110,17 @@ describe('webstatus-overview-table', () => {
     expect(sortedFeatures[3].feature_id).to.equal('test2');
   });
 
-  it('reorderByQueryTerms() sorts correctly with DEFAULT_BOOKMARKS', async () => {
+  it('reorderByQueryTerms() sorts correctly with DEFAULT_GLOBAL_SAVED_SEARCHES', async () => {
     const cssQuery =
       'id:anchor-positioning OR id:container-queries OR id:has OR id:nesting OR id:view-transitions OR id:subgrid OR id:grid OR name:scrollbar OR id:scroll-driven-animations OR id:scope';
-    const cssBookmark = {
-      name: 'css',
-      query: cssQuery,
-      description: 'test description1',
-      is_ordered: true,
+    const cssSavedSearch: CurrentSavedSearch = {
+      type: SavedSearchType.GlobalSavedSearch,
+      value: {
+        name: 'css',
+        query: cssQuery,
+        description: 'test description1',
+        is_ordered: true,
+      },
     };
     const cssPage = {
       data: [
@@ -177,7 +190,7 @@ describe('webstatus-overview-table', () => {
       await fixture<WebstatusOverviewTable>(
         html`<webstatus-overview-table
           .location=${location}
-          .bookmark=${cssBookmark}
+          .savedSearch=${cssSavedSearch}
           .taskTracker=${cssTaskTracker}
         ></webstatus-overview-table>`,
       );
@@ -208,7 +221,7 @@ describe('webstatus-overview-table', () => {
     const component = await fixture<WebstatusOverviewTable>(
       html`<webstatus-overview-table
         .location=${location}
-        .bookmark=${defaultOrderBookmark}
+        .savedSearch=${defaultOrderSavedSearch}
         .taskTracker=${taskTracker}
       ></webstatus-overview-table>`,
     );

--- a/frontend/src/static/js/components/webstatus-overview-cells.ts
+++ b/frontend/src/static/js/components/webstatus-overview-cells.ts
@@ -525,13 +525,13 @@ export function renderGroupsRow(columns: ColumnKey[]): TemplateResult {
   `;
 }
 
-export function renderBookmarkHeaderCells(
-  bookmarkName: string,
+export function renderSavedSearchHeaderCells(
+  name: string,
   columns: ColumnKey[],
 ): TemplateResult[] {
   const headerCells: TemplateResult[] = columns.map(col => {
     if (col === ColumnKey.Name) {
-      const title = `Sorted by ${bookmarkName} query order`;
+      const title = `Sorted by ${name} query order`;
       return html`${renderUnsortableHeaderCell(col, title)}`;
     } else {
       return html`${renderUnsortableHeaderCell(col)}`;

--- a/frontend/src/static/js/components/webstatus-overview-content.ts
+++ b/frontend/src/static/js/components/webstatus-overview-content.ts
@@ -34,7 +34,7 @@ import {TaskTracker} from '../utils/task-tracker.js';
 import {ApiError} from '../api/errors.js';
 import {
   AppBookmarkInfo,
-  bookmarkHelpers,
+  savedSearchHelpers,
 } from '../contexts/app-bookmark-info-context.js';
 
 @customElement('webstatus-overview-content')
@@ -88,12 +88,14 @@ export class WebstatusOverviewContent extends LitElement {
   }
 
   render(): TemplateResult {
-    const bookmark = bookmarkHelpers.getCurrentBookmark(
+    const savedSearch = savedSearchHelpers.getCurrentSavedSearch(
       this.appBookmarkInfo,
       this.location,
     );
-    const pageTitle = bookmark ? bookmark.name : 'Features overview';
-    const pageDescription = bookmark?.description;
+    const pageTitle = savedSearch
+      ? savedSearch.value.name
+      : 'Features overview';
+    const pageDescription = savedSearch?.value.description;
     return html`
       <div class="main">
         <div class="hbox halign-items-space-between header-line">
@@ -115,7 +117,7 @@ export class WebstatusOverviewContent extends LitElement {
         <webstatus-overview-table
           .location=${this.location}
           .taskTracker=${this.taskTracker}
-          .bookmark=${bookmark}
+          .savedSearch=${savedSearch}
         >
         </webstatus-overview-table>
         <webstatus-overview-pagination

--- a/frontend/src/static/js/components/webstatus-overview-filters.ts
+++ b/frontend/src/static/js/components/webstatus-overview-filters.ts
@@ -62,7 +62,7 @@ import {Toast} from '../utils/toast.js';
 import {navigateToUrl} from '../utils/app-router.js';
 import {
   AppBookmarkInfo,
-  bookmarkHelpers,
+  savedSearchHelpers,
 } from '../contexts/app-bookmark-info-context.js';
 import {VOCABULARY} from '../utils/constants.js';
 
@@ -155,7 +155,7 @@ export class WebstatusOverviewFilters extends LitElement {
       changedProperties.has('location') ||
       changedProperties.has('appBookmarkInfo')
     ) {
-      this._activeQuery = bookmarkHelpers.getCurrentQuery(
+      this._activeQuery = savedSearchHelpers.getCurrentQuery(
         this.appBookmarkInfo,
         this.location,
       );
@@ -191,7 +191,10 @@ export class WebstatusOverviewFilters extends LitElement {
       // TODO. allFeaturesFetcher should be moved to a separate task.
       this.allFeaturesFetcher = () => {
         return this.apiClient!.getAllFeatures(
-          bookmarkHelpers.getCurrentQuery(this.appBookmarkInfo, this.location),
+          savedSearchHelpers.getCurrentQuery(
+            this.appBookmarkInfo,
+            this.location,
+          ),
           getSortSpec(this.location) as FeatureSortOrderType,
           getWPTMetricView(this.location) as FeatureWPTMetricViewType,
         );

--- a/frontend/src/static/js/components/webstatus-overview-page.ts
+++ b/frontend/src/static/js/components/webstatus-overview-page.ts
@@ -39,7 +39,7 @@ import {toast} from '../utils/toast.js';
 import {
   appBookmarkInfoContext,
   AppBookmarkInfo,
-  bookmarkHelpers,
+  savedSearchHelpers,
 } from '../contexts/app-bookmark-info-context.js';
 
 @customElement('webstatus-overview-page')
@@ -128,7 +128,7 @@ export class OverviewPage extends LitElement {
       if (
         this.apiClient !== undefined &&
         this.currentLocation?.search !== this.location.search &&
-        !bookmarkHelpers.isBusyLoadingBookmarkInfo(
+        !savedSearchHelpers.isBusyLoadingSavedSearchInfo(
           this.appBookmarkInfo,
           this.location,
         )
@@ -147,7 +147,7 @@ export class OverviewPage extends LitElement {
       return Promise.reject(new Error('APIClient is not initialized.'));
     const sortSpec = getSortSpec(routerLocation) as FeatureSortOrderType;
     let searchQuery: string = '';
-    const query = bookmarkHelpers.getCurrentQuery(
+    const query = savedSearchHelpers.getCurrentQuery(
       appBookmarkInfo,
       routerLocation,
     );

--- a/frontend/src/static/js/components/webstatus-overview-table.ts
+++ b/frontend/src/static/js/components/webstatus-overview-table.ts
@@ -41,7 +41,7 @@ import {
 import {Toast} from '../utils/toast.js';
 import {
   CurrentSavedSearch,
-  SavedSearchType,
+  SavedSearchScope,
 } from '../contexts/app-bookmark-info-context.js';
 
 @customElement('webstatus-overview-table')
@@ -158,7 +158,7 @@ export class WebstatusOverviewTable extends LitElement {
   reorderByQueryTerms(): components['schemas']['Feature'][] | undefined {
     if (
       !this.savedSearch ||
-      this.savedSearch.type !== SavedSearchType.GlobalSavedSearch ||
+      this.savedSearch.scope !== SavedSearchScope.GlobalSavedSearch ||
       !this.savedSearch.value.is_ordered
     ) {
       return undefined;
@@ -194,7 +194,7 @@ export class WebstatusOverviewTable extends LitElement {
 
     let headerCells: TemplateResult[] = [];
     if (
-      this.savedSearch?.type === SavedSearchType.GlobalSavedSearch &&
+      this.savedSearch?.scope === SavedSearchScope.GlobalSavedSearch &&
       this.savedSearch.value?.is_ordered
     ) {
       headerCells = renderSavedSearchHeaderCells(

--- a/frontend/src/static/js/components/webstatus-overview-table.ts
+++ b/frontend/src/static/js/components/webstatus-overview-table.ts
@@ -30,16 +30,19 @@ import {
   renderColgroups,
   renderGroupsRow,
   renderHeaderCell,
-  renderBookmarkHeaderCells,
+  renderSavedSearchHeaderCells,
 } from './webstatus-overview-cells.js';
 import {TaskTracker} from '../utils/task-tracker.js';
 import {ApiError, BadRequestError} from '../api/errors.js';
 import {
   GITHUB_REPO_ISSUE_LINK,
   SEARCH_QUERY_README_LINK,
-  Bookmark,
 } from '../utils/constants.js';
 import {Toast} from '../utils/toast.js';
+import {
+  CurrentSavedSearch,
+  SavedSearchType,
+} from '../contexts/app-bookmark-info-context.js';
 
 @customElement('webstatus-overview-table')
 export class WebstatusOverviewTable extends LitElement {
@@ -54,7 +57,7 @@ export class WebstatusOverviewTable extends LitElement {
   location!: {search: string}; // Set by parent.
 
   @property({type: Object})
-  bookmark: Bookmark | undefined;
+  savedSearch: CurrentSavedSearch;
 
   static get styles(): CSSResultGroup {
     return [
@@ -153,11 +156,15 @@ export class WebstatusOverviewTable extends LitElement {
   }
 
   reorderByQueryTerms(): components['schemas']['Feature'][] | undefined {
-    if (!this.bookmark || !this.bookmark.is_ordered) {
+    if (
+      !this.savedSearch ||
+      this.savedSearch.type !== SavedSearchType.GlobalSavedSearch ||
+      !this.savedSearch.value.is_ordered
+    ) {
       return undefined;
     }
 
-    const atoms: string[] = this.bookmark.query.trim().split('OR');
+    const atoms: string[] = this.savedSearch.value.query.trim().split('OR');
     const features = [];
     for (const atom of atoms) {
       const terms = atom.trim().split(':');
@@ -169,7 +176,7 @@ export class WebstatusOverviewTable extends LitElement {
 
     if (features.length !== this.taskTracker?.data?.data?.length) {
       void new Toast().toast(
-        `Unable to apply custom sorting to bookmark "${this.bookmark.name}". Defaulting to normal sorting.`,
+        `Unable to apply custom sorting to saved search "${this.savedSearch.value.name}". Defaulting to normal sorting.`,
         'warning',
         'exclamation-triangle',
       );
@@ -186,8 +193,14 @@ export class WebstatusOverviewTable extends LitElement {
       getSortSpec(this.location) || (DEFAULT_SORT_SPEC as string);
 
     let headerCells: TemplateResult[] = [];
-    if (this.bookmark?.is_ordered) {
-      headerCells = renderBookmarkHeaderCells(this.bookmark.name, columns);
+    if (
+      this.savedSearch?.type === SavedSearchType.GlobalSavedSearch &&
+      this.savedSearch.value?.is_ordered
+    ) {
+      headerCells = renderSavedSearchHeaderCells(
+        this.savedSearch.value.name,
+        columns,
+      );
     } else {
       headerCells = columns.map(
         col => html`${renderHeaderCell(this.location, col, sortSpec)}`,

--- a/frontend/src/static/js/contexts/app-bookmark-info-context.ts
+++ b/frontend/src/static/js/contexts/app-bookmark-info-context.ts
@@ -31,14 +31,14 @@ export interface AppBookmarkInfo {
 export const appBookmarkInfoContext =
   createContext<AppBookmarkInfo>('app-bookmark-info');
 
-export enum SavedSearchType {
+export enum SavedSearchScope {
   GlobalSavedSearch,
   UserSavedSearch,
 }
 
 export type CurrentSavedSearch =
-  | {type: SavedSearchType.GlobalSavedSearch; value: GlobalSavedSearch}
-  | {type: SavedSearchType.UserSavedSearch; value: UserSavedSearch}
+  | {scope: SavedSearchScope.GlobalSavedSearch; value: GlobalSavedSearch}
+  | {scope: SavedSearchScope.UserSavedSearch; value: UserSavedSearch}
   | undefined;
 export const savedSearchHelpers = {
   /**
@@ -62,7 +62,10 @@ export const savedSearchHelpers = {
         item => item.id === searchID,
       );
       if (userSavedSearch !== undefined) {
-        return {type: SavedSearchType.UserSavedSearch, value: userSavedSearch};
+        return {
+          scope: SavedSearchScope.UserSavedSearch,
+          value: userSavedSearch,
+        };
       }
     }
     if (
@@ -72,14 +75,14 @@ export const savedSearchHelpers = {
       info?.userSavedSearchTask.data
     ) {
       return {
-        type: SavedSearchType.UserSavedSearch,
+        scope: SavedSearchScope.UserSavedSearch,
         value: info.userSavedSearchTask.data,
       };
     }
 
     if (info?.currentGlobalSavedSearch) {
       return {
-        type: SavedSearchType.GlobalSavedSearch,
+        scope: SavedSearchScope.GlobalSavedSearch,
         value: info.currentGlobalSavedSearch,
       };
     }
@@ -117,13 +120,13 @@ export const savedSearchHelpers = {
       location,
     );
     // User saved searches can be edited. And those have IDs
-    if (savedSearch?.type === SavedSearchType.UserSavedSearch) {
+    if (savedSearch?.scope === SavedSearchScope.UserSavedSearch) {
       // If there's a saved search, prioritize its query unless q is different.
       // If they are different, this could mean we are trying to edit.
       return q !== savedSearch.value.query && q !== ''
         ? q
         : savedSearch.value.query;
-    } else if (savedSearch?.type === SavedSearchType.GlobalSavedSearch) {
+    } else if (savedSearch?.scope === SavedSearchScope.GlobalSavedSearch) {
       // If there's a global saved search, use its query.
       return savedSearch.value.query;
     }

--- a/frontend/src/static/js/contexts/app-bookmark-info-context.ts
+++ b/frontend/src/static/js/contexts/app-bookmark-info-context.ts
@@ -15,71 +15,90 @@
  */
 
 import {createContext} from '@lit/context';
-import {Bookmark} from '../utils/constants.js';
+import {GlobalSavedSearch, UserSavedSearch} from '../utils/constants.js';
 import {TaskTracker} from '../utils/task-tracker.js';
 import {TaskStatus} from '@lit/task';
 import {getSearchID, getSearchQuery} from '../utils/urls.js';
 
 export interface AppBookmarkInfo {
-  globalBookmarks?: Bookmark[];
-  currentGlobalBookmark?: Bookmark;
-  userSavedSearchBookmarkTask?: TaskTracker<Bookmark, SavedSearchError>;
-  userSavedSearchBookmarksTask?: TaskTracker<Bookmark[], SavedSearchError>;
+  globalSavedSearches?: GlobalSavedSearch[];
+  currentGlobalSavedSearch?: GlobalSavedSearch;
+  userSavedSearchTask?: TaskTracker<UserSavedSearch, SavedSearchError>;
+  userSavedSearchesTask?: TaskTracker<UserSavedSearch[], SavedSearchError>;
   currentLocation?: {search: string};
 }
 
 export const appBookmarkInfoContext =
   createContext<AppBookmarkInfo>('app-bookmark-info');
 
-export const bookmarkHelpers = {
+export enum SavedSearchType {
+  GlobalSavedSearch,
+  UserSavedSearch,
+}
+
+export type CurrentSavedSearch =
+  | {type: SavedSearchType.GlobalSavedSearch; value: GlobalSavedSearch}
+  | {type: SavedSearchType.UserSavedSearch; value: UserSavedSearch}
+  | undefined;
+export const savedSearchHelpers = {
   /**
-   * Returns the current bookmark based on the provided AppBookmarkInfo and location.
+   * Returns the current saved search based on the provided AppBookmarkInfo and location.
    *
    * @param {AppBookmarkInfo?} info  - The AppBookmarkInfo object.
    * @param {{search: string}?} location - The location object containing the search parameters.
    */
-  getCurrentBookmark(
+  getCurrentSavedSearch(
     info?: AppBookmarkInfo,
     location?: {search: string},
-  ): Bookmark | undefined {
+  ): CurrentSavedSearch {
     const searchID = getSearchID(location ?? {search: ''});
     if (
       // There's a chance that the context has not been updated so we should check the search ID in the location.
       searchID &&
-      info?.userSavedSearchBookmarksTask?.status === TaskStatus.COMPLETE &&
-      info?.userSavedSearchBookmarksTask.data
+      info?.userSavedSearchesTask?.status === TaskStatus.COMPLETE &&
+      info?.userSavedSearchesTask.data
     ) {
-      const userBookmark = info.userSavedSearchBookmarksTask.data?.find(
+      const userSavedSearch = info.userSavedSearchesTask.data?.find(
         item => item.id === searchID,
       );
-      if (userBookmark !== undefined) {
-        return userBookmark;
+      if (userSavedSearch !== undefined) {
+        return {type: SavedSearchType.UserSavedSearch, value: userSavedSearch};
       }
     }
     if (
       // There's a chance that the context has not been updated so we should check the search ID in the location.
       searchID &&
-      info?.userSavedSearchBookmarkTask?.status === TaskStatus.COMPLETE &&
-      info?.userSavedSearchBookmarkTask.data
+      info?.userSavedSearchTask?.status === TaskStatus.COMPLETE &&
+      info?.userSavedSearchTask.data
     ) {
-      return info.userSavedSearchBookmarkTask.data;
+      return {
+        type: SavedSearchType.UserSavedSearch,
+        value: info.userSavedSearchTask.data,
+      };
     }
 
-    return info?.currentGlobalBookmark;
+    if (info?.currentGlobalSavedSearch) {
+      return {
+        type: SavedSearchType.GlobalSavedSearch,
+        value: info.currentGlobalSavedSearch,
+      };
+    }
+
+    return undefined;
   },
 
   /**
    * Returns the current query based on the provided AppBookmarkInfo and location.
    *
    * This function determines the active query string by considering both global
-   * and user-saved bookmarks, as well as the current location's search parameters.
+   * and user saved searches, as well as the current location's search parameters.
    *
-   * - If a user-saved bookmark is active (indicated by a matching `search_id` in
+   * - If a user saved search is active (indicated by a matching `search_id` in
    *   the location), its query is used unless the location's `q` parameter is
    *   different, which indicates the user is editing the query.
-   * - If a global bookmark is active, its query is used.
-   * - If no bookmark is active, the query from the location's `q` parameter is used.
-   * - If the bookmark information is still loading, the query from the location's `q` parameter is used.
+   * - If a global saved search is active, its query is used.
+   * - If no saved search is active, the query from the location's `q` parameter is used.
+   * - If the saved search information is still loading, the query from the location's `q` parameter is used.
    *
    * @param {AppBookmarkInfo?} info - The AppBookmarkInfo object.
    * @param {{search: string}?} location - The location object containing the search parameters.
@@ -90,18 +109,23 @@ export const bookmarkHelpers = {
     location?: {search: string},
   ): string => {
     const q = getSearchQuery(location ?? {search: ''});
-    if (bookmarkHelpers.isBusyLoadingBookmarkInfo(info, location)) {
+    if (savedSearchHelpers.isBusyLoadingSavedSearchInfo(info, location)) {
       return q;
     }
-    const bookmark = bookmarkHelpers.getCurrentBookmark(info, location);
-    // User saved bookmarks can be edited. And those have IDs
-    if (bookmark !== undefined && bookmark.id !== undefined) {
-      // If there's a bookmark, prioritize its query unless q is different.
+    const savedSearch = savedSearchHelpers.getCurrentSavedSearch(
+      info,
+      location,
+    );
+    // User saved searches can be edited. And those have IDs
+    if (savedSearch?.type === SavedSearchType.UserSavedSearch) {
+      // If there's a saved search, prioritize its query unless q is different.
       // If they are different, this could mean we are trying to edit.
-      return q !== bookmark.query && q !== '' ? q : bookmark.query;
-    } else if (bookmark !== undefined && bookmark.id === undefined) {
-      // If there's a global bookmark, use its query.
-      return bookmark.query;
+      return q !== savedSearch.value.query && q !== ''
+        ? q
+        : savedSearch.value.query;
+    } else if (savedSearch?.type === SavedSearchType.GlobalSavedSearch) {
+      // If there's a global saved search, use its query.
+      return savedSearch.value.query;
     }
 
     return q;
@@ -115,17 +139,17 @@ export const bookmarkHelpers = {
    * @param {{search: string}?} location - The location object containing the search parameters.
    * @returns {boolean} True if the bookmark info is loading or the location has changed, false otherwise.
    */
-  isBusyLoadingBookmarkInfo: (
+  isBusyLoadingSavedSearchInfo: (
     info?: AppBookmarkInfo,
     location?: {search: string},
   ): boolean => {
     return (
-      info?.userSavedSearchBookmarkTask === undefined ||
-      info?.userSavedSearchBookmarkTask?.status === TaskStatus.INITIAL ||
-      info?.userSavedSearchBookmarkTask?.status === TaskStatus.PENDING ||
-      info?.userSavedSearchBookmarksTask === undefined ||
-      info?.userSavedSearchBookmarksTask?.status === TaskStatus.INITIAL ||
-      info?.userSavedSearchBookmarksTask?.status === TaskStatus.PENDING ||
+      info?.userSavedSearchTask === undefined ||
+      info?.userSavedSearchTask?.status === TaskStatus.INITIAL ||
+      info?.userSavedSearchTask?.status === TaskStatus.PENDING ||
+      info?.userSavedSearchesTask === undefined ||
+      info?.userSavedSearchesTask?.status === TaskStatus.INITIAL ||
+      info?.userSavedSearchesTask?.status === TaskStatus.PENDING ||
       info?.currentLocation?.search !== location?.search
     );
   },
@@ -181,7 +205,7 @@ export class SavedSearchUnknownError extends Error {
 }
 
 /**
- * Represents an internal error that occurred while fetching a user's list of bookmaked saved searches.
+ * Represents an internal error that occurred while fetching a user's list of saved searches.
  */
 export class UserSavedSearchesInternalError extends Error {
   /**
@@ -189,14 +213,12 @@ export class UserSavedSearchesInternalError extends Error {
    * @param {string} msg - The error message.
    */
   constructor(msg: string) {
-    super(
-      `Internal error fetching list of bookmarked saved searches for user: ${msg}`,
-    );
+    super(`Internal error fetching list of saved searches for user: ${msg}`);
   }
 }
 
 /**
- * Represents an unknown error that occurred while fetching a user's list of bookmaked saved searches.
+ * Represents an unknown error that occurred while fetching a user's list of saved searches.
  */
 export class UserSavedSearchesUnknownError extends Error {
   /**
@@ -205,7 +227,7 @@ export class UserSavedSearchesUnknownError extends Error {
    */
   constructor(err: unknown) {
     super(
-      'Unknown error fetching list of bookmarked saved searches for user. Check console for details.',
+      'Unknown error fetching list of saved searches for user. Check console for details.',
     );
     console.error(err);
   }

--- a/frontend/src/static/js/contexts/test/app-bookmark-info-context.test.ts
+++ b/frontend/src/static/js/contexts/test/app-bookmark-info-context.test.ts
@@ -23,7 +23,7 @@ import {
   UserSavedSearchesInternalError,
   UserSavedSearchesUnknownError,
   CurrentSavedSearch,
-  SavedSearchType,
+  SavedSearchScope,
 } from '../app-bookmark-info-context.js';
 import {TaskStatus} from '@lit/task';
 import {expect} from '@open-wc/testing';
@@ -49,7 +49,7 @@ describe('app-bookmark-info-context', () => {
             search: '?search_id=123',
           }),
         ).to.deep.equal({
-          type: SavedSearchType.UserSavedSearch,
+          scope: SavedSearchScope.UserSavedSearch,
           value: {
             query: 'test',
             name: 'Test Bookmark',
@@ -60,7 +60,7 @@ describe('app-bookmark-info-context', () => {
 
       it('should return the currentGlobalSavedSearch if userSavedSearchTask is not complete', () => {
         const expectedData: CurrentSavedSearch = {
-          type: SavedSearchType.GlobalSavedSearch,
+          scope: SavedSearchScope.GlobalSavedSearch,
           value: {
             query: 'global',
             name: 'Global Bookmark',
@@ -126,7 +126,7 @@ describe('app-bookmark-info-context', () => {
         expect(
           savedSearchHelpers.getCurrentSavedSearch(info, location),
         ).to.deep.equal({
-          type: SavedSearchType.UserSavedSearch,
+          scope: SavedSearchScope.UserSavedSearch,
           value: {query: 'test', name: 'Test Bookmark', id: '123'},
         });
       });
@@ -144,7 +144,7 @@ describe('app-bookmark-info-context', () => {
             search: '?search_id=123',
           }),
         ).to.deep.equal({
-          type: SavedSearchType.UserSavedSearch,
+          scope: SavedSearchScope.UserSavedSearch,
           value: {query: 'test', name: 'Test Bookmark', id: '123'},
         });
       });
@@ -173,7 +173,7 @@ describe('app-bookmark-info-context', () => {
 
       it('should return the currentGlobalSavedSearch if userSavedSearchesTask is not complete', () => {
         const expectedData: CurrentSavedSearch = {
-          type: SavedSearchType.GlobalSavedSearch,
+          scope: SavedSearchScope.GlobalSavedSearch,
           value: {
             query: 'global',
             name: 'Global Bookmark',
@@ -294,7 +294,7 @@ describe('app-bookmark-info-context', () => {
           'getCurrentSavedSearch',
         );
         getCurrentBookmarkStub.returns({
-          type: SavedSearchType.UserSavedSearch,
+          scope: SavedSearchScope.UserSavedSearch,
           value: {
             query: 'test',
             name: 'Test Bookmark',

--- a/frontend/src/static/js/contexts/test/app-bookmark-info-context.test.ts
+++ b/frontend/src/static/js/contexts/test/app-bookmark-info-context.test.ts
@@ -15,98 +15,108 @@
  */
 
 import {
-  bookmarkHelpers,
+  savedSearchHelpers,
   SavedSearchNotFoundError,
   SavedSearchInternalError,
   SavedSearchUnknownError,
   AppBookmarkInfo,
   UserSavedSearchesInternalError,
   UserSavedSearchesUnknownError,
+  CurrentSavedSearch,
+  SavedSearchType,
 } from '../app-bookmark-info-context.js';
 import {TaskStatus} from '@lit/task';
 import {expect} from '@open-wc/testing';
 import sinon from 'sinon';
 
 describe('app-bookmark-info-context', () => {
-  describe('bookmarkHelpers', () => {
-    describe('getCurrentBookmark', () => {
+  describe('savedSearchHelpers', () => {
+    describe('getCurrentSavedSearch', () => {
       it('should return undefined if no info is provided', () => {
-        expect(bookmarkHelpers.getCurrentBookmark()).to.be.undefined;
+        expect(savedSearchHelpers.getCurrentSavedSearch()).to.be.undefined;
       });
 
-      it('should return the userSavedSearchBookmarkTask data if available and complete', () => {
+      it('should return the userSavedSearchTask data if available and complete', () => {
         const info: AppBookmarkInfo = {
-          userSavedSearchBookmarkTask: {
+          userSavedSearchTask: {
             status: TaskStatus.COMPLETE,
             data: {query: 'test', name: 'Test Bookmark', id: '123'},
             error: undefined,
           },
         };
         expect(
-          bookmarkHelpers.getCurrentBookmark(info, {search: '?search_id=123'}),
+          savedSearchHelpers.getCurrentSavedSearch(info, {
+            search: '?search_id=123',
+          }),
         ).to.deep.equal({
-          query: 'test',
-          name: 'Test Bookmark',
-          id: '123',
+          type: SavedSearchType.UserSavedSearch,
+          value: {
+            query: 'test',
+            name: 'Test Bookmark',
+            id: '123',
+          },
         });
       });
 
-      it('should return the currentGlobalBookmark if userSavedSearchBookmarkTask is not complete', () => {
-        const expectedData = {
-          query: 'global',
-          name: 'Global Bookmark',
-        };
-        // Pending state
-        const pendingInfo: AppBookmarkInfo = {
-          currentGlobalBookmark: {
+      it('should return the currentGlobalSavedSearch if userSavedSearchTask is not complete', () => {
+        const expectedData: CurrentSavedSearch = {
+          type: SavedSearchType.GlobalSavedSearch,
+          value: {
             query: 'global',
             name: 'Global Bookmark',
           },
-          userSavedSearchBookmarkTask: {
+        };
+        // Pending state
+        const pendingInfo: AppBookmarkInfo = {
+          currentGlobalSavedSearch: {
+            query: 'global',
+            name: 'Global Bookmark',
+          },
+          userSavedSearchTask: {
             status: TaskStatus.PENDING,
             data: undefined,
             error: undefined,
           },
         };
-        expect(bookmarkHelpers.getCurrentBookmark(pendingInfo)).to.deep.equal(
-          expectedData,
-        );
+        expect(
+          savedSearchHelpers.getCurrentSavedSearch(pendingInfo),
+        ).to.deep.equal(expectedData);
         // Initial state
         const initialInfo: AppBookmarkInfo = {
-          currentGlobalBookmark: {
+          currentGlobalSavedSearch: {
             query: 'global',
             name: 'Global Bookmark',
           },
-          userSavedSearchBookmarkTask: {
+          userSavedSearchTask: {
             status: TaskStatus.INITIAL,
             data: undefined,
             error: undefined,
           },
         };
-        expect(bookmarkHelpers.getCurrentBookmark(initialInfo)).to.deep.equal(
-          expectedData,
-        );
+        expect(
+          savedSearchHelpers.getCurrentSavedSearch(initialInfo),
+        ).to.deep.equal(expectedData);
         // Undefined state
         const undefinedInfo: AppBookmarkInfo = {
-          currentGlobalBookmark: {
+          currentGlobalSavedSearch: {
             query: 'global',
             name: 'Global Bookmark',
           },
-          userSavedSearchBookmarkTask: undefined,
+          userSavedSearchTask: undefined,
         };
-        expect(bookmarkHelpers.getCurrentBookmark(undefinedInfo)).to.deep.equal(
-          expectedData,
-        );
+        expect(
+          savedSearchHelpers.getCurrentSavedSearch(undefinedInfo),
+        ).to.deep.equal(expectedData);
       });
 
       it('should return undefined if no bookmark is found', () => {
         const info: AppBookmarkInfo = {};
-        expect(bookmarkHelpers.getCurrentBookmark(info)).to.be.undefined;
+        expect(savedSearchHelpers.getCurrentSavedSearch(info)).to.be.undefined;
       });
 
       it('should handle a location with a search ID', () => {
         const info: AppBookmarkInfo = {
-          userSavedSearchBookmarkTask: {
+          userSavedSearchTask: {
             status: TaskStatus.COMPLETE,
             data: {query: 'test', name: 'Test Bookmark', id: '123'},
             error: undefined,
@@ -114,100 +124,111 @@ describe('app-bookmark-info-context', () => {
         };
         const location = {search: '?search_id=123'};
         expect(
-          bookmarkHelpers.getCurrentBookmark(info, location),
-        ).to.deep.equal({query: 'test', name: 'Test Bookmark', id: '123'});
+          savedSearchHelpers.getCurrentSavedSearch(info, location),
+        ).to.deep.equal({
+          type: SavedSearchType.UserSavedSearch,
+          value: {query: 'test', name: 'Test Bookmark', id: '123'},
+        });
       });
 
-      it('should return the data from userSavedSearchBookmarksTask if available and complete', () => {
+      it('should return the data from userSavedSearchesTask if available and complete', () => {
         const info = {
-          userSavedSearchBookmarksTask: {
+          userSavedSearchesTask: {
             status: TaskStatus.COMPLETE,
             data: [{query: 'test', name: 'Test Bookmark', id: '123'}],
             error: undefined,
           },
         };
         expect(
-          bookmarkHelpers.getCurrentBookmark(info, {search: '?search_id=123'}),
-        ).to.deep.equal({query: 'test', name: 'Test Bookmark', id: '123'});
+          savedSearchHelpers.getCurrentSavedSearch(info, {
+            search: '?search_id=123',
+          }),
+        ).to.deep.equal({
+          type: SavedSearchType.UserSavedSearch,
+          value: {query: 'test', name: 'Test Bookmark', id: '123'},
+        });
       });
 
-      it('should return undefined if userSavedSearchBookmarksTask is not complete', () => {
+      it('should return undefined if userSavedSearchesTask is not complete', () => {
         const info = {
-          userSavedSearchBookmarksTask: {
+          userSavedSearchesTask: {
             status: TaskStatus.PENDING,
             data: undefined,
             error: undefined,
           },
         };
-        expect(bookmarkHelpers.getCurrentBookmark(info)).to.be.undefined;
+        expect(savedSearchHelpers.getCurrentSavedSearch(info)).to.be.undefined;
       });
 
-      it('should return undefined if userSavedSearchBookmarksTask data is empty', () => {
-        const info = {
-          userSavedSearchBookmarksTask: {
+      it('should return undefined if userSavedSearchesTask data is empty', () => {
+        const info: AppBookmarkInfo = {
+          userSavedSearchesTask: {
             status: TaskStatus.COMPLETE,
             data: [],
             error: undefined,
           },
         };
-        expect(bookmarkHelpers.getCurrentBookmark(info)).to.be.undefined;
+        expect(savedSearchHelpers.getCurrentSavedSearch(info)).to.be.undefined;
       });
 
-      it('should return the currentGlobalBookmark if userSavedSearchBookmarksTask is not complete', () => {
-        const expectedData = {
-          query: 'global',
-          name: 'Global Bookmark',
-        };
-        // Pending state
-        const pendingInfo: AppBookmarkInfo = {
-          currentGlobalBookmark: {
+      it('should return the currentGlobalSavedSearch if userSavedSearchesTask is not complete', () => {
+        const expectedData: CurrentSavedSearch = {
+          type: SavedSearchType.GlobalSavedSearch,
+          value: {
             query: 'global',
             name: 'Global Bookmark',
           },
-          userSavedSearchBookmarksTask: {
+        };
+        // Pending state
+        const pendingInfo: AppBookmarkInfo = {
+          currentGlobalSavedSearch: {
+            query: 'global',
+            name: 'Global Bookmark',
+          },
+          userSavedSearchesTask: {
             status: TaskStatus.PENDING,
             data: undefined,
             error: undefined,
           },
         };
-        expect(bookmarkHelpers.getCurrentBookmark(pendingInfo)).to.deep.equal(
-          expectedData,
-        );
+        expect(
+          savedSearchHelpers.getCurrentSavedSearch(pendingInfo),
+        ).to.deep.equal(expectedData);
         // Initial state
         const initialInfo: AppBookmarkInfo = {
-          currentGlobalBookmark: {
+          currentGlobalSavedSearch: {
             query: 'global',
             name: 'Global Bookmark',
           },
-          userSavedSearchBookmarksTask: {
+          userSavedSearchesTask: {
             status: TaskStatus.INITIAL,
             data: undefined,
             error: undefined,
           },
         };
-        expect(bookmarkHelpers.getCurrentBookmark(initialInfo)).to.deep.equal(
-          expectedData,
-        );
+        expect(
+          savedSearchHelpers.getCurrentSavedSearch(initialInfo),
+        ).to.deep.equal(expectedData);
         // Undefined state
         const undefinedInfo: AppBookmarkInfo = {
-          currentGlobalBookmark: {
+          currentGlobalSavedSearch: {
             query: 'global',
             name: 'Global Bookmark',
           },
-          userSavedSearchBookmarksTask: undefined,
+          userSavedSearchesTask: undefined,
         };
-        expect(bookmarkHelpers.getCurrentBookmark(undefinedInfo)).to.deep.equal(
-          expectedData,
-        );
+        expect(
+          savedSearchHelpers.getCurrentSavedSearch(undefinedInfo),
+        ).to.deep.equal(expectedData);
       });
     });
 
     describe('getCurrentQuery', () => {
       it('should return the query from the location if info is undefined', () => {
         const location = {search: '?q=test'};
-        expect(bookmarkHelpers.getCurrentQuery(undefined, location)).to.equal(
-          'test',
-        );
+        expect(
+          savedSearchHelpers.getCurrentQuery(undefined, location),
+        ).to.equal('test');
       });
 
       it('should return the query from the location if bookmark info is loading', () => {
@@ -215,141 +236,144 @@ describe('app-bookmark-info-context', () => {
         const expectedQuery = 'test';
         // Pending
         const pendingInfo: AppBookmarkInfo = {
-          userSavedSearchBookmarkTask: {
+          userSavedSearchTask: {
             status: TaskStatus.PENDING,
             data: undefined,
             error: undefined,
           },
-          userSavedSearchBookmarksTask: {
+          userSavedSearchesTask: {
             status: TaskStatus.PENDING,
             data: undefined,
             error: undefined,
           },
-        };
-        expect(bookmarkHelpers.getCurrentQuery(pendingInfo, location)).to.equal(
-          expectedQuery,
-        );
-        // Initial
-        const initialInfo: AppBookmarkInfo = {
-          userSavedSearchBookmarkTask: {
-            status: TaskStatus.INITIAL,
-            data: undefined,
-            error: undefined,
-          },
-          userSavedSearchBookmarksTask: {
-            status: TaskStatus.INITIAL,
-            data: undefined,
-            error: undefined,
-          },
-        };
-        expect(bookmarkHelpers.getCurrentQuery(initialInfo, location)).to.equal(
-          expectedQuery,
-        );
-        // Undefined
-        const undefinedInfo: AppBookmarkInfo = {
-          userSavedSearchBookmarkTask: undefined,
-          userSavedSearchBookmarksTask: undefined,
         };
         expect(
-          bookmarkHelpers.getCurrentQuery(undefinedInfo, location),
+          savedSearchHelpers.getCurrentQuery(pendingInfo, location),
+        ).to.equal(expectedQuery);
+        // Initial
+        const initialInfo: AppBookmarkInfo = {
+          userSavedSearchTask: {
+            status: TaskStatus.INITIAL,
+            data: undefined,
+            error: undefined,
+          },
+          userSavedSearchesTask: {
+            status: TaskStatus.INITIAL,
+            data: undefined,
+            error: undefined,
+          },
+        };
+        expect(
+          savedSearchHelpers.getCurrentQuery(initialInfo, location),
+        ).to.equal(expectedQuery);
+        // Undefined
+        const undefinedInfo: AppBookmarkInfo = {
+          userSavedSearchTask: undefined,
+          userSavedSearchesTask: undefined,
+        };
+        expect(
+          savedSearchHelpers.getCurrentQuery(undefinedInfo, location),
         ).to.equal(expectedQuery);
       });
 
-      it('should return the query from the userSavedSearchBookmarkTask if available and complete', () => {
+      it('should return the query from the userSavedSearchTask if available and complete', () => {
         const info: AppBookmarkInfo = {
-          userSavedSearchBookmarkTask: {
+          userSavedSearchTask: {
             status: TaskStatus.COMPLETE,
             data: {query: 'test', name: 'Test Bookmark', id: '123'},
             error: undefined,
           },
         };
         const isBusyStub = sinon.stub(
-          bookmarkHelpers,
-          'isBusyLoadingBookmarkInfo',
+          savedSearchHelpers,
+          'isBusyLoadingSavedSearchInfo',
         );
         isBusyStub.returns(false);
         const getCurrentBookmarkStub = sinon.stub(
-          bookmarkHelpers,
-          'getCurrentBookmark',
+          savedSearchHelpers,
+          'getCurrentSavedSearch',
         );
         getCurrentBookmarkStub.returns({
-          query: 'test',
-          name: 'Test Bookmark',
-          id: '123',
+          type: SavedSearchType.UserSavedSearch,
+          value: {
+            query: 'test',
+            name: 'Test Bookmark',
+            id: '123',
+          },
         });
         expect(
-          bookmarkHelpers.getCurrentQuery(info, {search: '?search_id=123'}),
+          savedSearchHelpers.getCurrentQuery(info, {search: '?search_id=123'}),
         ).to.equal('test');
         getCurrentBookmarkStub.restore();
         isBusyStub.restore();
       });
 
-      it('should return the query from the currentGlobalBookmark if available', () => {
+      it('should return the query from the currentGlobalSavedSearch if available', () => {
         const info: AppBookmarkInfo = {
-          currentGlobalBookmark: {
+          currentGlobalSavedSearch: {
             query: 'global',
             name: 'Global Bookmark',
           },
-          userSavedSearchBookmarkTask: {
+          userSavedSearchTask: {
             status: TaskStatus.COMPLETE,
             data: undefined,
             error: undefined,
           },
-          userSavedSearchBookmarksTask: {
+          userSavedSearchesTask: {
             status: TaskStatus.COMPLETE,
             data: undefined,
             error: undefined,
           },
         };
-        expect(bookmarkHelpers.getCurrentQuery(info)).to.equal('global');
+        expect(savedSearchHelpers.getCurrentQuery(info)).to.equal('global');
       });
 
       it('should return an empty string if no query is found', () => {
-        expect(bookmarkHelpers.getCurrentQuery()).to.equal('');
+        expect(savedSearchHelpers.getCurrentQuery()).to.equal('');
       });
 
       it('should prioritize q parameter over bookmark query if different', () => {
         const info: AppBookmarkInfo = {
-          userSavedSearchBookmarkTask: {
+          userSavedSearchTask: {
             status: TaskStatus.COMPLETE,
             data: {query: 'test', name: 'Test Bookmark', id: '123'},
             error: undefined,
           },
         };
         const location = {search: '?q=edited'};
-        expect(bookmarkHelpers.getCurrentQuery(info, location)).to.equal(
+        expect(savedSearchHelpers.getCurrentQuery(info, location)).to.equal(
           'edited',
         );
       });
     });
 
-    describe('isBusyLoadingBookmarkInfo', () => {
-      it('should return true if userSavedSearchBookmarkTask is pending/initial/undefined', () => {
+    describe('isBusyLoadingSavedSearchInfo', () => {
+      it('should return true if userSavedSearchTask is pending/initial/undefined', () => {
         const pendingInfo: AppBookmarkInfo = {
-          userSavedSearchBookmarkTask: {
+          userSavedSearchTask: {
             status: TaskStatus.PENDING,
             data: undefined,
             error: undefined,
           },
         };
-        expect(bookmarkHelpers.isBusyLoadingBookmarkInfo(pendingInfo)).to.equal(
-          true,
-        );
+        expect(
+          savedSearchHelpers.isBusyLoadingSavedSearchInfo(pendingInfo),
+        ).to.equal(true);
         const initialInfo: AppBookmarkInfo = {
-          userSavedSearchBookmarkTask: {
+          userSavedSearchTask: {
             status: TaskStatus.INITIAL,
             data: undefined,
             error: undefined,
           },
         };
-        expect(bookmarkHelpers.isBusyLoadingBookmarkInfo(initialInfo)).to.equal(
-          true,
-        );
+        expect(
+          savedSearchHelpers.isBusyLoadingSavedSearchInfo(initialInfo),
+        ).to.equal(true);
         const undefinedInfo: AppBookmarkInfo = {
-          userSavedSearchBookmarkTask: undefined,
+          userSavedSearchTask: undefined,
         };
         expect(
-          bookmarkHelpers.isBusyLoadingBookmarkInfo(undefinedInfo),
+          savedSearchHelpers.isBusyLoadingSavedSearchInfo(undefinedInfo),
         ).to.equal(true);
       });
 
@@ -357,18 +381,18 @@ describe('app-bookmark-info-context', () => {
         const info: AppBookmarkInfo = {currentLocation: {search: '?q=old'}};
         const location = {search: '?q=new'};
         expect(
-          bookmarkHelpers.isBusyLoadingBookmarkInfo(info, location),
+          savedSearchHelpers.isBusyLoadingSavedSearchInfo(info, location),
         ).to.equal(true);
       });
 
-      it('should return false if userSavedSearchBookmarkTask is complete and locations match', () => {
+      it('should return false if userSavedSearchTask is complete and locations match', () => {
         const info: AppBookmarkInfo = {
-          userSavedSearchBookmarkTask: {
+          userSavedSearchTask: {
             status: TaskStatus.COMPLETE,
             data: undefined,
             error: undefined,
           },
-          userSavedSearchBookmarksTask: {
+          userSavedSearchesTask: {
             status: TaskStatus.COMPLETE,
             data: undefined,
             error: undefined,
@@ -377,7 +401,7 @@ describe('app-bookmark-info-context', () => {
         };
         const location = {search: '?q=test'};
         expect(
-          bookmarkHelpers.isBusyLoadingBookmarkInfo(info, location),
+          savedSearchHelpers.isBusyLoadingSavedSearchInfo(info, location),
         ).to.equal(false);
       });
     });
@@ -409,7 +433,7 @@ describe('app-bookmark-info-context', () => {
     it('UserSavedSearchesInternalError should create correct error message', () => {
       const error = new UserSavedSearchesInternalError('Server Error');
       expect(error.message).to.equal(
-        'Internal error fetching list of bookmarked saved searches for user: Server Error',
+        'Internal error fetching list of saved searches for user: Server Error',
       );
     });
 
@@ -418,7 +442,7 @@ describe('app-bookmark-info-context', () => {
         new Error('User Saved Searches Unknown Test Error'),
       );
       expect(error.message).to.equal(
-        'Unknown error fetching list of bookmarked saved searches for user. Check console for details.',
+        'Unknown error fetching list of saved searches for user. Check console for details.',
       );
     });
   });

--- a/frontend/src/static/js/services/test/webstatus-bookmarks-service.test.ts
+++ b/frontend/src/static/js/services/test/webstatus-bookmarks-service.test.ts
@@ -28,7 +28,7 @@ import {
 import {WebstatusBookmarksService} from '../webstatus-bookmarks-service.js';
 import {fixture, expect, waitUntil} from '@open-wc/testing';
 import '../webstatus-bookmarks-service.js';
-import {DEFAULT_BOOKMARKS} from '../../utils/constants.js';
+import {DEFAULT_GLOBAL_SAVED_SEARCHES} from '../../utils/constants.js';
 import {APIClient} from '../../api/client.js';
 import {SinonStubbedInstance} from 'sinon';
 import {TaskStatus} from '@lit/task';
@@ -44,7 +44,9 @@ class TestBookmarkConsumer extends LitElement {
   appBookmarkInfo?: AppBookmarkInfo;
 
   render() {
-    return html`<div>${this.appBookmarkInfo?.globalBookmarks?.length}</div>`;
+    return html`<div>
+      ${this.appBookmarkInfo?.globalSavedSearches?.length}
+    </div>`;
   }
 }
 
@@ -67,10 +69,10 @@ describe('webstatus-bookmarks-service', () => {
       html`<webstatus-bookmarks-service> </webstatus-bookmarks-service>`,
     );
     expect(component).to.exist;
-    expect(component!.appBookmarkInfo.globalBookmarks).to.deep.equal(
-      DEFAULT_BOOKMARKS,
+    expect(component!.appBookmarkInfo.globalSavedSearches).to.deep.equal(
+      DEFAULT_GLOBAL_SAVED_SEARCHES,
     );
-    expect(component!.appBookmarkInfo.currentGlobalBookmark).to.deep.equal(
+    expect(component!.appBookmarkInfo.currentGlobalSavedSearch).to.deep.equal(
       undefined,
     );
   });
@@ -86,10 +88,10 @@ describe('webstatus-bookmarks-service', () => {
     );
     expect(el).to.exist;
     expect(consumer).to.exist;
-    expect(consumer!.appBookmarkInfo!.globalBookmarks).to.deep.equal(
-      DEFAULT_BOOKMARKS,
+    expect(consumer!.appBookmarkInfo!.globalSavedSearches).to.deep.equal(
+      DEFAULT_GLOBAL_SAVED_SEARCHES,
     );
-    expect(consumer!.appBookmarkInfo!.currentGlobalBookmark).to.deep.equal(
+    expect(consumer!.appBookmarkInfo!.currentGlobalSavedSearch).to.deep.equal(
       undefined,
     );
   });
@@ -109,33 +111,33 @@ describe('webstatus-bookmarks-service', () => {
     const consumer = el.querySelector<TestBookmarkConsumer>(
       'test-bookmark-consumer',
     );
-    el._globalBookmarks = [
+    el._globalSavedSearches = [
       {
         name: 'Test Bookmark 1',
         query: 'test_query_1',
       },
     ];
     el.appBookmarkInfo = {
-      globalBookmarks: [
+      globalSavedSearches: [
         {
           name: 'Test Bookmark 1',
           query: 'test_query_1',
         },
       ],
-      currentGlobalBookmark: undefined,
+      currentGlobalSavedSearch: undefined,
     };
     await el.updateComplete;
     await consumer!.updateComplete;
 
     // Initial state
     expect(consumer!.appBookmarkInfo).to.deep.equal({
-      globalBookmarks: [
+      globalSavedSearches: [
         {
           name: 'Test Bookmark 1',
           query: 'test_query_1',
         },
       ],
-      currentGlobalBookmark: undefined,
+      currentGlobalSavedSearch: undefined,
     });
 
     // Simulate popstate event with a query
@@ -147,13 +149,13 @@ describe('webstatus-bookmarks-service', () => {
     await consumer!.updateComplete;
 
     // Updated state
-    expect(consumer!.appBookmarkInfo!.globalBookmarks).to.deep.equal([
+    expect(consumer!.appBookmarkInfo!.globalSavedSearches).to.deep.equal([
       {
         name: 'Test Bookmark 1',
         query: 'test_query_1',
       },
     ]);
-    expect(consumer!.appBookmarkInfo!.currentGlobalBookmark).to.deep.equal({
+    expect(consumer!.appBookmarkInfo!.currentGlobalSavedSearch).to.deep.equal({
       name: 'Test Bookmark 1',
       query: 'test_query_1',
     });
@@ -184,11 +186,11 @@ describe('webstatus-bookmarks-service', () => {
 
       await waitUntil(
         () =>
-          service.appBookmarkInfo.userSavedSearchBookmarkTask?.status !==
+          service.appBookmarkInfo.userSavedSearchTask?.status !==
           TaskStatus.PENDING,
       );
       expect(
-        service.appBookmarkInfo.userSavedSearchBookmarkTask?.error,
+        service.appBookmarkInfo.userSavedSearchTask?.error,
       ).to.be.instanceOf(SavedSearchNotFoundError);
       expect(toastStub.toast).to.have.been.calledOnceWithExactly(
         'Saved search with id test not found',
@@ -216,11 +218,11 @@ describe('webstatus-bookmarks-service', () => {
       );
       await waitUntil(
         () =>
-          service.appBookmarkInfo.userSavedSearchBookmarkTask?.status !==
+          service.appBookmarkInfo.userSavedSearchTask?.status !==
           TaskStatus.PENDING,
       );
       expect(
-        service.appBookmarkInfo.userSavedSearchBookmarkTask?.error,
+        service.appBookmarkInfo.userSavedSearchTask?.error,
       ).to.be.instanceOf(SavedSearchInternalError);
       expect(toastStub.toast).to.have.been.calledOnceWithExactly(
         'Error fetching saved search ID test: Something went wrong',
@@ -248,11 +250,11 @@ describe('webstatus-bookmarks-service', () => {
       );
       await waitUntil(
         () =>
-          service.appBookmarkInfo.userSavedSearchBookmarkTask?.status !==
+          service.appBookmarkInfo.userSavedSearchTask?.status !==
           TaskStatus.PENDING,
       );
       expect(
-        service.appBookmarkInfo.userSavedSearchBookmarkTask?.error,
+        service.appBookmarkInfo.userSavedSearchTask?.error,
       ).to.be.instanceOf(SavedSearchUnknownError);
       expect(toastStub.toast).to.have.been.calledOnceWithExactly(
         'Unknown error fetching saved search ID test. Check console for details.',
@@ -278,14 +280,13 @@ describe('webstatus-bookmarks-service', () => {
       );
       await waitUntil(
         () =>
-          service.appBookmarkInfo.userSavedSearchBookmarkTask?.status !==
+          service.appBookmarkInfo.userSavedSearchTask?.status !==
           TaskStatus.PENDING,
       );
-      expect(
-        service.appBookmarkInfo.userSavedSearchBookmarkTask?.status,
-      ).to.equal(TaskStatus.COMPLETE);
-      expect(service.appBookmarkInfo.userSavedSearchBookmarkTask?.data).to.be
-        .undefined;
+      expect(service.appBookmarkInfo.userSavedSearchTask?.status).to.equal(
+        TaskStatus.COMPLETE,
+      );
+      expect(service.appBookmarkInfo.userSavedSearchTask?.data).to.be.undefined;
     });
 
     it('should complete successfully with bookmark data', async () => {
@@ -313,19 +314,19 @@ describe('webstatus-bookmarks-service', () => {
       );
       await waitUntil(
         () =>
-          service.appBookmarkInfo.userSavedSearchBookmarkTask?.status !==
+          service.appBookmarkInfo.userSavedSearchTask?.status !==
           TaskStatus.PENDING,
       );
-      expect(
-        service.appBookmarkInfo.userSavedSearchBookmarkTask?.status,
-      ).to.equal(TaskStatus.COMPLETE);
-      expect(
-        service.appBookmarkInfo.userSavedSearchBookmarkTask?.data,
-      ).to.deep.equal(mockBookmark);
+      expect(service.appBookmarkInfo.userSavedSearchTask?.status).to.equal(
+        TaskStatus.COMPLETE,
+      );
+      expect(service.appBookmarkInfo.userSavedSearchTask?.data).to.deep.equal(
+        mockBookmark,
+      );
     });
 
-    it('should complete successfully with bookmark data and update page url when "q" is the same as the bookmark\'s query', async () => {
-      const mockBookmark = {
+    it('should complete successfully with saved searches data and update page url when "q" is the same as the saved search\'s query', async () => {
+      const mockSavedSearch = {
         id: '123',
         query: 'foo',
         name: 'Test Bookmark',
@@ -336,7 +337,7 @@ describe('webstatus-bookmarks-service', () => {
       // First call is for the current search ID, second call is for the previous search ID
       getSearchIDStub.onCall(0).returns('test');
       getSearchIDStub.onCall(1).returns('');
-      apiClientStub.getSavedSearchByID.resolves(mockBookmark);
+      apiClientStub.getSavedSearchByID.resolves(mockSavedSearch);
       const mockLocation = {
         search: '?search_id=test&q=foo',
         href: '?search_id=test&q=foo',
@@ -353,18 +354,18 @@ describe('webstatus-bookmarks-service', () => {
       );
       await waitUntil(
         () =>
-          service.appBookmarkInfo.userSavedSearchBookmarkTask?.status !==
+          service.appBookmarkInfo.userSavedSearchTask?.status !==
           TaskStatus.PENDING,
         '',
         {timeout: 5000},
       );
       expect(apiClientStub.getSavedSearchByID).to.have.been.calledOnce;
-      expect(
-        service.appBookmarkInfo.userSavedSearchBookmarkTask?.status,
-      ).to.equal(TaskStatus.COMPLETE);
-      expect(
-        service.appBookmarkInfo.userSavedSearchBookmarkTask?.data,
-      ).to.deep.equal(mockBookmark);
+      expect(service.appBookmarkInfo.userSavedSearchTask?.status).to.equal(
+        TaskStatus.COMPLETE,
+      );
+      expect(service.appBookmarkInfo.userSavedSearchTask?.data).to.deep.equal(
+        mockSavedSearch,
+      );
       expect(getLocationStub.callCount).to.eq(1);
       expect(updatePageUrlStub).to.have.been.calledOnce;
     });
@@ -394,12 +395,10 @@ describe('webstatus-bookmarks-service', () => {
 
       // Assert that getSavedSearchByID was only called once
       expect(apiClientStub.getSavedSearchByID.calledOnce).to.be.true;
-      expect(service.appBookmarkInfo.userSavedSearchBookmarkTask?.status).to.eq(
+      expect(service.appBookmarkInfo.userSavedSearchTask?.status).to.eq(
         TaskStatus.COMPLETE,
       );
-      expect(
-        service.appBookmarkInfo.userSavedSearchBookmarkTask?.data,
-      ).to.deep.eq({
+      expect(service.appBookmarkInfo.userSavedSearchTask?.data).to.deep.eq({
         created_at: '',
         id: 'test',
         query: 'test',
@@ -408,18 +407,18 @@ describe('webstatus-bookmarks-service', () => {
       });
 
       // Manually trigger a re-run
-      service.loadingUserSavedBookmarkByIDTask.run();
+      service.loadingUserSavedSearchByIDTask.run();
       await service.updateComplete;
 
       // Assert that getSavedSearchByID was only called once still
       expect(apiClientStub.getSavedSearchByID.calledOnce).to.be.true;
-      expect(service.appBookmarkInfo.userSavedSearchBookmarkTask?.status).to.eq(
+      expect(service.appBookmarkInfo.userSavedSearchTask?.status).to.eq(
         TaskStatus.COMPLETE,
       );
     });
   });
 
-  describe('loadingUserSavedBookmarksTask', () => {
+  describe('loadingUserSavedSearchesTask', () => {
     let apiClientStub: SinonStubbedInstance<APIClient>;
     beforeEach(async () => {
       apiClientStub = sinon.stub(new APIClient(''));
@@ -437,14 +436,14 @@ describe('webstatus-bookmarks-service', () => {
           } as User}
         ></webstatus-bookmarks-service>`,
       );
+      expect(service.appBookmarkInfo.userSavedSearchesTask?.status).to.eq(
+        TaskStatus.ERROR,
+      );
       expect(
-        service.appBookmarkInfo.userSavedSearchBookmarksTask?.status,
-      ).to.eq(TaskStatus.ERROR);
-      expect(
-        service.appBookmarkInfo.userSavedSearchBookmarksTask?.error,
+        service.appBookmarkInfo.userSavedSearchesTask?.error,
       ).to.be.instanceOf(UserSavedSearchesInternalError);
       expect(toastStub.toast).to.have.been.calledOnceWithExactly(
-        'Internal error fetching list of bookmarked saved searches for user: Something went wrong',
+        'Internal error fetching list of saved searches for user: Something went wrong',
         'danger',
         'exclamation-triangle',
       );
@@ -462,21 +461,21 @@ describe('webstatus-bookmarks-service', () => {
           } as User}
         ></webstatus-bookmarks-service>`,
       );
+      expect(service.appBookmarkInfo.userSavedSearchesTask?.status).to.eq(
+        TaskStatus.ERROR,
+      );
       expect(
-        service.appBookmarkInfo.userSavedSearchBookmarksTask?.status,
-      ).to.eq(TaskStatus.ERROR);
-      expect(
-        service.appBookmarkInfo.userSavedSearchBookmarksTask?.error,
+        service.appBookmarkInfo.userSavedSearchesTask?.error,
       ).to.be.instanceOf(UserSavedSearchesUnknownError);
       expect(toastStub.toast).to.have.been.calledOnceWithExactly(
-        'Unknown error fetching list of bookmarked saved searches for user. Check console for details.',
+        'Unknown error fetching list of saved searches for user. Check console for details.',
         'danger',
         'exclamation-triangle',
       );
     });
 
     it('should complete successfully with bookmark data', async () => {
-      const mockBookmarks = [
+      const mockSavedSearches = [
         {
           id: '123',
           query: 'test',
@@ -485,7 +484,7 @@ describe('webstatus-bookmarks-service', () => {
           updated_at: '2023-08-13',
         },
       ];
-      apiClientStub.getAllUserSavedSearches.resolves(mockBookmarks);
+      apiClientStub.getAllUserSavedSearches.resolves(mockSavedSearches);
       const service = await fixture<WebstatusBookmarksService>(
         html`<webstatus-bookmarks-service
           .apiClient=${apiClientStub}
@@ -494,12 +493,12 @@ describe('webstatus-bookmarks-service', () => {
           } as User}
         ></webstatus-bookmarks-service>`,
       );
-      expect(
-        service.appBookmarkInfo.userSavedSearchBookmarksTask?.status,
-      ).to.equal(TaskStatus.COMPLETE);
-      expect(
-        service.appBookmarkInfo.userSavedSearchBookmarksTask?.data,
-      ).to.deep.equal(mockBookmarks);
+      expect(service.appBookmarkInfo.userSavedSearchesTask?.status).to.equal(
+        TaskStatus.COMPLETE,
+      );
+      expect(service.appBookmarkInfo.userSavedSearchesTask?.data).to.deep.equal(
+        mockSavedSearches,
+      );
     });
 
     it('should handle null user', async () => {
@@ -509,56 +508,59 @@ describe('webstatus-bookmarks-service', () => {
           .user=${null}
         ></webstatus-bookmarks-service>`,
       );
-      expect(
-        service.appBookmarkInfo.userSavedSearchBookmarksTask?.status,
-      ).to.eq(TaskStatus.COMPLETE);
-      expect(service.appBookmarkInfo.userSavedSearchBookmarksTask?.data).to.be
+      expect(service.appBookmarkInfo.userSavedSearchesTask?.status).to.eq(
+        TaskStatus.COMPLETE,
+      );
+      expect(service.appBookmarkInfo.userSavedSearchesTask?.data).to.be
         .undefined;
     });
   });
 
   describe('findCurrentBookmarkByQuery', () => {
-    it('should return undefined for empty bookmarks', () => {
+    it('should return undefined for empty saved searches', () => {
       const service = new WebstatusBookmarksService();
-      expect(service.findCurrentBookmarkByQuery()).to.be.undefined;
+      expect(service.findCurrentSavedSearchByQuery()).to.be.undefined;
     });
 
-    it('should find a matching bookmark', () => {
+    it('should find a matching saved search', () => {
       const service = new WebstatusBookmarksService();
       service._currentLocation = {
         search: '?q=test',
         href: '?q=test',
         pathname: '',
       };
-      const bookmarks = [{query: 'test', name: 'Test'}];
-      expect(service.findCurrentBookmarkByQuery(bookmarks)).to.deep.equal({
+      const savedSearches = [{query: 'test', name: 'Test'}];
+      expect(
+        service.findCurrentSavedSearchByQuery(savedSearches),
+      ).to.deep.equal({
         query: 'test',
         name: 'Test',
       });
     });
 
-    it('should return undefined if no bookmark matches', () => {
+    it('should return undefined if no saved search matches', () => {
       const service = new WebstatusBookmarksService();
       service._currentLocation = {
         search: '?q=test',
         href: '?q=test',
         pathname: '',
       };
-      const bookmarks = [{query: 'other', name: 'Other'}];
-      expect(service.findCurrentBookmarkByQuery(bookmarks)).to.be.undefined;
+      const savedSearches = [{query: 'other', name: 'Other'}];
+      expect(service.findCurrentSavedSearchByQuery(savedSearches)).to.be
+        .undefined;
     });
   });
 
   it('should refresh appBookmarkInfo correctly', () => {
     const service = new WebstatusBookmarksService();
-    service._globalBookmarks = [{query: 'global', name: 'Global'}];
-    service._currentGlobalBookmark = {query: 'global', name: 'Global'};
-    service._userSavedBookmarkByIDTaskTracker = {
+    service._globalSavedSearches = [{query: 'global', name: 'Global'}];
+    service._currentGlobalSavedSearch = {query: 'global', name: 'Global'};
+    service._userSavedSearchByIDTaskTracker = {
       status: TaskStatus.COMPLETE,
       data: {id: 'uuid', query: 'saved', name: 'Saved'},
       error: undefined,
     };
-    service._userSavedBookmarksTaskTracker = {
+    service._userSavedSearchesTaskTracker = {
       status: TaskStatus.COMPLETE,
       data: [
         {id: 'uuid1', query: 'saved', name: 'Saved'},
@@ -573,15 +575,15 @@ describe('webstatus-bookmarks-service', () => {
     };
     service.refreshAppBookmarkInfo();
     expect(service.appBookmarkInfo).to.deep.equal({
-      globalBookmarks: [{query: 'global', name: 'Global'}],
-      currentGlobalBookmark: {query: 'global', name: 'Global'},
-      userSavedSearchBookmarkTask: {
+      globalSavedSearches: [{query: 'global', name: 'Global'}],
+      currentGlobalSavedSearch: {query: 'global', name: 'Global'},
+      userSavedSearchTask: {
         status: TaskStatus.COMPLETE,
         data: {id: 'uuid', query: 'saved', name: 'Saved'},
         error: undefined,
       },
       currentLocation: {search: '?q=test', href: '?q=test', pathname: ''},
-      userSavedSearchBookmarksTask: {
+      userSavedSearchesTask: {
         status: TaskStatus.COMPLETE,
         data: [
           {id: 'uuid1', query: 'saved', name: 'Saved'},

--- a/frontend/src/static/js/utils/constants.ts
+++ b/frontend/src/static/js/utils/constants.ts
@@ -27,24 +27,39 @@ export type BookmarkPermissions =
 export const BookmarkOwnerRole: components['schemas']['UserSavedSearchPermissions']['role'] =
   'saved_search_owner';
 
-export interface Bookmark {
-  // Bookmark display name
+export type BookmarkStatus = components['schemas']['UserSavedSearchBookmark'];
+export const BookmarkStatusActive: components['schemas']['UserSavedSearchBookmark']['status'] =
+  'bookmark_active';
+
+export interface UserSavedSearch extends SavedSearch {
+  // Make id required
+  id: string;
+  // Permissions
+  permissions?: BookmarkPermissions;
+  // Bookmark status
+  bookmark_status?: BookmarkStatus;
+  // Updated At
+  updated_at?: string;
+  // Created At
+  created_at?: string;
+}
+
+export interface GlobalSavedSearch extends SavedSearch {
+  // Should display query results in query's order.
+  is_ordered?: boolean;
+  // Override the num parameter value, if provided.
+  override_num_param?: number;
+}
+export interface SavedSearch {
+  // Saved search display name
   name: string;
   // Query for filtering
   query: string;
   // Overview page description
   description?: string;
-  // Should display query results in query's order.
-  is_ordered?: boolean;
-  // Override the num parameter value, if provided.
-  override_num_param?: number;
-  // Server side id for bookmark
-  id?: string;
-  // Permissions
-  permissions?: BookmarkPermissions;
 }
 
-export const DEFAULT_BOOKMARKS: Bookmark[] = [
+export const DEFAULT_GLOBAL_SAVED_SEARCHES: GlobalSavedSearch[] = [
   {
     name: 'Baseline 2025',
     query: 'baseline_date:2025-01-01..2025-12-31',

--- a/frontend/src/static/js/utils/test/urls.test.ts
+++ b/frontend/src/static/js/utils/test/urls.test.ts
@@ -24,7 +24,7 @@ import {
   getWPTMetricView,
   getColumnOptions,
   getSearchID,
-  getEditBookmark,
+  getEditSavedSearch,
 } from '../urls.js';
 
 describe('getSearchQuery', () => {
@@ -131,19 +131,19 @@ describe('getSearchID', () => {
   });
 });
 
-describe('getEditBookmark', () => {
-  it('returns false when there was no edit_bookmark= param', () => {
-    const cs = getEditBookmark({search: ''});
+describe('getEditSavedSearch', () => {
+  it('returns false when there was no edit_saved_search= param', () => {
+    const cs = getEditSavedSearch({search: ''});
     assert.equal(cs, false);
   });
 
-  it('returns false when the edit_bookmark= param has no value', () => {
-    const cs = getEditBookmark({search: '?edit_bookmark='});
+  it('returns false when the edit_saved_search= param has no value', () => {
+    const cs = getEditSavedSearch({search: '?edit_saved_search='});
     assert.equal(cs, false);
   });
 
-  it('returns the string when the edit_bookmark= param was set', () => {
-    const cs = getEditBookmark({search: '?edit_bookmark=true'});
+  it('returns the string when the edit_saved_search= param was set', () => {
+    const cs = getEditSavedSearch({search: '?edit_saved_search=true'});
     assert.equal(cs, true);
   });
 });
@@ -226,9 +226,9 @@ describe('formatOverviewPageUrl', () => {
     assert.equal(url, '/?search_id=fake_uuid');
   });
 
-  it('returns a URL with navigational params when edit_bookmark param is set', () => {
-    const url = formatOverviewPageUrl({search: ''}, {edit_bookmark: true});
-    assert.equal(url, '/?edit_bookmark=true');
+  it('returns a URL with navigational params when edit_saved_search param is set', () => {
+    const url = formatOverviewPageUrl({search: ''}, {edit_saved_search: true});
+    assert.equal(url, '/?edit_saved_search=true');
   });
 });
 

--- a/frontend/src/static/js/utils/urls.ts
+++ b/frontend/src/static/js/utils/urls.ts
@@ -47,8 +47,8 @@ export function getSearchID(location: {search: string}): string {
   return getQueryParam(location.search, 'search_id');
 }
 
-export function getEditBookmark(location: {search: string}): boolean {
-  return Boolean(getQueryParam(location.search, 'edit_bookmark'));
+export function getEditSavedSearch(location: {search: string}): boolean {
+  return Boolean(getQueryParam(location.search, 'edit_saved_search'));
 }
 
 export interface DateRange {
@@ -85,7 +85,7 @@ export type QueryStringOverrides = {
   dateRange?: DateRange;
   column_options?: string[];
   search_id?: string;
-  edit_bookmark?: boolean;
+  edit_saved_search?: boolean;
 };
 
 /* Given the router location object, return a query string with
@@ -163,9 +163,9 @@ function getContextualQueryStringParams(
   }
 
   const editBookmark =
-    'edit_bookmark' in overrides ? overrides.edit_bookmark : undefined;
+    'edit_saved_search' in overrides ? overrides.edit_saved_search : undefined;
   if (editBookmark) {
-    searchParams.set('edit_bookmark', '' + editBookmark);
+    searchParams.set('edit_saved_search', '' + editBookmark);
   }
 
   return searchParams.toString() ? '?' + searchParams.toString() : '';


### PR DESCRIPTION
Previously, we used the phrases `bookmark` and `saved search` interchangeably. However, after creating the APIs, `saved searches` are the saved query objects and `bookmarks` describe a user's specific status related to a saved search.

This commit starts to rename a lot of the references to `bookmark` to `saved search`. We still need to rename the appBookmarkInfo to appSavedSearchInfo (since it's all about reading from the saved searches API), but that can come later (much later, this is just enough so that the UserSavedSearches functionality can land).

Besides the renaming mentioned above, there  are two new things:

## 1. `CurrentSavedSearch`
 `CurrentSavedSearch` is a new interface that can hold either one of the new interfaces: `UserSavedSearch` and `GlobalSavedSearch` This is done through a discriminated [union](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#discriminated-unions). I used this type of union vs the regular union with `|` because GlobalSavedSearch and UserSavedSearch have different fields but previously I was just allowing them to use both one interface (`Bookmark`) and marked all the fields optional. These two specific interfaces let consumers know that fields are actually expected for each interface. Additionally, the typescript compiler in vscode is smart enough to know what once you have checked for a certain type, it knows it is using that type.

## 2. Specific rendering methods for saved searches
Previously, we had `renderBookmark`. Now we have `renderGlobalSavedSearch` and `renderUserSavedSearch`. This uses `CurrentSavedSearch` from the previous point. No longer do we have to check the big Bookmark interface with all the optional properties. Now that we know the specific type of search, we can handle rendering specifically to that type.