### PR TITLE
feat: add FeatureGroupKeysLookup table for better feature search perf [Pt 1/3]

### DIFF
--- a/infra/storage/spanner/migrations/000018.sql
+++ b/infra/storage/spanner/migrations/000018.sql
@@ -1,0 +1,32 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- A denormalized lookup table mapping features to direct/inherited groups.
+-- Used by the feature search functionality.
+CREATE TABLE IF NOT EXISTS FeatureGroupKeysLookup (
+    GroupKey_Lowercase STRING(64) NOT NULL,
+    WebFeatureID STRING(36) NOT NULL,
+    GroupID STRING(36) NOT NULL,
+    -- The hierarchy level of the association. A value of 0 means a direct
+    -- link. A value of 1 means this group is the direct parent of the
+    -- feature's group, 2 means it's a grandparent, and so on.
+    -- TODO. Future queries may use this column
+    Depth INT64 NOT NULL,
+    CONSTRAINT FK_FeatureGroupKeysLookup_WebFeatureID
+        FOREIGN KEY (WebFeatureID) REFERENCES WebFeatures(ID) ON DELETE CASCADE,
+    CONSTRAINT FK_FeatureGroupKeysLookup_GroupID
+        FOREIGN KEY (GroupID) REFERENCES WebDXGroups(ID) ON DELETE CASCADE
+-- The primary key starts with GroupKey_Lowercase because the main search query
+-- filters by group name.
+) PRIMARY KEY (GroupKey_Lowercase, WebFeatureID);

--- a/lib/gcpspanner/feature_group_lookups.go
+++ b/lib/gcpspanner/feature_group_lookups.go
@@ -1,0 +1,120 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"log/slog"
+)
+
+const featureGroupKeysLookupTable = "FeatureGroupKeysLookup"
+
+type spannerFeatureGroupKeysLookup struct {
+	GroupKeyLowercase string `spanner:"GroupKey_Lowercase"`
+	WebFeatureID      string `spanner:"WebFeatureID"`
+	GroupID           string `spanner:"GroupID"`
+	Depth             int64  `spanner:"Depth"`
+}
+
+func (c *Client) UpsertFeatureGroupLookups(
+	ctx context.Context, featureKeyToGroupsMapping map[string][]string,
+	childGroupKeyToParentGroupKey map[string]string) error {
+	// TODO: We should do a diff and delete group lookups no longer needed.
+	// This hasn't happened yet.
+	txn := c.ReadOnlyTransaction()
+	defer txn.Close()
+
+	featureDetails, err := c.fetchAllWebFeatureIDsAndKeysWithTransaction(ctx, txn)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to get all feature details for feature group lookups", "error", err)
+
+		return err
+	}
+	featureKeyToID := make(map[string]string, len(featureDetails))
+	for _, featureDetail := range featureDetails {
+		featureKeyToID[featureDetail.FeatureKey] = featureDetail.ID
+	}
+
+	groupDetails, err := c.fetchAllGroupIDsAndKeysWithTransaction(ctx, txn)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to get all group details for feature group lookups", "error", err)
+
+		return err
+	}
+	groupKeyToGroupDetails := make(map[string]spannerGroupIDKeyAndKeyLowercase, len(featureDetails))
+	for _, groupDetail := range groupDetails {
+		groupKeyToGroupDetails[groupDetail.GroupKey] = groupDetail
+	}
+
+	return runConcurrentBatch(ctx,
+		c, func(entityChan chan<- spannerFeatureGroupKeysLookup) {
+			calculateAllFeatureGroupLookups(
+				ctx,
+				featureKeyToID,
+				featureKeyToGroupsMapping,
+				groupKeyToGroupDetails,
+				entityChan,
+				childGroupKeyToParentGroupKey)
+		}, featureGroupKeysLookupTable)
+}
+
+func calculateAllFeatureGroupLookups(
+	ctx context.Context,
+	featureKeyToID map[string]string,
+	featureKeyToGroupsMapping map[string][]string,
+	groupKeyToDetails map[string]spannerGroupIDKeyAndKeyLowercase,
+	entityChan chan<- spannerFeatureGroupKeysLookup,
+	childGroupKeyToParentGroupKey map[string]string,
+) {
+
+	for featureKey, featureID := range featureKeyToID {
+		featureGroups, found := featureKeyToGroupsMapping[featureKey]
+		if !found {
+			slog.WarnContext(ctx, "Unable to find feature group data for feature key. "+
+				"This is okay if the feature is not associated with a group", "featureKey", featureKey)
+
+			continue
+		}
+
+		for _, directGroupKey := range featureGroups {
+			currentGroupKey := directGroupKey
+			currentDepth := int64(0)
+
+			for {
+				groupData, found := groupKeyToDetails[currentGroupKey]
+				if !found {
+					slog.WarnContext(ctx, "group key not found during hierarchy traversal", "groupKey", currentGroupKey)
+
+					break
+				}
+
+				entityChan <- spannerFeatureGroupKeysLookup{
+					GroupID:           groupData.ID,
+					GroupKeyLowercase: groupData.GroupKeyLowercase,
+					WebFeatureID:      featureID,
+					Depth:             currentDepth,
+				}
+
+				// Move up to the parent.
+				parentGroupKey, hasParent := childGroupKeyToParentGroupKey[currentGroupKey]
+				if !hasParent {
+					break
+				}
+				currentGroupKey = parentGroupKey
+				currentDepth++
+			}
+		}
+	}
+}

--- a/lib/gcpspanner/feature_group_lookups_test.go
+++ b/lib/gcpspanner/feature_group_lookups_test.go
@@ -1,0 +1,246 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cmp"
+	"context"
+	"reflect"
+	"slices"
+	"sync"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+)
+
+func setupTablesForUpsertFeatureGroupLookups(
+	ctx context.Context,
+	t *testing.T,
+) ([]WebFeature, map[string]string, []Group, map[string]string) {
+	featureKeyToID := map[string]string{}
+	groupKeyToID := map[string]string{}
+
+	// 1. Insert sample data into WebFeatures
+	features := []WebFeature{
+		{FeatureKey: "FeatureX", Name: "Cool API", Description: "text", DescriptionHTML: "<html>"},
+		{FeatureKey: "FeatureY", Name: "Super API", Description: "text", DescriptionHTML: "<html>"},
+		{FeatureKey: "FeatureZ", Name: "Ultra API", Description: "text", DescriptionHTML: "<html>"},
+	}
+	for _, feature := range features {
+		id, err := spannerClient.UpsertWebFeature(ctx, feature)
+		if err != nil {
+			t.Fatalf("Failed to insert WebFeature: %v", err)
+		}
+		featureKeyToID[feature.FeatureKey] = *id
+	}
+
+	// Insert sample groups
+	groups := []Group{
+		{GroupKey: "parent", Name: "Group A"},
+		{GroupKey: "child", Name: "Group B"},
+	}
+	for _, group := range groups {
+		id, err := spannerClient.UpsertGroup(ctx, group)
+		if err != nil {
+			t.Fatalf("Failed to insert Group: %v", err)
+		}
+		groupKeyToID[group.GroupKey] = *id
+	}
+
+	return features, featureKeyToID, groups, groupKeyToID
+}
+
+func TestCalculateAllFeatureGroupLookups(t *testing.T) {
+	type testCase struct {
+		name                          string
+		featureKeyToID                map[string]string
+		featureKeyToGroupsMapping     map[string][]string
+		groupKeyToDetails             map[string]spannerGroupIDKeyAndKeyLowercase
+		childGroupKeyToParentGroupKey map[string]string
+		expectedLookups               []spannerFeatureGroupKeysLookup
+	}
+
+	testCases := []testCase{
+		{
+			name:                      "Deep Hierarchy",
+			featureKeyToID:            map[string]string{"feat1": "feature_id_1"},
+			featureKeyToGroupsMapping: map[string][]string{"feat1": {"grandchild"}},
+			groupKeyToDetails: map[string]spannerGroupIDKeyAndKeyLowercase{
+				"root":       {ID: "uuid_root", GroupKey: "root", GroupKeyLowercase: "root"},
+				"child":      {ID: "uuid_child", GroupKey: "child", GroupKeyLowercase: "child"},
+				"grandchild": {ID: "uuid_grandchild", GroupKey: "grandchild", GroupKeyLowercase: "grandchild"},
+			},
+			childGroupKeyToParentGroupKey: map[string]string{
+				"child":      "root",
+				"grandchild": "child",
+			},
+			expectedLookups: []spannerFeatureGroupKeysLookup{
+				{GroupID: "uuid_grandchild", WebFeatureID: "feature_id_1", Depth: 0, GroupKeyLowercase: "grandchild"},
+				{GroupID: "uuid_child", WebFeatureID: "feature_id_1", Depth: 1, GroupKeyLowercase: "child"},
+				{GroupID: "uuid_root", WebFeatureID: "feature_id_1", Depth: 2, GroupKeyLowercase: "root"},
+			},
+		},
+		{
+			name:                      "Multiple Direct Groups",
+			featureKeyToID:            map[string]string{"feat1": "feature_id_1"},
+			featureKeyToGroupsMapping: map[string][]string{"feat1": {"child1", "child2"}},
+			groupKeyToDetails: map[string]spannerGroupIDKeyAndKeyLowercase{
+				"root":   {ID: "uuid_root", GroupKey: "root", GroupKeyLowercase: "root"},
+				"child1": {ID: "uuid_child1", GroupKey: "child1", GroupKeyLowercase: "child1"},
+				"child2": {ID: "uuid_child2", GroupKey: "child2", GroupKeyLowercase: "child2"},
+			},
+			childGroupKeyToParentGroupKey: map[string]string{
+				"child1": "root",
+				"child2": "root",
+			},
+			expectedLookups: []spannerFeatureGroupKeysLookup{
+				{GroupID: "uuid_child1", WebFeatureID: "feature_id_1", Depth: 0, GroupKeyLowercase: "child1"},
+				{GroupID: "uuid_root", WebFeatureID: "feature_id_1", Depth: 1, GroupKeyLowercase: "root"},
+				{GroupID: "uuid_child2", WebFeatureID: "feature_id_1", Depth: 0, GroupKeyLowercase: "child2"},
+				{GroupID: "uuid_root", WebFeatureID: "feature_id_1", Depth: 1, GroupKeyLowercase: "root"},
+			},
+		},
+		{
+			name:                      "Feature with No Group Mapping",
+			featureKeyToID:            map[string]string{"feat1": "feature_id_1"},
+			featureKeyToGroupsMapping: map[string][]string{}, // No mapping for feat1
+			groupKeyToDetails: map[string]spannerGroupIDKeyAndKeyLowercase{
+				"group1": {ID: "uuid_1", GroupKey: "group1", GroupKeyLowercase: "group1"}},
+			childGroupKeyToParentGroupKey: map[string]string{},
+			expectedLookups:               []spannerFeatureGroupKeysLookup{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entityChan := make(chan spannerFeatureGroupKeysLookup, 100) // Buffered channel
+			var actualLookups []spannerFeatureGroupKeysLookup
+			var wg sync.WaitGroup
+			wg.Add(1)
+
+			// This goroutine reads all results from the channel.
+			go func() {
+				defer wg.Done()
+				for lookup := range entityChan {
+					actualLookups = append(actualLookups, lookup)
+				}
+			}()
+
+			// Run the function under test.
+			calculateAllFeatureGroupLookups(
+				context.Background(),
+				tc.featureKeyToID,
+				tc.featureKeyToGroupsMapping,
+				tc.groupKeyToDetails,
+				entityChan,
+				tc.childGroupKeyToParentGroupKey,
+			)
+			// Close the channel to signal to the reader goroutine that we're done.
+			close(entityChan)
+
+			// Wait for the reader goroutine to finish processing.
+			wg.Wait()
+
+			// Sort both slices for a deterministic comparison.
+			slices.SortFunc(tc.expectedLookups, sortFeatureGroupKeysLookups)
+			slices.SortFunc(actualLookups, sortFeatureGroupKeysLookups)
+
+			if !slices.Equal(actualLookups, tc.expectedLookups) {
+				t.Errorf("lookup slice mismatch.\ngot= %v\nwant=%v", actualLookups, tc.expectedLookups)
+			}
+		})
+	}
+}
+
+func TestUpsertFeatureGroupLookups(t *testing.T) {
+	t.Run("group look ups are inserted", func(t *testing.T) {
+		restartDatabaseContainer(t)
+		ctx := context.Background()
+		_, featureKeyToID, _, groupKeyToID := setupTablesForUpsertFeatureGroupLookups(ctx, t)
+		err := spannerClient.UpsertFeatureGroupLookups(ctx,
+			map[string][]string{
+				"FeatureX": {"parent"},
+				"FeatureZ": {"child"},
+			},
+			map[string]string{
+				"child": "parent",
+			},
+		)
+		if err != nil {
+			t.Fatalf("UpsertFeatureGroupLookups failed: %v", err)
+		}
+		// Assert the expected look ups
+		expectedLookups := []spannerFeatureGroupKeysLookup{
+			{GroupID: groupKeyToID["parent"], WebFeatureID: featureKeyToID["FeatureX"], Depth: 0, GroupKeyLowercase: "parent"},
+			{GroupID: groupKeyToID["parent"], WebFeatureID: featureKeyToID["FeatureZ"], Depth: 1, GroupKeyLowercase: "parent"},
+			{GroupID: groupKeyToID["child"], WebFeatureID: featureKeyToID["FeatureZ"], Depth: 0, GroupKeyLowercase: "child"},
+		}
+
+		assertFeatureGroupKeysLookups(ctx, t, expectedLookups)
+	})
+}
+
+func assertFeatureGroupKeysLookups(ctx context.Context, t *testing.T, expectedLookups []spannerFeatureGroupKeysLookup) {
+	actualLookups := spannerClient.readAllFeatureGroupKeysLookups(ctx, t)
+
+	// Assert that the actual events match the expected events
+	slices.SortFunc(expectedLookups, sortFeatureGroupKeysLookups)
+	slices.SortFunc(actualLookups, sortFeatureGroupKeysLookups)
+	if !reflect.DeepEqual(expectedLookups, actualLookups) {
+		t.Errorf("Unexpected data in FeatureGroupKeysLookup\nExpected (size: %d):\n%+v\nActual (size: %d):\n%+v",
+			len(expectedLookups), expectedLookups, len(actualLookups), actualLookups)
+	}
+}
+func sortFeatureGroupKeysLookups(a, b spannerFeatureGroupKeysLookup) int {
+	if a.GroupKeyLowercase != b.GroupKeyLowercase {
+		return cmp.Compare(a.GroupKeyLowercase, b.GroupKeyLowercase)
+	}
+	if a.WebFeatureID != b.WebFeatureID {
+		return cmp.Compare(a.WebFeatureID, b.WebFeatureID)
+	}
+	if a.GroupID != b.GroupID {
+		return cmp.Compare(a.GroupID, b.GroupID)
+	}
+	if a.Depth != b.Depth {
+		return cmp.Compare(a.Depth, b.Depth)
+	}
+
+	return 0
+}
+
+func (c *Client) readAllFeatureGroupKeysLookups(ctx context.Context, t *testing.T) []spannerFeatureGroupKeysLookup {
+	stmt := spanner.Statement{
+		SQL: `SELECT *
+              FROM FeatureGroupKeysLookup`,
+		Params: nil,
+	}
+	var actualLookups []spannerFeatureGroupKeysLookup
+	iter := spannerClient.Single().Query(ctx, stmt)
+	defer iter.Stop()
+	err := iter.Do(func(row *spanner.Row) error {
+		var lookup spannerFeatureGroupKeysLookup
+		if err := row.ToStruct(&lookup); err != nil {
+			return err
+		}
+		actualLookups = append(actualLookups, lookup)
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to fetch data from FeatureGroupKeysLookup: %v", err)
+	}
+
+	return actualLookups
+}

--- a/lib/gcpspanner/groups.go
+++ b/lib/gcpspanner/groups.go
@@ -99,3 +99,15 @@ func (c *Client) UpsertGroup(ctx context.Context, group Group) (*string, error) 
 func (c *Client) GetGroupIDFromGroupKey(ctx context.Context, groupKey string) (*string, error) {
 	return newEntityWriterWithIDRetrieval[groupSpannerMapper, string](c).getIDByKey(ctx, groupKey)
 }
+
+type spannerGroupIDKeyAndKeyLowercase struct {
+	ID                string `spanner:"ID"`
+	GroupKey          string `spanner:"GroupKey"`
+	GroupKeyLowercase string `spanner:"GroupKey_Lowercase"`
+}
+
+func (c *Client) fetchAllGroupIDsAndKeysWithTransaction(
+	ctx context.Context, txn *spanner.ReadOnlyTransaction) ([]spannerGroupIDKeyAndKeyLowercase, error) {
+	return fetchColumnValuesWithTransaction[spannerGroupIDKeyAndKeyLowercase](
+		ctx, txn, groupsTable, []string{"ID", "GroupKey", "GroupKey_Lowercase"})
+}


### PR DESCRIPTION
This change is a split up of #1630. Check that description for the high level reason.

This particular change is the first part where we add a new table that contains the data.

The spanner method `UpsertFeatureGroupLookups` contains the logic to gather all the data and populate the table.

Notes about the table:
- I added a `Depth` column to enable future use cases in case users want to know only the features at a given level and not all the features for children groups.