### PR TITLE
feat: webfeatures consumer uses sync method now to insert/update/delete features

### DIFF
--- a/lib/gcpspanner/web_features.go
+++ b/lib/gcpspanner/web_features.go
@@ -148,14 +148,21 @@ func (c *Client) FetchAllFeatureKeys(ctx context.Context) ([]string, error) {
 	return fetchSingleColumnValuesWithTransaction[string](ctx, txn, webFeaturesTable, "FeatureKey")
 }
 
-type spannerFeatureIDAndKey struct {
+type SpannerFeatureIDAndKey struct {
 	ID         string `spanner:"ID"`
 	FeatureKey string `spanner:"FeatureKey"`
 }
 
+func (c *Client) FetchAllWebFeatureIDsAndKeys(ctx context.Context) ([]SpannerFeatureIDAndKey, error) {
+	txn := c.ReadOnlyTransaction()
+	defer txn.Close()
+
+	return c.fetchAllWebFeatureIDsAndKeysWithTransaction(ctx, txn)
+}
+
 func (c *Client) fetchAllWebFeatureIDsAndKeysWithTransaction(
-	ctx context.Context, txn *spanner.ReadOnlyTransaction) ([]spannerFeatureIDAndKey, error) {
-	return fetchColumnValuesWithTransaction[spannerFeatureIDAndKey](
+	ctx context.Context, txn *spanner.ReadOnlyTransaction) ([]SpannerFeatureIDAndKey, error) {
+	return fetchColumnValuesWithTransaction[SpannerFeatureIDAndKey](
 		ctx, txn, webFeaturesTable, []string{"ID", "FeatureKey"})
 }
 


### PR DESCRIPTION
Fixes #321

This uses the work from #1692 to sync the state of web features in the web features consumer.

Instead of only upserting web features, this will allow us to delete features that no longer exist from the database.