### PR TITLE
chore: update tools and docker versions - 2025-06

### DIFF
--- a/.dev/auth/Dockerfile
+++ b/.dev/auth/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:22.15.0-bookworm-slim
+FROM node:22.16.0-bookworm-slim
 # FIREBASE_CLI_VERSION from https://github.com/firebase/firebase-tools/releases
-ARG FIREBASE_CLI_VERSION=13.29.1
+ARG FIREBASE_CLI_VERSION=14.5.1
 ADD https://github.com/firebase/firebase-tools/releases/download/v${FIREBASE_CLI_VERSION}/firebase-tools-linux /usr/local/bin/firebase
 RUN chmod +x /usr/local/bin/firebase
 ADD firebase.json firebase.json

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM mcr.microsoft.com/devcontainers/base:bookworm
 
-ENV CLOUD_SDK_VERSION=519.0.0
+ENV CLOUD_SDK_VERSION=525.0.0
 # Install gcloud similarly to how it is done in cloud-sdk-docker
 # https://github.com/GoogleCloudPlatform/cloud-sdk-docker/blob/master/debian_component_based/Dockerfile
 RUN if [ `uname -m` = 'x86_64' ]; then echo -n "x86_64" > /tmp/arch; else echo -n "arm" > /tmp/arch; fi;

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,22 +18,22 @@
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.24.2"
+      "version": "1.24.3"
     },
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": true
     },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "22.15.0"
+      "version": "22.16.0"
     },
     "ghcr.io/devcontainers/features/terraform:1": {
       // Get version from https://github.com/hashicorp/terraform/releases
-      "version": "1.11.4",
+      "version": "1.12.1",
       // We do not use terragrunt.
       "terragrunt": "none",
       // Get version from https://github.com/terraform-linters/tflint/releases
-      "tflint": "0.56.0"
+      "tflint": "0.58.0"
     },
     "ghcr.io/lukewiwa/features/shellcheck:0": {
       // Get version from https://github.com/koalaman/shellcheck/releases

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -30,7 +30,7 @@ sudo chown "$(whoami)":"$(whoami)" ~/.cache/
 go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1
 
 # Install wrench CLI
-go install github.com/cloudspannerecosystem/wrench@v1.10.1
+go install github.com/cloudspannerecosystem/wrench@v1.11.8
 
 # Install addlicense
 go install github.com/google/addlicense@v1.1.1

--- a/images/go_service.Dockerfile
+++ b/images/go_service.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24.3-alpine3.21 AS builder
+FROM golang:1.24.3-alpine3.22 AS builder
 
 WORKDIR /work
 

--- a/images/nodejs_service.Dockerfile
+++ b/images/nodejs_service.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:22.15.0-alpine3.21 AS base
+FROM node:22.16.0-alpine3.22 AS base
 
 FROM base AS builder
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12821,9 +12821,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Upgrade various local toolchains:
- go
- node
- terraform
- tflint
- wrench

Upgrade various Docker images: Mostly to alpine3.22 variations. Also bumped the node docker version to match bumped toolchain version.

Finally, update run `npm audit fix` to address https://github.com/GoogleChrome/webstatus.dev/security/dependabot/88 which would not resolve on its own.