### PR TITLE
Fix Chrome/Edge missing features table bug

### DIFF
--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -194,7 +194,8 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
     renderSuccess?: () => TemplateResult;
   } {
     const targetDate = event.detail.timestamp;
-    const label = event.detail.label;
+    const label =
+      event.detail.label === 'Chrome/Edge' ? 'Chrome' : event.detail.label;
     const targetBrowser = BROWSER_LABEL_TO_ID[label];
     const otherBrowsers = this.getOtherBrowsersFromTargetBrowser(targetBrowser);
     const task = new Task(this, {


### PR DESCRIPTION
Fixes #1471 

The "Chrome/Edge" label was not being effectively translated back to the BrowsersParameter version.