### PR TITLE
feat: Prepare for v3 data schema with Moved and Split types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ download-schemas:
 	wget -O jsonschema/mdn_browser-compat-data/browsers.schema.json \
 		https://raw.githubusercontent.com/mdn/browser-compat-data/main/schemas/browsers.schema.json
 
-jsonschema:
+jsonschema: clean-jsonschema
 	npx quicktype \
 		--src jsonschema/web-platform-dx_web-features/defs.schema.json \
 		--src-lang schema \
@@ -190,6 +190,7 @@ jsonschema:
 		--out $(JSONSCHEMA_OUT_DIR)/web_platform_dx__web_features/feature_data.go \
 		--package web_platform_dx__web_features \
 		--field-tags json
+	cp web_platform_dx__web_features_extras.txt $(JSONSCHEMA_OUT_DIR)/web_platform_dx__web_features/extras.go
 
 	npx quicktype \
 		--src jsonschema/mdn_browser-compat-data/browsers.schema.json \

--- a/lib/webdxfeaturetypes/types.go
+++ b/lib/webdxfeaturetypes/types.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webdxfeaturetypes
+
+import "github.com/GoogleChrome/webstatus.dev/lib/gen/jsonschema/web_platform_dx__web_features"
+
+// ProcessedWebFeaturesData is the top-level container for the fully parsed and
+// transformed data from the web-features package. It represents a clean,
+// application-ready view of the data, with features pre-sorted by kind.
+type ProcessedWebFeaturesData struct {
+	Snapshots map[string]web_platform_dx__web_features.SnapshotData
+	Browsers  web_platform_dx__web_features.Browsers
+	Groups    map[string]web_platform_dx__web_features.GroupData
+	Features  *FeatureKinds
+}
+
+// FeatureKinds is a container that categorizes all parsed web features by
+// their specific type. This makes it easy for application logic to consume
+// a specific kind of feature without needing to perform type assertions.
+type FeatureKinds struct {
+	Data  map[string]web_platform_dx__web_features.FeatureValue
+	Moved map[string]web_platform_dx__web_features.FeatureMovedData
+	Split map[string]web_platform_dx__web_features.FeatureSplitData
+}

--- a/web_platform_dx__web_features_extras.txt
+++ b/web_platform_dx__web_features_extras.txt
@@ -1,0 +1,30 @@
+package web_platform_dx__web_features
+
+// This is a temporary file until v3 lands
+// Takes files generated from https://github.com/GoogleChrome/webstatus.dev/pull/1635
+
+type FeatureMovedDataKind string
+
+const (
+	Moved FeatureMovedDataKind = "moved"
+)
+
+type FeatureSplitDataKind string
+
+const (
+	Split FeatureSplitDataKind = "split"
+)
+
+// A feature has permanently moved to exactly one other ID
+type FeatureMovedData struct {
+	Kind FeatureMovedDataKind `json:"kind"`
+	// The new ID for this feature
+	RedirectTarget string `json:"redirect_target"`
+}
+
+// A feature has split into two or more other features
+type FeatureSplitData struct {
+	Kind FeatureSplitDataKind `json:"kind"`
+	// The new IDs for this feature
+	RedirectTargets []string `json:"redirect_targets"`
+}

--- a/workflows/steps/services/web_feature_consumer/go.mod
+++ b/workflows/steps/services/web_feature_consumer/go.mod
@@ -5,6 +5,7 @@ go 1.24.5
 require (
 	github.com/GoogleChrome/webstatus.dev/lib v0.0.0-20250804165824-fd606c7d439d
 	github.com/GoogleChrome/webstatus.dev/lib/gen v0.0.0-20250804165824-fd606c7d439d
+	github.com/google/go-cmp v0.7.0
 )
 
 require (

--- a/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/jsonschema/web_platform_dx__web_features"
+	"github.com/GoogleChrome/webstatus.dev/lib/webdxfeaturetypes"
 )
 
 // AssetGetter describes the behavior to get a certain asset from a github release.
@@ -35,7 +36,7 @@ type AssetGetter interface {
 
 // AssetParser describes the behavior to parse the io.ReadCloser from AssetGetter into the expected data type.
 type AssetParser interface {
-	Parse(io.ReadCloser) (*web_platform_dx__web_features.FeatureData, error)
+	Parse(io.ReadCloser) (*webdxfeaturetypes.ProcessedWebFeaturesData, error)
 }
 
 // WebFeatureStorer describes the logic to insert the web features that were returned by the AssetParser.
@@ -118,28 +119,28 @@ func (p WebFeaturesJobProcessor) Process(ctx context.Context, job JobArguments) 
 		return err
 	}
 
-	mapping, err := p.storer.InsertWebFeatures(ctx, data.Features, job.startAt, job.endAt)
+	mapping, err := p.storer.InsertWebFeatures(ctx, data.Features.Data, job.startAt, job.endAt)
 	if err != nil {
 		slog.ErrorContext(ctx, "unable to store data", "error", err)
 
 		return err
 	}
 
-	err = p.metadataStorer.InsertWebFeaturesMetadata(ctx, mapping, data.Features)
+	err = p.metadataStorer.InsertWebFeaturesMetadata(ctx, mapping, data.Features.Data)
 	if err != nil {
 		slog.ErrorContext(ctx, "unable to store metadata", "error", err)
 
 		return err
 	}
 
-	err = p.groupStorer.InsertWebFeatureGroups(ctx, data.Features, data.Groups)
+	err = p.groupStorer.InsertWebFeatureGroups(ctx, data.Features.Data, data.Groups)
 	if err != nil {
 		slog.ErrorContext(ctx, "unable to store groups", "error", err)
 
 		return err
 	}
 
-	err = p.snapshotStorer.InsertWebFeatureSnapshots(ctx, mapping, data.Features, data.Snapshots)
+	err = p.snapshotStorer.InsertWebFeatureSnapshots(ctx, mapping, data.Features.Data, data.Snapshots)
 	if err != nil {
 		slog.ErrorContext(ctx, "unable to store snapshots", "error", err)
 

--- a/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker_test.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/jsonschema/web_platform_dx__web_features"
+	"github.com/GoogleChrome/webstatus.dev/lib/webdxfeaturetypes"
 )
 
 var (
@@ -67,11 +68,11 @@ type mockAssetParser struct {
 
 type mockParseConfig struct {
 	expectedFileContents string
-	returnData           *web_platform_dx__web_features.FeatureData
+	returnData           *webdxfeaturetypes.ProcessedWebFeaturesData
 	returnError          error
 }
 
-func (m *mockAssetParser) Parse(file io.ReadCloser) (*web_platform_dx__web_features.FeatureData, error) {
+func (m *mockAssetParser) Parse(file io.ReadCloser) (*webdxfeaturetypes.ProcessedWebFeaturesData, error) {
 	defer file.Close()
 	fileContents, err := io.ReadAll(file)
 	if err != nil {
@@ -248,34 +249,51 @@ func TestProcess(t *testing.T) {
 			},
 			mockParseCfg: mockParseConfig{
 				expectedFileContents: "hi features",
-				returnData: &web_platform_dx__web_features.FeatureData{
+				returnData: &webdxfeaturetypes.ProcessedWebFeaturesData{
 					Browsers: fakeBrowsersData,
-					Features: map[string]web_platform_dx__web_features.FeatureValue{
-						"feature1": {
-							Name:           "Feature 1",
-							Caniuse:        nil,
-							CompatFeatures: nil,
-							Discouraged:    nil,
-							Spec:           nil,
-							Status: web_platform_dx__web_features.Status{
-								Baseline:         nil,
-								BaselineHighDate: nil,
-								BaselineLowDate:  nil,
-								ByCompatKey:      nil,
-								Support: web_platform_dx__web_features.StatusSupport{
-									Chrome:         nil,
-									ChromeAndroid:  nil,
-									Edge:           nil,
-									Firefox:        nil,
-									FirefoxAndroid: nil,
-									Safari:         nil,
-									SafariIos:      nil,
+					Features: &webdxfeaturetypes.FeatureKinds{
+						Data: map[string]web_platform_dx__web_features.FeatureValue{
+							"feature1": {
+								Name:           "Feature 1",
+								Caniuse:        nil,
+								CompatFeatures: nil,
+								Discouraged:    nil,
+								Spec:           nil,
+								Status: web_platform_dx__web_features.Status{
+									Baseline:         nil,
+									BaselineHighDate: nil,
+									BaselineLowDate:  nil,
+									ByCompatKey:      nil,
+									Support: web_platform_dx__web_features.StatusSupport{
+										Chrome:         nil,
+										ChromeAndroid:  nil,
+										Edge:           nil,
+										Firefox:        nil,
+										FirefoxAndroid: nil,
+										Safari:         nil,
+										SafariIos:      nil,
+									},
+								},
+								Description:     "text",
+								DescriptionHTML: "<html>",
+								Group:           nil,
+								Snapshot:        nil,
+							},
+						},
+						Moved: map[string]web_platform_dx__web_features.FeatureMovedData{
+							"movedFeature": {
+								Kind:           web_platform_dx__web_features.Moved,
+								RedirectTarget: "new-feature",
+							},
+						},
+						Split: map[string]web_platform_dx__web_features.FeatureSplitData{
+							"splitFeature": {
+								Kind: web_platform_dx__web_features.Split,
+								RedirectTargets: []string{
+									"new-feature-1",
+									"new-feature-2",
 								},
 							},
-							Description:     "text",
-							DescriptionHTML: "<html>",
-							Group:           nil,
-							Snapshot:        nil,
 						},
 					},
 					Groups: map[string]web_platform_dx__web_features.GroupData{
@@ -525,35 +543,39 @@ func TestProcess(t *testing.T) {
 			},
 			mockParseCfg: mockParseConfig{
 				expectedFileContents: "hi features",
-				returnData: &web_platform_dx__web_features.FeatureData{
+				returnData: &webdxfeaturetypes.ProcessedWebFeaturesData{
 					Browsers: fakeBrowsersData,
-					Features: map[string]web_platform_dx__web_features.FeatureValue{
-						"feature1": {
-							Name:           "Feature 1",
-							Caniuse:        nil,
-							CompatFeatures: nil,
-							Discouraged:    nil,
-							Spec:           nil,
-							Status: web_platform_dx__web_features.Status{
-								Baseline:         nil,
-								BaselineHighDate: nil,
-								BaselineLowDate:  nil,
-								ByCompatKey:      nil,
-								Support: web_platform_dx__web_features.StatusSupport{
-									Chrome:         nil,
-									ChromeAndroid:  nil,
-									Edge:           nil,
-									Firefox:        nil,
-									FirefoxAndroid: nil,
-									Safari:         nil,
-									SafariIos:      nil,
+					Features: &webdxfeaturetypes.FeatureKinds{
+						Data: map[string]web_platform_dx__web_features.FeatureValue{
+							"feature1": {
+								Name:           "Feature 1",
+								Caniuse:        nil,
+								CompatFeatures: nil,
+								Discouraged:    nil,
+								Spec:           nil,
+								Status: web_platform_dx__web_features.Status{
+									Baseline:         nil,
+									BaselineHighDate: nil,
+									BaselineLowDate:  nil,
+									ByCompatKey:      nil,
+									Support: web_platform_dx__web_features.StatusSupport{
+										Chrome:         nil,
+										ChromeAndroid:  nil,
+										Edge:           nil,
+										Firefox:        nil,
+										FirefoxAndroid: nil,
+										Safari:         nil,
+										SafariIos:      nil,
+									},
 								},
+								Description:     "text",
+								DescriptionHTML: "<html>",
+								Group:           nil,
+								Snapshot:        nil,
 							},
-							Description:     "text",
-							DescriptionHTML: "<html>",
-							Group:           nil,
-							Snapshot:        nil,
 						},
+						Moved: nil,
+						Split: nil,
 					},
 					Groups:    nil,
 					Snapshots: nil,
@@ -623,35 +645,39 @@ func TestProcess(t *testing.T) {
 			},
 			mockParseCfg: mockParseConfig{
 				expectedFileContents: "hi features",
-				returnData: &web_platform_dx__web_features.FeatureData{
+				returnData: &webdxfeaturetypes.ProcessedWebFeaturesData{
 					Browsers: fakeBrowsersData,
-					Features: map[string]web_platform_dx__web_features.FeatureValue{
-						"feature1": {
-							Name:           "Feature 1",
-							Caniuse:        nil,
-							CompatFeatures: nil,
-							Discouraged:    nil,
-							Spec:           nil,
-							Status: web_platform_dx__web_features.Status{
-								Baseline:         nil,
-								BaselineHighDate: nil,
-								BaselineLowDate:  nil,
-								ByCompatKey:      nil,
-								Support: web_platform_dx__web_features.StatusSupport{
-									Chrome:         nil,
-									ChromeAndroid:  nil,
-									Edge:           nil,
-									Firefox:        nil,
-									FirefoxAndroid: nil,
-									Safari:         nil,
-									SafariIos:      nil,
+					Features: &webdxfeaturetypes.FeatureKinds{
+						Data: map[string]web_platform_dx__web_features.FeatureValue{
+							"feature1": {
+								Name:           "Feature 1",
+								Caniuse:        nil,
+								CompatFeatures: nil,
+								Discouraged:    nil,
+								Spec:           nil,
+								Status: web_platform_dx__web_features.Status{
+									Baseline:         nil,
+									BaselineHighDate: nil,
+									BaselineLowDate:  nil,
+									ByCompatKey:      nil,
+									Support: web_platform_dx__web_features.StatusSupport{
+										Chrome:         nil,
+										ChromeAndroid:  nil,
+										Edge:           nil,
+										Firefox:        nil,
+										FirefoxAndroid: nil,
+										Safari:         nil,
+										SafariIos:      nil,
+									},
 								},
+								Description:     "text",
+								DescriptionHTML: "<html>",
+								Group:           nil,
+								Snapshot:        nil,
 							},
-							Description:     "text",
-							DescriptionHTML: "<html>",
-							Group:           nil,
-							Snapshot:        nil,
 						},
+						Moved: nil,
+						Split: nil,
 					},
 					Groups:    nil,
 					Snapshots: nil,
@@ -750,35 +776,39 @@ func TestProcess(t *testing.T) {
 			},
 			mockParseCfg: mockParseConfig{
 				expectedFileContents: "hi features",
-				returnData: &web_platform_dx__web_features.FeatureData{
+				returnData: &webdxfeaturetypes.ProcessedWebFeaturesData{
 					Browsers: fakeBrowsersData,
-					Features: map[string]web_platform_dx__web_features.FeatureValue{
-						"feature1": {
-							Name:           "Feature 1",
-							Caniuse:        nil,
-							CompatFeatures: nil,
-							Discouraged:    nil,
-							Spec:           nil,
-							Status: web_platform_dx__web_features.Status{
-								Baseline:         nil,
-								BaselineHighDate: nil,
-								BaselineLowDate:  nil,
-								ByCompatKey:      nil,
-								Support: web_platform_dx__web_features.StatusSupport{
-									Chrome:         nil,
-									ChromeAndroid:  nil,
-									Edge:           nil,
-									Firefox:        nil,
-									FirefoxAndroid: nil,
-									Safari:         nil,
-									SafariIos:      nil,
+					Features: &webdxfeaturetypes.FeatureKinds{
+						Data: map[string]web_platform_dx__web_features.FeatureValue{
+							"feature1": {
+								Name:           "Feature 1",
+								Caniuse:        nil,
+								CompatFeatures: nil,
+								Discouraged:    nil,
+								Spec:           nil,
+								Status: web_platform_dx__web_features.Status{
+									Baseline:         nil,
+									BaselineHighDate: nil,
+									BaselineLowDate:  nil,
+									ByCompatKey:      nil,
+									Support: web_platform_dx__web_features.StatusSupport{
+										Chrome:         nil,
+										ChromeAndroid:  nil,
+										Edge:           nil,
+										Firefox:        nil,
+										FirefoxAndroid: nil,
+										Safari:         nil,
+										SafariIos:      nil,
+									},
 								},
+								Description:     "text",
+								DescriptionHTML: "<html>",
+								Group:           nil,
+								Snapshot:        nil,
 							},
-							Description:     "text",
-							DescriptionHTML: "<html>",
-							Group:           nil,
-							Snapshot:        nil,
 						},
+						Moved: nil,
+						Split: nil,
 					},
 					Groups: map[string]web_platform_dx__web_features.GroupData{
 						"group1": {
@@ -914,35 +944,39 @@ func TestProcess(t *testing.T) {
 			},
 			mockParseCfg: mockParseConfig{
 				expectedFileContents: "hi features",
-				returnData: &web_platform_dx__web_features.FeatureData{
+				returnData: &webdxfeaturetypes.ProcessedWebFeaturesData{
 					Browsers: fakeBrowsersData,
-					Features: map[string]web_platform_dx__web_features.FeatureValue{
-						"feature1": {
-							Name:           "Feature 1",
-							Caniuse:        nil,
-							CompatFeatures: nil,
-							Discouraged:    nil,
-							Spec:           nil,
-							Status: web_platform_dx__web_features.Status{
-								Baseline:         nil,
-								BaselineHighDate: nil,
-								BaselineLowDate:  nil,
-								ByCompatKey:      nil,
-								Support: web_platform_dx__web_features.StatusSupport{
-									Chrome:         nil,
-									ChromeAndroid:  nil,
-									Edge:           nil,
-									Firefox:        nil,
-									FirefoxAndroid: nil,
-									Safari:         nil,
-									SafariIos:      nil,
+					Features: &webdxfeaturetypes.FeatureKinds{
+						Data: map[string]web_platform_dx__web_features.FeatureValue{
+							"feature1": {
+								Name:           "Feature 1",
+								Caniuse:        nil,
+								CompatFeatures: nil,
+								Discouraged:    nil,
+								Spec:           nil,
+								Status: web_platform_dx__web_features.Status{
+									Baseline:         nil,
+									BaselineHighDate: nil,
+									BaselineLowDate:  nil,
+									ByCompatKey:      nil,
+									Support: web_platform_dx__web_features.StatusSupport{
+										Chrome:         nil,
+										ChromeAndroid:  nil,
+										Edge:           nil,
+										Firefox:        nil,
+										FirefoxAndroid: nil,
+										Safari:         nil,
+										SafariIos:      nil,
+									},
 								},
+								Description:     "text",
+								DescriptionHTML: "<html>",
+								Group:           nil,
+								Snapshot:        nil,
 							},
-							Description:     "text",
-							DescriptionHTML: "<html>",
-							Group:           nil,
-							Snapshot:        nil,
 						},
+						Moved: nil,
+						Split: nil,
 					},
 					Groups: map[string]web_platform_dx__web_features.GroupData{
 						"group1": {


### PR DESCRIPTION
Split up of #1701

This commit prepares the web feature consumer to handle the upcoming v3 data schema from the `web-platform-dx/web-features` repository. The v3 release will introduce `Moved` and `Split` feature types alongside the existing feature data.

This change introduces:

- **Temporary Type Definitions:** Since the v3 JSON schema is not yet published, temporary Go type definitions for `FeatureMovedData` and `FeatureSplitData` are added in a new `web_platform_dx__web_features_extras.txt` file. The `Makefile` is updated to copy this into the generated code directory. You can see this in action in #1635. These will be replaced by auto-generated types from the official schema once available.
- **New Data Structures:** A new `ProcessedWebFeaturesData` struct and a nested `FeatureKinds` struct are introduced to parse and categorize the features into `Data`, `Moved`, and `Split` maps. This allows the application to process each feature type correctly.

- **Parser Refactoring:** The data parser is updated to unmarshal the incoming JSON and sort the features into the new `FeatureKinds` structure.

- **Workflow and Test Updates:** The consumer workflow and its tests are updated to use the new `ProcessedWebFeaturesData` struct, ensuring the application continues to function correctly with the refactored data handling.

Other changes:
- Make sure jsonschema target runs clean-jsonschema target first to ensure there's a fresh directory.