### PR TITLE
feat: Web Feature Job uses UpsertFeatureGroupLookups [Pt 2/3]

### DIFF
--- a/lib/gcpspanner/spanneradapters/web_feature_groups_consumer.go
+++ b/lib/gcpspanner/spanneradapters/web_feature_groups_consumer.go
@@ -25,8 +25,8 @@ import (
 // WebFeatureGroupsClient expects a subset of the functionality from lib/gcpspanner that only apply to Groups.
 type WebFeatureGroupsClient interface {
 	UpsertGroup(ctx context.Context, group gcpspanner.Group) (*string, error)
-	UpsertWebFeatureGroup(ctx context.Context, group gcpspanner.WebFeatureGroup) error
-	UpsertGroupDescendantInfo(ctx context.Context, groupKey string, descendantInfo gcpspanner.GroupDescendantInfo) error
+	UpsertFeatureGroupLookups(ctx context.Context,
+		featureKeyToGroupsMapping map[string][]string, childGroupKeyToParentGroupKey map[string]string) error
 }
 
 // NewWebFeaturesConsumer constructs an adapter for the web features consumer service.
@@ -40,13 +40,35 @@ type WebFeatureGroupConsumer struct {
 	client WebFeatureGroupsClient
 }
 
+func extractFeatureKeyToGroupsMapping(
+	featuresData map[string]web_platform_dx__web_features.FeatureValue,
+) map[string][]string {
+	m := make(map[string][]string)
+
+	for featureKey, feature := range featuresData {
+		if feature.Group == nil {
+			continue
+		}
+		var directGroupKeys []string
+		if feature.Group.String != nil {
+			directGroupKeys = append(directGroupKeys, *feature.Group.String)
+		} else if feature.Group.StringArray != nil {
+			directGroupKeys = feature.Group.StringArray
+		}
+
+		m[featureKey] = directGroupKeys
+	}
+
+	return m
+}
+
 func (c *WebFeatureGroupConsumer) InsertWebFeatureGroups(
 	ctx context.Context,
-	featureKeyToID map[string]string,
 	featureData map[string]web_platform_dx__web_features.FeatureValue,
 	groupData map[string]web_platform_dx__web_features.GroupData) error {
 	groupKeyToInternalID := make(map[string]string, len(groupData))
-	// Upsert basic group data and get group ids
+	childToParentMap := make(map[string]string)
+	// Step 1. Upsert basic group data and get group ids
 	for key, group := range groupData {
 		id, err := c.client.UpsertGroup(ctx, gcpspanner.Group{
 			GroupKey: key,
@@ -58,105 +80,20 @@ func (c *WebFeatureGroupConsumer) InsertWebFeatureGroups(
 			return err
 		}
 		groupKeyToInternalID[key] = *id
-	}
-	// Upsert the group descendant info.
-	groupDescMap := c.buildGroupDescendants(groupData, groupKeyToInternalID)
-	for key, groupDescInfo := range groupDescMap {
-		err := c.client.UpsertGroupDescendantInfo(ctx, key, groupDescInfo)
-		if err != nil {
-			slog.ErrorContext(ctx, "unable to upsert group descendant info",
-				"error", err, "groupKey", key, "info", groupDescInfo)
 
-			return err
+		if group.Parent != nil {
+			childToParentMap[key] = *group.Parent
 		}
 	}
-	// Upsert the web-feature to group mappings
-	// nolint:dupl // TODO - we should fix this.
-	for featureKey, featureID := range featureKeyToID {
-		feature := featureData[featureKey]
-		if feature.Group == nil {
-			continue
-		}
-		var groupIDs []string
-		if feature.Group.String != nil {
-			internalID, found := groupKeyToInternalID[*feature.Group.String]
-			if !found {
-				slog.WarnContext(ctx, "unable to find internal group ID", "groupKey", *feature.Group.String)
 
-				continue
-			}
-			groupIDs = append(groupIDs, internalID)
-		} else if feature.Group.StringArray != nil {
-			for _, groupKey := range feature.Group.StringArray {
-				internalID, found := groupKeyToInternalID[groupKey]
-				if !found {
-					slog.WarnContext(ctx, "unable to find internal group ID", "groupKey", groupKey)
+	// Step 2: Upsert the feature group lookups for feature search
+	featureKeyToGroupsMapping := extractFeatureKeyToGroupsMapping(featureData)
+	err := c.client.UpsertFeatureGroupLookups(ctx, featureKeyToGroupsMapping, childToParentMap)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to UpsertFeatureGroupLookups", "error", err)
 
-					continue
-				}
-				groupIDs = append(groupIDs, internalID)
-			}
-		}
-		err := c.client.UpsertWebFeatureGroup(ctx, gcpspanner.WebFeatureGroup{
-			WebFeatureID: featureID,
-			GroupIDs:     groupIDs,
-		})
-		if err != nil {
-			slog.ErrorContext(ctx, "unable to upsert web feature group", "webFeatureID",
-				featureID, "featureKey", featureKey, "groupIDs", groupIDs, "error", err)
-
-			return err
-		}
+		return err
 	}
 
 	return nil
-}
-
-func (c *WebFeatureGroupConsumer) buildGroupDescendants(
-	data map[string]web_platform_dx__web_features.GroupData,
-	groupKeyToID map[string]string,
-) map[string]gcpspanner.GroupDescendantInfo {
-	m := make(map[string]gcpspanner.GroupDescendantInfo, len(data))
-	groupToChildrenGroupKeys := make(map[string][]string, len(data))
-	var rootGroupKeys []string
-	for groupKey, groupData := range data {
-		info := gcpspanner.GroupDescendantInfo{
-			DescendantGroupIDs: nil,
-		}
-		m[groupKey] = info
-		if groupData.Parent != nil {
-			groupToChildrenGroupKeys[*groupData.Parent] = append(groupToChildrenGroupKeys[*groupData.Parent], groupKey)
-		} else {
-			rootGroupKeys = append(rootGroupKeys, groupKey)
-		}
-	}
-	for _, rootGroupKey := range rootGroupKeys {
-		c.populateDescendants(rootGroupKey, m, groupToChildrenGroupKeys, groupKeyToID)
-	}
-
-	return m
-}
-
-func (c *WebFeatureGroupConsumer) populateDescendants(
-	groupKey string,
-	groupDescendantMap map[string]gcpspanner.GroupDescendantInfo,
-	groupToChildrenGroupKeys map[string][]string,
-	groupKeyToInternalID map[string]string) {
-	info := groupDescendantMap[groupKey]
-
-	// Base case: if no children, descendants are empty (no descendants, only itself)
-	if _, exists := groupToChildrenGroupKeys[groupKey]; !exists {
-		// DescendantGroupIDs is already nil. No need to update.
-		return
-	}
-
-	// Recursive case: collect descendants from children
-	for _, childGroupKey := range groupToChildrenGroupKeys[groupKey] {
-		c.populateDescendants(childGroupKey, groupDescendantMap, groupToChildrenGroupKeys, groupKeyToInternalID)
-		childInfo := groupDescendantMap[childGroupKey]
-		info.DescendantGroupIDs = append(info.DescendantGroupIDs, groupKeyToInternalID[childGroupKey])
-		info.DescendantGroupIDs = append(info.DescendantGroupIDs, childInfo.DescendantGroupIDs...)
-	}
-
-	groupDescendantMap[groupKey] = info
 }

--- a/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker.go
@@ -59,7 +59,6 @@ type WebFeatureMetadataStorer interface {
 type WebDXGroupStorer interface {
 	InsertWebFeatureGroups(
 		ctx context.Context,
-		featureKeyToID map[string]string,
 		featureData map[string]web_platform_dx__web_features.FeatureValue,
 		groupData map[string]web_platform_dx__web_features.GroupData) error
 }
@@ -133,7 +132,7 @@ func (p WebFeaturesJobProcessor) Process(ctx context.Context, job JobArguments) 
 		return err
 	}
 
-	err = p.groupStorer.InsertWebFeatureGroups(ctx, mapping, data.Features, data.Groups)
+	err = p.groupStorer.InsertWebFeatureGroups(ctx, data.Features, data.Groups)
 	if err != nil {
 		slog.ErrorContext(ctx, "unable to store groups", "error", err)
 

--- a/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker_test.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker_test.go
@@ -173,7 +173,6 @@ func (m *mockWebFeatureMetadataStorer) InsertWebFeaturesMetadata(
 type mockInsertWebFeatureGroupsConfig struct {
 	expectedFeatureData map[string]web_platform_dx__web_features.FeatureValue
 	expectedGroupData   map[string]web_platform_dx__web_features.GroupData
-	expectedMapping     map[string]string
 	returnError         error
 }
 
@@ -184,12 +183,10 @@ type mockWebFeatureGroupStorer struct {
 
 func (m *mockWebFeatureGroupStorer) InsertWebFeatureGroups(
 	_ context.Context,
-	featureKeyToID map[string]string,
 	featureData map[string]web_platform_dx__web_features.FeatureValue,
 	groupData map[string]web_platform_dx__web_features.GroupData) error {
 	if !reflect.DeepEqual(featureData, m.mockInsertWebFeatureGroupsCfg.expectedFeatureData) ||
-		!reflect.DeepEqual(groupData, m.mockInsertWebFeatureGroupsCfg.expectedGroupData) ||
-		!reflect.DeepEqual(featureKeyToID, m.mockInsertWebFeatureGroupsCfg.expectedMapping) {
+		!reflect.DeepEqual(groupData, m.mockInsertWebFeatureGroupsCfg.expectedGroupData) {
 		m.t.Error("unexpected input")
 	}
 
@@ -393,9 +390,6 @@ func TestProcess(t *testing.T) {
 						Snapshot:        nil,
 					},
 				},
-				expectedMapping: map[string]string{
-					"feature1": "id-1",
-				},
 				expectedGroupData: map[string]web_platform_dx__web_features.GroupData{
 					"group1": {
 						Name:   "Group 1",
@@ -473,7 +467,6 @@ func TestProcess(t *testing.T) {
 			mockInsertWebFeatureGroupsCfg: mockInsertWebFeatureGroupsConfig{
 				expectedFeatureData: nil,
 				expectedGroupData:   nil,
-				expectedMapping:     nil,
 				returnError:         nil,
 			},
 			mockInsertWebFeatureSnapshotsCfg: mockInsertWebFeatureSnapshotsConfig{
@@ -511,7 +504,6 @@ func TestProcess(t *testing.T) {
 			mockInsertWebFeatureGroupsCfg: mockInsertWebFeatureGroupsConfig{
 				expectedFeatureData: nil,
 				expectedGroupData:   nil,
-				expectedMapping:     nil,
 				returnError:         nil,
 			},
 			mockInsertWebFeatureSnapshotsCfg: mockInsertWebFeatureSnapshotsConfig{
@@ -610,7 +602,6 @@ func TestProcess(t *testing.T) {
 			mockInsertWebFeatureGroupsCfg: mockInsertWebFeatureGroupsConfig{
 				expectedFeatureData: nil,
 				expectedGroupData:   nil,
-				expectedMapping:     nil,
 				returnError:         nil,
 			},
 			mockInsertWebFeatureSnapshotsCfg: mockInsertWebFeatureSnapshotsConfig{
@@ -738,7 +729,6 @@ func TestProcess(t *testing.T) {
 			mockInsertWebFeatureGroupsCfg: mockInsertWebFeatureGroupsConfig{
 				expectedFeatureData: nil,
 				expectedGroupData:   nil,
-				expectedMapping:     nil,
 				returnError:         nil,
 			},
 			mockInsertWebFeatureSnapshotsCfg: mockInsertWebFeatureSnapshotsConfig{
@@ -896,9 +886,6 @@ func TestProcess(t *testing.T) {
 						Group:           nil,
 						Snapshot:        nil,
 					},
-				},
-				expectedMapping: map[string]string{
-					"feature1": "id-1",
 				},
 				expectedGroupData: map[string]web_platform_dx__web_features.GroupData{
 					"group1": {
@@ -1068,9 +1055,6 @@ func TestProcess(t *testing.T) {
 						Group:           nil,
 						Snapshot:        nil,
 					},
-				},
-				expectedMapping: map[string]string{
-					"feature1": "id-1",
 				},
 				expectedGroupData: map[string]web_platform_dx__web_features.GroupData{
 					"group1": {


### PR DESCRIPTION
This change updates the web features job to use UpsertFeatureGroupLookups and stop using UpsertWebFeatureGroup and UpsertGroupDescendantInfo (those tables can be removed in the future actually.)

This is a split up of #1630