### PR TITLE
Add saved search controls component

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-saved-search-controls.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-saved-search-controls.test.ts
@@ -1,0 +1,594 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {fixture, expect, html, waitUntil, oneEvent} from '@open-wc/testing';
+import sinon from 'sinon';
+import {TaskStatus} from '@lit/task';
+
+import '../webstatus-saved-search-controls.js';
+import {WebstatusSavedSearchControls} from '../webstatus-saved-search-controls.js';
+import {User} from '../../contexts/firebase-user-context.js';
+import {
+  BookmarkOwnerRole,
+  BookmarkStatusActive,
+  UserSavedSearch,
+} from '../../utils/constants.js';
+import {APIClient} from '../../api/client.js';
+import {ApiError} from '../../api/errors.js';
+import * as toastUtils from '../../utils/toast.js';
+
+// Mock child component
+import {WebstatusTypeahead} from '../webstatus-typeahead.js';
+import {WebstatusSavedSearchEditor} from '../webstatus-saved-search-editor.js';
+import {SlIconButton} from '@shoelace-style/shoelace';
+
+describe('WebstatusSavedSearchControls', () => {
+  let element: WebstatusSavedSearchControls;
+  let apiClientMock: sinon.SinonStubbedInstance<APIClient>;
+  let userMock: User;
+  let editor: WebstatusSavedSearchEditor;
+  let editorIsOpenStub: sinon.SinonStub;
+  let editorOpenSpy: sinon.SinonSpy;
+  let typeaheadMock: WebstatusTypeahead;
+  let formatOverviewPageUrlStub: sinon.SinonStub;
+  let getEditSavedSearchStub: sinon.SinonStub;
+  let updatePageUrlStub: sinon.SinonStub;
+  let toastStub: sinon.SinonStub;
+
+  const typeaheadQuery = 'mock query';
+
+  const mockSavedSearchOwner: UserSavedSearch = {
+    id: 'owner123',
+    name: 'My Search',
+    query: 'feature:css',
+    description: 'A search I own',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    permissions: {role: BookmarkOwnerRole},
+    bookmark_status: {status: BookmarkStatusActive}, // Owners always have it bookmarked implicitly
+  };
+
+  const mockSavedSearchViewerBookmarked: UserSavedSearch = {
+    id: 'viewerBM456',
+    name: 'Shared Search Bookmarked',
+    query: 'feature:js',
+    description: 'A search I view and bookmarked',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    permissions: undefined,
+    bookmark_status: {status: BookmarkStatusActive},
+  };
+
+  const mockSavedSearchViewerNotBookmarked: UserSavedSearch = {
+    id: 'viewerNB789',
+    name: 'Shared Search Not Bookmarked',
+    query: 'feature:html',
+    description: 'A search I view but have not bookmarked',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    permissions: undefined,
+    // No bookmark_status
+  };
+
+  const mockLocation = {search: '?q=feature:css'};
+
+  beforeEach(async () => {
+    apiClientMock = sinon.createStubInstance(APIClient);
+    userMock = {
+      getIdToken: sinon.stub().resolves('mock-token'),
+    } as unknown as User;
+
+    toastStub = sinon.stub(toastUtils.Toast.prototype, 'toast');
+
+    typeaheadMock = await fixture<WebstatusTypeahead>(
+      html`<webstatus-typeahead
+        .value=${typeaheadQuery}
+      ></webstatus-typeahead>`,
+    );
+
+    element = await fixture<WebstatusSavedSearchControls>(html`
+      <webstatus-saved-search-controls
+        .apiClient=${apiClientMock}
+        .user=${userMock}
+        .location=${mockLocation}
+        .overviewPageQueryInput=${typeaheadMock}
+      >
+      </webstatus-saved-search-controls>
+    `);
+
+    element._getOrigin = () => 'http://localhost:8080';
+
+    formatOverviewPageUrlStub = sinon
+      .stub(element, '_formatOverviewPageUrl')
+      .callsFake((location, params) => {
+        const url = new URL('http://localhost:8080/features');
+        url.search = location!.search;
+        if (params?.search_id) {
+          url.searchParams.set('search_id', params.search_id);
+        }
+        return url.pathname + url.search;
+      });
+    getEditSavedSearchStub = sinon
+      .stub(element, '_getEditSavedSearch')
+      .returns(false);
+    updatePageUrlStub = sinon.stub(element, '_updatePageUrl');
+    // Get the mocked editor instance after the element is rendered
+    editor = element.shadowRoot!.querySelector<WebstatusSavedSearchEditor>(
+      'webstatus-saved-search-editor',
+    )!;
+    editorOpenSpy = sinon.spy(editor, 'open');
+    editorIsOpenStub = sinon.stub(editor, 'isOpen');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('renders the save button initially', () => {
+    const saveButton = element.shadowRoot!.querySelector(
+      'sl-icon-button[name="floppy"]',
+    );
+    expect(saveButton).to.exist;
+  });
+
+  it('does not render active search controls when no savedSearch is provided', () => {
+    const shareButton = element.shadowRoot!.querySelector('sl-copy-button');
+    const bookmarkButton = element.shadowRoot!.querySelector(
+      'sl-icon-button[name^="star"]',
+    );
+    const editButton = element.shadowRoot!.querySelector(
+      'sl-icon-button[name="pencil"]',
+    );
+    const deleteButton = element.shadowRoot!.querySelector(
+      'sl-icon-button[name="trash"]',
+    );
+
+    expect(shareButton).to.not.exist;
+    expect(bookmarkButton).to.not.exist;
+    expect(editButton).to.not.exist;
+    expect(deleteButton).to.not.exist;
+  });
+
+  it('calls openNewSavedSearchDialog when save button is clicked', async () => {
+    const saveButton = element.shadowRoot!.querySelector<SlIconButton>(
+      'sl-icon-button[name="floppy"]',
+    )!;
+    saveButton.click();
+    await element.updateComplete;
+
+    expect(editorOpenSpy).to.have.been.calledOnceWith(
+      'save',
+      undefined,
+      typeaheadQuery,
+    );
+  });
+
+  describe('with active saved search (Viewer, Not Bookmarked)', () => {
+    beforeEach(async () => {
+      element.savedSearch = {...mockSavedSearchViewerNotBookmarked};
+      await element.updateComplete;
+    });
+
+    it('renders save, share, and bookmark (empty star) buttons', () => {
+      const saveButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="floppy"]',
+      );
+      const shareButton = element.shadowRoot!.querySelector('sl-copy-button');
+      const bookmarkButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="star"]',
+      );
+      const bookmarkFillButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="star-fill"]',
+      );
+      const editButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="pencil"]',
+      );
+      const deleteButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="trash"]',
+      );
+
+      expect(saveButton).to.exist;
+      expect(shareButton).to.exist;
+      expect(bookmarkButton).to.exist;
+      expect(bookmarkButton).to.not.have.attribute('disabled');
+      expect(bookmarkFillButton).to.not.exist;
+      expect(editButton).to.not.exist;
+      expect(deleteButton).to.not.exist;
+    });
+
+    it('configures share button correctly', () => {
+      const copyButton = element.shadowRoot!.querySelector('sl-copy-button');
+      const expectedUrl = `http://localhost:8080/features?q=feature%3Acss&search_id=${mockSavedSearchViewerNotBookmarked.id}`;
+      expect(copyButton).to.have.attribute('value', expectedUrl);
+      expect(formatOverviewPageUrlStub).to.have.been.calledWith(mockLocation, {
+        search_id: mockSavedSearchViewerNotBookmarked.id,
+      });
+    });
+
+    it('calls handleBookmarkSavedSearch to bookmark when bookmark button is clicked', async () => {
+      apiClientMock.putUserSavedSearchBookmark.resolves();
+      const bookmarkButton = element.shadowRoot!.querySelector<SlIconButton>(
+        'sl-icon-button[name="star"]',
+      )!;
+      const eventPromise = oneEvent(element, 'saved-search-bookmarked');
+
+      bookmarkButton.click();
+
+      // Wait for the task to complete
+      await waitUntil(
+        () => element['_bookmarkTask']?.status === TaskStatus.COMPLETE,
+      );
+      await element.updateComplete; // Ensure UI updates
+
+      const event = await eventPromise;
+
+      expect((userMock.getIdToken as sinon.SinonStub).calledOnce).to.be.true;
+      expect(
+        apiClientMock.putUserSavedSearchBookmark,
+      ).to.have.been.calledOnceWith(
+        mockSavedSearchViewerNotBookmarked.id,
+        'mock-token',
+      );
+      expect(apiClientMock.removeUserSavedSearchBookmark).to.not.have.been
+        .called;
+
+      // Check event detail
+      expect(event.detail).to.deep.equal({
+        ...mockSavedSearchViewerNotBookmarked,
+        bookmark_status: {status: BookmarkStatusActive},
+      });
+
+      // Check UI update
+      const bookmarkFillButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="star-fill"]',
+      );
+      expect(bookmarkFillButton).to.exist;
+      expect(element.shadowRoot!.querySelector('sl-icon-button[name="star"]'))
+        .to.not.exist;
+    });
+
+    it('shows spinner during bookmark operation', async () => {
+      apiClientMock.putUserSavedSearchBookmark.resolves(); // Will resolve eventually
+      const bookmarkButton = element.shadowRoot!.querySelector<SlIconButton>(
+        'sl-icon-button[name="star"]',
+      )!;
+
+      bookmarkButton.click();
+      await element.updateComplete; // Let the task start
+
+      // Check immediately after click (task is PENDING)
+      expect(element['_bookmarkTask']?.status).to.equal(TaskStatus.PENDING);
+      let spinner = element.shadowRoot!.querySelector('#bookmark-task-spinner');
+      expect(spinner).to.exist;
+      expect(bookmarkButton).to.have.attribute('disabled');
+
+      // Wait for completion
+      await waitUntil(
+        () => element['_bookmarkTask']?.status === TaskStatus.COMPLETE,
+      );
+      await element.updateComplete; // Let UI update after completion
+
+      spinner = element.shadowRoot!.querySelector('#bookmark-task-spinner');
+      expect(spinner).to.not.exist;
+      const bookmarkFillButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="star-fill"]',
+      );
+      expect(bookmarkFillButton).to.exist;
+      expect(bookmarkFillButton).to.not.have.attribute('disabled');
+    });
+
+    it('handles API error during bookmarking', async () => {
+      const error = new ApiError('Bookmark failed', 500);
+      apiClientMock.putUserSavedSearchBookmark.rejects(error);
+      const bookmarkButton = element.shadowRoot!.querySelector<SlIconButton>(
+        'sl-icon-button[name="star"]',
+      )!;
+
+      bookmarkButton.click();
+
+      await waitUntil(
+        () => element['_bookmarkTask']?.status === TaskStatus.ERROR,
+      );
+      await element.updateComplete;
+
+      expect(apiClientMock.putUserSavedSearchBookmark).to.have.been.calledOnce;
+      expect(toastStub).to.have.been.calledOnceWith(
+        error.message,
+        'danger',
+        'exclamation-triangle',
+      );
+
+      // UI should revert/remain unchanged
+      const bookmarkEmptyButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="star"]',
+      );
+      expect(bookmarkEmptyButton).to.exist;
+      expect(bookmarkEmptyButton).to.not.have.attribute('disabled');
+      expect(
+        element.shadowRoot!.querySelector('sl-icon-button[name="star-fill"]'),
+      ).to.not.exist;
+      expect(element.shadowRoot!.querySelector('#bookmark-task-spinner')).to.not
+        .exist;
+    });
+  });
+
+  describe('with active saved search (Viewer, Bookmarked)', () => {
+    beforeEach(async () => {
+      element.savedSearch = {...mockSavedSearchViewerBookmarked};
+      await element.updateComplete;
+    });
+
+    it('renders save, share, and bookmark (filled star) buttons', () => {
+      const saveButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="floppy"]',
+      );
+      const shareButton = element.shadowRoot!.querySelector('sl-copy-button');
+      const bookmarkButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="star"]',
+      );
+      const bookmarkFillButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="star-fill"]',
+      );
+      const editButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="pencil"]',
+      );
+      const deleteButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="trash"]',
+      );
+
+      expect(saveButton).to.exist;
+      expect(shareButton).to.exist;
+      expect(bookmarkButton).to.not.exist;
+      expect(bookmarkFillButton).to.exist;
+      expect(bookmarkFillButton).to.not.have.attribute('disabled');
+      expect(editButton).to.not.exist;
+      expect(deleteButton).to.not.exist;
+    });
+
+    it('calls handleBookmarkSavedSearch to unbookmark when bookmark button is clicked', async () => {
+      apiClientMock.removeUserSavedSearchBookmark.resolves();
+      const bookmarkButton = element.shadowRoot!.querySelector<SlIconButton>(
+        'sl-icon-button[name="star-fill"]',
+      )!;
+      const eventPromise = oneEvent(element, 'saved-search-unbookmarked');
+
+      bookmarkButton.click();
+
+      await waitUntil(
+        () => element['_bookmarkTask']?.status === TaskStatus.COMPLETE,
+      );
+      await element.updateComplete;
+
+      const event = await eventPromise;
+
+      expect((userMock.getIdToken as sinon.SinonStub).calledOnce).to.be.true;
+      expect(
+        apiClientMock.removeUserSavedSearchBookmark,
+      ).to.have.been.calledOnceWith(
+        mockSavedSearchViewerBookmarked.id,
+        'mock-token',
+      );
+      expect(apiClientMock.putUserSavedSearchBookmark).to.not.have.been.called;
+
+      // Check event detail
+      expect(event.detail).to.deep.equal(mockSavedSearchViewerBookmarked.id);
+
+      // Assume the parent updates the saved search object from the bookmark info store
+      element.savedSearch = {
+        ...mockSavedSearchViewerBookmarked,
+        bookmark_status: undefined,
+      };
+      await element.updateComplete;
+      // Check UI update
+      const bookmarkEmptyButton =
+        element.shadowRoot!.querySelector<SlIconButton>(
+          'sl-icon-button[name="star"]',
+        );
+      expect(bookmarkEmptyButton).to.exist;
+      expect(
+        element.shadowRoot!.querySelector('sl-icon-button[name="star-fill"]'),
+      ).to.not.exist;
+    });
+
+    it('handles API error during unbookmarking', async () => {
+      const error = new ApiError('Unbookmark failed', 500);
+      apiClientMock.removeUserSavedSearchBookmark.rejects(error);
+      const bookmarkButton = element.shadowRoot!.querySelector<SlIconButton>(
+        'sl-icon-button[name="star-fill"]',
+      )!;
+
+      bookmarkButton.click();
+
+      await waitUntil(
+        () => element['_bookmarkTask']?.status === TaskStatus.ERROR,
+      );
+      await element.updateComplete;
+
+      expect(apiClientMock.removeUserSavedSearchBookmark).to.have.been
+        .calledOnce;
+      expect(toastStub).to.have.been.calledOnceWith(
+        error.message,
+        'danger',
+        'exclamation-triangle',
+      );
+
+      // UI should revert/remain unchanged
+      const bookmarkFillButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="star-fill"]',
+      );
+      expect(bookmarkFillButton).to.exist;
+      expect(bookmarkFillButton).to.not.have.attribute('disabled');
+      expect(element.shadowRoot!.querySelector('sl-icon-button[name="star"]'))
+        .to.not.exist;
+      expect(element.shadowRoot!.querySelector('#bookmark-task-spinner')).to.not
+        .exist;
+    });
+  });
+
+  describe('with active saved search (Owner)', () => {
+    beforeEach(async () => {
+      element.savedSearch = {...mockSavedSearchOwner};
+      await element.updateComplete;
+    });
+
+    it('renders save, share, bookmark (filled, disabled), edit, and delete buttons', () => {
+      const saveButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="floppy"]',
+      );
+      const shareButton = element.shadowRoot!.querySelector('sl-copy-button');
+      const bookmarkButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="star"]',
+      );
+      const bookmarkFillButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="star-fill"]',
+      );
+      const editButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="pencil"]',
+      );
+      const deleteButton = element.shadowRoot!.querySelector(
+        'sl-icon-button[name="trash"]',
+      );
+
+      expect(saveButton).to.exist;
+      expect(shareButton).to.exist;
+      expect(bookmarkButton).to.not.exist;
+      expect(bookmarkFillButton).to.exist;
+      expect(bookmarkFillButton).to.have.attribute('disabled'); // Key check for owner
+      expect(editButton).to.exist;
+      expect(deleteButton).to.exist;
+    });
+
+    it('configures share button correctly for owner', () => {
+      const copyButton = element.shadowRoot!.querySelector('sl-copy-button');
+      const expectedUrl = `http://localhost:8080/features?q=feature%3Acss&search_id=${mockSavedSearchOwner.id}`;
+      expect(copyButton).to.have.attribute('value', expectedUrl);
+      expect(formatOverviewPageUrlStub).to.have.been.calledWith(mockLocation, {
+        search_id: mockSavedSearchOwner.id,
+      });
+    });
+
+    it('calls openEditSavedSearchDialog when edit button is clicked', async () => {
+      const editButton = element.shadowRoot!.querySelector<SlIconButton>(
+        'sl-icon-button[name="pencil"]',
+      )!;
+      editButton.click();
+      await element.updateComplete;
+
+      expect(editorOpenSpy).to.have.been.calledOnceWith(
+        'edit',
+        element.savedSearch,
+        typeaheadQuery,
+      );
+    });
+
+    it('calls openDeleteSavedSearchDialog when delete button is clicked', async () => {
+      const deleteButton = element.shadowRoot!.querySelector<SlIconButton>(
+        'sl-icon-button[name="trash"]',
+      )!;
+      deleteButton.click();
+      await element.updateComplete;
+
+      expect(editorOpenSpy).to.have.been.calledOnceWith(
+        'delete',
+        element.savedSearch,
+      );
+    });
+
+    it('does not call handleBookmarkSavedSearch when disabled bookmark button is clicked', async () => {
+      const bookmarkButton = element.shadowRoot!.querySelector<SlIconButton>(
+        'sl-icon-button[name="star-fill"]',
+      )!;
+      const handleBookmarkSpy = sinon.spy(element, 'handleBookmarkSavedSearch');
+
+      bookmarkButton.click(); // Click the disabled button
+      await element.updateComplete;
+
+      expect(handleBookmarkSpy).to.not.have.been.called;
+      expect(apiClientMock.putUserSavedSearchBookmark).to.not.have.been.called;
+      expect(apiClientMock.removeUserSavedSearchBookmark).to.not.have.been
+        .called;
+    });
+  });
+
+  describe('updated lifecycle hook', () => {
+    it('opens edit dialog and updates URL if edit_saved_search param is present', async () => {
+      element.location = {search: 'test'};
+      element.savedSearch = {...mockSavedSearchOwner};
+      getEditSavedSearchStub.returns(true); // Simulate finding the param
+      editorIsOpenStub.returns(false); // Simulate editor not already open
+
+      // Trigger the updated lifecycle hook manually for testing
+      element.requestUpdate();
+      await element.updateComplete;
+
+      // It should call openEditSavedSearchDialog, which calls editor.open
+      expect(editorOpenSpy).to.have.been.calledOnceWith(
+        'edit',
+        element.savedSearch,
+        typeaheadQuery,
+      );
+      // It should remove the URL parameter
+      expect(updatePageUrlStub).to.have.been.calledOnceWith(
+        '',
+        element.location,
+        {edit_saved_search: undefined},
+      );
+    });
+
+    it('does not open edit dialog if editor is already open', async () => {
+      element.savedSearch = {...mockSavedSearchOwner};
+      getEditSavedSearchStub.returns(true);
+      editorIsOpenStub.returns(true);
+
+      element.requestUpdate();
+      await element.updateComplete;
+
+      expect(editorOpenSpy).to.not.have.been.called;
+      // Should not update URL if dialog wasn't opened by this hook
+      expect(updatePageUrlStub).to.not.have.been.called;
+      expect(getEditSavedSearchStub).to.have.been.called;
+    });
+
+    it('does not open edit dialog if edit_saved_search param is not present', async () => {
+      element.savedSearch = {...mockSavedSearchOwner};
+      getEditSavedSearchStub.returns(false); // Param not present
+
+      editorIsOpenStub.returns(false);
+
+      element.requestUpdate();
+      await element.updateComplete;
+
+      expect(editorIsOpenStub).to.not.have.been.called;
+      expect(updatePageUrlStub).to.not.have.been.called;
+    });
+
+    it('does not open edit dialog if savedSearch is not available', async () => {
+      element.savedSearch = undefined; // No saved search loaded yet
+      getEditSavedSearchStub.returns(true);
+      editorIsOpenStub.returns(false);
+
+      element.requestUpdate();
+      await element.updateComplete;
+
+      expect(editorOpenSpy).to.not.have.been.called;
+      // updatePageUrl might still be called depending on exact logic,
+      // but the primary action (opening dialog) shouldn't happen.
+      // Let's assert it's not called for clarity, though the original code
+      // might call it regardless. The important part is the dialog doesn't open.
+      expect(updatePageUrlStub).to.not.have.been.called;
+    });
+  });
+});

--- a/frontend/src/static/js/components/webstatus-saved-search-controls.ts
+++ b/frontend/src/static/js/components/webstatus-saved-search-controls.ts
@@ -1,0 +1,299 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  LitElement,
+  PropertyValueMap,
+  TemplateResult,
+  css,
+  html,
+  nothing,
+} from 'lit';
+import {customElement, property, query, state} from 'lit/decorators.js';
+import {APIClient} from '../contexts/api-client-context.js';
+import {User} from '../contexts/firebase-user-context.js';
+import {
+  BookmarkOwnerRole,
+  BookmarkStatusActive,
+  UserSavedSearch,
+} from '../utils/constants.js';
+import {WebstatusSavedSearchEditor} from './webstatus-saved-search-editor.js';
+
+import './webstatus-saved-search-editor.js';
+import {
+  formatOverviewPageUrl,
+  getEditSavedSearch,
+  getOrigin,
+  updatePageUrl,
+} from '../utils/urls.js';
+import {ifDefined} from 'lit/directives/if-defined.js';
+import {Task, TaskStatus} from '@lit/task';
+import {ApiError} from '../api/errors.js';
+import {Toast} from '../utils/toast.js';
+import {type WebstatusTypeahead} from './webstatus-typeahead.js';
+
+@customElement('webstatus-saved-search-controls')
+export class WebstatusSavedSearchControls extends LitElement {
+  @property({type: Object})
+  apiClient!: APIClient;
+
+  @property({type: Object})
+  user!: User;
+
+  @property({type: Object})
+  savedSearch?: UserSavedSearch;
+
+  @property({type: Object})
+  overviewPageQueryInput?: WebstatusTypeahead;
+
+  @property({type: Object})
+  location!: {search: string};
+
+  @query('webstatus-saved-search-editor')
+  savedSearchEditor!: WebstatusSavedSearchEditor;
+
+  @state()
+  private _bookmarkTask?: Task;
+
+  // Members that are used for testing with sinon.
+  _getOrigin: () => string = getOrigin;
+  _getEditSavedSearch: (location: {search: string}) => boolean =
+    getEditSavedSearch;
+  _updatePageUrl: (
+    pathname: string,
+    location: {search: string},
+    overrides: {edit_saved_search?: boolean},
+  ) => void = updatePageUrl;
+  _formatOverviewPageUrl: (
+    location: {search: string},
+    overrides: {search_id?: string},
+  ) => string = formatOverviewPageUrl;
+
+  static styles = css`
+    #bookmark-task-spinner {
+      font-size: 1rem;
+    }
+  `;
+
+  async openNewSavedSearchDialog() {
+    await this.savedSearchEditor.open(
+      'save',
+      undefined,
+      this.overviewPageQueryInput?.value,
+    );
+  }
+
+  async openEditSavedSearchDialog() {
+    await this.savedSearchEditor.open(
+      'edit',
+      this.savedSearch,
+      this.overviewPageQueryInput?.value,
+    );
+  }
+
+  async openDeleteSavedSearchDialog() {
+    await this.savedSearchEditor.open('delete', this.savedSearch);
+  }
+
+  async handleBookmarkSavedSearch(
+    savedSearch: UserSavedSearch,
+    isBookmarkStatusActive: boolean,
+  ) {
+    this._bookmarkTask = new Task(this, {
+      autoRun: false,
+      task: async ([
+        apiClient,
+        user,
+        savedSearchID,
+        isBookmarkStatusActive,
+      ]) => {
+        const token = await user.getIdToken();
+        if (isBookmarkStatusActive) {
+          await apiClient.removeUserSavedSearchBookmark(savedSearchID, token);
+        } else {
+          await apiClient.putUserSavedSearchBookmark(savedSearchID, token);
+        }
+
+        // Return the new bookmark status
+        return !isBookmarkStatusActive;
+      },
+      args: () => [
+        this.apiClient,
+        this.user,
+        savedSearch.id,
+        isBookmarkStatusActive,
+      ],
+      onComplete: async isNewBookmarkStatusActive => {
+        if (isNewBookmarkStatusActive) {
+          savedSearch.bookmark_status = {
+            status: BookmarkStatusActive,
+          };
+          this.dispatchEvent(
+            new CustomEvent('saved-search-bookmarked', {
+              detail: savedSearch,
+              bubbles: true,
+              composed: true,
+            }),
+          );
+        } else {
+          this.dispatchEvent(
+            new CustomEvent('saved-search-unbookmarked', {
+              detail: savedSearch.id,
+              bubbles: true,
+              composed: true,
+            }),
+          );
+        }
+      },
+      async onError(error: unknown) {
+        let message: string;
+        if (error instanceof ApiError) {
+          message = error.message;
+        } else {
+          message =
+            'Unknown error toggling bookmark status. Check console for details.';
+          console.error(error);
+        }
+        await new Toast().toast(message, 'danger', 'exclamation-triangle');
+      },
+    });
+    // Run manually to prevent changes to any variables from retriggering the task.
+    await this._bookmarkTask.run();
+  }
+
+  renderBookmarkControl(
+    savedSearch: UserSavedSearch,
+    isOwner: boolean,
+  ): TemplateResult {
+    let bookmarkStatusIcon: 'star-fill' | 'star' = 'star';
+    let bookmarkTooltipText: string = 'Bookmark this search';
+    let bookmarkTooltipLabel: string = 'Bookmark';
+    let bookmarkButtonDisabled: boolean = false;
+    let isBookmarkStatusActive: boolean = false;
+    if (savedSearch.bookmark_status?.status === BookmarkStatusActive) {
+      bookmarkStatusIcon = 'star-fill';
+      bookmarkTooltipText = 'Unbookmark this search';
+      bookmarkTooltipLabel = 'Unbookmark';
+      isBookmarkStatusActive = true;
+    }
+    if (isOwner) {
+      bookmarkButtonDisabled = true;
+      bookmarkTooltipText =
+        'Users cannot remove the bookmark for saved searches they own';
+    }
+    const inProgress = this._bookmarkTask?.status === TaskStatus.PENDING;
+    return html`
+      <sl-tooltip content="${bookmarkTooltipText}">
+        <sl-icon-button
+          name="${bookmarkStatusIcon}"
+          label="${bookmarkTooltipLabel}"
+          .disabled=${bookmarkButtonDisabled || inProgress}
+          @click=${ifDefined(isOwner)
+            ? undefined
+            : () =>
+                this.handleBookmarkSavedSearch(
+                  savedSearch,
+                  isBookmarkStatusActive,
+                )}
+        ></sl-icon-button>
+      </sl-tooltip>
+      ${inProgress
+        ? html`<sl-spinner id="bookmark-task-spinner"></sl-spinner>`
+        : nothing}
+    `;
+  }
+
+  renderActiveSavedSearchControls(
+    savedSearch: UserSavedSearch,
+  ): TemplateResult {
+    const isOwner = savedSearch.permissions?.role === BookmarkOwnerRole;
+    const shareableUrl = `${this._getOrigin()}${this._formatOverviewPageUrl(this.location, {search_id: savedSearch.id})}`;
+    return html`
+      <sl-copy-button
+        value="${shareableUrl}"
+        copy-label="Copy saved search URL to clipboard"
+        success-label="Copied"
+        error-label="Whoops, your browser doesn't support this!"
+        ><sl-icon-button
+          slot="copy-icon"
+          name="share"
+          label="Copy"
+        ></sl-icon-button
+        ><sl-icon-button
+          slot="success-icon"
+          name="share-fill"
+          label="Copy Success"
+        ></sl-icon-button>
+      </sl-copy-button>
+      ${this.renderBookmarkControl(savedSearch, isOwner)}
+      ${isOwner
+        ? html`
+            <sl-tooltip content="Edit current saved search">
+              <sl-icon-button
+                name="pencil"
+                label="Edit"
+                @click=${() => this.openEditSavedSearchDialog()}
+              ></sl-icon-button>
+            </sl-tooltip>
+            <sl-tooltip content="Delete saved search">
+              <sl-icon-button
+                name="trash"
+                label="Delete"
+                @click=${() => this.openDeleteSavedSearchDialog()}
+              ></sl-icon-button>
+            </sl-tooltip>
+          `
+        : nothing}
+    `;
+  }
+
+  protected async updated(
+    _changedProperties: PropertyValueMap<this>,
+  ): Promise<void> {
+    if (
+      this._getEditSavedSearch(this.location) &&
+      !this.savedSearchEditor.isOpen() &&
+      this.savedSearch
+    ) {
+      void this.openEditSavedSearchDialog();
+      this._updatePageUrl('', this.location, {edit_saved_search: undefined});
+    }
+  }
+
+  render() {
+    return html`
+      <div slot="anchor" class="popup-anchor saved-search-controls"></div>
+      <div class="popup-content">
+        <sl-tooltip content="Create a new saved search">
+          <sl-icon-button
+            name="floppy"
+            label="Save"
+            @click=${() => this.openNewSavedSearchDialog()}
+          ></sl-icon-button>
+        </sl-tooltip>
+        ${this.savedSearch !== undefined
+          ? this.renderActiveSavedSearchControls(this.savedSearch)
+          : nothing}
+      </div>
+      <webstatus-saved-search-editor
+        .apiClient=${this.apiClient}
+        .user=${this.user}
+        .savedSearch=${this.savedSearch}
+        .location=${this.location}
+      ></webstatus-saved-search-editor>
+    `;
+  }
+}

--- a/frontend/src/static/js/utils/urls.ts
+++ b/frontend/src/static/js/utils/urls.ts
@@ -205,3 +205,8 @@ export function updatePageUrl(
   const url = `${pathname}${qs}`;
   window.history.replaceState({}, '', url);
 }
+
+/* Return the origin of the current page. */
+export function getOrigin(): string {
+  return window.location.origin;
+}


### PR DESCRIPTION
This component will be entrypoint to controlling saved searches and bookmark status on the overview page.

For creating/updating/deleting saved searches, this component will open the saved search editor component created in #1411

For bookmarking/unbookmarking, the controls component itself will handle the HTTP tasks to toggle the status. This component will dispatch either `saved-search-bookmarked` or `saved-search-unbookmarked` which will be handled by webstatus-bookmarks-service