### PR TITLE
feat(api): Handle moved and split features in GetFeature endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"slices"
 	"time"
@@ -75,6 +76,13 @@ func main() {
 		slog.InfoContext(ctx, "setting spanner to local mode")
 		spannerClient.SetFeatureSearchBaseQuery(gcpspanner.LocalFeatureBaseQuery{})
 		spannerClient.SetMisingOneImplementationQuery(gcpspanner.LocalMissingOneImplementationQuery{})
+	}
+
+	baseURLString := os.Getenv("BASE_URL")
+	baseURL, err := url.Parse(baseURLString)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to parse base url", "error", err, "base_url_string", baseURLString)
+		os.Exit(1)
 	}
 
 	// Allowed Origin. Can remove after UbP.
@@ -178,6 +186,7 @@ func main() {
 
 	srv := httpserver.NewHTTPServer(
 		"8080",
+		baseURL,
 		datastoreadapters.NewBackend(fs),
 		spanneradapters.NewBackend(spannerClient),
 		cache,

--- a/backend/manifests/pod.yaml
+++ b/backend/manifests/pod.yaml
@@ -30,6 +30,8 @@ spec:
         tcpSocket:
           port: 8080
       env:
+        - name: BASE_URL
+          value: 'http://localhost:8080'
         - name: SPANNER_DATABASE
           value: 'local'
         - name: SPANNER_INSTANCE

--- a/backend/pkg/httpserver/create_saved_search_test.go
+++ b/backend/pkg/httpserver/create_saved_search_test.go
@@ -365,7 +365,7 @@ func TestCreateSavedSearch(t *testing.T) {
 				t:                        t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: nil}
+				operationResponseCaches: nil, baseURL: getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 		})

--- a/backend/pkg/httpserver/get_feature_metadata_test.go
+++ b/backend/pkg/httpserver/get_feature_metadata_test.go
@@ -113,7 +113,8 @@ func TestGetFeatureMetadata(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: mockMetadataStorer,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			mockCacher.AssertExpectations()
 			// TODO: Start tracking call count and assert call count.

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -534,7 +534,8 @@ func TestListFeatures(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountFeaturesSearch,
 				"FeaturesSearch", mockCacher)

--- a/backend/pkg/httpserver/get_saved_search_test.go
+++ b/backend/pkg/httpserver/get_saved_search_test.go
@@ -73,7 +73,7 @@ func TestGetSavedSearch(t *testing.T) {
 				t:                 t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: nil}
+				operationResponseCaches: nil, baseURL: getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 		})

--- a/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
+++ b/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
@@ -297,7 +297,8 @@ func TestListAggregatedBaselineStatusCounts(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListBaselineStatusCounts,
 				"ListBaselineStatusCounts", mockCacher)

--- a/backend/pkg/httpserver/list_aggregated_feature_support_test.go
+++ b/backend/pkg/httpserver/list_aggregated_feature_support_test.go
@@ -314,7 +314,8 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListBrowserFeatureCountMetric,
 				"ListBrowserFeatureCountMetric", mockCacher)

--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
@@ -300,7 +300,8 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMetricsOverTimeWithAggregatedTotals,
 				"ListMetricsOverTimeWithAggregatedTotals", mockCacher)

--- a/backend/pkg/httpserver/list_chromium_usage_test.go
+++ b/backend/pkg/httpserver/list_chromium_usage_test.go
@@ -154,7 +154,8 @@ func TestListChromeDailyUsageStats(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListChromeDailyUsageStats,
 				"ListChromeDailyUsageStats", mockCacher)

--- a/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
@@ -296,7 +296,8 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMetricsForFeatureIDBrowserAndChannel,
 				"ListMetricsForFeatureIDBrowserAndChannel", mockCacher)

--- a/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
@@ -345,7 +345,8 @@ func TestListMissingOneImplementationCounts(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMissingOneImplCounts,
 				"ListMissingOneImplCounts", mockCacher)

--- a/backend/pkg/httpserver/list_missing_one_implementation_features_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_features_test.go
@@ -198,7 +198,8 @@ func TestListMissingOneImplementationFeatures(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, nil, nil)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())}
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMissingOneImplFeatures,
 				"ListMissingOneImplementationFeatures", mockCacher)

--- a/backend/pkg/httpserver/list_user_saved_searches_test.go
+++ b/backend/pkg/httpserver/list_user_saved_searches_test.go
@@ -179,7 +179,7 @@ func TestListUserSavedSearches(t *testing.T) {
 				t:                        t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: nil}
+				operationResponseCaches: nil, baseURL: getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListUserSavedSearches,

--- a/backend/pkg/httpserver/put_user_saved_search_bookmark_test.go
+++ b/backend/pkg/httpserver/put_user_saved_search_bookmark_test.go
@@ -106,7 +106,8 @@ func TestPutUserSavedSearchBookmark(t *testing.T) {
 				t:                             t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: nil}
+				operationResponseCaches: nil,
+				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{authMiddlewareOption}...)
 			assertMocksExpectations(t, 1, mockStorer.callCountPutUserSavedSearchBookmark,

--- a/backend/pkg/httpserver/remove_saved_search_test.go
+++ b/backend/pkg/httpserver/remove_saved_search_test.go
@@ -106,7 +106,7 @@ func TestRemoveSavedSearch(t *testing.T) {
 				t:                        t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: nil}
+				operationResponseCaches: nil, baseURL: getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{authMiddlewareOption}...)
 			assertMocksExpectations(t, 1, mockStorer.callCountDeleteUserSavedSearch,

--- a/backend/pkg/httpserver/remove_user_saved_search_bookmark_test.go
+++ b/backend/pkg/httpserver/remove_user_saved_search_bookmark_test.go
@@ -106,7 +106,7 @@ func TestRemoveUserSavedSearchBookmark(t *testing.T) {
 				t:                                t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: nil}
+				operationResponseCaches: nil, baseURL: getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{authMiddlewareOption}...)
 			assertMocksExpectations(t, 1, mockStorer.callCountRemoveUserSavedSearchBookmark,

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -21,8 +21,10 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
@@ -77,7 +79,7 @@ type WPTMetricsStorer interface {
 		featureID string,
 		wptMetricType backend.WPTMetricView,
 		browsers []backend.BrowserPathParam,
-	) (*backend.Feature, error)
+	) (*backendtypes.GetFeatureResult, error)
 	ListBrowserFeatureCountMetric(
 		ctx context.Context,
 		targetBrowser string,
@@ -148,6 +150,7 @@ type Server struct {
 	metadataStorer          WebFeatureMetadataStorer
 	wptMetricsStorer        WPTMetricsStorer
 	operationResponseCaches *operationResponseCaches
+	baseURL                 *url.URL
 }
 
 func defaultBrowsers() []backend.BrowserPathParam {
@@ -202,6 +205,7 @@ type RouteCacheOptions struct {
 
 func NewHTTPServer(
 	port string,
+	baseURL *url.URL,
 	metadataStorer WebFeatureMetadataStorer,
 	wptMetricsStorer WPTMetricsStorer,
 	rawBytesDataCacher RawBytesDataCacher,
@@ -213,6 +217,7 @@ func NewHTTPServer(
 		metadataStorer:          metadataStorer,
 		wptMetricsStorer:        wptMetricsStorer,
 		operationResponseCaches: initOperationResponseCaches(rawBytesDataCacher, routeCacheOptions),
+		baseURL:                 baseURL,
 	}
 
 	return createOpenAPIServerServer(port, srv, preRequestValidationMiddlewares, authMiddleware)

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"slices"
 	"strings"
@@ -28,6 +29,7 @@ import (
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	"github.com/GoogleChrome/webstatus.dev/lib/httpmiddlewares"
@@ -111,7 +113,7 @@ type MockGetFeatureByIDConfig struct {
 	expectedFeatureID     string
 	expectedWPTMetricView backend.WPTMetricView
 	expectedBrowsers      []backend.BrowserPathParam
-	data                  *backend.Feature
+	data                  *backendtypes.GetFeatureResult
 	err                   error
 }
 
@@ -376,7 +378,7 @@ func (m *MockWPTMetricsStorer) GetFeature(
 	featureID string,
 	view backend.WPTMetricView,
 	browsers []backend.BrowserPathParam,
-) (*backend.Feature, error) {
+) (*backendtypes.GetFeatureResult, error) {
 	m.callCountGetFeature++
 
 	if featureID != m.getFeatureByIDConfig.expectedFeatureID ||
@@ -1022,4 +1024,13 @@ func TestGenericErrorFn(t *testing.T) {
 			}
 		})
 	}
+}
+
+func getTestBaseURL(t *testing.T) *url.URL {
+	baseURL, err := url.Parse("http://localhost:8080")
+	if err != nil {
+		t.Fatalf("failed to parse base URL: %v", err)
+	}
+
+	return baseURL
 }

--- a/backend/pkg/httpserver/update_saved_search_test.go
+++ b/backend/pkg/httpserver/update_saved_search_test.go
@@ -355,7 +355,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 				t:                        t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil,
-				operationResponseCaches: nil}
+				operationResponseCaches: nil, baseURL: getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 		})

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -135,6 +135,10 @@ resource "google_cloud_run_v2_service" "service" {
         name  = "OTEL_GCP_PROJECT_ID"
         value = var.projects.public
       }
+      env {
+        name  = "BASE_URL"
+        value = var.backend_api_url
+      }
     }
     containers {
       name  = "otel"

--- a/infra/backend/variables.tf
+++ b/infra/backend/variables.tf
@@ -103,3 +103,8 @@ variable "firebase_settings" {
     tenant_id = string
   })
 }
+
+variable "backend_api_url" {
+  type = string
+}
+

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -118,6 +118,7 @@ module "backend" {
   cors_allowed_origin       = var.backend_cors_allowed_origin
   min_instance_count        = var.backend_min_instance_count
   max_instance_count        = var.backend_max_instance_count
+  backend_api_url           = var.backend_api_url
   firebase_settings = {
     tenant_id = module.auth.tenant_id
   }

--- a/lib/backendtypes/feature_result.go
+++ b/lib/backendtypes/feature_result.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backendtypes
+
+import (
+	"context"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// FeatureResultVisitor defines the methods for visiting each result type.
+type FeatureResultVisitor interface {
+	VisitRegularFeature(ctx context.Context, result RegularFeatureResult) error
+	VisitMovedFeature(ctx context.Context, result MovedFeatureResult) error
+	VisitSplitFeature(ctx context.Context, result SplitFeatureResult) error
+}
+
+// RegularFeatureResult represents a result for a regular feature.
+type RegularFeatureResult struct {
+	feature *backend.Feature
+}
+
+func (r RegularFeatureResult) Visit(ctx context.Context, v FeatureResultVisitor) error {
+	return v.VisitRegularFeature(ctx, r)
+}
+
+func (r RegularFeatureResult) Feature() *backend.Feature {
+	return r.feature
+}
+
+// RegularFeatureResult creates a new RegularFeatureResult for a regular feature.
+func NewRegularFeatureResult(feature *backend.Feature) *RegularFeatureResult {
+	return &RegularFeatureResult{
+		feature: feature,
+	}
+}
+
+// SplitFeatureResult represents a result for a split feature.
+type SplitFeatureResult struct {
+	splitFeature backend.FeatureEvolutionSplit
+}
+
+func (s SplitFeatureResult) Visit(ctx context.Context, v FeatureResultVisitor) error {
+	return v.VisitSplitFeature(ctx, s)
+}
+
+func (s SplitFeatureResult) SplitFeature() backend.FeatureEvolutionSplit {
+	return s.splitFeature
+}
+
+// NewSplitFeatureResult creates a new SplitFeatureResult for a split feature.
+func NewSplitFeatureResult(splitFeature backend.FeatureEvolutionSplit) *SplitFeatureResult {
+	return &SplitFeatureResult{
+		splitFeature: splitFeature,
+	}
+}
+
+// MovedFeatureResult represents a result for a moved feature.
+type MovedFeatureResult struct {
+	newFeatureID string
+}
+
+func (m MovedFeatureResult) Visit(ctx context.Context, v FeatureResultVisitor) error {
+	return v.VisitMovedFeature(ctx, m)
+}
+
+// NewMovedFeatureResult creates a new MovedFeatureResult for a moved feature.
+func NewMovedFeatureResult(newFeatureID string) *MovedFeatureResult {
+	return &MovedFeatureResult{
+		newFeatureID: newFeatureID,
+	}
+}
+
+func (m MovedFeatureResult) NewFeatureID() string {
+	return m.newFeatureID
+}
+
+// FeatureResult is the interface that all concrete results implement.
+// The Visit method allows a visitor to operate on the concrete type.
+type FeatureResult interface {
+	Visit(ctx context.Context, visitor FeatureResultVisitor) error
+}
+
+// GetFeatureResult is a container for the result of a GetFeature operation.
+type GetFeatureResult struct {
+	result FeatureResult
+}
+
+// Visit allows a visitor to operate on the result.
+func (g GetFeatureResult) Visit(ctx context.Context, v FeatureResultVisitor) error {
+	return g.result.Visit(ctx, v)
+}
+
+// NewGetFeatureResult creates a new GetFeatureResult.
+func NewGetFeatureResult(result FeatureResult) *GetFeatureResult {
+	return &GetFeatureResult{
+		result: result,
+	}
+}

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -1057,7 +1057,7 @@ func (s *Backend) GetFeature(
 	featureID string,
 	wptMetricView backend.WPTMetricView,
 	browsers []backend.BrowserPathParam,
-) (*backend.Feature, error) {
+) (*backendtypes.GetFeatureResult, error) {
 	filter := gcpspanner.NewFeatureKeyFilter(featureID)
 	featureResult, err := s.client.GetFeature(ctx, filter, getSpannerWPTMetricView(wptMetricView),
 		BrowserList(browsers).ToStringList())
@@ -1065,7 +1065,8 @@ func (s *Backend) GetFeature(
 		return nil, err
 	}
 
-	return s.convertFeatureResult(featureResult), nil
+	return backendtypes.NewGetFeatureResult(
+		backendtypes.NewRegularFeatureResult(s.convertFeatureResult(featureResult))), nil
 }
 
 func (s *Backend) GetIDFromFeatureKey(

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -1404,12 +1404,15 @@ components:
       description: |
         Represents various reasons a feature might be gone due to evolution.
         Clients should check the 'type' field to determine the specific error structure.
-      oneOf:
-        - $ref: '#/components/schemas/FeatureGoneSplit'
-      discriminator:
-        propertyName: type
-        mapping:
-          split: '#/components/schemas/FeatureGoneSplit'
+      $ref: '#/components/schemas/FeatureGoneSplit'
+      # Cannot use oneOf until this bug is fixed
+      # https://github.com/oapi-codegen/oapi-codegen/issues/970
+      # oneOf:
+      #   - $ref: '#/components/schemas/FeatureGoneSplit'
+      # discriminator:
+      #   propertyName: type
+      #   mapping:
+      #     split: '#/components/schemas/FeatureGoneSplit'
     FeatureGoneSplit:
       allOf:
         - $ref: '#/components/schemas/BasicErrorModel'


### PR DESCRIPTION
This commit introduces logic to handle feature evolution, where a feature can be moved (renamed) or split into multiple new features. The `/v1/features/{feature_id}` endpoint now provides specific responses to guide clients on how to handle these cases.

A `FeatureResult` visitor pattern has been implemented to differentiate between three outcomes:

-   **Regular Feature**: The endpoint returns a `200 OK` with the feature data as before.
-   **Moved Feature**: The endpoint returns a `301 Moved Permanently` redirect with a `Location` header pointing to the new feature's canonical URL.
-   **Split Feature**: The endpoint returns a `410 Gone` with a response body detailing the new features that have replaced the requested one.

To support the `301` redirect, a `BASE_URL` environment variable has been added. This allows the server to construct absolute URLs for the `Location` header. The configuration has been updated in the local pod manifest and the Terraform definitions for Cloud Run.

Other changes:
- The OpenAPI specification was also updated to correctly define this response, working around a current limitation in the oapi-codegen tool.

Split up of #1706