### PR TITLE
chore: Update GEMINI.md and have GEMINI update the toolchains

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,7 @@
     },
     "ghcr.io/lukewiwa/features/shellcheck:0": {
       // Get version from https://github.com/koalaman/shellcheck/releases
-      "version": "v0.10.0"
+      "version": "v0.11.0"
     },
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
       // We don't use helm

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -296,6 +296,18 @@ For other tools defined as features in the devcontainer: When evaluating these i
 
 ### 6.3. How-To: Update Dependencies
 
+**General Instructions**
+
+- **Always Upgrade**: When changing a version, **always upgrade** to a newer one. Never downgrade. Most tools use Semantic Versioning (SemVer), which you can use to compare versions.
+- **Verify Your Local Version**: Before running commands to update dependencies, ensure your local tool's version matches the new version you've specified.
+- **Commit Before Verifying**: You must create a commit **before** running any verification commands (e.g., pre-commit hooks).
+  - The commit message must use the `chore:` prefix.
+  - In the commit description, summarize the upgrade and the steps taken.
+  - The commit description should also indicate that these steps were completed by AI. Including any prompt(s) given by the user to generate these changes.
+  - If you need to make more changes later, amend this commit and update the message.
+  - If there are any existing manual changes made, make a note in the commit message.
+  - In the commit message, let users know that they will need to rebuild the devcontainer after merging.
+
 #### Updating Go Dependencies
 
 This guide outlines the process for updating Go dependencies after the Go toolchain has been updated and the devcontainer rebuilt.

--- a/images/nodejs_service.Dockerfile
+++ b/images/nodejs_service.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:22.16.0-alpine3.22 AS base
+FROM node:22.18.0-alpine3.22 AS base
 
 FROM base AS builder
 


### PR DESCRIPTION
## GEMINI.md changes:
Separated the "Update Dependencies" steps for Go and Node.js into new, dedicated "How-To" sections. This clarifies the process, as dependency updates typically occur after a toolchain version upgrade and devcontainer rebuild.

## Automated changes

### Change 1
Commit https://github.com/GoogleChrome/webstatus.dev/commit/96ca90a8817b110d49d44eb7dfdda14e4918cd80 was completely generated by AI

I told it `Update all the toolchains` and it generated that

Message: 
```
chore: upgrade Go, Node.js, and Shellcheck toolchains

This commit upgrades the following toolchains:
- Go: Updated devcontainer version from 1.24.5 to 1.24.6.
- Node.js: Updated Dockerfile and devcontainer versions from 22.16.0/22.17.1 to 22.18.0 (LTS).
- Shellcheck: Updated devcontainer version from v0.10.0 to v0.11.0.

These steps were completed by AI. Users will need to rebuild the devcontainer after merging.
```

