### PR TITLE
Add mobile browsers to search syntax

### DIFF
--- a/antlr/FeatureSearch.g4
+++ b/antlr/FeatureSearch.g4
@@ -14,7 +14,14 @@ WS: [ \t\r\n]+ -> skip;
 // Identifiers
 BROWSER_NAME options {
 	caseInsensitive = true;
-}: 'chrome' | 'firefox' | 'edge' | 'safari';
+}:
+	'chrome'
+	| 'chrome_android'
+	| 'firefox'
+	| 'firefox_android'
+	| 'edge'
+	| 'safari'
+	| 'safari_ios';
 BASELINE_STATUS: 'limited' | 'newly' | 'widely';
 DATE:
 	[2][0-9][0-9][0-9]'-' [01][0-9]'-' [0-3][0-9]; // YYYY-MM-DD (starting from 2000)

--- a/antlr/FeatureSearch.md
+++ b/antlr/FeatureSearch.md
@@ -7,7 +7,7 @@ This query language enables you to construct flexible searches to find features 
 - Terms: The basic building blocks of a search query. Each term has an identifier (available_on, baseline_status, name) followed by a colon (:) and its corresponding value without any spaces.
 - **Value Types:**
   - browsers (`BROWSER_NAME`)
-    - Accepted Values: `[a-z]+`
+    - Accepted Values: `chrome`, `chrome_android`, `firefox`, `firefox_android`, `edge`, `safari`, `safari_ios`
     - Example:
       - chrome
   - features (`FEATURE_NAME`)

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -100,6 +100,114 @@ func TestParseQuery(t *testing.T) {
 			},
 		},
 		{
+			InputQuery: "available_on:chrome_android",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Term: &SearchTerm{
+							Identifier: IdentifierAvailableOn,
+							Value:      "chrome_android",
+							Operator:   OperatorEq,
+						},
+						Children: nil,
+						Keyword:  KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: "-available_on:chrome_android",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Term: &SearchTerm{
+							Identifier: IdentifierAvailableOn,
+							Value:      "chrome_android",
+							Operator:   OperatorNeq,
+						},
+						Children: nil,
+						Keyword:  KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: "available_on:firefox_android",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Term: &SearchTerm{
+							Identifier: IdentifierAvailableOn,
+							Value:      "firefox_android",
+							Operator:   OperatorEq,
+						},
+						Children: nil,
+						Keyword:  KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: "-available_on:firefox_android",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Term: &SearchTerm{
+							Identifier: IdentifierAvailableOn,
+							Value:      "firefox_android",
+							Operator:   OperatorNeq,
+						},
+						Children: nil,
+						Keyword:  KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: "available_on:safari_ios",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Term: &SearchTerm{
+							Identifier: IdentifierAvailableOn,
+							Value:      "safari_ios",
+							Operator:   OperatorEq,
+						},
+						Children: nil,
+						Keyword:  KeywordNone,
+					},
+				},
+			},
+		},
+		{
+			InputQuery: "-available_on:safari_ios",
+			ExpectedTree: &SearchNode{
+				Keyword: KeywordRoot,
+				Term:    nil,
+				Children: []*SearchNode{
+					{
+						Term: &SearchTerm{
+							Identifier: IdentifierAvailableOn,
+							Value:      "safari_ios",
+							Operator:   OperatorNeq,
+						},
+						Children: nil,
+						Keyword:  KeywordNone,
+					},
+				},
+			},
+		},
+		{
 			InputQuery: "available_date:chrome:2000-01-01..2000-12-31",
 			ExpectedTree: &SearchNode{
 				Keyword: KeywordRoot,


### PR DESCRIPTION
Previously, we only the desktop browsers were in the BROWSER_LIST in the search syntax. This change adds the mobile browsers too.