### PR TITLE
Set startup probe for backend as the same as otel

### DIFF
--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -74,6 +74,15 @@ resource "google_cloud_run_v2_service" "service" {
         container_port = 8080
       }
       depends_on = ["otel"]
+      startup_probe {
+        initial_delay_seconds = 0
+        timeout_seconds       = 1
+        period_seconds        = 3
+        failure_threshold     = 10
+        tcp_socket {
+          port = 8080
+        }
+      }
       env {
         name  = "SPANNER_DATABASE"
         value = var.spanner_datails.database


### PR DESCRIPTION
We should set the startup probe to the same as the otel package.

The backend container depends on the otel image to startup first. But AFAIK, the probe for the main container does not start evaluating until the sidecar (otel) container is live. But regardless, the default startup probe fails after one failure.