### PR TITLE
chore: Use npm ci instead of npm install

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -35,8 +35,8 @@ go install github.com/cloudspannerecosystem/wrench@v1.11.8
 # Install addlicense
 go install github.com/google/addlicense@v1.1.1
 
-# Install repo-wide npm tools
-npm i --workspaces=false
+# Install repo-wide npm tools only (e.g. Playwright, gts)
+npm ci --workspaces=false
 
 # Generate files
 make gen -B

--- a/Makefile
+++ b/Makefile
@@ -398,8 +398,9 @@ go-workspace-clean:
 ################################
 # Node Misc
 ################################
+# Install all the packages from all workspaces.
 node-install:
-	npm install -ws --foreground-scripts
+	npm ci --include-workspace-root=true --foreground-scripts=true
 
 node-update:
 	npm update

--- a/images/nodejs_service.Dockerfile
+++ b/images/nodejs_service.Dockerfile
@@ -26,7 +26,7 @@ COPY ${service_dir}/package.json ${service_dir}/package.json
 COPY lib/gen/openapi/ lib/gen/openapi/
 WORKDIR /work/${service_dir}
 RUN --mount=type=cache,target=/root/.npm \
-    npm install --ignore-scripts --include-workspace-root=true
+    npm ci --ignore-scripts --include-workspace-root=true
 COPY ${service_dir}/ /work/${service_dir}/
 RUN npm run postinstall || true
 RUN npm run build
@@ -41,7 +41,7 @@ COPY --from=builder /work/package-lock.json /work/package-lock.json
 COPY --from=builder /work/${service_dir}/package.json /work/${service_dir}/package.json
 WORKDIR /work/${service_dir}
 RUN --mount=type=cache,target=/root/.npm \
-    npm install --ignore-scripts --production
+    npm ci --ignore-scripts --production
 RUN ln -s /work/node_modules /work/${service_dir}/node_modules
 COPY --from=builder /work/${service_dir}/dist /work/${service_dir}/dist
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
This should also prevent unexpected changes to package-lock.json.

`npm ci` installs exactly what is in the lock file. npm install may update things if the dependency is prefixed with `^`