### PR TITLE
feat: Add FeatureGroupIDsLookup table for better feature search perf

### DIFF
--- a/infra/storage/spanner/migrations/000018.sql
+++ b/infra/storage/spanner/migrations/000018.sql
@@ -28,3 +28,22 @@ CREATE TABLE IF NOT EXISTS FeatureGroupIDsLookup (
     CONSTRAINT FK_FeatureGroupIDsLookup_WebDXGroups FOREIGN KEY (ID) REFERENCES WebDXGroups(ID)
 ) PRIMARY KEY (ID, WebFeatureID)
 ,   INTERLEAVE IN PARENT WebDXGroups ON DELETE CASCADE;
+
+-- A denormalized lookup table mapping features to direct/inherited groups.
+-- Used by the feature search functionality.
+CREATE TABLE IF NOT EXISTS FeatureGroupKeysLookup (
+    GroupKey_Lowercase STRING(64) NOT NULL,
+    WebFeatureID STRING(36) NOT NULL,
+    GroupID STRING(36) NOT NULL,
+    -- The hierarchy level of the association. A value of 0 means a direct
+    -- link. A value of 1 means this group is the direct parent of the
+    -- feature's group, 2 means it's a grandparent, and so on.
+    -- TODO. Future queries may use this column
+    Depth INT64 NOT NULL,
+    CONSTRAINT FK_FeatureGroupKeysLookup_WebFeatureID
+        FOREIGN KEY (WebFeatureID) REFERENCES WebFeatures(ID) ON DELETE CASCADE,
+    CONSTRAINT FK_FeatureGroupKeysLookup_GroupID
+        FOREIGN KEY (GroupID) REFERENCES WebDXGroups(ID) ON DELETE CASCADE
+-- The primary key starts with GroupKey_Lowercase because the main search query
+-- filters by group name.
+) PRIMARY KEY (GroupKey_Lowercase, WebFeatureID);

--- a/infra/storage/spanner/migrations/000018.sql
+++ b/infra/storage/spanner/migrations/000018.sql
@@ -1,0 +1,30 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- A denormalized lookup table mapping features to direct/inherited groups.
+-- It is interleaved in WebDXGroups to optimize search query JOINs.
+CREATE TABLE IF NOT EXISTS FeatureGroupIDsLookup (
+    -- This column's name, 'ID', must match the primary key
+    -- column's name in the interleaved parent table, 'WebDXGroups'.
+    ID STRING(36) NOT NULL,
+    WebFeatureID STRING(36) NOT NULL,
+    -- The hierarchy level of the association. A value of 0 means a direct
+    -- link. A value of 1 means this group is the direct parent of the
+    -- feature's group, 2 means it's a grandparent, and so on.
+    -- TODO. Future queries may use this column
+    Depth INT64 NOT NULL,
+    CONSTRAINT FK_FeatureGroupIDsLookup_WebFeatures FOREIGN KEY (WebFeatureID) REFERENCES WebFeatures(ID) ON DELETE CASCADE,
+    CONSTRAINT FK_FeatureGroupIDsLookup_WebDXGroups FOREIGN KEY (ID) REFERENCES WebDXGroups(ID)
+) PRIMARY KEY (ID, WebFeatureID)
+,   INTERLEAVE IN PARENT WebDXGroups ON DELETE CASCADE;

--- a/infra/storage/spanner/migrations/000018.sql
+++ b/infra/storage/spanner/migrations/000018.sql
@@ -13,23 +13,6 @@
 -- limitations under the License.
 
 -- A denormalized lookup table mapping features to direct/inherited groups.
--- It is interleaved in WebDXGroups to optimize search query JOINs.
-CREATE TABLE IF NOT EXISTS FeatureGroupIDsLookup (
-    -- This column's name, 'ID', must match the primary key
-    -- column's name in the interleaved parent table, 'WebDXGroups'.
-    ID STRING(36) NOT NULL,
-    WebFeatureID STRING(36) NOT NULL,
-    -- The hierarchy level of the association. A value of 0 means a direct
-    -- link. A value of 1 means this group is the direct parent of the
-    -- feature's group, 2 means it's a grandparent, and so on.
-    -- TODO. Future queries may use this column
-    Depth INT64 NOT NULL,
-    CONSTRAINT FK_FeatureGroupIDsLookup_WebFeatures FOREIGN KEY (WebFeatureID) REFERENCES WebFeatures(ID) ON DELETE CASCADE,
-    CONSTRAINT FK_FeatureGroupIDsLookup_WebDXGroups FOREIGN KEY (ID) REFERENCES WebDXGroups(ID)
-) PRIMARY KEY (ID, WebFeatureID)
-,   INTERLEAVE IN PARENT WebDXGroups ON DELETE CASCADE;
-
--- A denormalized lookup table mapping features to direct/inherited groups.
 -- Used by the feature search functionality.
 CREATE TABLE IF NOT EXISTS FeatureGroupKeysLookup (
     GroupKey_Lowercase STRING(64) NOT NULL,

--- a/lib/gcpspanner/feature_group_lookups.go
+++ b/lib/gcpspanner/feature_group_lookups.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import "context"
+
+const featureGroupIDsLookupTable = "FeatureGroupIDsLookup"
+
+type FeatureGroupIDsLookup struct {
+	ID           string // This is the GroupID. See infra/storage/spanner/migrations/000018.sql
+	WebFeatureID string
+	Depth        int64
+}
+
+func (c *Client) UpsertFeatureGroupLookups(
+	ctx context.Context, lookups []FeatureGroupIDsLookup) error {
+	// TODO: We should do a diff and delete group lookups no longer needed.
+	// This hasn't happened yet.
+
+	return runConcurrentBatch(ctx,
+		c, func(entityChan chan<- FeatureGroupIDsLookup) {
+			for _, entity := range lookups {
+				entityChan <- entity
+			}
+		}, featureGroupIDsLookupTable)
+}

--- a/lib/gcpspanner/feature_group_lookups.go
+++ b/lib/gcpspanner/feature_group_lookups.go
@@ -28,12 +28,6 @@ type spannerFeatureGroupKeysLookup struct {
 	Depth             int64  `spanner:"Depth"`
 }
 
-type FeatureGroupIDsLookup struct {
-	GroupID      string
-	WebFeatureID string
-	Depth        int64
-}
-
 func (c *Client) UpsertFeatureGroupLookups(
 	ctx context.Context, featureKeyToGroupsMapping map[string][]string,
 	childGroupKeyToParentGroupKey map[string]string) error {
@@ -88,7 +82,8 @@ func calculateAllFeatureGroupLookups(
 	for featureKey, featureID := range featureKeyToID {
 		featureGroups, found := featureKeyToGroupsMapping[featureKey]
 		if !found {
-			slog.WarnContext(ctx, "unable to find feature group data by feature key", "featureKey", featureKey)
+			slog.WarnContext(ctx, "Unable to find feature group data for feature key. "+
+				"This is okay if the feature is not associated with a group", "featureKey", featureKey)
 
 			continue
 		}

--- a/lib/gcpspanner/feature_group_lookups.go
+++ b/lib/gcpspanner/feature_group_lookups.go
@@ -14,25 +14,112 @@
 
 package gcpspanner
 
-import "context"
+import (
+	"context"
+	"log/slog"
+)
 
-const featureGroupIDsLookupTable = "FeatureGroupIDsLookup"
+const featureGroupKeysLookupTable = "FeatureGroupKeysLookup"
+
+type spannerFeatureGroupKeysLookup struct {
+	GroupKeyLowercase string `spanner:"GroupKey_Lowercase"`
+	WebFeatureID      string `spanner:"WebFeatureID"`
+	GroupID           string `spanner:"GroupID"`
+	Depth             int64  `spanner:"Depth"`
+}
 
 type FeatureGroupIDsLookup struct {
-	ID           string // This is the GroupID. See infra/storage/spanner/migrations/000018.sql
+	GroupID      string
 	WebFeatureID string
 	Depth        int64
 }
 
 func (c *Client) UpsertFeatureGroupLookups(
-	ctx context.Context, lookups []FeatureGroupIDsLookup) error {
+	ctx context.Context, featureKeyToGroupsMapping map[string][]string,
+	childGroupKeyToParentGroupKey map[string]string) error {
 	// TODO: We should do a diff and delete group lookups no longer needed.
 	// This hasn't happened yet.
+	txn := c.ReadOnlyTransaction()
+	defer txn.Close()
+
+	featureDetails, err := c.fetchAllWebFeatureIDsAndKeysWithTransaction(ctx, txn)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to get all feature details for feature group lookups", "error", err)
+
+		return err
+	}
+	featureKeyToID := make(map[string]string, len(featureDetails))
+	for _, featureDetail := range featureDetails {
+		featureKeyToID[featureDetail.FeatureKey] = featureDetail.ID
+	}
+
+	groupDetails, err := c.fetchAllGroupIDsAndKeysWithTransaction(ctx, txn)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to get all group details for feature group lookups", "error", err)
+
+		return err
+	}
+	groupKeyToGroupDetails := make(map[string]spannerGroupIDKeyAndKeyLowercase, len(featureDetails))
+	for _, groupDetail := range groupDetails {
+		groupKeyToGroupDetails[groupDetail.GroupKey] = groupDetail
+	}
 
 	return runConcurrentBatch(ctx,
-		c, func(entityChan chan<- FeatureGroupIDsLookup) {
-			for _, entity := range lookups {
-				entityChan <- entity
+		c, func(entityChan chan<- spannerFeatureGroupKeysLookup) {
+			calculateAllFeatureGroupLookups(
+				ctx,
+				featureKeyToID,
+				featureKeyToGroupsMapping,
+				groupKeyToGroupDetails,
+				entityChan,
+				childGroupKeyToParentGroupKey)
+		}, featureGroupKeysLookupTable)
+}
+
+func calculateAllFeatureGroupLookups(
+	ctx context.Context,
+	featureKeyToID map[string]string,
+	featureKeyToGroupsMapping map[string][]string,
+	groupKeyToDetails map[string]spannerGroupIDKeyAndKeyLowercase,
+	entityChan chan<- spannerFeatureGroupKeysLookup,
+	childGroupKeyToParentGroupKey map[string]string,
+) {
+
+	for featureKey, featureID := range featureKeyToID {
+		featureGroups, found := featureKeyToGroupsMapping[featureKey]
+		if !found {
+			slog.WarnContext(ctx, "unable to find feature group data by feature key", "featureKey", featureKey)
+
+			continue
+		}
+
+		for _, directGroupKey := range featureGroups {
+			currentGroupKey := directGroupKey
+			currentDepth := int64(0)
+
+			for {
+				groupData, found := groupKeyToDetails[currentGroupKey]
+				if !found {
+					slog.WarnContext(ctx, "group key not found during hierarchy traversal", "groupKey", currentGroupKey)
+
+					break
+				}
+
+				entityChan <- spannerFeatureGroupKeysLookup{
+					GroupID:           groupData.ID,
+					GroupKeyLowercase: groupData.GroupKeyLowercase,
+					WebFeatureID:      featureID,
+					Depth:             currentDepth,
+				}
+
+				// Move up to the parent.
+				parentGroupKey, hasParent := childGroupKeyToParentGroupKey[currentGroupKey]
+				if !hasParent {
+					break
+				}
+				currentGroupKey = parentGroupKey
+				currentDepth++
 			}
-		}, featureGroupIDsLookupTable)
+		}
+	}
 }

--- a/lib/gcpspanner/feature_group_lookups_test.go
+++ b/lib/gcpspanner/feature_group_lookups_test.go
@@ -15,9 +15,11 @@
 package gcpspanner
 
 import (
+	"cmp"
 	"context"
 	"reflect"
 	"slices"
+	"sync"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -46,8 +48,8 @@ func setupTablesForUpsertFeatureGroupLookups(
 
 	// Insert sample groups
 	groups := []Group{
-		{GroupKey: "group-a", Name: "Group A"},
-		{GroupKey: "group-b", Name: "Group B"},
+		{GroupKey: "parent", Name: "Group A"},
+		{GroupKey: "child", Name: "Group B"},
 	}
 	for _, group := range groups {
 		id, err := spannerClient.UpsertGroup(ctx, group)
@@ -60,77 +62,185 @@ func setupTablesForUpsertFeatureGroupLookups(
 	return features, featureKeyToID, groups, groupKeyToID
 }
 
+func TestCalculateAllFeatureGroupLookups(t *testing.T) {
+	type testCase struct {
+		name                          string
+		featureKeyToID                map[string]string
+		featureKeyToGroupsMapping     map[string][]string
+		groupKeyToDetails             map[string]spannerGroupIDKeyAndKeyLowercase
+		childGroupKeyToParentGroupKey map[string]string
+		expectedLookups               []spannerFeatureGroupKeysLookup
+	}
+
+	testCases := []testCase{
+		{
+			name:                      "Deep Hierarchy",
+			featureKeyToID:            map[string]string{"feat1": "feature_id_1"},
+			featureKeyToGroupsMapping: map[string][]string{"feat1": {"grandchild"}},
+			groupKeyToDetails: map[string]spannerGroupIDKeyAndKeyLowercase{
+				"root":       {ID: "uuid_root", GroupKey: "root", GroupKeyLowercase: "root"},
+				"child":      {ID: "uuid_child", GroupKey: "child", GroupKeyLowercase: "child"},
+				"grandchild": {ID: "uuid_grandchild", GroupKey: "grandchild", GroupKeyLowercase: "grandchild"},
+			},
+			childGroupKeyToParentGroupKey: map[string]string{
+				"child":      "root",
+				"grandchild": "child",
+			},
+			expectedLookups: []spannerFeatureGroupKeysLookup{
+				{GroupID: "uuid_grandchild", WebFeatureID: "feature_id_1", Depth: 0, GroupKeyLowercase: "grandchild"},
+				{GroupID: "uuid_child", WebFeatureID: "feature_id_1", Depth: 1, GroupKeyLowercase: "child"},
+				{GroupID: "uuid_root", WebFeatureID: "feature_id_1", Depth: 2, GroupKeyLowercase: "root"},
+			},
+		},
+		{
+			name:                      "Multiple Direct Groups",
+			featureKeyToID:            map[string]string{"feat1": "feature_id_1"},
+			featureKeyToGroupsMapping: map[string][]string{"feat1": {"child1", "child2"}},
+			groupKeyToDetails: map[string]spannerGroupIDKeyAndKeyLowercase{
+				"root":   {ID: "uuid_root", GroupKey: "root", GroupKeyLowercase: "root"},
+				"child1": {ID: "uuid_child1", GroupKey: "child1", GroupKeyLowercase: "child1"},
+				"child2": {ID: "uuid_child2", GroupKey: "child2", GroupKeyLowercase: "child2"},
+			},
+			childGroupKeyToParentGroupKey: map[string]string{
+				"child1": "root",
+				"child2": "root",
+			},
+			expectedLookups: []spannerFeatureGroupKeysLookup{
+				{GroupID: "uuid_child1", WebFeatureID: "feature_id_1", Depth: 0, GroupKeyLowercase: "child1"},
+				{GroupID: "uuid_root", WebFeatureID: "feature_id_1", Depth: 1, GroupKeyLowercase: "root"},
+				{GroupID: "uuid_child2", WebFeatureID: "feature_id_1", Depth: 0, GroupKeyLowercase: "child2"},
+				{GroupID: "uuid_root", WebFeatureID: "feature_id_1", Depth: 1, GroupKeyLowercase: "root"},
+			},
+		},
+		{
+			name:                      "Feature with No Group Mapping",
+			featureKeyToID:            map[string]string{"feat1": "feature_id_1"},
+			featureKeyToGroupsMapping: map[string][]string{}, // No mapping for feat1
+			groupKeyToDetails: map[string]spannerGroupIDKeyAndKeyLowercase{
+				"group1": {ID: "uuid_1", GroupKey: "group1", GroupKeyLowercase: "group1"}},
+			childGroupKeyToParentGroupKey: map[string]string{},
+			expectedLookups:               []spannerFeatureGroupKeysLookup{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entityChan := make(chan spannerFeatureGroupKeysLookup, 100) // Buffered channel
+			var actualLookups []spannerFeatureGroupKeysLookup
+			var wg sync.WaitGroup
+			wg.Add(1)
+
+			// This goroutine reads all results from the channel.
+			go func() {
+				defer wg.Done()
+				for lookup := range entityChan {
+					actualLookups = append(actualLookups, lookup)
+				}
+			}()
+
+			// Run the function under test.
+			calculateAllFeatureGroupLookups(
+				context.Background(),
+				tc.featureKeyToID,
+				tc.featureKeyToGroupsMapping,
+				tc.groupKeyToDetails,
+				entityChan,
+				tc.childGroupKeyToParentGroupKey,
+			)
+			// Close the channel to signal to the reader goroutine that we're done.
+			close(entityChan)
+
+			// Wait for the reader goroutine to finish processing.
+			wg.Wait()
+
+			// Sort both slices for a deterministic comparison.
+			slices.SortFunc(tc.expectedLookups, sortFeatureGroupKeysLookups)
+			slices.SortFunc(actualLookups, sortFeatureGroupKeysLookups)
+
+			if !slices.Equal(actualLookups, tc.expectedLookups) {
+				t.Errorf("lookup slice mismatch.\ngot= %v\nwant=%v", actualLookups, tc.expectedLookups)
+			}
+		})
+	}
+}
+
 func TestUpsertFeatureGroupLookups(t *testing.T) {
 	t.Run("group look ups are inserted", func(t *testing.T) {
 		restartDatabaseContainer(t)
 		ctx := context.Background()
 		_, featureKeyToID, _, groupKeyToID := setupTablesForUpsertFeatureGroupLookups(ctx, t)
-		err := spannerClient.UpsertFeatureGroupLookups(ctx, []FeatureGroupIDsLookup{
-			{ID: groupKeyToID["group-a"], WebFeatureID: featureKeyToID["FeatureX"], Depth: 0},
-			{ID: groupKeyToID["group-b"], WebFeatureID: featureKeyToID["FeatureX"], Depth: 1},
-			{ID: groupKeyToID["group-b"], WebFeatureID: featureKeyToID["FeatureZ"], Depth: 0},
-		})
+		err := spannerClient.UpsertFeatureGroupLookups(ctx,
+			map[string][]string{
+				"FeatureX": {"parent"},
+				"FeatureZ": {"child"},
+			},
+			map[string]string{
+				"child": "parent",
+			},
+		)
 		if err != nil {
 			t.Fatalf("UpsertFeatureGroupLookups failed: %v", err)
 		}
 		// Assert the expected look ups
-		expectedLookups := []FeatureGroupIDsLookup{
-			{ID: groupKeyToID["group-a"], WebFeatureID: featureKeyToID["FeatureX"], Depth: 0},
-			{ID: groupKeyToID["group-b"], WebFeatureID: featureKeyToID["FeatureX"], Depth: 1},
-			{ID: groupKeyToID["group-b"], WebFeatureID: featureKeyToID["FeatureZ"], Depth: 0},
+		expectedLookups := []spannerFeatureGroupKeysLookup{
+			{GroupID: groupKeyToID["parent"], WebFeatureID: featureKeyToID["FeatureX"], Depth: 0, GroupKeyLowercase: "parent"},
+			{GroupID: groupKeyToID["parent"], WebFeatureID: featureKeyToID["FeatureZ"], Depth: 1, GroupKeyLowercase: "parent"},
+			{GroupID: groupKeyToID["child"], WebFeatureID: featureKeyToID["FeatureZ"], Depth: 0, GroupKeyLowercase: "child"},
 		}
 
 		assertFeatureGroupIDsLookups(ctx, t, expectedLookups)
 	})
 }
 
-func assertFeatureGroupIDsLookups(ctx context.Context, t *testing.T, expectedEvents []FeatureGroupIDsLookup) {
-	actualEvents := spannerClient.readAllFeatureGroupIDsLookups(ctx, t)
+func assertFeatureGroupIDsLookups(ctx context.Context, t *testing.T, expectedLookups []spannerFeatureGroupKeysLookup) {
+	actualLookups := spannerClient.readAllFeatureGroupKeysLookups(ctx, t)
 
 	// Assert that the actual events match the expected events
-	slices.SortFunc(expectedEvents, sortFeatureGroupIDsLookups)
-	slices.SortFunc(actualEvents, sortFeatureGroupIDsLookups)
-	if !reflect.DeepEqual(expectedEvents, actualEvents) {
+	slices.SortFunc(expectedLookups, sortFeatureGroupKeysLookups)
+	slices.SortFunc(actualLookups, sortFeatureGroupKeysLookups)
+	if !reflect.DeepEqual(expectedLookups, actualLookups) {
 		t.Errorf("Unexpected data in FeatureGroupIDsLookups\nExpected (size: %d):\n%+v\nActual (size: %d):\n%+v",
-			len(expectedEvents), expectedEvents, len(actualEvents), actualEvents)
+			len(expectedLookups), expectedLookups, len(actualLookups), actualLookups)
 	}
 }
-func sortFeatureGroupIDsLookups(a, b FeatureGroupIDsLookup) int {
-	if a.WebFeatureID != b.WebFeatureID {
-		return slices.Compare([]string{a.WebFeatureID}, []string{b.WebFeatureID})
+func sortFeatureGroupKeysLookups(a, b spannerFeatureGroupKeysLookup) int {
+	if a.GroupKeyLowercase != b.GroupKeyLowercase {
+		return cmp.Compare(a.GroupKeyLowercase, b.GroupKeyLowercase)
 	}
-	if a.ID != b.ID {
-		return slices.Compare([]string{a.ID}, []string{b.ID})
+	if a.WebFeatureID != b.WebFeatureID {
+		return cmp.Compare(a.WebFeatureID, b.WebFeatureID)
+	}
+	if a.GroupID != b.GroupID {
+		return cmp.Compare(a.GroupID, b.GroupID)
 	}
 	if a.Depth != b.Depth {
-		return int(a.Depth - b.Depth)
+		return cmp.Compare(a.Depth, b.Depth)
 	}
 
 	return 0
 }
 
-func (c *Client) readAllFeatureGroupIDsLookups(ctx context.Context, t *testing.T) []FeatureGroupIDsLookup {
-	// Fetch all rows from FeatureGroupIDsLookup
+func (c *Client) readAllFeatureGroupKeysLookups(ctx context.Context, t *testing.T) []spannerFeatureGroupKeysLookup {
 	stmt := spanner.Statement{
 		SQL: `SELECT *
-              FROM FeatureGroupIDsLookup`,
+              FROM FeatureGroupKeysLookup`,
 		Params: nil,
 	}
-	var actualEvents []FeatureGroupIDsLookup
+	var actualLookups []spannerFeatureGroupKeysLookup
 	iter := spannerClient.Single().Query(ctx, stmt)
 	defer iter.Stop()
 	err := iter.Do(func(row *spanner.Row) error {
-		var event FeatureGroupIDsLookup
-		if err := row.ToStruct(&event); err != nil {
+		var lookup spannerFeatureGroupKeysLookup
+		if err := row.ToStruct(&lookup); err != nil {
 			return err
 		}
-		actualEvents = append(actualEvents, event)
+		actualLookups = append(actualLookups, lookup)
 
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("Failed to fetch data from FeatureGroupIDsLookup: %v", err)
+		t.Fatalf("Failed to fetch data from FeatureGroupKeysLookup: %v", err)
 	}
 
-	return actualEvents
+	return actualLookups
 }

--- a/lib/gcpspanner/feature_group_lookups_test.go
+++ b/lib/gcpspanner/feature_group_lookups_test.go
@@ -188,18 +188,18 @@ func TestUpsertFeatureGroupLookups(t *testing.T) {
 			{GroupID: groupKeyToID["child"], WebFeatureID: featureKeyToID["FeatureZ"], Depth: 0, GroupKeyLowercase: "child"},
 		}
 
-		assertFeatureGroupIDsLookups(ctx, t, expectedLookups)
+		assertFeatureGroupKeysLookups(ctx, t, expectedLookups)
 	})
 }
 
-func assertFeatureGroupIDsLookups(ctx context.Context, t *testing.T, expectedLookups []spannerFeatureGroupKeysLookup) {
+func assertFeatureGroupKeysLookups(ctx context.Context, t *testing.T, expectedLookups []spannerFeatureGroupKeysLookup) {
 	actualLookups := spannerClient.readAllFeatureGroupKeysLookups(ctx, t)
 
 	// Assert that the actual events match the expected events
 	slices.SortFunc(expectedLookups, sortFeatureGroupKeysLookups)
 	slices.SortFunc(actualLookups, sortFeatureGroupKeysLookups)
 	if !reflect.DeepEqual(expectedLookups, actualLookups) {
-		t.Errorf("Unexpected data in FeatureGroupIDsLookups\nExpected (size: %d):\n%+v\nActual (size: %d):\n%+v",
+		t.Errorf("Unexpected data in FeatureGroupKeysLookup\nExpected (size: %d):\n%+v\nActual (size: %d):\n%+v",
 			len(expectedLookups), expectedLookups, len(actualLookups), actualLookups)
 	}
 }

--- a/lib/gcpspanner/feature_group_lookups_test.go
+++ b/lib/gcpspanner/feature_group_lookups_test.go
@@ -1,0 +1,136 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"reflect"
+	"slices"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+)
+
+func setupTablesForUpsertFeatureGroupLookups(
+	ctx context.Context,
+	t *testing.T,
+) ([]WebFeature, map[string]string, []Group, map[string]string) {
+	featureKeyToID := map[string]string{}
+	groupKeyToID := map[string]string{}
+
+	// 1. Insert sample data into WebFeatures
+	features := []WebFeature{
+		{FeatureKey: "FeatureX", Name: "Cool API", Description: "text", DescriptionHTML: "<html>"},
+		{FeatureKey: "FeatureY", Name: "Super API", Description: "text", DescriptionHTML: "<html>"},
+		{FeatureKey: "FeatureZ", Name: "Ultra API", Description: "text", DescriptionHTML: "<html>"},
+	}
+	for _, feature := range features {
+		id, err := spannerClient.UpsertWebFeature(ctx, feature)
+		if err != nil {
+			t.Fatalf("Failed to insert WebFeature: %v", err)
+		}
+		featureKeyToID[feature.FeatureKey] = *id
+	}
+
+	// Insert sample groups
+	groups := []Group{
+		{GroupKey: "group-a", Name: "Group A"},
+		{GroupKey: "group-b", Name: "Group B"},
+	}
+	for _, group := range groups {
+		id, err := spannerClient.UpsertGroup(ctx, group)
+		if err != nil {
+			t.Fatalf("Failed to insert Group: %v", err)
+		}
+		groupKeyToID[group.GroupKey] = *id
+	}
+
+	return features, featureKeyToID, groups, groupKeyToID
+}
+
+func TestUpsertFeatureGroupLookups(t *testing.T) {
+	t.Run("group look ups are inserted", func(t *testing.T) {
+		restartDatabaseContainer(t)
+		ctx := context.Background()
+		_, featureKeyToID, _, groupKeyToID := setupTablesForUpsertFeatureGroupLookups(ctx, t)
+		err := spannerClient.UpsertFeatureGroupLookups(ctx, []FeatureGroupIDsLookup{
+			{ID: groupKeyToID["group-a"], WebFeatureID: featureKeyToID["FeatureX"], Depth: 0},
+			{ID: groupKeyToID["group-b"], WebFeatureID: featureKeyToID["FeatureX"], Depth: 1},
+			{ID: groupKeyToID["group-b"], WebFeatureID: featureKeyToID["FeatureZ"], Depth: 0},
+		})
+		if err != nil {
+			t.Fatalf("UpsertFeatureGroupLookups failed: %v", err)
+		}
+		// Assert the expected look ups
+		expectedLookups := []FeatureGroupIDsLookup{
+			{ID: groupKeyToID["group-a"], WebFeatureID: featureKeyToID["FeatureX"], Depth: 0},
+			{ID: groupKeyToID["group-b"], WebFeatureID: featureKeyToID["FeatureX"], Depth: 1},
+			{ID: groupKeyToID["group-b"], WebFeatureID: featureKeyToID["FeatureZ"], Depth: 0},
+		}
+
+		assertFeatureGroupIDsLookups(ctx, t, expectedLookups)
+	})
+}
+
+func assertFeatureGroupIDsLookups(ctx context.Context, t *testing.T, expectedEvents []FeatureGroupIDsLookup) {
+	actualEvents := spannerClient.readAllFeatureGroupIDsLookups(ctx, t)
+
+	// Assert that the actual events match the expected events
+	slices.SortFunc(expectedEvents, sortFeatureGroupIDsLookups)
+	slices.SortFunc(actualEvents, sortFeatureGroupIDsLookups)
+	if !reflect.DeepEqual(expectedEvents, actualEvents) {
+		t.Errorf("Unexpected data in FeatureGroupIDsLookups\nExpected (size: %d):\n%+v\nActual (size: %d):\n%+v",
+			len(expectedEvents), expectedEvents, len(actualEvents), actualEvents)
+	}
+}
+func sortFeatureGroupIDsLookups(a, b FeatureGroupIDsLookup) int {
+	if a.WebFeatureID != b.WebFeatureID {
+		return slices.Compare([]string{a.WebFeatureID}, []string{b.WebFeatureID})
+	}
+	if a.ID != b.ID {
+		return slices.Compare([]string{a.ID}, []string{b.ID})
+	}
+	if a.Depth != b.Depth {
+		return int(a.Depth - b.Depth)
+	}
+
+	return 0
+}
+
+func (c *Client) readAllFeatureGroupIDsLookups(ctx context.Context, t *testing.T) []FeatureGroupIDsLookup {
+	// Fetch all rows from FeatureGroupIDsLookup
+	stmt := spanner.Statement{
+		SQL: `SELECT *
+              FROM FeatureGroupIDsLookup`,
+		Params: nil,
+	}
+	var actualEvents []FeatureGroupIDsLookup
+	iter := spannerClient.Single().Query(ctx, stmt)
+	defer iter.Stop()
+	err := iter.Do(func(row *spanner.Row) error {
+		var event FeatureGroupIDsLookup
+		if err := row.ToStruct(&event); err != nil {
+			return err
+		}
+		actualEvents = append(actualEvents, event)
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to fetch data from FeatureGroupIDsLookup: %v", err)
+	}
+
+	return actualEvents
+}

--- a/lib/gcpspanner/feature_search_query.go
+++ b/lib/gcpspanner/feature_search_query.go
@@ -337,12 +337,11 @@ func (b *FeatureSearchFilterBuilder) groupFilter(group string, op searchtypes.Se
 	opStr := searchOperatorToSpannerBinaryOperator(op)
 
 	return fmt.Sprintf(`
-	wf.ID IN (
-		SELECT l.WebFeatureID
-		FROM FeatureGroupIDsLookup AS l
-		JOIN WebDXGroups AS g ON l.ID = g.ID
-		WHERE g.GroupKey_Lowercase %s @%s
-	)`, opStr, paramName)
+    wf.ID IN (
+        SELECT WebFeatureID
+        FROM FeatureGroupKeysLookup
+        WHERE GroupKey_Lowercase %s @%s
+    )`, opStr, paramName)
 }
 
 func (b *FeatureSearchFilterBuilder) snapshotFilter(snapshot string, op searchtypes.SearchOperator) string {

--- a/lib/gcpspanner/feature_search_query.go
+++ b/lib/gcpspanner/feature_search_query.go
@@ -337,23 +337,12 @@ func (b *FeatureSearchFilterBuilder) groupFilter(group string, op searchtypes.Se
 	opStr := searchOperatorToSpannerBinaryOperator(op)
 
 	return fmt.Sprintf(`
-    wf.ID IN (
-        SELECT wfg.WebFeatureID
-        FROM WebFeatureGroups wfg
-        WHERE
-            EXISTS (
-                SELECT 1
-                FROM WebDXGroups g
-                LEFT JOIN WebDXGroupDescendants gd ON g.ID = gd.GroupID
-                WHERE g.GroupKey_Lowercase %s @%s
-                  AND (
-                      g.ID IN UNNEST(wfg.GroupIDs)
-                      OR
-                      ARRAY_INCLUDES_ANY(gd.DescendantGroupIDs, wfg.GroupIDs)
-                  )
-            )
-    )
-    `, opStr, paramName)
+	wf.ID IN (
+		SELECT l.WebFeatureID
+		FROM FeatureGroupIDsLookup AS l
+		JOIN WebDXGroups AS g ON l.ID = g.ID
+		WHERE g.GroupKey_Lowercase %s @%s
+	)`, opStr, paramName)
 }
 
 func (b *FeatureSearchFilterBuilder) snapshotFilter(snapshot string, op searchtypes.SearchOperator) string {

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -548,29 +548,15 @@ func setupRequiredTablesForFeaturesSearch(ctx context.Context,
 		}
 		groupKeyToInternalID[group.GroupKey] = *id
 	}
-	groupLookups := []FeatureGroupIDsLookup{
-		{
-			ID:           groupKeyToInternalID["parent1"],
-			WebFeatureID: webFeatureKeyToInternalFeatureID["feature1"],
-			Depth:        0,
-		},
-		{
-			ID:           groupKeyToInternalID["parent1"],
-			WebFeatureID: webFeatureKeyToInternalFeatureID["feature3"],
-			Depth:        1,
-		},
-		{
-			ID:           groupKeyToInternalID["child3"],
-			WebFeatureID: webFeatureKeyToInternalFeatureID["feature3"],
-			Depth:        0,
-		},
-		{
-			ID:           groupKeyToInternalID["parent2"],
-			WebFeatureID: webFeatureKeyToInternalFeatureID["feature2"],
-			Depth:        0,
-		},
+	featureKeyToGroupsMapping := map[string][]string{
+		"feature1": {"parent1"},
+		"feature2": {"parent2"},
+		"feature3": {"child3"},
 	}
-	err = client.UpsertFeatureGroupLookups(ctx, groupLookups)
+	childGroupKeyToParentGroupKey := map[string]string{
+		"child3": "parent1",
+	}
+	err = client.UpsertFeatureGroupLookups(ctx, featureKeyToGroupsMapping, childGroupKeyToParentGroupKey)
 	if err != nil {
 		t.Fatalf("unable to insert group feature lookups err %s", err)
 	}

--- a/lib/gcpspanner/groups.go
+++ b/lib/gcpspanner/groups.go
@@ -99,3 +99,15 @@ func (c *Client) UpsertGroup(ctx context.Context, group Group) (*string, error) 
 func (c *Client) GetGroupIDFromGroupKey(ctx context.Context, groupKey string) (*string, error) {
 	return newEntityWriterWithIDRetrieval[groupSpannerMapper, string](c).getIDByKey(ctx, groupKey)
 }
+
+type spannerGroupIDKeyAndKeyLowercase struct {
+	ID                string `spanner:"ID"`
+	GroupKey          string `spanner:"GroupKey"`
+	GroupKeyLowercase string `spanner:"GroupKey_Lowercase"`
+}
+
+func (c *Client) fetchAllGroupIDsAndKeysWithTransaction(
+	ctx context.Context, txn *spanner.ReadOnlyTransaction) ([]spannerGroupIDKeyAndKeyLowercase, error) {
+	return fetchColumnValuesWithTransaction[spannerGroupIDKeyAndKeyLowercase](
+		ctx, txn, groupsTable, []string{"ID", "GroupKey", "GroupKey_Lowercase"})
+}

--- a/lib/gcpspanner/spanneradapters/web_feature_groups_consumer.go
+++ b/lib/gcpspanner/spanneradapters/web_feature_groups_consumer.go
@@ -25,8 +25,7 @@ import (
 // WebFeatureGroupsClient expects a subset of the functionality from lib/gcpspanner that only apply to Groups.
 type WebFeatureGroupsClient interface {
 	UpsertGroup(ctx context.Context, group gcpspanner.Group) (*string, error)
-	UpsertWebFeatureGroup(ctx context.Context, group gcpspanner.WebFeatureGroup) error
-	UpsertGroupDescendantInfo(ctx context.Context, groupKey string, descendantInfo gcpspanner.GroupDescendantInfo) error
+	UpsertFeatureGroupLookups(ctx context.Context, lookups []gcpspanner.FeatureGroupIDsLookup) error
 }
 
 // NewWebFeaturesConsumer constructs an adapter for the web features consumer service.
@@ -40,13 +39,69 @@ type WebFeatureGroupConsumer struct {
 	client WebFeatureGroupsClient
 }
 
+func (c *WebFeatureGroupConsumer) calculateAllLookups(
+	ctx context.Context,
+	featureKeyToID map[string]string,
+	featureData map[string]web_platform_dx__web_features.FeatureValue,
+	groupKeyToID map[string]string,
+	childToParentMap map[string]string,
+) []gcpspanner.FeatureGroupIDsLookup {
+	var allLookups []gcpspanner.FeatureGroupIDsLookup
+
+	for featureKey, featureID := range featureKeyToID {
+		feature := featureData[featureKey]
+		if feature.Group == nil {
+			continue
+		}
+
+		var directGroupKeys []string
+		if feature.Group.String != nil {
+			directGroupKeys = append(directGroupKeys, *feature.Group.String)
+		} else if feature.Group.StringArray != nil {
+			directGroupKeys = feature.Group.StringArray
+		}
+
+		// For each direct group associated with the feature...
+		for _, directGroupKey := range directGroupKeys {
+			currentGroupKey := directGroupKey
+			currentDepth := int64(0)
+
+			for {
+				groupID, found := groupKeyToID[currentGroupKey]
+				if !found {
+					slog.WarnContext(ctx, "group key not found during hierarchy traversal", "groupKey", currentGroupKey)
+
+					break
+				}
+
+				allLookups = append(allLookups, gcpspanner.FeatureGroupIDsLookup{
+					ID:           groupID,
+					WebFeatureID: featureID,
+					Depth:        currentDepth,
+				})
+
+				// Move up to the parent.
+				parentGroupKey, hasParent := childToParentMap[currentGroupKey]
+				if !hasParent {
+					break
+				}
+				currentGroupKey = parentGroupKey
+				currentDepth++
+			}
+		}
+	}
+
+	return allLookups
+}
+
 func (c *WebFeatureGroupConsumer) InsertWebFeatureGroups(
 	ctx context.Context,
 	featureKeyToID map[string]string,
 	featureData map[string]web_platform_dx__web_features.FeatureValue,
 	groupData map[string]web_platform_dx__web_features.GroupData) error {
 	groupKeyToInternalID := make(map[string]string, len(groupData))
-	// Upsert basic group data and get group ids
+	childToParentMap := make(map[string]string)
+	// Step 1. Upsert basic group data and get group ids
 	for key, group := range groupData {
 		id, err := c.client.UpsertGroup(ctx, gcpspanner.Group{
 			GroupKey: key,
@@ -58,105 +113,21 @@ func (c *WebFeatureGroupConsumer) InsertWebFeatureGroups(
 			return err
 		}
 		groupKeyToInternalID[key] = *id
-	}
-	// Upsert the group descendant info.
-	groupDescMap := c.buildGroupDescendants(groupData, groupKeyToInternalID)
-	for key, groupDescInfo := range groupDescMap {
-		err := c.client.UpsertGroupDescendantInfo(ctx, key, groupDescInfo)
-		if err != nil {
-			slog.ErrorContext(ctx, "unable to upsert group descendant info",
-				"error", err, "groupKey", key, "info", groupDescInfo)
 
-			return err
+		if group.Parent != nil {
+			childToParentMap[key] = *group.Parent
 		}
 	}
-	// Upsert the web-feature to group mappings
-	// nolint:dupl // TODO - we should fix this.
-	for featureKey, featureID := range featureKeyToID {
-		feature := featureData[featureKey]
-		if feature.Group == nil {
-			continue
-		}
-		var groupIDs []string
-		if feature.Group.String != nil {
-			internalID, found := groupKeyToInternalID[*feature.Group.String]
-			if !found {
-				slog.WarnContext(ctx, "unable to find internal group ID", "groupKey", *feature.Group.String)
 
-				continue
-			}
-			groupIDs = append(groupIDs, internalID)
-		} else if feature.Group.StringArray != nil {
-			for _, groupKey := range feature.Group.StringArray {
-				internalID, found := groupKeyToInternalID[groupKey]
-				if !found {
-					slog.WarnContext(ctx, "unable to find internal group ID", "groupKey", groupKey)
+	// Step 2: Perform the core calculation in its own helper.
+	lookupsToUpsert := c.calculateAllLookups(
+		ctx, featureKeyToID, featureData, groupKeyToInternalID, childToParentMap,
+	)
 
-					continue
-				}
-				groupIDs = append(groupIDs, internalID)
-			}
-		}
-		err := c.client.UpsertWebFeatureGroup(ctx, gcpspanner.WebFeatureGroup{
-			WebFeatureID: featureID,
-			GroupIDs:     groupIDs,
-		})
-		if err != nil {
-			slog.ErrorContext(ctx, "unable to upsert web feature group", "webFeatureID",
-				featureID, "featureKey", featureKey, "groupIDs", groupIDs, "error", err)
-
-			return err
-		}
+	// Step 3: Call the client to perform the final database write.
+	if len(lookupsToUpsert) > 0 {
+		return c.client.UpsertFeatureGroupLookups(ctx, lookupsToUpsert)
 	}
 
 	return nil
-}
-
-func (c *WebFeatureGroupConsumer) buildGroupDescendants(
-	data map[string]web_platform_dx__web_features.GroupData,
-	groupKeyToID map[string]string,
-) map[string]gcpspanner.GroupDescendantInfo {
-	m := make(map[string]gcpspanner.GroupDescendantInfo, len(data))
-	groupToChildrenGroupKeys := make(map[string][]string, len(data))
-	var rootGroupKeys []string
-	for groupKey, groupData := range data {
-		info := gcpspanner.GroupDescendantInfo{
-			DescendantGroupIDs: nil,
-		}
-		m[groupKey] = info
-		if groupData.Parent != nil {
-			groupToChildrenGroupKeys[*groupData.Parent] = append(groupToChildrenGroupKeys[*groupData.Parent], groupKey)
-		} else {
-			rootGroupKeys = append(rootGroupKeys, groupKey)
-		}
-	}
-	for _, rootGroupKey := range rootGroupKeys {
-		c.populateDescendants(rootGroupKey, m, groupToChildrenGroupKeys, groupKeyToID)
-	}
-
-	return m
-}
-
-func (c *WebFeatureGroupConsumer) populateDescendants(
-	groupKey string,
-	groupDescendantMap map[string]gcpspanner.GroupDescendantInfo,
-	groupToChildrenGroupKeys map[string][]string,
-	groupKeyToInternalID map[string]string) {
-	info := groupDescendantMap[groupKey]
-
-	// Base case: if no children, descendants are empty (no descendants, only itself)
-	if _, exists := groupToChildrenGroupKeys[groupKey]; !exists {
-		// DescendantGroupIDs is already nil. No need to update.
-		return
-	}
-
-	// Recursive case: collect descendants from children
-	for _, childGroupKey := range groupToChildrenGroupKeys[groupKey] {
-		c.populateDescendants(childGroupKey, groupDescendantMap, groupToChildrenGroupKeys, groupKeyToInternalID)
-		childInfo := groupDescendantMap[childGroupKey]
-		info.DescendantGroupIDs = append(info.DescendantGroupIDs, groupKeyToInternalID[childGroupKey])
-		info.DescendantGroupIDs = append(info.DescendantGroupIDs, childInfo.DescendantGroupIDs...)
-	}
-
-	groupDescendantMap[groupKey] = info
 }

--- a/lib/gcpspanner/spanneradapters/web_feature_groups_consumer.go
+++ b/lib/gcpspanner/spanneradapters/web_feature_groups_consumer.go
@@ -46,6 +46,9 @@ func extractFeatureKeyToGroupsMapping(
 	m := make(map[string][]string)
 
 	for featureKey, feature := range featuresData {
+		if feature.Group == nil {
+			continue
+		}
 		var directGroupKeys []string
 		if feature.Group.String != nil {
 			directGroupKeys = append(directGroupKeys, *feature.Group.String)

--- a/lib/gcpspanner/spanneradapters/web_feature_groups_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/web_feature_groups_consumer_test.go
@@ -26,100 +26,6 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/jsonschema/web_platform_dx__web_features"
 )
 
-func TestBuildGroupDescendants(t *testing.T) {
-	testCases := []struct {
-		name                  string
-		groupData             map[string]web_platform_dx__web_features.GroupData
-		groupKeyToInternalID  map[string]string
-		expectedDescendantMap map[string]gcpspanner.GroupDescendantInfo
-	}{
-		{
-			name: "Simple Hierarchy",
-			groupData: map[string]web_platform_dx__web_features.GroupData{
-				"group1": {Parent: nil, Name: "Group 1"},
-				"group2": {Name: "Group 2", Parent: valuePtr("group1")},
-				"group3": {Name: "Group 3", Parent: valuePtr("group1")},
-			},
-			groupKeyToInternalID: map[string]string{
-				"group1": "uuid1",
-				"group2": "uuid2",
-				"group3": "uuid3",
-			},
-			expectedDescendantMap: map[string]gcpspanner.GroupDescendantInfo{
-				"group1": {DescendantGroupIDs: []string{"uuid2", "uuid3"}},
-				"group2": {DescendantGroupIDs: nil},
-				"group3": {DescendantGroupIDs: nil},
-			},
-		},
-		{
-			name: "Deeper Hierarchy",
-			groupData: map[string]web_platform_dx__web_features.GroupData{
-				"group1": {Parent: nil, Name: "Group 1"},
-				"group2": {Name: "Group 2", Parent: valuePtr("group1")},
-				"group3": {Name: "Group 3", Parent: valuePtr("group2")},
-				"group4": {Name: "Group 4", Parent: valuePtr("group2")},
-			},
-			groupKeyToInternalID: map[string]string{
-				"group1": "uuid1",
-				"group2": "uuid2",
-				"group3": "uuid3",
-				"group4": "uuid4",
-			},
-			expectedDescendantMap: map[string]gcpspanner.GroupDescendantInfo{
-				"group1": {DescendantGroupIDs: []string{"uuid2", "uuid3", "uuid4"}},
-				"group2": {DescendantGroupIDs: []string{"uuid3", "uuid4"}},
-				"group3": {DescendantGroupIDs: nil},
-				"group4": {DescendantGroupIDs: nil},
-			},
-		},
-		{
-			name: "Multiple Roots",
-			groupData: map[string]web_platform_dx__web_features.GroupData{
-				"group1": {Parent: nil, Name: "Group 1"},
-				"group2": {Parent: nil, Name: "Group 2"},
-				"group3": {Name: "Group 3", Parent: valuePtr("group1")},
-			},
-			groupKeyToInternalID: map[string]string{
-				"group1": "uuid1",
-				"group2": "uuid2",
-				"group3": "uuid3",
-			},
-			expectedDescendantMap: map[string]gcpspanner.GroupDescendantInfo{
-				"group1": {DescendantGroupIDs: []string{"uuid3"}},
-				"group2": {DescendantGroupIDs: nil},
-				"group3": {DescendantGroupIDs: nil},
-			},
-		},
-		{
-			name: "No Children",
-			groupData: map[string]web_platform_dx__web_features.GroupData{
-				"group1": {Name: "Group 1", Parent: nil},
-			},
-			groupKeyToInternalID: map[string]string{
-				"group1": "uuid1",
-			},
-			expectedDescendantMap: map[string]gcpspanner.GroupDescendantInfo{
-				"group1": {DescendantGroupIDs: nil},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			consumer := &WebFeatureGroupConsumer{client: nil}
-			actualDescendantMap := consumer.buildGroupDescendants(tc.groupData, tc.groupKeyToInternalID)
-
-			for _, info := range actualDescendantMap {
-				slices.Sort(info.DescendantGroupIDs)
-			}
-
-			if !reflect.DeepEqual(actualDescendantMap, tc.expectedDescendantMap) {
-				t.Errorf("Descendant maps not equal.\nExpected: %v\nReceived: %v", tc.expectedDescendantMap, actualDescendantMap)
-			}
-		})
-	}
-}
-
 type mockUpsertGroupConfig struct {
 	expectedInputs map[string]gcpspanner.Group
 	outputIDs      map[string]string
@@ -127,28 +33,207 @@ type mockUpsertGroupConfig struct {
 	expectedCount  int
 }
 
-type mockUpsertGroupDescendantInfoConfig struct {
-	expectedInputs map[string]gcpspanner.GroupDescendantInfo
-	outputs        map[string]error
-	expectedCount  int
+type mockUpsertFeatureGroupLookupsConfig struct {
+	expectedInput []gcpspanner.FeatureGroupIDsLookup
+	output        error
+	expectedCount int
 }
 
-type mockUpsertWebFeatureGroupConfig struct {
-	expectedInputs map[string]gcpspanner.WebFeatureGroup
-	outputs        map[string]error
-	expectedCount  int
+func TestCalculateAllLookups(t *testing.T) {
+	testCases := []struct {
+		name             string
+		featureKeyToID   map[string]string
+		featureData      map[string]web_platform_dx__web_features.FeatureValue
+		groupKeyToID     map[string]string
+		childToParentMap map[string]string
+		expectedLookups  []gcpspanner.FeatureGroupIDsLookup
+	}{
+		{
+			name:           "Deep Hierarchy",
+			featureKeyToID: map[string]string{"feat1": "feature_id_1"},
+			featureData: map[string]web_platform_dx__web_features.FeatureValue{
+				"feat1": {
+					Caniuse:         nil,
+					CompatFeatures:  nil,
+					Description:     "feature 1",
+					DescriptionHTML: "<html>",
+					Discouraged:     nil,
+					Name:            "Feature 1",
+					Snapshot:        nil,
+					Spec:            nil,
+					Status: web_platform_dx__web_features.Status{
+						Baseline:         nil,
+						BaselineHighDate: nil,
+						BaselineLowDate:  nil,
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
+							Chrome:         nil,
+							ChromeAndroid:  nil,
+							Edge:           nil,
+							Firefox:        nil,
+							FirefoxAndroid: nil,
+							Safari:         nil,
+							SafariIos:      nil,
+						},
+					},
+					Group: &web_platform_dx__web_features.StringOrStringArray{
+						String: valuePtr("grandchild"), StringArray: nil},
+				},
+			},
+			groupKeyToID: map[string]string{
+				"root":       "uuid_root",
+				"child":      "uuid_child",
+				"grandchild": "uuid_grandchild",
+			},
+			childToParentMap: map[string]string{
+				"child":      "root",
+				"grandchild": "child",
+			},
+			expectedLookups: []gcpspanner.FeatureGroupIDsLookup{
+				{ID: "uuid_grandchild", WebFeatureID: "feature_id_1", Depth: 0},
+				{ID: "uuid_child", WebFeatureID: "feature_id_1", Depth: 1},
+				{ID: "uuid_root", WebFeatureID: "feature_id_1", Depth: 2},
+			},
+		},
+		{
+			name:           "Multiple Direct Groups",
+			featureKeyToID: map[string]string{"feat1": "feature_id_1"},
+			featureData: map[string]web_platform_dx__web_features.FeatureValue{
+				"feat1": {
+					Caniuse:         nil,
+					CompatFeatures:  nil,
+					Description:     "feature 1",
+					DescriptionHTML: "<html>",
+					Discouraged:     nil,
+					Name:            "Feature 1",
+					Snapshot:        nil,
+					Spec:            nil,
+					Status: web_platform_dx__web_features.Status{
+						Baseline:         nil,
+						BaselineHighDate: nil,
+						BaselineLowDate:  nil,
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
+							Chrome:         nil,
+							ChromeAndroid:  nil,
+							Edge:           nil,
+							Firefox:        nil,
+							FirefoxAndroid: nil,
+							Safari:         nil,
+							SafariIos:      nil,
+						},
+					},
+					Group: &web_platform_dx__web_features.StringOrStringArray{
+						StringArray: []string{"child1", "child2"}, String: nil},
+				},
+			},
+			groupKeyToID: map[string]string{
+				"root":   "uuid_root",
+				"child1": "uuid_child1",
+				"child2": "uuid_child2",
+			},
+			childToParentMap: map[string]string{
+				"child1": "root",
+				"child2": "root",
+			},
+			expectedLookups: []gcpspanner.FeatureGroupIDsLookup{
+				{ID: "uuid_child1", WebFeatureID: "feature_id_1", Depth: 0},
+				{ID: "uuid_root", WebFeatureID: "feature_id_1", Depth: 1},
+				{ID: "uuid_child2", WebFeatureID: "feature_id_1", Depth: 0},
+				// Note: Duplicates are expected here and handled by the DB.
+				{ID: "uuid_root", WebFeatureID: "feature_id_1", Depth: 1},
+			},
+		},
+		{
+			name:           "Feature with No Group",
+			featureKeyToID: map[string]string{"feat1": "feature_id_1"},
+			featureData: map[string]web_platform_dx__web_features.FeatureValue{
+				"feat1": {
+					Caniuse:         nil,
+					CompatFeatures:  nil,
+					Description:     "feature 1",
+					DescriptionHTML: "<html>",
+					Discouraged:     nil,
+					Name:            "Feature 1",
+					Snapshot:        nil,
+					Spec:            nil,
+					Status: web_platform_dx__web_features.Status{
+						Baseline:         nil,
+						BaselineHighDate: nil,
+						BaselineLowDate:  nil,
+						ByCompatKey:      nil,
+						Support: web_platform_dx__web_features.StatusSupport{
+							Chrome:         nil,
+							ChromeAndroid:  nil,
+							Edge:           nil,
+							Firefox:        nil,
+							FirefoxAndroid: nil,
+							Safari:         nil,
+							SafariIos:      nil,
+						},
+					},
+					// No group associated
+					Group: nil,
+				},
+			},
+			groupKeyToID:     map[string]string{"group1": "uuid_1"},
+			childToParentMap: map[string]string{},
+			expectedLookups:  []gcpspanner.FeatureGroupIDsLookup{}, // Expect no lookups
+		},
+		{
+			name:             "No Features",
+			featureKeyToID:   map[string]string{},
+			featureData:      map[string]web_platform_dx__web_features.FeatureValue{},
+			groupKeyToID:     map[string]string{"group1": "uuid_1"},
+			childToParentMap: map[string]string{},
+			expectedLookups:  []gcpspanner.FeatureGroupIDsLookup{},
+		},
+	}
+
+	consumer := NewWebFeatureGroupsConsumer(nil)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Run the calculation
+			actualLookups := consumer.calculateAllLookups(
+				context.Background(), tc.featureKeyToID, tc.featureData, tc.groupKeyToID, tc.childToParentMap)
+
+			sortLookups(actualLookups)
+			sortLookups(tc.expectedLookups)
+
+			if !slices.Equal(actualLookups, tc.expectedLookups) {
+				t.Errorf("lookup slice mismatch.\ngot= %v\nwant=%v", actualLookups, tc.expectedLookups)
+			}
+		})
+	}
+}
+
+// sortLookups sorts the slice for deterministic testing.
+func sortLookups(lookups []gcpspanner.FeatureGroupIDsLookup) {
+	slices.SortFunc(lookups, func(a, b gcpspanner.FeatureGroupIDsLookup) int {
+		if a.WebFeatureID != b.WebFeatureID {
+			return slices.Compare([]string{a.WebFeatureID}, []string{b.WebFeatureID})
+		}
+		if a.ID != b.ID {
+			return slices.Compare([]string{a.ID}, []string{b.ID})
+		}
+		if a.Depth != b.Depth {
+			return int(a.Depth - b.Depth)
+		}
+
+		return 0
+	})
 }
 
 func TestInsertWebFeatureGroups(t *testing.T) {
 	testCases := []struct {
-		name                         string
-		mockUpsertGroupCfg           mockUpsertGroupConfig
-		mockUpsertGroupDescendantCfg mockUpsertGroupDescendantInfoConfig
-		mockUpsertWebFeatureGroupCfg mockUpsertWebFeatureGroupConfig
-		featureKeyToID               map[string]string
-		featureData                  map[string]web_platform_dx__web_features.FeatureValue
-		groupData                    map[string]web_platform_dx__web_features.GroupData
-		expectedError                error
+		name                             string
+		mockUpsertGroupCfg               mockUpsertGroupConfig
+		mockUpsertFeatureGroupLookupsCfg mockUpsertFeatureGroupLookupsConfig
+		featureKeyToID                   map[string]string
+		featureData                      map[string]web_platform_dx__web_features.FeatureValue
+		groupData                        map[string]web_platform_dx__web_features.GroupData
+		expectedError                    error
 	}{
 		{
 			name: "Success with single and multiple groups per feature",
@@ -170,29 +255,14 @@ func TestInsertWebFeatureGroups(t *testing.T) {
 				},
 				expectedCount: 3,
 			},
-			mockUpsertGroupDescendantCfg: mockUpsertGroupDescendantInfoConfig{
-				expectedInputs: map[string]gcpspanner.GroupDescendantInfo{
-					"group1": {DescendantGroupIDs: []string{"uuid3"}},
-					"group2": {DescendantGroupIDs: nil},
-					"child3": {DescendantGroupIDs: nil},
+			mockUpsertFeatureGroupLookupsCfg: mockUpsertFeatureGroupLookupsConfig{
+				expectedInput: []gcpspanner.FeatureGroupIDsLookup{
+					{ID: "uuid1", WebFeatureID: "featureID1", Depth: 0},
+					{ID: "uuid2", WebFeatureID: "featureID1", Depth: 0},
+					{ID: "uuid2", WebFeatureID: "featureID2", Depth: 0},
 				},
-				outputs: map[string]error{
-					"group1": nil,
-					"group2": nil,
-					"child3": nil,
-				},
-				expectedCount: 3,
-			},
-			mockUpsertWebFeatureGroupCfg: mockUpsertWebFeatureGroupConfig{
-				expectedInputs: map[string]gcpspanner.WebFeatureGroup{
-					"featureID1": {WebFeatureID: "featureID1", GroupIDs: []string{"uuid1", "uuid3"}},
-					"featureID2": {WebFeatureID: "featureID2", GroupIDs: []string{"uuid2"}},
-				},
-				outputs: map[string]error{
-					"featureID1": nil,
-					"featureID2": nil,
-				},
-				expectedCount: 2,
+				output:        nil,
+				expectedCount: 1,
 			},
 			featureKeyToID: map[string]string{
 				"feature1": "featureID1",
@@ -201,7 +271,7 @@ func TestInsertWebFeatureGroups(t *testing.T) {
 			featureData: map[string]web_platform_dx__web_features.FeatureValue{
 				"feature1": {
 					Group: &web_platform_dx__web_features.StringOrStringArray{
-						StringArray: []string{"group1", "child3"},
+						StringArray: []string{"group1", "group2"},
 						String:      nil,
 					},
 					Caniuse:         nil,
@@ -270,7 +340,7 @@ func TestInsertWebFeatureGroups(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := newMockWebFeatureGroupsClient(
-				t, tc.mockUpsertGroupCfg, tc.mockUpsertGroupDescendantCfg, tc.mockUpsertWebFeatureGroupCfg)
+				t, tc.mockUpsertGroupCfg, tc.mockUpsertFeatureGroupLookupsCfg)
 			consumer := NewWebFeatureGroupsConsumer(mockClient)
 
 			err := consumer.InsertWebFeatureGroups(context.TODO(), tc.featureKeyToID, tc.featureData, tc.groupData)
@@ -284,14 +354,9 @@ func TestInsertWebFeatureGroups(t *testing.T) {
 					tc.mockUpsertGroupCfg.expectedCount, mockClient.upsertGroupCount)
 			}
 
-			if mockClient.upsertGroupDescendantInfoCount != tc.mockUpsertGroupDescendantCfg.expectedCount {
-				t.Errorf("expected %d calls to UpsertGroupDescendantInfo, got %d",
-					tc.mockUpsertGroupDescendantCfg.expectedCount, mockClient.upsertGroupDescendantInfoCount)
-			}
-
-			if mockClient.upsertWebFeatureGroupCount != tc.mockUpsertWebFeatureGroupCfg.expectedCount {
-				t.Errorf("expected %d calls to UpsertWebFeatureGroup, got %d",
-					tc.mockUpsertWebFeatureGroupCfg.expectedCount, mockClient.upsertWebFeatureGroupCount)
+			if mockClient.upsertFeatureGroupLookupsCount != tc.mockUpsertFeatureGroupLookupsCfg.expectedCount {
+				t.Errorf("expected %d calls to UpsertFeatureGroupLookups, got %d",
+					tc.mockUpsertFeatureGroupLookupsCfg.expectedCount, mockClient.upsertFeatureGroupLookupsCount)
 			}
 		})
 	}
@@ -300,13 +365,11 @@ func TestInsertWebFeatureGroups(t *testing.T) {
 type mockWebFeatureGroupsClient struct {
 	t *testing.T
 
-	mockUpsertGroupCfg           mockUpsertGroupConfig
-	mockUpsertGroupDescendantCfg mockUpsertGroupDescendantInfoConfig
-	mockUpsertWebFeatureGroupCfg mockUpsertWebFeatureGroupConfig
+	mockUpsertGroupCfg               mockUpsertGroupConfig
+	mockUpsertFeatureGroupLookupsCfg mockUpsertFeatureGroupLookupsConfig
 
 	upsertGroupCount               int
-	upsertGroupDescendantInfoCount int
-	upsertWebFeatureGroupCount     int
+	upsertFeatureGroupLookupsCount int
 }
 
 func (c *mockWebFeatureGroupsClient) UpsertGroup(_ context.Context, group gcpspanner.Group) (*string, error) {
@@ -331,59 +394,29 @@ func (c *mockWebFeatureGroupsClient) UpsertGroup(_ context.Context, group gcpspa
 	return &output, c.mockUpsertGroupCfg.outputs[group.GroupKey]
 }
 
-func (c *mockWebFeatureGroupsClient) UpsertGroupDescendantInfo(
-	_ context.Context, groupKey string, descendantInfo gcpspanner.GroupDescendantInfo) error {
-	if len(c.mockUpsertGroupDescendantCfg.expectedInputs) <= c.upsertGroupDescendantInfoCount {
-		c.t.Fatal("no more expected input for UpsertGroupDescendantInfo")
+func (c *mockWebFeatureGroupsClient) UpsertFeatureGroupLookups(
+	_ context.Context, lookups []gcpspanner.FeatureGroupIDsLookup) error {
+	expectedInput := c.mockUpsertFeatureGroupLookupsCfg.expectedInput
+	sortLookups(expectedInput)
+	sortLookups(lookups)
+	if !slices.Equal(expectedInput, lookups) {
+		c.t.Errorf("unexpected input for UpsertFeatureGroupLookups expected %v received %v", expectedInput, lookups)
 	}
-	if len(c.mockUpsertGroupDescendantCfg.outputs) <= c.upsertGroupDescendantInfoCount {
-		c.t.Fatal("no more configured outputs for UpsertGroupDescendantInfo")
-	}
+	c.upsertFeatureGroupLookupsCount++
 
-	expectedInput, found := c.mockUpsertGroupDescendantCfg.expectedInputs[groupKey]
-	if !found {
-		c.t.Errorf("unexpected input %v for groupKey %s", descendantInfo, groupKey)
-	}
-	if !reflect.DeepEqual(expectedInput, descendantInfo) {
-		c.t.Errorf("unexpected input for groupKey %s expected %v received %v", groupKey, expectedInput, descendantInfo)
-	}
-	c.upsertGroupDescendantInfoCount++
-
-	return c.mockUpsertGroupDescendantCfg.outputs[groupKey]
-}
-
-func (c *mockWebFeatureGroupsClient) UpsertWebFeatureGroup(_ context.Context, group gcpspanner.WebFeatureGroup) error {
-	if len(c.mockUpsertWebFeatureGroupCfg.expectedInputs) <= c.upsertWebFeatureGroupCount {
-		c.t.Fatal("no more expected input for UpsertWebFeatureGroup")
-	}
-	if len(c.mockUpsertWebFeatureGroupCfg.outputs) <= c.upsertWebFeatureGroupCount {
-		c.t.Fatal("no more configured outputs for UpsertWebFeatureGroup")
-	}
-
-	expectedInput, found := c.mockUpsertWebFeatureGroupCfg.expectedInputs[group.WebFeatureID]
-	if !found {
-		c.t.Errorf("unexpected input %v", group)
-	}
-	if !reflect.DeepEqual(expectedInput, group) {
-		c.t.Errorf("unexpected input expected %v received %v", expectedInput, group)
-	}
-	c.upsertWebFeatureGroupCount++
-
-	return c.mockUpsertWebFeatureGroupCfg.outputs[group.WebFeatureID]
+	return c.mockUpsertFeatureGroupLookupsCfg.output
 }
 
 func newMockWebFeatureGroupsClient(t *testing.T,
 	upsertGroupCfg mockUpsertGroupConfig,
-	upsertGroupDescendantCfg mockUpsertGroupDescendantInfoConfig,
-	upsertWebFeatureGroupCfg mockUpsertWebFeatureGroupConfig) *mockWebFeatureGroupsClient {
+	upsertFeatureGroupLookupsCfg mockUpsertFeatureGroupLookupsConfig,
+) *mockWebFeatureGroupsClient {
 
 	return &mockWebFeatureGroupsClient{
-		t:                              t,
-		mockUpsertGroupCfg:             upsertGroupCfg,
-		mockUpsertGroupDescendantCfg:   upsertGroupDescendantCfg,
-		mockUpsertWebFeatureGroupCfg:   upsertWebFeatureGroupCfg,
-		upsertGroupCount:               0,
-		upsertGroupDescendantInfoCount: 0,
-		upsertWebFeatureGroupCount:     0,
+		t:                                t,
+		mockUpsertGroupCfg:               upsertGroupCfg,
+		mockUpsertFeatureGroupLookupsCfg: upsertFeatureGroupLookupsCfg,
+		upsertGroupCount:                 0,
+		upsertFeatureGroupLookupsCount:   0,
 	}
 }

--- a/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker.go
@@ -59,7 +59,6 @@ type WebFeatureMetadataStorer interface {
 type WebDXGroupStorer interface {
 	InsertWebFeatureGroups(
 		ctx context.Context,
-		featureKeyToID map[string]string,
 		featureData map[string]web_platform_dx__web_features.FeatureValue,
 		groupData map[string]web_platform_dx__web_features.GroupData) error
 }
@@ -133,7 +132,7 @@ func (p WebFeaturesJobProcessor) Process(ctx context.Context, job JobArguments) 
 		return err
 	}
 
-	err = p.groupStorer.InsertWebFeatureGroups(ctx, mapping, data.Features, data.Groups)
+	err = p.groupStorer.InsertWebFeatureGroups(ctx, data.Features, data.Groups)
 	if err != nil {
 		slog.ErrorContext(ctx, "unable to store groups", "error", err)
 

--- a/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker_test.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker_test.go
@@ -173,7 +173,6 @@ func (m *mockWebFeatureMetadataStorer) InsertWebFeaturesMetadata(
 type mockInsertWebFeatureGroupsConfig struct {
 	expectedFeatureData map[string]web_platform_dx__web_features.FeatureValue
 	expectedGroupData   map[string]web_platform_dx__web_features.GroupData
-	expectedMapping     map[string]string
 	returnError         error
 }
 
@@ -184,12 +183,10 @@ type mockWebFeatureGroupStorer struct {
 
 func (m *mockWebFeatureGroupStorer) InsertWebFeatureGroups(
 	_ context.Context,
-	featureKeyToID map[string]string,
 	featureData map[string]web_platform_dx__web_features.FeatureValue,
 	groupData map[string]web_platform_dx__web_features.GroupData) error {
 	if !reflect.DeepEqual(featureData, m.mockInsertWebFeatureGroupsCfg.expectedFeatureData) ||
-		!reflect.DeepEqual(groupData, m.mockInsertWebFeatureGroupsCfg.expectedGroupData) ||
-		!reflect.DeepEqual(featureKeyToID, m.mockInsertWebFeatureGroupsCfg.expectedMapping) {
+		!reflect.DeepEqual(groupData, m.mockInsertWebFeatureGroupsCfg.expectedGroupData) {
 		m.t.Error("unexpected input")
 	}
 
@@ -393,9 +390,6 @@ func TestProcess(t *testing.T) {
 						Snapshot:        nil,
 					},
 				},
-				expectedMapping: map[string]string{
-					"feature1": "id-1",
-				},
 				expectedGroupData: map[string]web_platform_dx__web_features.GroupData{
 					"group1": {
 						Name:   "Group 1",
@@ -473,7 +467,6 @@ func TestProcess(t *testing.T) {
 			mockInsertWebFeatureGroupsCfg: mockInsertWebFeatureGroupsConfig{
 				expectedFeatureData: nil,
 				expectedGroupData:   nil,
-				expectedMapping:     nil,
 				returnError:         nil,
 			},
 			mockInsertWebFeatureSnapshotsCfg: mockInsertWebFeatureSnapshotsConfig{
@@ -511,7 +504,6 @@ func TestProcess(t *testing.T) {
 			mockInsertWebFeatureGroupsCfg: mockInsertWebFeatureGroupsConfig{
 				expectedFeatureData: nil,
 				expectedGroupData:   nil,
-				expectedMapping:     nil,
 				returnError:         nil,
 			},
 			mockInsertWebFeatureSnapshotsCfg: mockInsertWebFeatureSnapshotsConfig{
@@ -610,7 +602,6 @@ func TestProcess(t *testing.T) {
 			mockInsertWebFeatureGroupsCfg: mockInsertWebFeatureGroupsConfig{
 				expectedFeatureData: nil,
 				expectedGroupData:   nil,
-				expectedMapping:     nil,
 				returnError:         nil,
 			},
 			mockInsertWebFeatureSnapshotsCfg: mockInsertWebFeatureSnapshotsConfig{
@@ -738,7 +729,6 @@ func TestProcess(t *testing.T) {
 			mockInsertWebFeatureGroupsCfg: mockInsertWebFeatureGroupsConfig{
 				expectedFeatureData: nil,
 				expectedGroupData:   nil,
-				expectedMapping:     nil,
 				returnError:         nil,
 			},
 			mockInsertWebFeatureSnapshotsCfg: mockInsertWebFeatureSnapshotsConfig{
@@ -896,9 +886,6 @@ func TestProcess(t *testing.T) {
 						Group:           nil,
 						Snapshot:        nil,
 					},
-				},
-				expectedMapping: map[string]string{
-					"feature1": "id-1",
 				},
 				expectedGroupData: map[string]web_platform_dx__web_features.GroupData{
 					"group1": {
@@ -1068,9 +1055,6 @@ func TestProcess(t *testing.T) {
 						Group:           nil,
 						Snapshot:        nil,
 					},
-				},
-				expectedMapping: map[string]string{
-					"feature1": "id-1",
 				},
 				expectedGroupData: map[string]web_platform_dx__web_features.GroupData{
 					"group1": {


### PR DESCRIPTION
Performance on the front page search begins to suffer when there are multiple group terms separated by OR operators.

Upon inspection, it turns out that the existing `groupFilter` is pretty complex because on the fly it tries to find the features not only belonging to a group but the child groups too.

It would be better to calculate this data for better performance.

FeatureGroupIDsLookup contains that calculated data.