### PR TITLE
Fix playwright test flakiness

### DIFF
--- a/.dev/auth/manifests/pod.yaml
+++ b/.dev/auth/manifests/pod.yaml
@@ -28,6 +28,10 @@ spec:
           name: auth-port
         - containerPort: 9100
           name: auth-ui-port
+      readinessProbe:
+        tcpSocket:
+          port: 9099
+        initialDelaySeconds: 15
       startupProbe:
         httpGet:
           port: auth-ui-port

--- a/.dev/datastore/manifests/pod.yaml
+++ b/.dev/datastore/manifests/pod.yaml
@@ -29,7 +29,7 @@ spec:
       resources:
         limits:
           cpu: 250m
-          memory: 2048Mi
+          memory: 1024Mi
         requests:
           cpu: 100m
           memory: 128Mi

--- a/.dev/datastore/manifests/pod.yaml
+++ b/.dev/datastore/manifests/pod.yaml
@@ -29,7 +29,11 @@ spec:
       resources:
         limits:
           cpu: 250m
-          memory: 1024Mi
+          memory: 2048Mi
         requests:
           cpu: 100m
           memory: 128Mi
+      readinessProbe:
+        tcpSocket:
+          port: 8086
+        initialDelaySeconds: 10

--- a/.dev/spanner/manifests/pod.yaml
+++ b/.dev/spanner/manifests/pod.yaml
@@ -35,7 +35,7 @@ spec:
       resources:
         limits:
           cpu: '2'
-          memory: '4.5Gi'
+          memory: '5.5Gi'
         requests:
           cpu: '300m'
           memory: '256Mi'

--- a/.dev/spanner/manifests/pod.yaml
+++ b/.dev/spanner/manifests/pod.yaml
@@ -28,10 +28,14 @@ spec:
           name: grpc-port
         - containerPort: 9020
           name: rest-port
+      readinessProbe:
+        tcpSocket:
+          port: 9010
+        initialDelaySeconds: 10
       resources:
         limits:
           cpu: '2'
-          memory: '3.5Gi'
+          memory: '4.5Gi'
         requests:
           cpu: '300m'
           memory: '256Mi'

--- a/.dev/valkey/manifests/pod.yaml
+++ b/.dev/valkey/manifests/pod.yaml
@@ -26,6 +26,9 @@ spec:
       ports:
         - containerPort: 6379
           name: valkey-port
+      readinessProbe:
+        tcpSocket:
+          port: 6379
       resources:
         limits:
           cpu: 250m

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "alias grun='java org.antlr.v4.gui.TestRig'" >> ~/.bashrc
 
 ENV CLASSPATH=.:/usr/local/lib/antlr-${ANTLR4_VERSION}-complete.jar
 
+# Install netcat (nc)
+RUN apt-get update && apt-get install -y netcat-traditional
+
 # Switch to the default user and append to PATH
 USER vscode
 

--- a/backend/manifests/pod.yaml
+++ b/backend/manifests/pod.yaml
@@ -26,6 +26,9 @@ spec:
       ports:
         - containerPort: 8080
           name: http-backend
+      readinessProbe:
+        tcpSocket:
+          port: 8080
       env:
         - name: SPANNER_DATABASE
           value: 'local'

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -61,10 +61,10 @@ Developers may still need to inspect and manually fix the error.
 ### Note about running Playwright Makefile Targets
 
 If you have a running local development environment
-(established via `make start-local`) with the necessary fake users (`make dev_fake_users`),
-fake data (`make dev_fake_data`), and port forwarding
-(`make port-forward-manual`), you can expedite Playwright testing by skipping
-the environment setup.
+(established via `make start-local`) with the necessary port forwarding
+(`make port-forward-manual`), fake users (`make dev_fake_users`) and
+fake data (`make dev_fake_data`), you can expedite Playwright testing by
+skipping the environment setup.
 
 To do this, prefix your `make` command with `SKIP_FRESH_ENV=1`. This is
 particularly useful for rapid iteration, as `make start-local` leverages

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -122,17 +122,10 @@ export async function resetUserData() {
   const projectRootDir = path.resolve(__dirname, '../..');
 
   try {
-    const cmd1 = 'make check-local-ports';
-    console.log(`Executing command: ${cmd1} in ${projectRootDir}`);
-    execSync(cmd1, {
-      cwd: projectRootDir,
-      stdio: 'inherit',
-    });
+    const cmd = `make dev_fake_data -o build -o is_local_migration_ready LOAD_FAKE_DATA_FLAGS='-scope=user -reset'`;
 
-    const cmd2 = `make dev_fake_data -o build -o is_local_migration_ready LOAD_FAKE_DATA_FLAGS='-scope=user -reset'`;
-
-    console.log(`Executing command: ${cmd2} in ${projectRootDir}`);
-    execSync(cmd2, {cwd: projectRootDir, stdio: 'inherit'});
+    console.log(`Executing command: ${cmd} in ${projectRootDir}`);
+    execSync(cmd, {cwd: projectRootDir, stdio: 'inherit'});
 
     console.log('Reset command finished successfully.');
   } catch (error) {

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -122,19 +122,19 @@ export async function resetUserData() {
   const projectRootDir = path.resolve(__dirname, '../..');
 
   try {
-    const cmd1 = `make dev_fake_data -o build -o is_local_migration_ready LOAD_FAKE_DATA_FLAGS='-scope=user -reset'`;
-
+    const cmd1 = 'make check-local-ports';
     console.log(`Executing command: ${cmd1} in ${projectRootDir}`);
-    execSync(cmd1, {cwd: projectRootDir, stdio: 'inherit'});
-
-    console.log('Reset command finished successfully.');
-
-    const cmd2 = 'make port-forward-manual';
-    console.log(`Executing command: ${cmd2} in ${projectRootDir}`);
-    execSync(cmd2, {
+    execSync(cmd1, {
       cwd: projectRootDir,
       stdio: 'inherit',
     });
+
+    const cmd2 = `make dev_fake_data -o build -o is_local_migration_ready LOAD_FAKE_DATA_FLAGS='-scope=user -reset'`;
+
+    console.log(`Executing command: ${cmd2} in ${projectRootDir}`);
+    execSync(cmd2, {cwd: projectRootDir, stdio: 'inherit'});
+
+    console.log('Reset command finished successfully.');
   } catch (error) {
     console.error('Error reset command (make dev_fake_data):', error);
     throw new Error('Reset command finished, halting tests.');

--- a/frontend/manifests/pod.yaml
+++ b/frontend/manifests/pod.yaml
@@ -29,6 +29,9 @@ spec:
       ports:
         - containerPort: 5555
           name: http-frontend
+      readinessProbe:
+        tcpSocket:
+          port: 5555
       env:
         - name: API_URL
           value: http://localhost:8080


### PR DESCRIPTION
During the saved search playwright tests, we kill and reopen the ports needed for the database (as well as all other ports).

We do this because beforehand, we did not port forward the ports for the database and only forwarded the ports needed to connect to the app (the backend already had access to the database internally)

But instead of doing that, we now port forward the database ports during `make port-forward-manual`. To help with that, I modified the helper makefile target to check if the port is live.  We use `nc` instead of curl because it did not work with grpc (which the spanner emulator uses). The devcontainer Dockerfile has been updated to install that dependency (devs will need to rebuild their devcontainer)

I also started to add readinessProbes for some of the pods. And for the database  and auth pods, I modified the initial delay before checking for readiness since sometimes those take some time.

Hopefully, this will reduce the times when the port fails to forward again on subsequent tries since we never have to forward it again.

Resources:
- I allocated more resources to the local kubernetes cluster
  - With this, I increased the limits for some pods.

A few things to note:
- Now developers will need to run make port-forward-manual first before dev_fake_data and other commands after running start-local
- As mentioned earlier, this change requires developers to rebuild their devcontainer