### PR TITLE
Clarify table text

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
@@ -216,11 +216,11 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
            <strong>
              as of today
            </strong>
-           ,
-          and not at the selected timestamp.
+           , and not at the selected timestamp.
          </div>
       </div>
     `;
+
     expect(header).dom.to.equal(expectedHeader);
 
     const table = el.shadowRoot!.querySelector('webstatus-overview-table');

--- a/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-stats-missing-one-impl-chart-panel.test.ts
@@ -212,7 +212,7 @@ describe('WebstatusStatsMissingOneImplChartPanel', () => {
         Missing features on 2024-01-01 for Chrome:
         <a href="/?q=id%3Agrid+OR+id%3Ahtml+OR+id%3Ajs+OR+id%3Abluetooth">4 features</a>
         <div class="table-description">
-           * This table represents feature values
+           * This table represents values for Availability and Usage
            <strong>
              as of today
            </strong>

--- a/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
+++ b/frontend/src/static/js/components/webstatus-stats-missing-one-impl-chart-panel.ts
@@ -258,8 +258,8 @@ export class WebstatusStatsMissingOneImplChartPanel extends WebstatusLineChartPa
           >${this.missingFeaturesList.length} features</a
         >
         <div class="table-description">
-          * This table represents feature values <strong>as of today</strong>,
-          and not at the selected timestamp.
+          * This table represents values for Availability and Usage
+          <strong>as of today</strong>, and not at the selected timestamp.
         </div>
       </div>
       ${this.renderMissingFeaturesTable()}


### PR DESCRIPTION
Per discussions, this is a basic change to the text displayed on the missing one table.