### PR TITLE
Change ANY_VALUE to use feature description identifier

### DIFF
--- a/antlr/FeatureSearch.md
+++ b/antlr/FeatureSearch.md
@@ -51,7 +51,7 @@ This query language enables you to construct flexible searches to find features 
 - **Keywords:** These are reserved words used in the grammar, such as `AND`, `OR`
   - `AND`: Combine terms with the AND keyword for explicit logical AND, or use a space between terms for implied AND.
   - `OR`: Combine terms with OR for logical OR operations.
-- **Standalone Feature Names:** Search by feature name without a `name:` prefix.
+- **Standalone Feature Names:** Search by feature description and name without a `name:` or `desc:` prefix.
 
 ## Example Queries
 

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -1042,7 +1042,7 @@ func TestParseQuery(t *testing.T) {
 				Children: []*SearchNode{
 					{
 						Term: &SearchTerm{
-							Identifier: IdentifierName,
+							Identifier: IdentifierDescription,
 							Value:      "grid",
 							Operator:   OperatorLike,
 						},
@@ -1060,7 +1060,7 @@ func TestParseQuery(t *testing.T) {
 				Children: []*SearchNode{
 					{
 						Term: &SearchTerm{
-							Identifier: IdentifierName,
+							Identifier: IdentifierDescription,
 							Value:      "CSS Grid",
 							Operator:   OperatorLike,
 						},
@@ -1079,7 +1079,7 @@ func TestParseQuery(t *testing.T) {
 					{
 						Children: nil,
 						Term: &SearchTerm{
-							Identifier: IdentifierName,
+							Identifier: IdentifierDescription,
 							Value:      "::backdrop",
 							Operator:   OperatorLike,
 						},
@@ -1115,7 +1115,7 @@ func TestParseQuery(t *testing.T) {
 					{
 						Children: nil,
 						Term: &SearchTerm{
-							Identifier: IdentifierName,
+							Identifier: IdentifierDescription,
 							Value:      ":has()",
 							Operator:   OperatorLike,
 						},
@@ -1133,7 +1133,7 @@ func TestParseQuery(t *testing.T) {
 					{
 						Children: nil,
 						Term: &SearchTerm{
-							Identifier: IdentifierName,
+							Identifier: IdentifierDescription,
 							Value:      "<a>",
 							Operator:   OperatorLike,
 						},
@@ -1187,7 +1187,7 @@ func TestParseQuery(t *testing.T) {
 					{
 						Children: nil,
 						Term: &SearchTerm{
-							Identifier: IdentifierName,
+							Identifier: IdentifierDescription,
 							Value:      "@charset",
 							Operator:   OperatorLike,
 						},
@@ -1241,7 +1241,7 @@ func TestParseQuery(t *testing.T) {
 					{
 						Children: nil,
 						Term: &SearchTerm{
-							Identifier: IdentifierName,
+							Identifier: IdentifierDescription,
 							Value:      "intl.segmenter",
 							Operator:   OperatorLike,
 						},
@@ -1259,7 +1259,7 @@ func TestParseQuery(t *testing.T) {
 					{
 						Children: nil,
 						Term: &SearchTerm{
-							Identifier: IdentifierName,
+							Identifier: IdentifierDescription,
 							Value:      "intl.segmenter",
 							Operator:   OperatorLike,
 						},
@@ -1408,7 +1408,7 @@ func TestParseQuery(t *testing.T) {
 								Keyword:  KeywordNone,
 								Children: nil,
 								Term: &SearchTerm{
-									Identifier: IdentifierName,
+									Identifier: IdentifierDescription,
 									Value:      "CSS Grid",
 									Operator:   OperatorLike,
 								},

--- a/lib/gcpspanner/searchtypes/features_search_visitor.go
+++ b/lib/gcpspanner/searchtypes/features_search_visitor.go
@@ -555,10 +555,10 @@ func (v *FeaturesSearchVisitor) VisitGeneric_search_term(ctx *parser.Generic_sea
 func (v *FeaturesSearchVisitor) VisitSearch_criteria(ctx *parser.Search_criteriaContext) interface{} {
 	// Handle the default ANY_VALUE case.
 	// This is needed for the feature name that does not have the prefix.
-	// Even though createNameNode will return nil if node is nil, it will add an error.
+	// Even though createDescriptionNode will return nil if node is nil, it will add an error.
 	// So we proactively check for node.
 	if node := ctx.ANY_VALUE(); node != nil {
-		return v.createNameNode(node)
+		return v.createDescriptionNode(node)
 	}
 
 	return v.VisitChildren(ctx)


### PR DESCRIPTION
Currently, when a user searches without a term, it defaults to using the name identifier which does a wildcard search on the name.

This commit changes the behavior so that it uses the description identifier.

And since the spanner layer searches both the description and the name using a wildcard search when it sees description identifier, I updated the search docs.

This change should happen on a separate deployment from this [PR](https://github.com/GoogleChrome/webstatus.dev/pull/1586) because we need the description to be populated in the spanner database. Otherwise, current users without the term will get zero results suddenly.