### PR TITLE
Improve unit test ability for frontend code

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,8 +16,8 @@
     "postinstall": "./scripts/postinstall.js",
     "start": "node dist/server/index.js",
     "cp-imgs": "mkdir -p build/public/img && cp -v -r src/static/img/* build/public/img && cp -v .postinstall/static/img/* build/public/img",
-    "test": "npm run build && npm run cp-imgs && wtr --coverage",
-    "test:watch": "npm run build && concurrently -k --raw \"tsc --watch --preserveWatchOutput\"  \"wtr --watch --coverage\" "
+    "test": "BUILD_ENV=local npm run build && npm run cp-imgs && wtr --coverage",
+    "test:watch": "BUILD_ENV=local npm run build && concurrently -k --raw \"tsc --watch --preserveWatchOutput\"  \"wtr --watch --coverage\" "
   },
   "devDependencies": {
     "@browser-logos/chrome": "^2.0.0",

--- a/frontend/web-test-runner.config.mjs
+++ b/frontend/web-test-runner.config.mjs
@@ -34,12 +34,12 @@ export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
   },
 
   // in a monorepo you need to set the root dir to resolve modules
-  rootDir: 'build/',
+  rootDir: '.',
 
   files: [
     // Have to compile tests
     // Taken from https://github.com/open-wc/create/blob/master/src/generators/testing-wtr-ts/templates/static/web-test-runner.config.mjs
-    '**/test/*.test.js',
+    'build/**/test/*.test.js',
   ],
   testRunnerHtml: testFramework => `
   <html>


### PR DESCRIPTION
Previously, while running web test runner, it could not find the source code.

As a result, a developer could not insert break points.

This fixes that.