### PR TITLE
bugfix: Fix mapping of enums to feature IDs

### DIFF
--- a/lib/gcpspanner/browser_feature_support_event.go
+++ b/lib/gcpspanner/browser_feature_support_event.go
@@ -101,6 +101,8 @@ func calculateBrowserSupportEvents(
 // PrecalculateBrowserFeatureSupportEvents populates the BrowserFeatureSupportEvents table with pre-calculated data.
 func (c *Client) PrecalculateBrowserFeatureSupportEvents(ctx context.Context, startAt, endAt time.Time) error {
 	txn := c.ReadOnlyTransaction()
+	defer txn.Close()
+
 	// 1. Fetch all BrowserFeatureAvailabilities
 	availabilities, err := c.fetchAllBrowserAvailabilitiesWithTransaction(ctx, txn)
 	if err != nil {

--- a/lib/gcpspanner/web_features_test.go
+++ b/lib/gcpspanner/web_features_test.go
@@ -125,4 +125,19 @@ func TestUpsertWebFeature(t *testing.T) {
 	if !slices.Equal[[]WebFeature](expectedPageAfterUpdate, features) {
 		t.Errorf("unequal features after update. expected %+v actual %+v", sampleFeatures, features)
 	}
+
+	expectedKeys := []string{
+		"feature1",
+		"feature2",
+		"feature3",
+		"feature4",
+	}
+	keys, err := spannerClient.FetchAllFeatureKeys(ctx)
+	if err != nil {
+		t.Errorf("unexpected error fetching all keys")
+	}
+	slices.Sort(keys)
+	if !slices.Equal(keys, expectedKeys) {
+		t.Errorf("unequal keys. expected %+v actual %+v", expectedKeys, keys)
+	}
 }

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -159,7 +159,7 @@ require (
 	golang.org/x/oauth2 v0.29.0
 	golang.org/x/sync v0.13.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
-	golang.org/x/text v0.24.0 // indirect
+	golang.org/x/text v0.24.0
 	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/genproto v0.0.0-20250428153025-10db94c68c34 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250428153025-10db94c68c34 // indirect


### PR DESCRIPTION
The instructions in the mojom file[[1]](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/use_counter/metrics/webdx_feature.mojom;l=35-47;drc=822a70f9ac61a75babe9d24ddfc32ab475acc7e1) were updated to reflect how feature developers should translate feature IDs found in the web features repo to enum labels in the mojom file by doing the equivalent of `id.title().replace("-", "")`

However, our code takes the enum labels and tries to map convert labels to feature IDs.

Unfortunately, there's too much data loss to reliably convert back to the feature ID.

Examples:

* **Case 1: `http3` (WebDX ID) -> `Http3` (Enum Label)** The original ID `http3` has **no hyphen** between the letter 'p' and the digit '3'. A reverse algorithm designed to insert hyphens (e.g., between letters and digits) would incorrectly produce `http-3`.

* **Case 2: `canvas-2d-color-management` (WebDX ID) -> `Canvas2DColorManagement` (Enum Label)** Here, the original ID *does* have hyphens (e.g., `canvas-2d`). However, the enum label `Canvas2DColorManagement` provides no explicit signal for these specific hyphens. An algorithm that didn't insert hyphens (to avoid breaking `http3`) would then fail to restore them.

As a result, we now get all the feature IDs, convert them using the equivalent algorithm in Go into their respective labels and try to use them. There are some labels that have special cases. We handle those as well with a short special cases mapping.

We still have a logging message that the log based [metrics](https://pantheon.corp.google.com/logs/metrics/edit/projects%2Fwebstatus-dev-internal-prod%2Fmetrics%2Fmissing_feature_id_warnings?inv=1&invt=AbzVIw&project=webstatus-dev-internal-prod) check for. That is now emitted two potential places so that string is now a constant variable.