### PR TITLE
Minimize valkey downtime by creating the new instance first

### DIFF
--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -40,6 +40,25 @@ provider "registry.terraform.io/hashicorp/null" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.7.2"
+  hashes = [
+    "h1:356j/3XnXEKr9nyicLUufzoF4Yr6hRy481KIxRVpK0c=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}
+
 provider "registry.terraform.io/kreuzwerker/docker" {
   version     = "3.6.2"
   constraints = ">= 3.0.2"

--- a/infra/storage/outputs.tf
+++ b/infra/storage/outputs.tf
@@ -47,8 +47,8 @@ output "valkey_env_vars" {
   value = {
     for region, _ in var.region_to_subnet_info_map :
     region => {
-      host = google_memorystore_instance.valkey_instance[region].discovery_endpoints[0].address
-      port = google_memorystore_instance.valkey_instance[region].discovery_endpoints[0].port
+      host = google_memorystore_instance.valkey_instance[region].endpoints[0].connections[0].psc_auto_connection[0].ip_address
+      port = google_memorystore_instance.valkey_instance[region].endpoints[0].connections[0].psc_auto_connection[0].port
     }
   }
 }

--- a/infra/storage/providers.tf
+++ b/infra/storage/providers.tf
@@ -21,5 +21,8 @@ terraform {
         google.public_project,
       ]
     }
+    random = {
+      source = "hashicorp/random"
+    }
   }
 }

--- a/infra/storage/valkey.tf
+++ b/infra/storage/valkey.tf
@@ -30,7 +30,7 @@ resource "google_network_connectivity_service_connection_policy" "valkey_policy"
 resource "google_memorystore_instance" "valkey_instance" {
   project     = var.projects.internal
   for_each    = var.region_to_subnet_info_map
-  instance_id = "${var.env_id}-valkey-${each.key}"
+  instance_id = "${var.env_id}-valkey-${each.key}-${random_id.valkey_instance_suffix[each.key].hex}"
   shard_count = 1
   node_type   = "SHARED_CORE_NANO"
   desired_auto_created_endpoints {
@@ -41,4 +41,12 @@ resource "google_memorystore_instance" "valkey_instance" {
   location                    = each.key
   depends_on                  = [google_network_connectivity_service_connection_policy.valkey_policy]
   deletion_protection_enabled = var.deletion_protection
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "random_id" "valkey_instance_suffix" {
+  for_each    = var.region_to_subnet_info_map
+  byte_length = 2
 }


### PR DESCRIPTION
There was a recent change that causes valkey to recreate the instance. By default, terraform will terminate the instance (10-15 mins) before creating it (10-15 minutes).
When I deployed this week's release to staging #1575 , it was discovered that the app hangs while still trying to connect to valkey and it messes up the response time during the full 30 minutes of waiting.

This change minimizes valkey downtime by creating the new instance before terminating the old one. To do this, we have to add some random characters to the end of the name since there can only be one instance with a given name per GCP project. Terraform will generate a new random string the next time it has to create it. Now, there should be minimal performance degradation since the new instance is active and ready before the old one is terminated.

An added plus, this allows us to easily keep up to date with Valkey since valkey 8.1 was released. Just waiting on GCP to support it.

Other changes:
- Update the output from the deprecated way retrieving connection details to the new way.

In the future, we should also add a timeout to the context for the caching layer. So that it will not hang and still return the result if the caching layer fails. Previously, when there was a single cache middleware layer, the app could handle this gracefully even without the timeout (without us doing anything).
But when we moved to per endpoint caching, something happened.

Also, we should look at other resources and see if we could benefit from using the `create_before_destroy` lifecycle hook.