### PR TITLE
Ingest WPT scores for mobile browsers

### DIFF
--- a/lib/gcpspanner/spanneradapters/wptconsumertypes/types.go
+++ b/lib/gcpspanner/spanneradapters/wptconsumertypes/types.go
@@ -39,3 +39,16 @@ var ErrUnableToStoreWPTRun = errors.New("unable to store wpt run data")
 // ErrUnableToStoreWPTRunFeatureMetrics indicates that the storage layer was
 // unable to save the wpt run feature metrics.
 var ErrUnableToStoreWPTRunFeatureMetrics = errors.New("unable to store wpt run feature metrics")
+
+// BrowserName is an enumeration of the supported browsers for WPT runs.
+type BrowserName string
+
+const (
+	Chrome         BrowserName = "chrome"
+	Edge           BrowserName = "edge"
+	Firefox        BrowserName = "firefox"
+	Safari         BrowserName = "safari"
+	ChromeAndroid  BrowserName = "chrome_android"
+	FirefoxAndroid BrowserName = "firefox_android"
+	SafariIos      BrowserName = "safari_ios"
+)

--- a/workflows/steps/services/wpt_consumer/cmd/job/main.go
+++ b/workflows/steps/services/wpt_consumer/cmd/job/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/wptconsumertypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gds"
 	"github.com/GoogleChrome/webstatus.dev/lib/localcache"
 	"github.com/GoogleChrome/webstatus.dev/lib/workerpool"
@@ -105,7 +106,15 @@ func main() {
 	// Job Generation
 	jobs := []workflow.JobArguments{}
 	startAt := time.Now().UTC().Add(-duration)
-	browsers := shared.GetDefaultBrowserNames()
+	browsers := []string{
+		string(wptconsumertypes.Chrome),
+		string(wptconsumertypes.Edge),
+		string(wptconsumertypes.Firefox),
+		string(wptconsumertypes.Safari),
+		string(wptconsumertypes.ChromeAndroid),
+		string(wptconsumertypes.FirefoxAndroid),
+		string(wptconsumertypes.SafariIos),
+	}
 	channels := []string{shared.StableLabel, shared.ExperimentalLabel}
 	for _, browser := range browsers {
 		for _, channel := range channels {


### PR DESCRIPTION
Part of #1361 and #996

Previously, the default browsers listed in WPT.fyi were being used to determine which browser run data we were pulling. This change adds mobile browsers to that list of browsers.