### PR TITLE
bugfix: Reduce the batch writer's batch size.

### DIFF
--- a/lib/gcpspanner/client.go
+++ b/lib/gcpspanner/client.go
@@ -129,7 +129,7 @@ type searchConfig struct {
 
 const defaultMaxOwnedSearchesPerUser = 25
 const defaultMaxBookmarksPerUser = 25
-const defaultBatchSize = 10000
+const defaultBatchSize = 5000
 const defaultBatchWriters = 8
 
 func combineAndDeduplicate(excluded []string, discouraged []string) []string {
@@ -900,7 +900,7 @@ func runConcurrentBatch[SpannerStruct any](ctx context.Context, c *Client,
 		slog.InfoContext(ctx, "batch write wait group to finished", "table", table)
 		close(doneChan)
 	}()
-	for i := 0; i < workers; i++ {
+	for i := range workers {
 		go concurrentBatchWriteEntity(ctx, c, &wg, c.batchSize, entityChan, table, errChan, i)
 	}
 	producerFn(entityChan)


### PR DESCRIPTION
The web features job is currently failing

Currently, I see this error:

```
ERROR invalid status while batch writing status="rpc error: code = InvalidArgument desc = The transaction contains too many mutations. Insert and update operations count with the multiplicity of the number of columns they affect. For example, inserting values into one key column and four non-key columns count as five mutations total for the insert. Delete and delete range operations count as one mutation regardless of the number of columns affected. The total mutation count includes any changes to indexes that the transaction generates. Please reduce the number of writes, or use fewer indexes. (Maximum number: 80000)"
```

You'll see that a transaction can actually count multiple times if there things like an index. So I just reduced the batchSize down to something that works. (Tested in on [staging](https://pantheon.corp.google.com/run/jobs/details/europe-west1/staging-europe-west1-web-features/executions?inv=1&invt=Abx65w&project=webstatus-dev-internal-staging))

Other changes:
- My IDE highlighted an optimization on the looping for the concurrent batch size writer. So I just used the auto-fix for that.