### PR TITLE
Utilize overview table in "Missing One" panel

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
@@ -215,21 +215,8 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
     `;
     expect(header).dom.to.equal(expectedHeader);
 
-    const table = el.shadowRoot!.querySelector('.missing-features-table');
+    const table = el.shadowRoot!.querySelector('webstatus-overview-table');
     expect(table).to.exist;
-
-    const rows = table!
-      .getElementsByTagName('tbody')[0]
-      .getElementsByTagName('tr');
-    expect(rows.length).to.equal(10, 'should have 10 rows');
-
-    const firstRowCells = rows[0].querySelectorAll('td');
-    const textContent = firstRowCells[0].textContent
-      ?.split('\n')
-      .map(word => word.trim())
-      .filter(word => word.length > 0)
-      .join(' ');
-    expect(textContent).to.equal('grid TOP CSS', 'first row ID');
   });
 
   it('renders empty features footer', async () => {

--- a/frontend/src/static/js/components/webstatus-overview-data-loader.ts
+++ b/frontend/src/static/js/components/webstatus-overview-data-loader.ts
@@ -140,7 +140,7 @@ export class WebstatusOverviewDataLoader extends LitElement {
       .isLoading=${this.taskTracker.status === TaskStatus.PENDING ||
       this.taskTracker.status === TaskStatus.INITIAL}
       .dataError=${this.taskTracker.error}
-      .data=${this.taskTracker?.data?.data}
+      .data=${data}
     ></webstatus-overview-table>`;
   }
 }

--- a/frontend/src/static/js/components/webstatus-overview-data-loader.ts
+++ b/frontend/src/static/js/components/webstatus-overview-data-loader.ts
@@ -37,6 +37,16 @@ import {
 @customElement('webstatus-overview-data-loader')
 export class WebstatusOverviewDataLoader extends LitElement {
   @property({type: Object})
+  featureTaskTracker: TaskTracker<
+    components['schemas']['Feature'][],
+    ApiError
+  > = {
+    status: TaskStatus.INITIAL, // Initial state
+    error: undefined,
+    data: undefined,
+  };
+
+  @property({type: Object})
   taskTracker: TaskTracker<components['schemas']['FeaturePage'], ApiError> = {
     status: TaskStatus.INITIAL, // Initial state
     error: undefined,
@@ -53,12 +63,12 @@ export class WebstatusOverviewDataLoader extends LitElement {
     searchKey: string,
     searchValue: string,
   ): components['schemas']['Feature'][] {
-    if (!this.taskTracker.data?.data) {
+    if (!this.taskTracker.data) {
       return [];
     }
 
     const features: components['schemas']['Feature'][] = [];
-    for (const feature of this.taskTracker.data.data) {
+    for (const feature of this.taskTracker.data?.data) {
       if (searchKey === 'id' && feature?.feature_id === searchValue) {
         features.push(feature);
         break;
@@ -126,8 +136,8 @@ export class WebstatusOverviewDataLoader extends LitElement {
     }
 
     if (
-      this.taskTracker.status === TaskStatus.COMPLETE &&
-      this.taskTracker.data
+      this.taskTracker.data?.data &&
+      this.taskTracker.status === TaskStatus.COMPLETE
     ) {
       this.taskTracker.data.data =
         this.reorderByQueryTerms() || this.taskTracker.data?.data;
@@ -137,7 +147,9 @@ export class WebstatusOverviewDataLoader extends LitElement {
       .columns=${columns}
       .headerCells=${headerCells}
       .location=${this.location}
-      .taskTracker=${this.taskTracker}
+      .taskStatus=${this.taskTracker.status}
+      .taskError=${this.taskTracker.error}
+      .data=${this.taskTracker.data?.data}
     ></webstatus-overview-table>`;
   }
 }

--- a/frontend/src/static/js/components/webstatus-overview-data-loader.ts
+++ b/frontend/src/static/js/components/webstatus-overview-data-loader.ts
@@ -37,16 +37,6 @@ import {
 @customElement('webstatus-overview-data-loader')
 export class WebstatusOverviewDataLoader extends LitElement {
   @property({type: Object})
-  featureTaskTracker: TaskTracker<
-    components['schemas']['Feature'][],
-    ApiError
-  > = {
-    status: TaskStatus.INITIAL, // Initial state
-    error: undefined,
-    data: undefined,
-  };
-
-  @property({type: Object})
   taskTracker: TaskTracker<components['schemas']['FeaturePage'], ApiError> = {
     status: TaskStatus.INITIAL, // Initial state
     error: undefined,

--- a/frontend/src/static/js/components/webstatus-overview-data-loader.ts
+++ b/frontend/src/static/js/components/webstatus-overview-data-loader.ts
@@ -58,7 +58,8 @@ export class WebstatusOverviewDataLoader extends LitElement {
     }
 
     const features: components['schemas']['Feature'][] = [];
-    for (const feature of this.taskTracker.data?.data) {
+    const data = this.taskTracker.data?.data || [];
+    for (const feature of data) {
       if (searchKey === 'id' && feature?.feature_id === searchValue) {
         features.push(feature);
         break;

--- a/frontend/src/static/js/components/webstatus-overview-data-loader.ts
+++ b/frontend/src/static/js/components/webstatus-overview-data-loader.ts
@@ -133,13 +133,20 @@ export class WebstatusOverviewDataLoader extends LitElement {
         this.reorderByQueryTerms() || this.taskTracker.data?.data;
     }
 
+    const featureTaskTracker: TaskTracker<
+      components['schemas']['Feature'][],
+      ApiError
+    > = {
+      status: this.taskTracker.status,
+      error: this.taskTracker.error,
+      data: this.taskTracker.data?.data,
+    };
+
     return html`<webstatus-overview-table
       .columns=${columns}
       .headerCells=${headerCells}
       .location=${this.location}
-      .taskStatus=${this.taskTracker.status}
-      .taskError=${this.taskTracker.error}
-      .data=${this.taskTracker.data?.data}
+      .taskTracker=${featureTaskTracker}
     ></webstatus-overview-table>`;
   }
 }

--- a/frontend/src/static/js/components/webstatus-overview-data-loader.ts
+++ b/frontend/src/static/js/components/webstatus-overview-data-loader.ts
@@ -125,18 +125,19 @@ export class WebstatusOverviewDataLoader extends LitElement {
       );
     }
 
-    let data = this.taskTracker.data?.data;
-    if (this.taskTracker.status === TaskStatus.COMPLETE) {
-      data = this.reorderByQueryTerms() || this.taskTracker.data?.data;
+    if (
+      this.taskTracker.status === TaskStatus.COMPLETE &&
+      this.taskTracker.data
+    ) {
+      this.taskTracker.data.data =
+        this.reorderByQueryTerms() || this.taskTracker.data?.data;
     }
 
     return html`<webstatus-overview-table
       .columns=${columns}
       .headerCells=${headerCells}
       .location=${this.location}
-      .taskStatus=${this.taskTracker.status}
-      .dataError=${this.taskTracker.error}
-      .data=${data}
+      .taskTracker=${this.taskTracker}
     ></webstatus-overview-table>`;
   }
 }

--- a/frontend/src/static/js/components/webstatus-overview-data-loader.ts
+++ b/frontend/src/static/js/components/webstatus-overview-data-loader.ts
@@ -137,7 +137,10 @@ export class WebstatusOverviewDataLoader extends LitElement {
       .columns=${columns}
       .headerCells=${headerCells}
       .location=${this.location}
-      .taskTracker=${this.taskTracker}
+      .isLoading=${this.taskTracker.status === TaskStatus.PENDING ||
+      this.taskTracker.status === TaskStatus.INITIAL}
+      .dataError=${this.taskTracker.error}
+      .data=${this.taskTracker?.data?.data}
     ></webstatus-overview-table>`;
   }
 }

--- a/frontend/src/static/js/components/webstatus-overview-data-loader.ts
+++ b/frontend/src/static/js/components/webstatus-overview-data-loader.ts
@@ -125,20 +125,16 @@ export class WebstatusOverviewDataLoader extends LitElement {
       );
     }
 
-    if (
-      this.taskTracker.status === TaskStatus.COMPLETE &&
-      this.taskTracker.data
-    ) {
-      this.taskTracker.data.data =
-        this.reorderByQueryTerms() || this.taskTracker.data?.data;
+    let data = this.taskTracker.data?.data;
+    if (this.taskTracker.status === TaskStatus.COMPLETE) {
+      data = this.reorderByQueryTerms() || this.taskTracker.data?.data;
     }
 
     return html`<webstatus-overview-table
       .columns=${columns}
       .headerCells=${headerCells}
       .location=${this.location}
-      .isLoading=${this.taskTracker.status === TaskStatus.PENDING ||
-      this.taskTracker.status === TaskStatus.INITIAL}
+      .taskStatus=${this.taskTracker.status}
       .dataError=${this.taskTracker.error}
       .data=${data}
     ></webstatus-overview-table>`;

--- a/frontend/src/static/js/components/webstatus-overview-table.ts
+++ b/frontend/src/static/js/components/webstatus-overview-table.ts
@@ -17,7 +17,7 @@ import {LitElement, type TemplateResult, html, CSSResultGroup, css} from 'lit';
 import {TaskStatus} from '@lit/task';
 import {range} from 'lit/directives/range.js';
 import {map} from 'lit/directives/map.js';
-import {customElement, property} from 'lit/decorators.js';
+import {customElement, property, state} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {type components} from 'webstatus.dev-backend';
 import {
@@ -36,27 +36,14 @@ import {CurrentSavedSearch} from '../contexts/app-bookmark-info-context.js';
 
 @customElement('webstatus-overview-table')
 export class WebstatusOverviewTable extends LitElement {
-  @property({type: Boolean})
-  isLoading = false;
-
-  @property({attribute: false})
+  @state()
   data?: components['schemas']['Feature'][];
 
   @property({attribute: false})
   dataError?: ApiError | Error;
 
-  @property({attribute: false})
-  columns: ColumnKey[] = [];
-
-  @property({attribute: false})
-  headerCells: TemplateResult[] = [];
-
-  @property({type: Object})
-  taskTracker: TaskTracker<components['schemas']['FeaturePage'], ApiError> = {
-    status: TaskStatus.INITIAL, // Initial state
-    error: undefined,
-    data: undefined,
-  };
+  @state()
+  taskStatus: TaskStatus = TaskStatus.INITIAL;
 
   @property({attribute: false})
   columns: ColumnKey[] = [];
@@ -176,13 +163,13 @@ export class WebstatusOverviewTable extends LitElement {
   }
 
   renderTableBody(columns: ColumnKey[]): TemplateResult {
-    switch (this.taskTracker.status) {
+    switch (this.taskStatus) {
       case TaskStatus.INITIAL:
         return this.renderBodyWhenPending(columns);
       case TaskStatus.PENDING:
         return this.renderBodyWhenPending(columns);
       case TaskStatus.COMPLETE:
-        return this.taskTracker.data?.data?.length === 0
+        return this.data?.length === 0
           ? this.renderBodyWhenNoResults(columns)
           : this.renderBodyWhenComplete(columns);
       case TaskStatus.ERROR:

--- a/frontend/src/static/js/components/webstatus-overview-table.ts
+++ b/frontend/src/static/js/components/webstatus-overview-table.ts
@@ -33,10 +33,24 @@ import {
   SEARCH_QUERY_README_LINK,
 } from '../utils/constants.js';
 import {CurrentSavedSearch} from '../contexts/app-bookmark-info-context.js';
-import {TaskTracker} from '../utils/task-tracker.js';
 
 @customElement('webstatus-overview-table')
 export class WebstatusOverviewTable extends LitElement {
+  @property({type: Boolean})
+  isLoading = false;
+
+  @property({attribute: false})
+  data?: components['schemas']['Feature'][];
+
+  @property({attribute: false})
+  dataError?: ApiError | Error;
+
+  @property({attribute: false})
+  columns: ColumnKey[] = [];
+
+  @property({attribute: false})
+  headerCells: TemplateResult[] = [];
+
   @property({type: Object})
   taskTracker: TaskTracker<components['schemas']['FeaturePage'], ApiError> = {
     status: TaskStatus.INITIAL, // Initial state
@@ -177,11 +191,7 @@ export class WebstatusOverviewTable extends LitElement {
   }
 
   renderBodyWhenComplete(columns: ColumnKey[]): TemplateResult {
-    return html`
-      ${this.taskTracker.data?.data?.map(f =>
-        this.renderFeatureRow(f, columns),
-      )}
-    `;
+    return html` ${this.data?.map(f => this.renderFeatureRow(f, columns))} `;
   }
 
   renderBodyWhenNoResults(columns: ColumnKey[]): TemplateResult {
@@ -196,7 +206,7 @@ export class WebstatusOverviewTable extends LitElement {
   }
 
   renderBodyWhenError(columns: ColumnKey[]): TemplateResult {
-    if (this.taskTracker.error instanceof BadRequestError) {
+    if (this.dataError instanceof BadRequestError) {
       return html`
         <tr>
           <td class="message" colspan=${columns.length}>
@@ -233,8 +243,7 @@ export class WebstatusOverviewTable extends LitElement {
 
   renderBodyWhenPending(columns: ColumnKey[]): TemplateResult {
     const DEFAULT_SKELETON_ROWS = 10;
-    const skeleton_rows =
-      this.taskTracker.data?.data?.length || DEFAULT_SKELETON_ROWS;
+    const skeleton_rows = this.data?.length || DEFAULT_SKELETON_ROWS;
     return html`
       ${map(
         range(skeleton_rows),

--- a/frontend/src/static/js/components/webstatus-overview-table.ts
+++ b/frontend/src/static/js/components/webstatus-overview-table.ts
@@ -40,12 +40,6 @@ export class WebstatusOverviewTable extends LitElement {
   data?: components['schemas']['Feature'][];
 
   @property({attribute: false})
-  dataError?: ApiError | Error;
-
-  @state()
-  taskStatus: TaskStatus = TaskStatus.INITIAL;
-
-  @property({attribute: false})
   columns: ColumnKey[] = [];
 
   @property({attribute: false})

--- a/frontend/src/static/js/components/webstatus-overview-table.ts
+++ b/frontend/src/static/js/components/webstatus-overview-table.ts
@@ -33,17 +33,16 @@ import {
   SEARCH_QUERY_README_LINK,
 } from '../utils/constants.js';
 import {CurrentSavedSearch} from '../contexts/app-bookmark-info-context.js';
+import {TaskTracker} from '../utils/task-tracker.js';
 
 @customElement('webstatus-overview-table')
 export class WebstatusOverviewTable extends LitElement {
-  @property({type: Number})
-  taskStatus: TaskStatus = TaskStatus.INITIAL;
-
-  @property({attribute: false})
-  taskError?: ApiError | Error;
-
-  @property({type: Array})
-  data?: components['schemas']['Feature'][];
+  @property({type: Object})
+  taskTracker: TaskTracker<components['schemas']['Feature'][], ApiError> = {
+    status: TaskStatus.INITIAL, // Initial state
+    error: undefined,
+    data: undefined,
+  };
 
   @property({attribute: false})
   columns: ColumnKey[] = [];
@@ -163,13 +162,13 @@ export class WebstatusOverviewTable extends LitElement {
   }
 
   renderTableBody(columns: ColumnKey[]): TemplateResult {
-    switch (this.taskStatus) {
+    switch (this.taskTracker.status) {
       case TaskStatus.INITIAL:
         return this.renderBodyWhenPending(columns);
       case TaskStatus.PENDING:
         return this.renderBodyWhenPending(columns);
       case TaskStatus.COMPLETE:
-        return this.data?.length === 0
+        return this.taskTracker.data?.length === 0
           ? this.renderBodyWhenNoResults(columns)
           : this.renderBodyWhenComplete(columns);
       case TaskStatus.ERROR:
@@ -178,7 +177,9 @@ export class WebstatusOverviewTable extends LitElement {
   }
 
   renderBodyWhenComplete(columns: ColumnKey[]): TemplateResult {
-    return html` ${this.data?.map(f => this.renderFeatureRow(f, columns))} `;
+    return html`
+      ${this.taskTracker.data?.map(f => this.renderFeatureRow(f, columns))}
+    `;
   }
 
   renderBodyWhenNoResults(columns: ColumnKey[]): TemplateResult {
@@ -193,7 +194,7 @@ export class WebstatusOverviewTable extends LitElement {
   }
 
   renderBodyWhenError(columns: ColumnKey[]): TemplateResult {
-    if (this.taskError instanceof BadRequestError) {
+    if (this.taskTracker.error instanceof BadRequestError) {
       return html`
         <tr>
           <td class="message" colspan=${columns.length}>
@@ -230,7 +231,8 @@ export class WebstatusOverviewTable extends LitElement {
 
   renderBodyWhenPending(columns: ColumnKey[]): TemplateResult {
     const DEFAULT_SKELETON_ROWS = 10;
-    const skeleton_rows = this.data?.length || DEFAULT_SKELETON_ROWS;
+    const skeleton_rows =
+      this.taskTracker.data?.length || DEFAULT_SKELETON_ROWS;
     return html`
       ${map(
         range(skeleton_rows),

--- a/frontend/src/static/js/components/webstatus-overview-table.ts
+++ b/frontend/src/static/js/components/webstatus-overview-table.ts
@@ -17,7 +17,7 @@ import {LitElement, type TemplateResult, html, CSSResultGroup, css} from 'lit';
 import {TaskStatus} from '@lit/task';
 import {range} from 'lit/directives/range.js';
 import {map} from 'lit/directives/map.js';
-import {customElement, property, state} from 'lit/decorators.js';
+import {customElement, property} from 'lit/decorators.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 import {type components} from 'webstatus.dev-backend';
 import {
@@ -33,11 +33,16 @@ import {
   SEARCH_QUERY_README_LINK,
 } from '../utils/constants.js';
 import {CurrentSavedSearch} from '../contexts/app-bookmark-info-context.js';
+import {TaskTracker} from '../utils/task-tracker.js';
 
 @customElement('webstatus-overview-table')
 export class WebstatusOverviewTable extends LitElement {
-  @state()
-  data?: components['schemas']['Feature'][];
+  @property({type: Object})
+  taskTracker: TaskTracker<components['schemas']['FeaturePage'], ApiError> = {
+    status: TaskStatus.INITIAL, // Initial state
+    error: undefined,
+    data: undefined,
+  };
 
   @property({attribute: false})
   columns: ColumnKey[] = [];
@@ -157,13 +162,13 @@ export class WebstatusOverviewTable extends LitElement {
   }
 
   renderTableBody(columns: ColumnKey[]): TemplateResult {
-    switch (this.taskStatus) {
+    switch (this.taskTracker.status) {
       case TaskStatus.INITIAL:
         return this.renderBodyWhenPending(columns);
       case TaskStatus.PENDING:
         return this.renderBodyWhenPending(columns);
       case TaskStatus.COMPLETE:
-        return this.data?.length === 0
+        return this.taskTracker.data?.data?.length === 0
           ? this.renderBodyWhenNoResults(columns)
           : this.renderBodyWhenComplete(columns);
       case TaskStatus.ERROR:
@@ -172,7 +177,11 @@ export class WebstatusOverviewTable extends LitElement {
   }
 
   renderBodyWhenComplete(columns: ColumnKey[]): TemplateResult {
-    return html` ${this.data?.map(f => this.renderFeatureRow(f, columns))} `;
+    return html`
+      ${this.taskTracker.data?.data?.map(f =>
+        this.renderFeatureRow(f, columns),
+      )}
+    `;
   }
 
   renderBodyWhenNoResults(columns: ColumnKey[]): TemplateResult {
@@ -187,7 +196,7 @@ export class WebstatusOverviewTable extends LitElement {
   }
 
   renderBodyWhenError(columns: ColumnKey[]): TemplateResult {
-    if (this.dataError instanceof BadRequestError) {
+    if (this.taskTracker.error instanceof BadRequestError) {
       return html`
         <tr>
           <td class="message" colspan=${columns.length}>
@@ -224,7 +233,8 @@ export class WebstatusOverviewTable extends LitElement {
 
   renderBodyWhenPending(columns: ColumnKey[]): TemplateResult {
     const DEFAULT_SKELETON_ROWS = 10;
-    const skeleton_rows = this.data?.length || DEFAULT_SKELETON_ROWS;
+    const skeleton_rows =
+      this.taskTracker.data?.data?.length || DEFAULT_SKELETON_ROWS;
     return html`
       ${map(
         range(skeleton_rows),

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -295,9 +295,7 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
     return html`<webstatus-overview-table
       .columns=${columns}
       .headerCells=${headerCells}
-      .taskStatus=${this.taskTracker.status}
-      .taskError=${this.taskTracker.error}
-      .data=${this.taskTracker.data}
+      .taskTracker=${this.taskTracker}
     ></webstatus-overview-table>`;
   }
 }

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {Task} from '@lit/task';
+import {Task, TaskStatus} from '@lit/task';
 import {TemplateResult, html, nothing, css} from 'lit';
+import {type components} from 'webstatus.dev-backend';
 import {
   FetchFunctionConfig,
   WebstatusLineChartPanel,
@@ -29,16 +30,33 @@ import {
   BROWSER_ID_TO_LABEL,
 } from '../api/client.js';
 import {ChartSelectPointEvent} from './webstatus-gchart.js';
-import {customElement} from 'lit/decorators.js';
+import {customElement, property} from 'lit/decorators.js';
 import {formatOverviewPageUrl} from '../utils/urls.js';
 import {
-  getTopCssIdentifierTemplate,
-  getTopHtmlIdentifierTemplate,
-} from './utils.js';
+  ColumnKey,
+  parseColumnsSpec,
+  renderSavedSearchHeaderCells,
+} from './webstatus-overview-cells.js';
+import {MISSING_ONE_TABLE_COLUMNS} from '../utils/constants.js';
+import {TaskTracker} from '../utils/task-tracker.js';
+import {ApiError, UnknownError} from '../api/errors.js';
+import {toast} from '../utils/toast.js';
 
 @customElement('webstatus-stats-missing-one-impl-chart-panel')
 export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPanel<BrowsersParameter> {
   readonly series: BrowsersParameter[] = ['chrome', 'firefox', 'safari'];
+
+  @property({type: Object})
+  taskTracker: TaskTracker<components['schemas']['Feature'][], ApiError> = {
+    status: TaskStatus.INITIAL, // Initial state
+    error: undefined,
+    data: undefined,
+  };
+
+  supportedBrowsers: BrowsersParameter[] = ['chrome', 'firefox', 'safari'];
+
+  @property({type: Boolean})
+  isLoadingFeatures = false;
 
   missingFeaturesList: MissingOneImplFeaturesList = [];
   selectedBrowser: string = '';
@@ -153,6 +171,16 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
     this.featureListHref = formatOverviewPageUrl({search: ''}, {q: query});
   }
 
+  async getAllFeatureData(
+    features: MissingOneImplFeaturesList,
+  ): Promise<components['schemas']['Feature'][]> {
+    if (features.length === 0) {
+      return [];
+    }
+    const query = `id:${features.map(f => f.feature_id).join(' OR id:')}`;
+    return await this.apiClient.getAllFeatures(query, 'name_asc');
+  }
+
   /**
    * Creates a task and a renderer for handling point-selected events.
    * Overrides createPointSelectedTask() in the parent class when an point is
@@ -181,9 +209,33 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
         this.selectedDate = targetDate.toISOString().substring(0, 10);
         this.selectedBrowser = label;
         this.updateFeatureListHref(features);
-        return features;
+        return await this.getAllFeatureData(features);
       },
       args: () => [targetDate, targetBrowser],
+      onComplete: features => {
+        this.taskTracker = {
+          status: TaskStatus.COMPLETE,
+          error: undefined,
+          data: features,
+        };
+      },
+      onError: async (error: unknown) => {
+        if (error instanceof ApiError) {
+          this.taskTracker = {
+            status: TaskStatus.ERROR,
+            error: error,
+            data: undefined,
+          };
+          await toast(`${error.message}`, 'danger', 'exclamation-triangle');
+        } else {
+          // Should never reach here but let's handle it.
+          this.taskTracker = {
+            status: TaskStatus.ERROR,
+            error: new UnknownError('unknown error fetching features'),
+            data: undefined,
+          };
+        }
+      },
     });
     return {task: task, renderSuccess: this.pointSelectedTaskRenderOnSuccess};
   }
@@ -236,52 +288,16 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
   }
 
   renderMissingFeaturesTable(): TemplateResult {
-    const numCols = Math.ceil(this.missingFeaturesList.length / 10);
+    const columns: ColumnKey[] = parseColumnsSpec(MISSING_ONE_TABLE_COLUMNS);
+    let headerCells: TemplateResult[] = [];
+    headerCells = renderSavedSearchHeaderCells(this.getPanelText(), columns);
 
-    // Create table body with `numCols` columns and 10 rows each.
-    const bodyRows = [];
-    for (let i = 0; i < 10; i++) {
-      const cells = [];
-      for (let j = 0; j < numCols; j++) {
-        const featureIndex = j * 10 + i;
-        if (featureIndex < this.missingFeaturesList.length) {
-          const featureId = this.missingFeaturesList[featureIndex].feature_id;
-          const extraIdentifiers: TemplateResult[] = [];
-          const cssIdentifier = getTopCssIdentifierTemplate(featureId);
-          if (cssIdentifier) {
-            extraIdentifiers.push(cssIdentifier);
-          }
-          const htmlIdentifier = getTopHtmlIdentifierTemplate(featureId);
-          if (htmlIdentifier) {
-            extraIdentifiers.push(htmlIdentifier);
-          }
-          cells.push(
-            html` <td>
-              <div class="missing-feature-id">
-                <a href="/features/${featureId}">${featureId}</a>
-                ${extraIdentifiers}
-              </div>
-            </td>`,
-          );
-        } else {
-          // Empty cell.
-          cells.push(html`<td></td>`);
-        }
-      }
-
-      bodyRows.push(
-        html`<tr>
-          ${cells}
-        </tr>`,
-      );
-    }
-
-    return html`
-      <table class="missing-features-table">
-        <tbody>
-          ${bodyRows}
-        </tbody>
-      </table>
-    `;
+    return html`<webstatus-overview-table
+      .columns=${columns}
+      .headerCells=${headerCells}
+      .taskStatus=${this.taskTracker.status}
+      .taskError=${this.taskTracker.error}
+      .data=${this.taskTracker.data}
+    ></webstatus-overview-table>`;
   }
 }

--- a/frontend/src/static/js/utils/constants.ts
+++ b/frontend/src/static/js/utils/constants.ts
@@ -214,3 +214,6 @@ export const VOCABULARY = [
     doc: 'Negate search term with a leading minus',
   },
 ];
+
+export const MISSING_ONE_TABLE_COLUMNS: string =
+  'name,availability_chrome,availability_firefox,availability_safari,availability_chrome_android,availability_firefox_android,availability_safari_ios,chrome_usage';


### PR DESCRIPTION
This change updates the table displayed in the "Missing one" chart to use the existing `webstatus-overview-table` component.