### PR TITLE
feat: Support developer signals in the openapi doc

### DIFF
--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -61,6 +61,7 @@ func TestGetFeature(t *testing.T) {
 							openapi_types.Date{Time: time.Date(2001, time.January, 1, 0, 0, 0, 0, time.UTC)},
 						),
 					},
+					DeveloperSignals: nil,
 					BrowserImplementations: &map[string]backend.BrowserImplementation{
 						"chrome": {
 							Status:  valuePtr(backend.Available),
@@ -175,6 +176,9 @@ func TestGetFeature(t *testing.T) {
 							openapi_types.Date{Time: time.Date(2001, time.January, 1, 0, 0, 0, 0, time.UTC)},
 						),
 					},
+					DeveloperSignals: &backend.FeatureDeveloperSignals{
+						PositiveCount: 10,
+					},
 					BrowserImplementations: &map[string]backend.BrowserImplementation{
 						"chrome": {
 							Status:  valuePtr(backend.Available),
@@ -205,6 +209,7 @@ func TestGetFeature(t *testing.T) {
 						`{"baseline":{"high_date":"2001-01-01","low_date":"2000-01-01","status":"widely"},` +
 							`"browser_implementations":` +
 							`{"chrome":{"date":"1999-01-01","status":"available","version":"100"}},` +
+							`"developer_signals":{"positive_count":10},` +
 							`"feature_id":"feature1","name":"feature 1"}`,
 					),
 					CacheCfg: getDefaultCacheConfig(),
@@ -225,6 +230,7 @@ func TestGetFeature(t *testing.T) {
 			"version":"100"
 		}
 	},
+	"developer_signals":{"positive_count":10},
 	"feature_id":"feature1",
 	"name":"feature 1"
 }`,
@@ -242,6 +248,7 @@ func TestGetFeature(t *testing.T) {
 						`{"baseline":{"high_date":"2001-01-01","low_date":"2000-01-01","status":"widely"},` +
 							`"browser_implementations":` +
 							`{"chrome":{"date":"1999-01-01","status":"available","version":"100"}},` +
+							`"developer_signals":{"positive_count":10},` +
 							`"feature_id":"feature1","name":"feature 1"}`,
 					),
 					Err: nil,
@@ -263,6 +270,7 @@ func TestGetFeature(t *testing.T) {
 			"version":"100"
 		}
 	},
+	"developer_signals":{"positive_count":10},
 	"feature_id":"feature1",
 	"name":"feature 1"
 }`,

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -84,6 +84,7 @@ func TestListFeatures(t *testing.T) {
 									Version: valuePtr("101"),
 								},
 							},
+							DeveloperSignals: nil,
 						},
 					},
 				},
@@ -251,6 +252,9 @@ func TestListFeatures(t *testing.T) {
 									Version: valuePtr("101"),
 								},
 							},
+							DeveloperSignals: &backend.FeatureDeveloperSignals{
+								PositiveCount: 24,
+							},
 						},
 					},
 				},
@@ -272,6 +276,7 @@ func TestListFeatures(t *testing.T) {
 						`{"data":[{"baseline":{"high_date":"2001-01-01","low_date":"2000-01-01","status":"widely"},` +
 							`"browser_implementations":` +
 							`{"chrome":{"date":"1999-01-01","status":"available","version":"101"}},` +
+							`"developer_signals":{"positive_count":24},` +
 							`"feature_id":"feature1","name":"feature 1"}],` +
 							`"metadata":{"next_page_token":"next-page-token","total":100}}`,
 					),
@@ -294,6 +299,9 @@ func TestListFeatures(t *testing.T) {
 				"status":"available",
 				"version":"101"
 				}
+			},
+			"developer_signals":{
+				"positive_count":24
 			},
 			"feature_id":"feature1",
 			"name":"feature 1"

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -821,6 +821,8 @@ func (s *Backend) convertFeatureResult(featureResult *gcpspanner.FeatureResult) 
 			Chrome: convertChromeUsageToBackend(featureResult.ChromiumUsage),
 		},
 		BrowserImplementations: nil,
+		// TODO https://github.com/GoogleChrome/webstatus.dev/issues/1675
+		DeveloperSignals: nil,
 	}
 
 	if len(featureResult.ExperimentalMetrics) > 0 {
@@ -1036,6 +1038,10 @@ func getFeatureSearchSortOrder(
 		return gcpspanner.NewBrowserFeatureSupportSort(true, string(backend.SafariIos))
 	case backend.AvailabilitySafariIosDesc:
 		return gcpspanner.NewBrowserFeatureSupportSort(false, string(backend.SafariIos))
+	case backend.DeveloperSignalPositiveCountAsc, backend.DeveloperSignalPositiveCountDesc:
+		// TODO https://github.com/GoogleChrome/webstatus.dev/issues/1675
+
+		return gcpspanner.NewBaselineStatusSort(false)
 	}
 
 	// Unknown sort order

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -1270,6 +1270,8 @@ func TestFeaturesSearch(t *testing.T) {
 								Version: valuePtr("103"),
 							},
 						},
+						// TODO https://github.com/GoogleChrome/webstatus.dev/issues/1675
+						DeveloperSignals: nil,
 					},
 					{
 						Baseline: &backend.BaselineInfo{
@@ -1336,6 +1338,8 @@ func TestFeaturesSearch(t *testing.T) {
 								Version: valuePtr("102"),
 							},
 						},
+						// TODO https://github.com/GoogleChrome/webstatus.dev/issues/1675
+						DeveloperSignals: nil,
 					},
 				},
 			},
@@ -1573,6 +1577,8 @@ func TestGetFeature(t *testing.T) {
 						Version: nil,
 					},
 				},
+				// TODO https://github.com/GoogleChrome/webstatus.dev/issues/1675
+				DeveloperSignals: nil,
 			},
 		},
 	}
@@ -2822,6 +2828,8 @@ func TestConvertFeatureResult(t *testing.T) {
 				},
 				Wpt:                    nil,
 				BrowserImplementations: nil,
+				// TODO https://github.com/GoogleChrome/webstatus.dev/issues/1675
+				DeveloperSignals: nil,
 			},
 		},
 	}

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -88,6 +88,8 @@ paths:
               - experimental_safari_ios_desc
               - chrome_usage_asc
               - chrome_usage_desc
+              - developer_signal_positive_count_asc
+              - developer_signal_positive_count_desc
               # availability_{browser}_{direction}
               - availability_chrome_asc
               - availability_chrome_desc
@@ -1116,6 +1118,14 @@ components:
           format: int64 # Currently, 'count(*)' from spanner comes as int64 https://cloud.google.com/spanner/docs/reference/standard-sql/data-types
       required:
         - total
+    FeatureDeveloperSignals:
+      type: object
+      properties:
+        positive_count:
+          type: integer
+          description: Count of positive feedback for a feature
+      required:
+        - positive_count
     FeaturePage:
       type: object
       properties:
@@ -1335,6 +1345,11 @@ components:
           $ref: '#/components/schemas/BrowserUsage'
         wpt:
           $ref: '#/components/schemas/FeatureWPTSnapshots'
+        developer_signals:
+          description: >
+            The absence of this object means the feature does not have an active issue
+            in https://github.com/web-platform-dx/developer-signals.
+          $ref: '#/components/schemas/FeatureDeveloperSignals'
       required:
         - feature_id
         - name


### PR DESCRIPTION
This adds support for the positive developer signals that will land in https://github.com/web-platform-dx/developer-signals

Makes the developer_signals object optional since not all features will have issues in that repository.

The database logic to get this data will happen in a future PR.

Fixes #1664