### PR TITLE
chore: Update docs about wrench, use version from tools/go.mod

### DIFF
--- a/.dev/spanner/Dockerfile
+++ b/.dev/spanner/Dockerfile
@@ -23,12 +23,15 @@ ENV SPANNER_DATABASE_ID=local
 ENV SPANNER_EMULATOR_HOST=0.0.0.0:9010
 
 # Install Wrench - https://github.com/cloudspannerecosystem/wrench
-ENV WRENCH_VERSION="1.10.1"
-RUN echo "Downloading for version ${WRENCH_VERSION} for architecture ${TARGETARCH}"
-RUN curl \
+COPY tools/go.mod tools.go.mod
+RUN WRENCH_VERSION=$(grep 'github.com/cloudspannerecosystem/wrench' tools.go.mod | awk '{print $2}' | sed 's/v//' | tr -d '[:space:]') && \
+    echo "Downloading wrench version ${WRENCH_VERSION} for architecture ${TARGETARCH}" && \
+    curl \
     -L -o wrench.tar.gz \
     "https://github.com/cloudspannerecosystem/wrench/releases/download/v${WRENCH_VERSION}/wrench-${WRENCH_VERSION}-linux-${TARGETARCH}.tar.gz" && \
-    tar -xf wrench.tar.gz && mv wrench /bin/
+    tar -xf wrench.tar.gz && \
+    mv wrench /bin/ && \
+    rm wrench.tar.gz tools.go.mod
 
 RUN gcloud config set auth/disable_credentials true && \
     gcloud config set project ${SPANNER_PROJECT_ID} && \

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -74,7 +74,7 @@ Create the tables by running:
 export SPANNER_PROJECT_ID=webstatus-dev-internal-staging
 export SPANNER_DATABASE_ID=${ENV_ID}-database
 export SPANNER_INSTANCE_ID=${ENV_ID}-spanner
-wrench migrate up --directory ./storage/spanner/
+go tool wrench migrate up --directory ./storage/spanner/
 ```
 
 Populate data:
@@ -129,7 +129,7 @@ Migrate the tables if any schemas changed (assuming you already authenticated wi
 export SPANNER_PROJECT_ID=webstatus-dev-internal-staging
 export SPANNER_DATABASE_ID=${ENV_ID}-database
 export SPANNER_INSTANCE_ID=${ENV_ID}-spanner
-wrench migrate up --directory ./storage/spanner/
+go tool wrench migrate up --directory ./storage/spanner/
 ```
 
 Assuming the plan output by the terraform plan command looks fine, run:
@@ -163,7 +163,7 @@ Migrate the tables if any schemas changed (assuming you already authenticated wi
 export SPANNER_PROJECT_ID=webstatus-dev-internal-prod
 export SPANNER_DATABASE_ID=${ENV_ID}-database
 export SPANNER_INSTANCE_ID=${ENV_ID}-spanner
-wrench migrate up --directory ./storage/spanner/
+go tool wrench migrate up --directory ./storage/spanner/
 ```
 
 Assuming the plan output by the terraform plan command looks fine, run:


### PR DESCRIPTION
After #1674, wrench is accessed via `go tool wrench`. This change updates the deployment documentation to reflect that.

Also, I saw that the wrench tool that the spanner emulator uses was outdated.

Now that we have the version in go.mod, I extract the version from the go.mod file and use that in the spanner dockerfile. Now, we only have to maintain one place for the version.