### PR TITLE
chore: Run npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8837,9 +8837,9 @@
       "license": "MIT"
     },
     "node_modules/koa": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.1.tgz",
-      "integrity": "sha512-umfX9d3iuSxTQP4pnzLOz0HKnPg0FaUUIKcye2lOiz3KPu1Y3M3xlz76dISdFPQs37P9eJz1wUpcTS6KDPn9fA==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.2.tgz",
+      "integrity": "sha512-+CCssgnrWKx9aI3OeZwroa/ckG4JICxvIFnSiOUyl2Uv+UTI+xIw0FfFrWS7cQFpoePpr9o8csss7KzsTzNL8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
This fixes this security alert: https://github.com/GoogleChrome/webstatus.dev/security/dependabot/93

It was low risk because it was a nested dependency in web test runner.

I tried to trigger dependabot to create the PR but it did not work. So I manually ran `npm audit fix` to address it.