### PR TITLE
Fix #1553

### DIFF
--- a/infra/storage/valkey.tf
+++ b/infra/storage/valkey.tf
@@ -33,7 +33,7 @@ resource "google_memorystore_instance" "valkey_instance" {
   instance_id = "${var.env_id}-valkey-${each.key}"
   shard_count = 1
   node_type   = "SHARED_CORE_NANO"
-  desired_psc_auto_connections {
+  desired_auto_created_endpoints {
     network    = var.vpc_id
     project_id = var.projects.internal
   }


### PR DESCRIPTION
While finishing up the deployment for https://github.com/GoogleChrome/webstatus.dev/issues/1539, I saw a message. This fixes that.

This will cause a recreation of the valkey instance but will keep its config up to date with current values. (i.e.  valkey will be down for a little bit but not the full app)

This is the proposed plan when using this change:

```hcl
Terraform will perform the following actions:

  # module.backend.google_cloud_run_v2_service.service["europe-west1"] will be updated in-place
  ~ resource "google_cloud_run_v2_service" "service" {
        id                      = "projects/webstatus-dev-public-prod/locations/europe-west1/services/prod-europe-west1-webstatus-backend"
        name                    = "prod-europe-west1-webstatus-backend"
        # (33 unchanged attributes hidden)

      ~ template {
            # (10 unchanged attributes hidden)

          ~ containers {
                name           = "backend"
                # (7 unchanged attributes hidden)

              - env {
                  - name  = "VALKEYHOST" -> null
                  - value = "10.3.0.3" -> null
                }
              - env {
                  - name  = "VALKEYPORT" -> null
                  - value = "6379" -> null
                }
              + env {
                  + name  = "VALKEYHOST"
                  + value = (known after apply)
                }
              + env {
                  + name  = "VALKEYPORT"
                  + value = (known after apply)
                }

                # (14 unchanged blocks hidden)
            }

            # (3 unchanged blocks hidden)
        }

        # (1 unchanged block hidden)
    }

  # module.backend.google_cloud_run_v2_service.service["us-central1"] will be updated in-place
  ~ resource "google_cloud_run_v2_service" "service" {
        id                      = "projects/webstatus-dev-public-prod/locations/us-central1/services/prod-us-central1-webstatus-backend"
        name                    = "prod-us-central1-webstatus-backend"
        # (33 unchanged attributes hidden)

      ~ template {
            # (10 unchanged attributes hidden)

          ~ containers {
                name           = "backend"
                # (7 unchanged attributes hidden)

              - env {
                  - name  = "VALKEYHOST" -> null
                  - value = "10.1.0.3" -> null
                }
              - env {
                  - name  = "VALKEYPORT" -> null
                  - value = "6379" -> null
                }
              + env {
                  + name  = "VALKEYHOST"
                  + value = (known after apply)
                }
              + env {
                  + name  = "VALKEYPORT"
                  + value = (known after apply)
                }

                # (14 unchanged blocks hidden)
            }

            # (3 unchanged blocks hidden)
        }

        # (1 unchanged block hidden)
    }

  # module.storage.google_memorystore_instance.valkey_instance["europe-west1"] must be replaced
-/+ resource "google_memorystore_instance" "valkey_instance" {
      ~ authorization_mode          = "AUTH_DISABLED" -> (known after apply)
      + backup_collection           = (known after apply)
      ~ create_time                 = "2025-01-15T16:09:59.241282057Z" -> (known after apply)
      ~ discovery_endpoints         = [
          - {
              - address = "10.3.0.3"
              - network = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network"
              - port    = 6379
            },
        ] -> (known after apply)
      ~ endpoints                   = [
          - {
              - connections = [
                  - {
                      - psc_auto_connection = [
                          - {
                              - connection_type    = "CONNECTION_TYPE_DISCOVERY"
                              - forwarding_rule    = "https://www.googleapis.com/compute/v1/projects/webstatus-dev-internal-prod/regions/europe-west1/forwardingRules/sca-auto-fr-fd4a0461-006c-453a-b142-217c6eeef072"
                              - ip_address         = "10.3.0.3"
                              - network            = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network"
                              - port               = 6379
                              - project_id         = "webstatus-dev-internal-prod"
                              - psc_connection_id  = "52505653239021571"
                              - service_attachment = "projects/255115935709/regions/europe-west1/serviceAttachments/gcp-memorystore-auto-597ed0d1-80c5-49-psc-sa"
                            },
                        ]
                    },
                  - {
                      - psc_auto_connection = [
                          - {
                              - forwarding_rule    = "https://www.googleapis.com/compute/v1/projects/webstatus-dev-internal-prod/regions/europe-west1/forwardingRules/sca-auto-fr-b0c4a185-b473-4339-94cc-b28e8983b5f4"
                              - ip_address         = "10.3.0.2"
                              - network            = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network"
                              - port               = 6379
                              - project_id         = "webstatus-dev-internal-prod"
                              - psc_connection_id  = "52505653239021570"
                              - service_attachment = "projects/255115935709/regions/europe-west1/serviceAttachments/gcp-memorystore-auto-597ed0d1-80c5-49-psc-sa-2"
                                # (1 unchanged attribute hidden)
                            },
                        ]
                    },
                ]
            },
        ] -> (known after apply)
      - engine_configs              = {} -> null
      ~ id                          = "projects/webstatus-dev-internal-prod/locations/europe-west1/instances/prod-valkey-europe-west1" -> (known after apply)
      - labels                      = {} -> null
      ~ maintenance_schedule        = [] -> (known after apply)
      ~ mode                        = "CLUSTER" -> (known after apply)
      ~ name                        = "projects/webstatus-dev-internal-prod/locations/europe-west1/instances/prod-valkey-europe-west1" -> (known after apply)
      ~ node_config                 = [
          - {
              - size_gb = 1.4
            },
        ] -> (known after apply)
      ~ psc_attachment_details      = [
          - {
              - connection_type    = "CONNECTION_TYPE_DISCOVERY"
              - service_attachment = "projects/255115935709/regions/europe-west1/serviceAttachments/gcp-memorystore-auto-597ed0d1-80c5-49-psc-sa"
            },
          - {
              - service_attachment = "projects/255115935709/regions/europe-west1/serviceAttachments/gcp-memorystore-auto-597ed0d1-80c5-49-psc-sa-2"
                # (1 unchanged attribute hidden)
            },
        ] -> (known after apply)
      ~ psc_auto_connections        = [
          - {
              - connection_type       = "CONNECTION_TYPE_DISCOVERY"
              - forwarding_rule       = "https://www.googleapis.com/compute/v1/projects/webstatus-dev-internal-prod/regions/europe-west1/forwardingRules/sca-auto-fr-fd4a0461-006c-453a-b142-217c6eeef072"
              - ip_address            = "10.3.0.3"
              - network               = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network"
              - port                  = 6379
              - project_id            = "webstatus-dev-internal-prod"
              - psc_connection_id     = "52505653239021571"
              - service_attachment    = "projects/255115935709/regions/europe-west1/serviceAttachments/gcp-memorystore-auto-597ed0d1-80c5-49-psc-sa"
                # (1 unchanged attribute hidden)
            },
          - {
              - forwarding_rule       = "https://www.googleapis.com/compute/v1/projects/webstatus-dev-internal-prod/regions/europe-west1/forwardingRules/sca-auto-fr-b0c4a185-b473-4339-94cc-b28e8983b5f4"
              - ip_address            = "10.3.0.2"
              - network               = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network"
              - port                  = 6379
              - project_id            = "webstatus-dev-internal-prod"
              - psc_connection_id     = "52505653239021570"
              - service_attachment    = "projects/255115935709/regions/europe-west1/serviceAttachments/gcp-memorystore-auto-597ed0d1-80c5-49-psc-sa-2"
                # (2 unchanged attributes hidden)
            },
        ] -> (known after apply)
      ~ replica_count               = 0 -> (known after apply)
      ~ state                       = "ACTIVE" -> (known after apply)
      ~ state_info                  = [] -> (known after apply)
      ~ transit_encryption_mode     = "TRANSIT_ENCRYPTION_DISABLED" -> (known after apply)
      ~ uid                         = "597ed0d1-80c5-4942-b72c-584bc1b2b4f6" -> (known after apply)
      ~ update_time                 = "2025-05-12T21:30:01.598813124Z" -> (known after apply)
        # (9 unchanged attributes hidden)

      ~ cross_instance_replication_config (known after apply)

      + desired_auto_created_endpoints { # forces replacement
          + network    = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network"
          + project_id = "webstatus-dev-internal-prod"
        }

      - desired_psc_auto_connections { # forces replacement
          - network    = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network" -> null
          - project_id = "webstatus-dev-internal-prod" -> null
        }

      ~ persistence_config (known after apply)
      - persistence_config {
          - mode = "DISABLED" -> null
        }

      ~ zone_distribution_config (known after apply)
      - zone_distribution_config {
          - mode = "MULTI_ZONE" -> null
            # (1 unchanged attribute hidden)
        }
    }

  # module.storage.google_memorystore_instance.valkey_instance["us-central1"] must be replaced
-/+ resource "google_memorystore_instance" "valkey_instance" {
      ~ authorization_mode          = "AUTH_DISABLED" -> (known after apply)
      + backup_collection           = (known after apply)
      ~ create_time                 = "2025-01-15T16:10:03.098868885Z" -> (known after apply)
      ~ discovery_endpoints         = [
          - {
              - address = "10.1.0.3"
              - network = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network"
              - port    = 6379
            },
        ] -> (known after apply)
      ~ endpoints                   = [
          - {
              - connections = [
                  - {
                      - psc_auto_connection = [
                          - {
                              - connection_type    = "CONNECTION_TYPE_DISCOVERY"
                              - forwarding_rule    = "https://www.googleapis.com/compute/v1/projects/webstatus-dev-internal-prod/regions/us-central1/forwardingRules/sca-auto-fr-abc19914-83e9-4673-bcaf-077bd03abf73"
                              - ip_address         = "10.1.0.3"
                              - network            = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network"
                              - port               = 6379
                              - project_id         = "webstatus-dev-internal-prod"
                              - psc_connection_id  = "52505653238890499"
                              - service_attachment = "projects/256916904125/regions/us-central1/serviceAttachments/gcp-memorystore-auto-824077b0-37b2-4d-psc-sa"
                            },
                        ]
                    },
                  - {
                      - psc_auto_connection = [
                          - {
                              - forwarding_rule    = "https://www.googleapis.com/compute/v1/projects/webstatus-dev-internal-prod/regions/us-central1/forwardingRules/sca-auto-fr-a1165c39-5044-4b97-aac3-dc00cfa7aaa8"
                              - ip_address         = "10.1.0.2"
                              - network            = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network"
                              - port               = 6379
                              - project_id         = "webstatus-dev-internal-prod"
                              - psc_connection_id  = "52505653238890498"
                              - service_attachment = "projects/256916904125/regions/us-central1/serviceAttachments/gcp-memorystore-auto-824077b0-37b2-4d-psc-sa-2"
                                # (1 unchanged attribute hidden)
                            },
                        ]
                    },
                ]
            },
        ] -> (known after apply)
      - engine_configs              = {} -> null
      ~ id                          = "projects/webstatus-dev-internal-prod/locations/us-central1/instances/prod-valkey-us-central1" -> (known after apply)
      - labels                      = {} -> null
      ~ maintenance_schedule        = [] -> (known after apply)
      ~ mode                        = "CLUSTER" -> (known after apply)
      ~ name                        = "projects/webstatus-dev-internal-prod/locations/us-central1/instances/prod-valkey-us-central1" -> (known after apply)
      ~ node_config                 = [
          - {
              - size_gb = 1.4
            },
        ] -> (known after apply)
      ~ psc_attachment_details      = [
          - {
              - connection_type    = "CONNECTION_TYPE_DISCOVERY"
              - service_attachment = "projects/256916904125/regions/us-central1/serviceAttachments/gcp-memorystore-auto-824077b0-37b2-4d-psc-sa"
            },
          - {
              - service_attachment = "projects/256916904125/regions/us-central1/serviceAttachments/gcp-memorystore-auto-824077b0-37b2-4d-psc-sa-2"
                # (1 unchanged attribute hidden)
            },
        ] -> (known after apply)
      ~ psc_auto_connections        = [
          - {
              - connection_type       = "CONNECTION_TYPE_DISCOVERY"
              - forwarding_rule       = "https://www.googleapis.com/compute/v1/projects/webstatus-dev-internal-prod/regions/us-central1/forwardingRules/sca-auto-fr-abc19914-83e9-4673-bcaf-077bd03abf73"
              - ip_address            = "10.1.0.3"
              - network               = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network"
              - port                  = 6379
              - project_id            = "webstatus-dev-internal-prod"
              - psc_connection_id     = "52505653238890499"
              - service_attachment    = "projects/256916904125/regions/us-central1/serviceAttachments/gcp-memorystore-auto-824077b0-37b2-4d-psc-sa"
                # (1 unchanged attribute hidden)
            },
          - {
              - forwarding_rule       = "https://www.googleapis.com/compute/v1/projects/webstatus-dev-internal-prod/regions/us-central1/forwardingRules/sca-auto-fr-a1165c39-5044-4b97-aac3-dc00cfa7aaa8"
              - ip_address            = "10.1.0.2"
              - network               = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network"
              - port                  = 6379
              - project_id            = "webstatus-dev-internal-prod"
              - psc_connection_id     = "52505653238890498"
              - service_attachment    = "projects/256916904125/regions/us-central1/serviceAttachments/gcp-memorystore-auto-824077b0-37b2-4d-psc-sa-2"
                # (2 unchanged attributes hidden)
            },
        ] -> (known after apply)
      ~ replica_count               = 0 -> (known after apply)
      ~ state                       = "ACTIVE" -> (known after apply)
      ~ state_info                  = [] -> (known after apply)
      ~ transit_encryption_mode     = "TRANSIT_ENCRYPTION_DISABLED" -> (known after apply)
      ~ uid                         = "824077b0-37b2-4d8b-9a7e-447af9271392" -> (known after apply)
      ~ update_time                 = "2025-05-12T21:35:27.708341164Z" -> (known after apply)
        # (9 unchanged attributes hidden)

      ~ cross_instance_replication_config (known after apply)

      + desired_auto_created_endpoints { # forces replacement
          + network    = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network"
          + project_id = "webstatus-dev-internal-prod"
        }

      - desired_psc_auto_connections { # forces replacement
          - network    = "projects/web-compass-prod/global/networks/prod-webstatus-dev-network" -> null
          - project_id = "webstatus-dev-internal-prod" -> null
        }

      ~ persistence_config (known after apply)
      - persistence_config {
          - mode = "DISABLED" -> null
        }

      ~ zone_distribution_config (known after apply)
      - zone_distribution_config {
          - mode = "MULTI_ZONE" -> null
            # (1 unchanged attribute hidden)
        }
    }

Plan: 2 to add, 2 to change, 2 to destroy.
```