### PR TITLE
bugfix: Fix wptconsumer

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,6 +57,10 @@ linters:
     dupl:
       # The default is 150
       threshold: 175
+    exhaustive:
+      check:
+        - switch
+        - map
   exclusions:
     generated: lax
     presets:

--- a/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer_test.go
@@ -81,7 +81,7 @@ func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
 				},
 			},
 			data: metricdatatypes.HistogramMapping{
-				"histogram": []metricdatatypes.HistogramEnumValue{
+				metricdatatypes.WebDXFeatureEnum: []metricdatatypes.HistogramEnumValue{
 					{Value: 1, Label: "EnumLabel"},
 				},
 			},
@@ -99,7 +99,7 @@ func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
 				getIDFromFeatureKey:                        nil,
 			},
 			data: metricdatatypes.HistogramMapping{
-				"histogram": []metricdatatypes.HistogramEnumValue{
+				metricdatatypes.WebDXFeatureEnum: []metricdatatypes.HistogramEnumValue{
 					{Value: 1, Label: "EnumLabel"},
 				},
 			},
@@ -120,7 +120,7 @@ func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
 				getIDFromFeatureKey:                        nil,
 			},
 			data: metricdatatypes.HistogramMapping{
-				"histogram": []metricdatatypes.HistogramEnumValue{
+				metricdatatypes.WebDXFeatureEnum: []metricdatatypes.HistogramEnumValue{
 					{Value: 1, Label: "EnumLabel"},
 				},
 			},
@@ -144,7 +144,7 @@ func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
 				upsertWebFeatureChromiumHistogramEnumValue: nil,
 			},
 			data: metricdatatypes.HistogramMapping{
-				"histogram": []metricdatatypes.HistogramEnumValue{
+				metricdatatypes.WebDXFeatureEnum: []metricdatatypes.HistogramEnumValue{
 					{Value: 1, Label: "EnumLabel"},
 				},
 			},
@@ -171,7 +171,7 @@ func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
 				},
 			},
 			data: metricdatatypes.HistogramMapping{
-				"histogram": []metricdatatypes.HistogramEnumValue{
+				metricdatatypes.WebDXFeatureEnum: []metricdatatypes.HistogramEnumValue{
 					{Value: 1, Label: "EnumLabel"},
 				},
 			},

--- a/lib/gcpspanner/spanneradapters/wptconsumertypes/types.go
+++ b/lib/gcpspanner/spanneradapters/wptconsumertypes/types.go
@@ -43,6 +43,12 @@ var ErrUnableToStoreWPTRunFeatureMetrics = errors.New("unable to store wpt run f
 // BrowserName is an enumeration of the supported browsers for WPT runs.
 type BrowserName string
 
+// nolint:lll // WONTFIX: commit URL is useful
+// Only use browsers from
+// https://github.com/web-platform-tests/wpt.fyi/blob/da8187c63fe9ac7e6dddb9137db5657063e32f74/shared/product_spec.go#L71-L110
+// to avoid a 400 error.
+// Update the link above when the next snapshot of the list is used.
+// Also, update the list used in workflows/steps/services/wpt_consumer/cmd/job/main.go so that it will be consumed.
 const (
 	Chrome         BrowserName = "chrome"
 	Edge           BrowserName = "edge"
@@ -50,5 +56,4 @@ const (
 	Safari         BrowserName = "safari"
 	ChromeAndroid  BrowserName = "chrome_android"
 	FirefoxAndroid BrowserName = "firefox_android"
-	SafariIos      BrowserName = "safari_ios"
 )

--- a/lib/wptfyi/client_integration_test.go
+++ b/lib/wptfyi/client_integration_test.go
@@ -18,20 +18,84 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/spanneradapters/wptconsumertypes"
 )
 
 func TestGetRunsIntegration(t *testing.T) {
-	client := NewHTTPClient("wpt.fyi")
-	pageSize := 100
-	runs, err := client.GetRuns(context.TODO(), time.Now().AddDate(0, 0, -365).UTC(), pageSize, "chrome", "stable")
-	if err != nil {
-		t.Errorf("unexpected error getting runs: %s\n", err.Error())
+	specialNoResultsExpectedValue := -1
+	type testCase struct {
+		// expectedMinimumResultSize specifies the minimum number of runs expected for a given browser
+		// and channel over the tested time period. This is used to verify that the client
+		// correctly fetches all pages of results and not just the first page (which maxes out at 100).
+		// A value of -1 indicates that no results are expected yet
+		expectedMinimumResultSize int
+		willFail                  bool
 	}
-	// Looking back a year, we should have more than 100 runs given there is a one run per day
-	// This test is only to make sure we get more than the pageSize of results because currently
-	// the external client will fetch the first pageSize of results but there may be actually more.
-	// Our code ensures we get all the pages, not just the first page.
-	if len(runs) <= pageSize {
-		t.Errorf("unexpected page size %d. expected more than %d runs", len(runs), pageSize)
+	client := NewHTTPClient("wpt.fyi")
+	// longTermResultSize means the product has been around for awhile and should get at least 100 results
+	longTermResultSize := 100
+	browsers := map[wptconsumertypes.BrowserName]testCase{
+		// Desktop browsers
+		wptconsumertypes.Chrome: {
+			expectedMinimumResultSize: longTermResultSize,
+			willFail:                  false,
+		},
+		wptconsumertypes.Edge: {
+			expectedMinimumResultSize: longTermResultSize,
+			willFail:                  false,
+		},
+		wptconsumertypes.Firefox: {
+			expectedMinimumResultSize: longTermResultSize,
+			willFail:                  false,
+		},
+		wptconsumertypes.Safari: {
+			expectedMinimumResultSize: longTermResultSize,
+			willFail:                  false,
+		},
+
+		// Mobile browsers
+		// Stable results just started coming for ChromeAndroid
+		wptconsumertypes.ChromeAndroid: {
+			expectedMinimumResultSize: 1,
+			willFail:                  false,
+		},
+		// No stable results for FirefoxAndroid yet
+		wptconsumertypes.FirefoxAndroid: {
+			expectedMinimumResultSize: specialNoResultsExpectedValue,
+			willFail:                  false,
+		},
+
+		// Bad browser name
+		wptconsumertypes.BrowserName("badname"): {
+			expectedMinimumResultSize: 0,
+			willFail:                  true,
+		},
+	}
+	for browser, testCase := range browsers {
+		// For now, we only care about stable channel.
+		runs, err := client.GetRuns(context.TODO(), time.Now().AddDate(0, 0, -365).UTC(),
+			longTermResultSize, string(browser), "stable")
+		if err != nil && !testCase.willFail {
+			t.Errorf("unexpected error getting runs: %s\n", err.Error())
+		} else if err == nil && testCase.willFail {
+			t.Error("expected an error but received none")
+		}
+
+		// Looking back a year, we should have more than 100 runs given there is a one run per day
+		// This test is only to make sure we get more than the pageSize of results because currently
+		// the external client will fetch the first pageSize of results but there may be actually more.
+		// Our code ensures we get all the pages, not just the first page.
+		if err == nil {
+			// Special handling for cases where no results are expected.
+			// In such cases, a successful call with 0 results is acceptable.
+			if testCase.expectedMinimumResultSize == specialNoResultsExpectedValue && len(runs) == 0 {
+				// No stable results expected and none received, test passes for this condition.
+				return
+			} else if len(runs) < testCase.expectedMinimumResultSize {
+				t.Errorf("unexpected number of runs for %s. Expected at least %d runs, but got %d.",
+					browser, testCase.expectedMinimumResultSize, len(runs))
+			}
+		}
 	}
 }

--- a/workflows/steps/services/chromium_histogram_enums/workflow/job_processor_test.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/job_processor_test.go
@@ -33,9 +33,9 @@ var (
 )
 
 func TestProcess(t *testing.T) {
-	sampleHistograms := []metricdatatypes.HistogramName{"TestHistogram1", "TestHistogram2"}
+	sampleHistograms := []metricdatatypes.HistogramName{metricdatatypes.WebDXFeatureEnum, "TestHistogram2"}
 	sampleMapping := metricdatatypes.HistogramMapping{
-		"TestHistogram1": {
+		metricdatatypes.WebDXFeatureEnum: {
 			{
 				Label: "EnumValue1",
 				Value: 1,

--- a/workflows/steps/services/wpt_consumer/cmd/job/main.go
+++ b/workflows/steps/services/wpt_consumer/cmd/job/main.go
@@ -113,7 +113,6 @@ func main() {
 		string(wptconsumertypes.Safari),
 		string(wptconsumertypes.ChromeAndroid),
 		string(wptconsumertypes.FirefoxAndroid),
-		string(wptconsumertypes.SafariIos),
 	}
 	channels := []string{shared.StableLabel, shared.ExperimentalLabel}
 	for _, browser := range browsers {


### PR DESCRIPTION
Currently, the wpt consumer job is failing [logs](https://cloudlogging.app.goo.gl/Cqax2o5RFX342mXr7).

The reason why it is failing comes from a few reasons:
- We are using the imported Go code from wpt.fyi incorrectly. It causes the formed URL to be wrong and cause 404.
- No `safari_ios` product exists in the product spec [code](https://github.com/web-platform-tests/wpt.fyi/blob/da8187c63fe9ac7e6dddb9137db5657063e32f74/shared/product_spec.go#L71-L110)

This change addresses those. In particular, I removed safari_ios for now because the wpt.fyi API results in an 400 error.  We can re-add it then. Also, the wpt.fyi api returns 404 when there's no available information for an actual product so I added a special case to check for that.

Additionally, I reconfigured the linter to also check for exhaustiveness on maps and not just switch statements for enums. That way we can update the integration test there too. As a result of configuring that, I had to adjust some nonrelated code to comply as well.