### PR TITLE
feat: Workflow handles for Moved and Split features

### DIFF
--- a/lib/gcpspanner/spanneradapters/web_features_consumer.go
+++ b/lib/gcpspanner/spanneradapters/web_features_consumer.go
@@ -148,6 +148,20 @@ func (c *WebFeaturesConsumer) InsertWebFeatures(
 	return ret, nil
 }
 
+func (c *WebFeaturesConsumer) InsertMovedWebFeatures(
+	_ context.Context,
+	_ map[string]web_platform_dx__web_features.FeatureMovedData) error {
+	// TODO: implement this after the database method is ready.
+	return nil
+}
+
+func (c *WebFeaturesConsumer) InsertSplitWebFeatures(
+	_ context.Context,
+	_ map[string]web_platform_dx__web_features.FeatureSplitData) error {
+	// TODO: implement this after the database method is ready.
+	return nil
+}
+
 func consumeFeatureSpecInformation(ctx context.Context,
 	client WebFeatureSpannerClient,
 	featureID string,

--- a/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker.go
@@ -45,6 +45,14 @@ type WebFeatureStorer interface {
 		ctx context.Context,
 		data map[string]web_platform_dx__web_features.FeatureValue,
 		startAt time.Time, endAt time.Time) (map[string]string, error)
+	InsertMovedWebFeatures(
+		ctx context.Context,
+		data map[string]web_platform_dx__web_features.FeatureMovedData,
+	) error
+	InsertSplitWebFeatures(
+		ctx context.Context,
+		data map[string]web_platform_dx__web_features.FeatureSplitData,
+	) error
 }
 
 // WebFeatureMetadataStorer describes the logic to insert the non-relation metadata about web features that
@@ -143,6 +151,20 @@ func (p WebFeaturesJobProcessor) Process(ctx context.Context, job JobArguments) 
 	err = p.snapshotStorer.InsertWebFeatureSnapshots(ctx, mapping, data.Features.Data, data.Snapshots)
 	if err != nil {
 		slog.ErrorContext(ctx, "unable to store snapshots", "error", err)
+
+		return err
+	}
+
+	err = p.storer.InsertMovedWebFeatures(ctx, data.Features.Moved)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to store moved features", "error", err)
+
+		return err
+	}
+
+	err = p.storer.InsertSplitWebFeatures(ctx, data.Features.Split)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to store split features", "error", err)
 
 		return err
 	}

--- a/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker_test.go
+++ b/workflows/steps/services/web_feature_consumer/pkg/workflow/web_features_worker_test.go
@@ -29,12 +29,14 @@ import (
 )
 
 var (
-	errTestFailToGetAsset       = errors.New("fail to get asset")
-	errTestCannotParseData      = errors.New("cannot parse data")
-	errTestFailToStoreData      = errors.New("fail to store data")
-	errTestFailToStoreMetadata  = errors.New("fail to store metadata")
-	errTestFailToStoreGroups    = errors.New("fail to store groups")
-	errTestFailToStoreSnapshots = errors.New("fail to store snapshots")
+	errTestFailToGetAsset           = errors.New("fail to get asset")
+	errTestCannotParseData          = errors.New("cannot parse data")
+	errTestFailToStoreData          = errors.New("fail to store data")
+	errTestFailToStoreMetadata      = errors.New("fail to store metadata")
+	errTestFailToStoreGroups        = errors.New("fail to store groups")
+	errTestFailToStoreSnapshots     = errors.New("fail to store snapshots")
+	errTestFailToStoreMovedFeatures = errors.New("fail to store moved features")
+	errTestFailToStoreSplitFeatures = errors.New("fail to store split features")
 )
 
 type mockAssetGetter struct {
@@ -127,9 +129,39 @@ type mockInsertWebFeaturesConfig struct {
 	returnError     error
 }
 
+type mockInsertMovedFeaturesConfig struct {
+	expectedData map[string]web_platform_dx__web_features.FeatureMovedData
+	returnError  error
+}
+
+type mockInsertSplitFeaturesConfig struct {
+	expectedData map[string]web_platform_dx__web_features.FeatureSplitData
+	returnError  error
+}
+
 type mockWebFeatureStorer struct {
-	t                        *testing.T
-	mockInsertWebFeaturesCfg mockInsertWebFeaturesConfig
+	t                             *testing.T
+	mockInsertWebFeaturesCfg      mockInsertWebFeaturesConfig
+	mockInsertMovedWebFeaturesCfg *mockInsertMovedFeaturesConfig
+	mockInsertSplitWebFeaturesCfg *mockInsertSplitFeaturesConfig
+}
+
+func (m *mockWebFeatureStorer) InsertMovedWebFeatures(
+	_ context.Context, data map[string]web_platform_dx__web_features.FeatureMovedData) error {
+	if !reflect.DeepEqual(data, m.mockInsertMovedWebFeaturesCfg.expectedData) {
+		m.t.Error("unexpected data")
+	}
+
+	return m.mockInsertMovedWebFeaturesCfg.returnError
+}
+
+func (m *mockWebFeatureStorer) InsertSplitWebFeatures(
+	_ context.Context, data map[string]web_platform_dx__web_features.FeatureSplitData) error {
+	if !reflect.DeepEqual(data, m.mockInsertSplitWebFeaturesCfg.expectedData) {
+		m.t.Error("unexpected data")
+	}
+
+	return m.mockInsertSplitWebFeaturesCfg.returnError
 }
 
 func (m *mockWebFeatureStorer) InsertWebFeatures(
@@ -236,6 +268,8 @@ func TestProcess(t *testing.T) {
 		mockInsertWebFeaturesMetadataCfg mockInsertWebFeaturesMetadataConfig
 		mockInsertWebFeatureGroupsCfg    mockInsertWebFeatureGroupsConfig
 		mockInsertWebFeatureSnapshotsCfg mockInsertWebFeatureSnapshotsConfig
+		mockInsertMovedFeaturesCfg       *mockInsertMovedFeaturesConfig
+		mockInsertSplitFeaturesCfg       *mockInsertSplitFeaturesConfig
 		expectedError                    error
 	}{
 		{
@@ -456,6 +490,27 @@ func TestProcess(t *testing.T) {
 				},
 				returnError: nil,
 			},
+			mockInsertMovedFeaturesCfg: &mockInsertMovedFeaturesConfig{
+				expectedData: map[string]web_platform_dx__web_features.FeatureMovedData{
+					"movedFeature": {
+						Kind:           web_platform_dx__web_features.Moved,
+						RedirectTarget: "new-feature",
+					},
+				},
+				returnError: nil,
+			},
+			mockInsertSplitFeaturesCfg: &mockInsertSplitFeaturesConfig{
+				expectedData: map[string]web_platform_dx__web_features.FeatureSplitData{
+					"splitFeature": {
+						Kind: web_platform_dx__web_features.Split,
+						RedirectTargets: []string{
+							"new-feature-1",
+							"new-feature-2",
+						},
+					},
+				},
+				returnError: nil,
+			},
 			expectedError: nil,
 		},
 		{
@@ -493,7 +548,9 @@ func TestProcess(t *testing.T) {
 				expectedMapping:      nil,
 				returnError:          nil,
 			},
-			expectedError: errTestFailToGetAsset,
+			mockInsertMovedFeaturesCfg: nil,
+			mockInsertSplitFeaturesCfg: nil,
+			expectedError:              errTestFailToGetAsset,
 		},
 		{
 			name: "fail to parse data",
@@ -530,7 +587,9 @@ func TestProcess(t *testing.T) {
 				expectedMapping:      nil,
 				returnError:          nil,
 			},
-			expectedError: errTestCannotParseData,
+			mockInsertMovedFeaturesCfg: nil,
+			mockInsertSplitFeaturesCfg: nil,
+			expectedError:              errTestCannotParseData,
 		},
 		{
 			name: "fail to store data",
@@ -632,7 +691,9 @@ func TestProcess(t *testing.T) {
 				expectedMapping:      nil,
 				returnError:          nil,
 			},
-			expectedError: errTestFailToStoreData,
+			mockInsertMovedFeaturesCfg: nil,
+			mockInsertSplitFeaturesCfg: nil,
+			expectedError:              errTestFailToStoreData,
 		},
 		{
 			name: "fail to store metadata",
@@ -763,7 +824,9 @@ func TestProcess(t *testing.T) {
 				expectedMapping:      nil,
 				returnError:          nil,
 			},
-			expectedError: errTestFailToStoreMetadata,
+			mockInsertMovedFeaturesCfg: nil,
+			mockInsertSplitFeaturesCfg: nil,
+			expectedError:              errTestFailToStoreMetadata,
 		},
 		{
 			name: "fail to store groups",
@@ -931,7 +994,9 @@ func TestProcess(t *testing.T) {
 				expectedMapping:      nil,
 				returnError:          nil,
 			},
-			expectedError: errTestFailToStoreGroups,
+			mockInsertMovedFeaturesCfg: nil,
+			mockInsertSplitFeaturesCfg: nil,
+			expectedError:              errTestFailToStoreGroups,
 		},
 		{
 			name: "fail to store snapshots",
@@ -1138,7 +1203,480 @@ func TestProcess(t *testing.T) {
 				},
 				returnError: errTestFailToStoreSnapshots,
 			},
-			expectedError: errTestFailToStoreSnapshots,
+			mockInsertMovedFeaturesCfg: nil,
+			mockInsertSplitFeaturesCfg: nil,
+			expectedError:              errTestFailToStoreSnapshots,
+		},
+		{
+			name: "fail to store moved features",
+			mockDownloadFileFromReleaseCfg: mockDownloadFileFromReleaseConfig{
+				expectedOwner:    testRepoOwner,
+				expectedRepo:     testRepoName,
+				expectedFileName: testFileName,
+				returnReadCloser: io.NopCloser(strings.NewReader("hi features")),
+				returnError:      nil,
+			},
+			mockParseCfg: mockParseConfig{
+				expectedFileContents: "hi features",
+				returnData: &webdxfeaturetypes.ProcessedWebFeaturesData{
+					Browsers: fakeBrowsersData,
+					Features: &webdxfeaturetypes.FeatureKinds{
+						Data: map[string]web_platform_dx__web_features.FeatureValue{
+							"feature1": {
+								Name:           "Feature 1",
+								Caniuse:        nil,
+								CompatFeatures: nil,
+								Discouraged:    nil,
+								Spec:           nil,
+								Status: web_platform_dx__web_features.Status{
+									Baseline:         nil,
+									BaselineHighDate: nil,
+									BaselineLowDate:  nil,
+									ByCompatKey:      nil,
+									Support: web_platform_dx__web_features.StatusSupport{
+										Chrome:         nil,
+										ChromeAndroid:  nil,
+										Edge:           nil,
+										Firefox:        nil,
+										FirefoxAndroid: nil,
+										Safari:         nil,
+										SafariIos:      nil,
+									},
+								},
+								Description:     "text",
+								DescriptionHTML: "<html>",
+								Group:           nil,
+								Snapshot:        nil,
+							},
+						},
+						Moved: map[string]web_platform_dx__web_features.FeatureMovedData{
+							"movedFeature": {
+								Kind:           web_platform_dx__web_features.Moved,
+								RedirectTarget: "new-feature",
+							},
+						},
+						Split: map[string]web_platform_dx__web_features.FeatureSplitData{
+							"splitFeature": {
+								Kind: web_platform_dx__web_features.Split,
+								RedirectTargets: []string{
+									"new-feature-1",
+									"new-feature-2",
+								},
+							},
+						},
+					},
+					Groups: map[string]web_platform_dx__web_features.GroupData{
+						"group1": {
+							Name:   "Group 1",
+							Parent: nil,
+						},
+					},
+					Snapshots: map[string]web_platform_dx__web_features.SnapshotData{
+						"snapshot1": {
+							Name: "Snapshot 1",
+							Spec: "",
+						},
+					},
+				},
+				returnError: nil,
+			},
+			mockInsertWebFeaturesCfg: mockInsertWebFeaturesConfig{
+				expectedData: map[string]web_platform_dx__web_features.FeatureValue{
+					"feature1": {
+						Name:           "Feature 1",
+						Caniuse:        nil,
+						CompatFeatures: nil,
+						Discouraged:    nil,
+						Spec:           nil,
+						Status: web_platform_dx__web_features.Status{
+							Baseline:         nil,
+							BaselineHighDate: nil,
+							BaselineLowDate:  nil,
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
+								Chrome:         nil,
+								ChromeAndroid:  nil,
+								Edge:           nil,
+								Firefox:        nil,
+								FirefoxAndroid: nil,
+								Safari:         nil,
+								SafariIos:      nil,
+							},
+						},
+						Description:     "text",
+						DescriptionHTML: "<html>",
+						Group:           nil,
+						Snapshot:        nil,
+					},
+				},
+				returnedMapping: map[string]string{
+					"feature1": "id-1",
+				},
+				returnError: nil,
+			},
+			mockInsertWebFeaturesMetadataCfg: mockInsertWebFeaturesMetadataConfig{
+				expectedData: map[string]web_platform_dx__web_features.FeatureValue{
+					"feature1": {
+						Name:           "Feature 1",
+						Caniuse:        nil,
+						CompatFeatures: nil,
+						Discouraged:    nil,
+						Spec:           nil,
+						Status: web_platform_dx__web_features.Status{
+							Baseline:         nil,
+							BaselineHighDate: nil,
+							BaselineLowDate:  nil,
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
+								Chrome:         nil,
+								ChromeAndroid:  nil,
+								Edge:           nil,
+								Firefox:        nil,
+								FirefoxAndroid: nil,
+								Safari:         nil,
+								SafariIos:      nil,
+							},
+						},
+						Description:     "text",
+						DescriptionHTML: "<html>",
+						Group:           nil,
+						Snapshot:        nil,
+					},
+				},
+				expectedMapping: map[string]string{
+					"feature1": "id-1",
+				},
+				returnError: nil,
+			},
+			mockInsertWebFeatureGroupsCfg: mockInsertWebFeatureGroupsConfig{
+				expectedFeatureData: map[string]web_platform_dx__web_features.FeatureValue{
+					"feature1": {
+						Name:           "Feature 1",
+						Caniuse:        nil,
+						CompatFeatures: nil,
+						Discouraged:    nil,
+						Spec:           nil,
+						Status: web_platform_dx__web_features.Status{
+							Baseline:         nil,
+							BaselineHighDate: nil,
+							BaselineLowDate:  nil,
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
+								Chrome:         nil,
+								ChromeAndroid:  nil,
+								Edge:           nil,
+								Firefox:        nil,
+								FirefoxAndroid: nil,
+								Safari:         nil,
+								SafariIos:      nil,
+							},
+						},
+						Description:     "text",
+						DescriptionHTML: "<html>",
+						Group:           nil,
+						Snapshot:        nil,
+					},
+				},
+				expectedGroupData: map[string]web_platform_dx__web_features.GroupData{
+					"group1": {
+						Name:   "Group 1",
+						Parent: nil,
+					},
+				},
+				returnError: nil,
+			},
+			mockInsertWebFeatureSnapshotsCfg: mockInsertWebFeatureSnapshotsConfig{
+				expectedFeatureData: map[string]web_platform_dx__web_features.FeatureValue{
+					"feature1": {
+						Name:           "Feature 1",
+						Caniuse:        nil,
+						CompatFeatures: nil,
+						Discouraged:    nil,
+						Spec:           nil,
+						Status: web_platform_dx__web_features.Status{
+							Baseline:         nil,
+							BaselineHighDate: nil,
+							BaselineLowDate:  nil,
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
+								Chrome:         nil,
+								ChromeAndroid:  nil,
+								Edge:           nil,
+								Firefox:        nil,
+								FirefoxAndroid: nil,
+								Safari:         nil,
+								SafariIos:      nil,
+							},
+						},
+						Description:     "text",
+						DescriptionHTML: "<html>",
+						Group:           nil,
+						Snapshot:        nil,
+					},
+				},
+				expectedMapping: map[string]string{
+					"feature1": "id-1",
+				},
+				expectedSnapshotData: map[string]web_platform_dx__web_features.SnapshotData{
+					"snapshot1": {
+						Name: "Snapshot 1",
+						Spec: "",
+					},
+				},
+				returnError: nil,
+			},
+			mockInsertMovedFeaturesCfg: &mockInsertMovedFeaturesConfig{
+				expectedData: map[string]web_platform_dx__web_features.FeatureMovedData{
+					"movedFeature": {
+						Kind:           web_platform_dx__web_features.Moved,
+						RedirectTarget: "new-feature",
+					},
+				},
+				returnError: errTestFailToStoreMovedFeatures,
+			},
+			mockInsertSplitFeaturesCfg: nil,
+			expectedError:              errTestFailToStoreMovedFeatures,
+		},
+		{
+			name: "fail to store split features",
+			mockDownloadFileFromReleaseCfg: mockDownloadFileFromReleaseConfig{
+				expectedOwner:    testRepoOwner,
+				expectedRepo:     testRepoName,
+				expectedFileName: testFileName,
+				returnReadCloser: io.NopCloser(strings.NewReader("hi features")),
+				returnError:      nil,
+			},
+			mockParseCfg: mockParseConfig{
+				expectedFileContents: "hi features",
+				returnData: &webdxfeaturetypes.ProcessedWebFeaturesData{
+					Browsers: fakeBrowsersData,
+					Features: &webdxfeaturetypes.FeatureKinds{
+						Data: map[string]web_platform_dx__web_features.FeatureValue{
+							"feature1": {
+								Name:           "Feature 1",
+								Caniuse:        nil,
+								CompatFeatures: nil,
+								Discouraged:    nil,
+								Spec:           nil,
+								Status: web_platform_dx__web_features.Status{
+									Baseline:         nil,
+									BaselineHighDate: nil,
+									BaselineLowDate:  nil,
+									ByCompatKey:      nil,
+									Support: web_platform_dx__web_features.StatusSupport{
+										Chrome:         nil,
+										ChromeAndroid:  nil,
+										Edge:           nil,
+										Firefox:        nil,
+										FirefoxAndroid: nil,
+										Safari:         nil,
+										SafariIos:      nil,
+									},
+								},
+								Description:     "text",
+								DescriptionHTML: "<html>",
+								Group:           nil,
+								Snapshot:        nil,
+							},
+						},
+						Moved: map[string]web_platform_dx__web_features.FeatureMovedData{
+							"movedFeature": {
+								Kind:           web_platform_dx__web_features.Moved,
+								RedirectTarget: "new-feature",
+							},
+						},
+						Split: map[string]web_platform_dx__web_features.FeatureSplitData{
+							"splitFeature": {
+								Kind: web_platform_dx__web_features.Split,
+								RedirectTargets: []string{
+									"new-feature-1",
+									"new-feature-2",
+								},
+							},
+						},
+					},
+					Groups: map[string]web_platform_dx__web_features.GroupData{
+						"group1": {
+							Name:   "Group 1",
+							Parent: nil,
+						},
+					},
+					Snapshots: map[string]web_platform_dx__web_features.SnapshotData{
+						"snapshot1": {
+							Name: "Snapshot 1",
+							Spec: "",
+						},
+					},
+				},
+				returnError: nil,
+			},
+			mockInsertWebFeaturesCfg: mockInsertWebFeaturesConfig{
+				expectedData: map[string]web_platform_dx__web_features.FeatureValue{
+					"feature1": {
+						Name:           "Feature 1",
+						Caniuse:        nil,
+						CompatFeatures: nil,
+						Discouraged:    nil,
+						Spec:           nil,
+						Status: web_platform_dx__web_features.Status{
+							Baseline:         nil,
+							BaselineHighDate: nil,
+							BaselineLowDate:  nil,
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
+								Chrome:         nil,
+								ChromeAndroid:  nil,
+								Edge:           nil,
+								Firefox:        nil,
+								FirefoxAndroid: nil,
+								Safari:         nil,
+								SafariIos:      nil,
+							},
+						},
+						Description:     "text",
+						DescriptionHTML: "<html>",
+						Group:           nil,
+						Snapshot:        nil,
+					},
+				},
+				returnedMapping: map[string]string{
+					"feature1": "id-1",
+				},
+				returnError: nil,
+			},
+			mockInsertWebFeaturesMetadataCfg: mockInsertWebFeaturesMetadataConfig{
+				expectedData: map[string]web_platform_dx__web_features.FeatureValue{
+					"feature1": {
+						Name:           "Feature 1",
+						Caniuse:        nil,
+						CompatFeatures: nil,
+						Discouraged:    nil,
+						Spec:           nil,
+						Status: web_platform_dx__web_features.Status{
+							Baseline:         nil,
+							BaselineHighDate: nil,
+							BaselineLowDate:  nil,
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
+								Chrome:         nil,
+								ChromeAndroid:  nil,
+								Edge:           nil,
+								Firefox:        nil,
+								FirefoxAndroid: nil,
+								Safari:         nil,
+								SafariIos:      nil,
+							},
+						},
+						Description:     "text",
+						DescriptionHTML: "<html>",
+						Group:           nil,
+						Snapshot:        nil,
+					},
+				},
+				expectedMapping: map[string]string{
+					"feature1": "id-1",
+				},
+				returnError: nil,
+			},
+			mockInsertWebFeatureGroupsCfg: mockInsertWebFeatureGroupsConfig{
+				expectedFeatureData: map[string]web_platform_dx__web_features.FeatureValue{
+					"feature1": {
+						Name:           "Feature 1",
+						Caniuse:        nil,
+						CompatFeatures: nil,
+						Discouraged:    nil,
+						Spec:           nil,
+						Status: web_platform_dx__web_features.Status{
+							Baseline:         nil,
+							BaselineHighDate: nil,
+							BaselineLowDate:  nil,
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
+								Chrome:         nil,
+								ChromeAndroid:  nil,
+								Edge:           nil,
+								Firefox:        nil,
+								FirefoxAndroid: nil,
+								Safari:         nil,
+								SafariIos:      nil,
+							},
+						},
+						Description:     "text",
+						DescriptionHTML: "<html>",
+						Group:           nil,
+						Snapshot:        nil,
+					},
+				},
+				expectedGroupData: map[string]web_platform_dx__web_features.GroupData{
+					"group1": {
+						Name:   "Group 1",
+						Parent: nil,
+					},
+				},
+				returnError: nil,
+			},
+			mockInsertWebFeatureSnapshotsCfg: mockInsertWebFeatureSnapshotsConfig{
+				expectedFeatureData: map[string]web_platform_dx__web_features.FeatureValue{
+					"feature1": {
+						Name:           "Feature 1",
+						Caniuse:        nil,
+						CompatFeatures: nil,
+						Discouraged:    nil,
+						Spec:           nil,
+						Status: web_platform_dx__web_features.Status{
+							Baseline:         nil,
+							BaselineHighDate: nil,
+							BaselineLowDate:  nil,
+							ByCompatKey:      nil,
+							Support: web_platform_dx__web_features.StatusSupport{
+								Chrome:         nil,
+								ChromeAndroid:  nil,
+								Edge:           nil,
+								Firefox:        nil,
+								FirefoxAndroid: nil,
+								Safari:         nil,
+								SafariIos:      nil,
+							},
+						},
+						Description:     "text",
+						DescriptionHTML: "<html>",
+						Group:           nil,
+						Snapshot:        nil,
+					},
+				},
+				expectedMapping: map[string]string{
+					"feature1": "id-1",
+				},
+				expectedSnapshotData: map[string]web_platform_dx__web_features.SnapshotData{
+					"snapshot1": {
+						Name: "Snapshot 1",
+						Spec: "",
+					},
+				},
+				returnError: nil,
+			},
+			mockInsertMovedFeaturesCfg: &mockInsertMovedFeaturesConfig{
+				expectedData: map[string]web_platform_dx__web_features.FeatureMovedData{
+					"movedFeature": {
+						Kind:           web_platform_dx__web_features.Moved,
+						RedirectTarget: "new-feature",
+					},
+				},
+				returnError: nil,
+			},
+			mockInsertSplitFeaturesCfg: &mockInsertSplitFeaturesConfig{
+				expectedData: map[string]web_platform_dx__web_features.FeatureSplitData{
+					"splitFeature": {
+						Kind: web_platform_dx__web_features.Split,
+						RedirectTargets: []string{
+							"new-feature-1",
+							"new-feature-2",
+						},
+					},
+				},
+				returnError: errTestFailToStoreSplitFeatures,
+			},
+			expectedError: errTestFailToStoreSplitFeatures,
 		},
 	}
 	for _, tc := range testCases {
@@ -1152,8 +1690,10 @@ func TestProcess(t *testing.T) {
 				mockParseCfg: tc.mockParseCfg,
 			}
 			mockStorer := &mockWebFeatureStorer{
-				t:                        t,
-				mockInsertWebFeaturesCfg: tc.mockInsertWebFeaturesCfg,
+				t:                             t,
+				mockInsertWebFeaturesCfg:      tc.mockInsertWebFeaturesCfg,
+				mockInsertMovedWebFeaturesCfg: tc.mockInsertMovedFeaturesCfg,
+				mockInsertSplitWebFeaturesCfg: tc.mockInsertSplitFeaturesCfg,
 			}
 			mockMetadataStorer := &mockWebFeatureMetadataStorer{
 				t:                                t,


### PR DESCRIPTION
This commit builds on the previous changes by having the workflow call the glue layer to store moved and split features.

The `WebFeatureStorer` interface is extended with `InsertMovedWebFeatures` and `InsertSplitWebFeatures` methods. The main job processor in the workflow now calls these new methods.

In the future, we will intrdouce the spanner tables and implement the methods in the spanner layer that will actually be used.

Future TODO: DRY up the code in web_features_worker_test.go