### PR TITLE
feat(spanneradapters): Implement multi-step lookup for feature evolution

### DIFF
--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -74,6 +74,14 @@ type BackendSpannerClient interface {
 		wptMetricView gcpspanner.WPTMetricView,
 		browsers []string,
 	) (*gcpspanner.FeatureResult, error)
+	GetMovedWebFeatureDetailsByOriginalFeatureKey(
+		ctx context.Context,
+		featureKey string,
+	) (*gcpspanner.MovedWebFeature, error)
+	GetSplitWebFeatureByOriginalFeatureKey(
+		ctx context.Context,
+		featureKey string,
+	) (*gcpspanner.SplitWebFeature, error)
 	GetIDFromFeatureKey(
 		ctx context.Context,
 		filter *gcpspanner.FeatureIDFilter,
@@ -1059,14 +1067,49 @@ func (s *Backend) GetFeature(
 	browsers []backend.BrowserPathParam,
 ) (*backendtypes.GetFeatureResult, error) {
 	filter := gcpspanner.NewFeatureKeyFilter(featureID)
-	featureResult, err := s.client.GetFeature(ctx, filter, getSpannerWPTMetricView(wptMetricView),
-		BrowserList(browsers).ToStringList())
-	if err != nil {
+	featureResult, err := s.client.GetFeature(
+		ctx, filter, getSpannerWPTMetricView(wptMetricView), BrowserList(browsers).ToStringList())
+	if err == nil {
+		return backendtypes.NewGetFeatureResult(
+			backendtypes.NewRegularFeatureResult(s.convertFeatureResult(featureResult))), nil
+	}
+
+	if !errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {
 		return nil, err
 	}
 
-	return backendtypes.NewGetFeatureResult(
-		backendtypes.NewRegularFeatureResult(s.convertFeatureResult(featureResult))), nil
+	// If the feature is not found, check if it has been moved.
+	movedFeatureResult, err := s.client.GetMovedWebFeatureDetailsByOriginalFeatureKey(ctx, featureID)
+	if err == nil {
+		return backendtypes.NewGetFeatureResult(
+			backendtypes.NewMovedFeatureResult(movedFeatureResult.NewFeatureKey)), nil
+	}
+	if !errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {
+		return nil, err
+	}
+
+	// If the feature is not found and not moved, check if it has been split.
+	splitFeatureResult, err := s.client.GetSplitWebFeatureByOriginalFeatureKey(ctx, featureID)
+	if err == nil {
+		features := make([]backend.FeatureSplitInfo, 0, len(splitFeatureResult.TargetFeatureKeys))
+		for _, feature := range splitFeatureResult.TargetFeatureKeys {
+			features = append(features, backend.FeatureSplitInfo{
+				Id: feature,
+			})
+		}
+
+		return backendtypes.NewGetFeatureResult(
+			backendtypes.NewSplitFeatureResult(backend.FeatureEvolutionSplit{
+				Features: features,
+			}),
+		), nil
+	}
+	if !errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {
+		return nil, err
+	}
+
+	// If the feature is not found, not moved, and not split, then it does not exist in the database.
+	return nil, errors.Join(err, backendtypes.ErrEntityDoesNotExist)
 }
 
 func (s *Backend) GetIDFromFeatureKey(

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -64,6 +64,18 @@ type mockGetIDByFeaturesIDConfig struct {
 	returnedError      error
 }
 
+type mockGetMovedWebFeatureDetailsByOriginalFeatureKeyConfig struct {
+	expectedFeatureKey string
+	result             *gcpspanner.MovedWebFeature
+	returnedError      error
+}
+
+type mockGetSplitWebFeatureByOriginalFeatureKeyConfig struct {
+	expectedFeatureKey string
+	result             *gcpspanner.SplitWebFeature
+	returnedError      error
+}
+
 type mockListBrowserFeatureCountMetricConfig struct {
 	result        *gcpspanner.BrowserFeatureCountResultPage
 	returnedError error
@@ -146,6 +158,31 @@ type mockBackendSpannerClient struct {
 	mockDeleteUserSearchBookmarkCfg      *mockDeleteUserSearchBookmarkConfig
 	pageToken                            *string
 	err                                  error
+
+	mockGetMovedWebFeatureDetailsByOriginalFeatureKeyCfg *mockGetMovedWebFeatureDetailsByOriginalFeatureKeyConfig
+	mockGetSplitWebFeatureByOriginalFeatureKeyCfg        *mockGetSplitWebFeatureByOriginalFeatureKeyConfig
+}
+
+// GetMovedWebFeatureDetailsByOriginalFeatureKey implements BackendSpannerClient.
+func (c mockBackendSpannerClient) GetMovedWebFeatureDetailsByOriginalFeatureKey(
+	_ context.Context, featureKey string) (*gcpspanner.MovedWebFeature, error) {
+	if featureKey != c.mockGetMovedWebFeatureDetailsByOriginalFeatureKeyCfg.expectedFeatureKey {
+		c.t.Errorf("unexpected input to mock: %s", featureKey)
+	}
+
+	return c.mockGetMovedWebFeatureDetailsByOriginalFeatureKeyCfg.result,
+		c.mockGetMovedWebFeatureDetailsByOriginalFeatureKeyCfg.returnedError
+}
+
+// GetSplitWebFeatureByOriginalFeatureKey implements BackendSpannerClient.
+func (c mockBackendSpannerClient) GetSplitWebFeatureByOriginalFeatureKey(
+	_ context.Context, featureKey string) (*gcpspanner.SplitWebFeature, error) {
+	if featureKey != c.mockGetSplitWebFeatureByOriginalFeatureKeyCfg.expectedFeatureKey {
+		c.t.Errorf("unexpected input to mock: %s", featureKey)
+	}
+
+	return c.mockGetSplitWebFeatureByOriginalFeatureKeyCfg.result,
+		c.mockGetSplitWebFeatureByOriginalFeatureKeyCfg.returnedError
 }
 
 // AddUserSearchBookmark implements BackendSpannerClient.
@@ -199,7 +236,7 @@ func (c mockBackendSpannerClient) GetFeature(
 		c.t.Error("unexpected input to mock")
 	}
 
-	return c.mockGetFeatureCfg.result, c.mockFeaturesSearchCfg.returnedError
+	return c.mockGetFeatureCfg.result, c.mockGetFeatureCfg.returnedError
 }
 
 func (c mockBackendSpannerClient) GetIDFromFeatureKey(
@@ -1484,10 +1521,12 @@ func TestGetFeature(t *testing.T) {
 		}
 	)
 	testCases := []struct {
-		name          string
-		cfg           mockGetFeatureConfig
-		visitor       func(t *testing.T) backendtypes.FeatureResultVisitor
-		expectedError error
+		name            string
+		cfg             mockGetFeatureConfig
+		movedFeatureCfg *mockGetMovedWebFeatureDetailsByOriginalFeatureKeyConfig
+		splitFeatureCfg *mockGetSplitWebFeatureByOriginalFeatureKeyConfig
+		visitor         func(t *testing.T) backendtypes.FeatureResultVisitor
+		expectedError   error
 	}{
 		{
 			name: "regular",
@@ -1535,6 +1574,8 @@ func TestGetFeature(t *testing.T) {
 				},
 				returnedError: nil,
 			},
+			splitFeatureCfg: nil,
+			movedFeatureCfg: nil,
 			visitor: func(t *testing.T) backendtypes.FeatureResultVisitor {
 				return &TestRegularFeatureVisitor{
 					t: t,
@@ -1595,6 +1636,106 @@ func TestGetFeature(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		{
+			name: "moved",
+			cfg: mockGetFeatureConfig{
+				expectedFilterable:    gcpspanner.NewFeatureKeyFilter("feature1"),
+				expectedWPTMetricView: gcpspanner.WPTSubtestView,
+				expectedBrowsers: []string{
+					"browser1",
+					"browser2",
+					"browser3",
+				},
+				result:        nil,
+				returnedError: gcpspanner.ErrQueryReturnedNoResults,
+			},
+			splitFeatureCfg: nil,
+			movedFeatureCfg: &mockGetMovedWebFeatureDetailsByOriginalFeatureKeyConfig{
+				expectedFeatureKey: "feature1",
+				result: &gcpspanner.MovedWebFeature{
+					OriginalFeatureKey: "feature1",
+					NewFeatureKey:      "feature2",
+				},
+				returnedError: nil,
+			},
+			visitor: func(t *testing.T) backendtypes.FeatureResultVisitor {
+				return &TestMovedFeatureVisitor{
+					t:        t,
+					expected: *backendtypes.NewMovedFeatureResult("feature2"),
+				}
+			},
+			expectedError: nil,
+		},
+		{
+			name: "split",
+			cfg: mockGetFeatureConfig{
+				expectedFilterable:    gcpspanner.NewFeatureKeyFilter("feature1"),
+				expectedWPTMetricView: gcpspanner.WPTSubtestView,
+				expectedBrowsers: []string{
+					"browser1",
+					"browser2",
+					"browser3",
+				},
+				result:        nil,
+				returnedError: gcpspanner.ErrQueryReturnedNoResults,
+			},
+			splitFeatureCfg: &mockGetSplitWebFeatureByOriginalFeatureKeyConfig{
+				expectedFeatureKey: "feature1",
+				result: &gcpspanner.SplitWebFeature{
+					OriginalFeatureKey: "feature1",
+					TargetFeatureKeys:  []string{"feature2", "feature3"},
+				},
+				returnedError: nil,
+			},
+			movedFeatureCfg: &mockGetMovedWebFeatureDetailsByOriginalFeatureKeyConfig{
+				expectedFeatureKey: "feature1",
+				result:             nil,
+				returnedError:      gcpspanner.ErrQueryReturnedNoResults,
+			},
+			visitor: func(t *testing.T) backendtypes.FeatureResultVisitor {
+				return &TestSplitFeatureVisitor{
+					t: t,
+					expected: *backendtypes.NewSplitFeatureResult(
+						backend.FeatureEvolutionSplit{
+							Features: []backend.FeatureSplitInfo{
+								{Id: "feature2"},
+								{Id: "feature3"},
+							},
+						},
+					),
+				}
+			},
+			expectedError: nil,
+		},
+		{
+			name: "feature not found",
+			cfg: mockGetFeatureConfig{
+				expectedFilterable:    gcpspanner.NewFeatureKeyFilter("feature1"),
+				expectedWPTMetricView: gcpspanner.WPTSubtestView,
+				expectedBrowsers: []string{
+					"browser1",
+					"browser2",
+					"browser3",
+				},
+				result:        nil,
+				returnedError: gcpspanner.ErrQueryReturnedNoResults,
+			},
+			splitFeatureCfg: &mockGetSplitWebFeatureByOriginalFeatureKeyConfig{
+				expectedFeatureKey: "feature1",
+				result: &gcpspanner.SplitWebFeature{
+					OriginalFeatureKey: "feature1",
+					TargetFeatureKeys:  []string{"feature2", "feature3"},
+				},
+				returnedError: gcpspanner.ErrQueryReturnedNoResults,
+			},
+			movedFeatureCfg: &mockGetMovedWebFeatureDetailsByOriginalFeatureKeyConfig{
+				expectedFeatureKey: "feature1",
+				result:             nil,
+				returnedError:      gcpspanner.ErrQueryReturnedNoResults,
+			},
+			visitor:       nil,
+			expectedError: backendtypes.ErrEntityDoesNotExist,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1602,6 +1743,8 @@ func TestGetFeature(t *testing.T) {
 			mock := mockBackendSpannerClient{
 				t:                 t,
 				mockGetFeatureCfg: tc.cfg,
+				mockGetMovedWebFeatureDetailsByOriginalFeatureKeyCfg: tc.movedFeatureCfg,
+				mockGetSplitWebFeatureByOriginalFeatureKeyCfg:        tc.splitFeatureCfg,
 			}
 			bk := NewBackend(mock)
 			feature, err := bk.GetFeature(
@@ -1617,7 +1760,6 @@ func TestGetFeature(t *testing.T) {
 			if err != nil {
 				t.Error("unexpected error")
 			}
-
 		})
 	}
 }
@@ -1646,6 +1788,62 @@ func (v *TestRegularFeatureVisitor) VisitMovedFeature(_ context.Context, actual 
 
 func (v *TestRegularFeatureVisitor) VisitSplitFeature(_ context.Context, actual backendtypes.SplitFeatureResult) error {
 	v.t.Errorf("VisitSplitFeature called unexpectedly for a RegularFeature test. Actual: %+v", actual)
+
+	return nil
+}
+
+// TestMovedFeatureVisitor expects a MovedFeatureResult and compares it.
+// Other Visit methods will cause an error.
+type TestMovedFeatureVisitor struct {
+	t        *testing.T
+	expected backendtypes.MovedFeatureResult
+}
+
+func (v *TestMovedFeatureVisitor) VisitMovedFeature(_ context.Context, actual backendtypes.MovedFeatureResult) error {
+	if !reflect.DeepEqual(v.expected, actual) {
+		v.t.Errorf("MovedFeature mismatch:\nExpected: %+v\nActual:   %+v", v.expected, actual)
+	}
+
+	return nil
+}
+
+func (v *TestMovedFeatureVisitor) VisitRegularFeature(_ context.Context,
+	actual backendtypes.RegularFeatureResult) error {
+	v.t.Errorf("VisitRegularFeature called unexpectedly for a MovedFeature test. Actual: %+v", actual)
+
+	return nil
+}
+
+func (v *TestMovedFeatureVisitor) VisitSplitFeature(_ context.Context, actual backendtypes.SplitFeatureResult) error {
+	v.t.Errorf("VisitSplitFeature called unexpectedly for a MovedFeature test. Actual: %+v", actual)
+
+	return nil
+}
+
+// TestSplitFeatureVisitor expects a SplitFeatureResult and compares it.
+// Other Visit methods will cause an error.
+type TestSplitFeatureVisitor struct {
+	t        *testing.T
+	expected backendtypes.SplitFeatureResult
+}
+
+func (v *TestSplitFeatureVisitor) VisitSplitFeature(_ context.Context, actual backendtypes.SplitFeatureResult) error {
+	if !reflect.DeepEqual(v.expected, actual) {
+		v.t.Errorf("SplitFeature mismatch:\nExpected: %+v\nActual:   %+v", v.expected, actual)
+	}
+
+	return nil
+}
+
+func (v *TestSplitFeatureVisitor) VisitRegularFeature(_ context.Context,
+	actual backendtypes.RegularFeatureResult) error {
+	v.t.Errorf("VisitRegularFeature called unexpectedly for a SplitFeature test. Actual: %+v", actual)
+
+	return nil
+}
+
+func (v *TestSplitFeatureVisitor) VisitMovedFeature(_ context.Context, actual backendtypes.MovedFeatureResult) error {
+	v.t.Errorf("VisitMovedFeature called unexpectedly for a SplitFeature test. Actual: %+v", actual)
 
 	return nil
 }


### PR DESCRIPTION
This commit updates the Spanner backend adapter to handle cases where a feature has evolved by being moved or split. The `GetFeature` function is now responsible for orchestrating the lookup logic to determine the feature's current state.

The function implements a sequential lookup process:
1.  It first attempts to fetch the feature as a standard entry.
2.  If the feature is not found (`ErrQueryReturnedNoResults`), it subsequently queries for a "moved" record associated with the feature key.
3.  If still not found, it performs a final query for a "split" record.

To communicate the result of this process, the function's signature now returns a `*backendtypes.GetFeatureResult`, which uses the visitor pattern. This allows the calling layer (the HTTP server) to cleanly handle the three distinct outcomes: `RegularFeature`, `MovedFeature`, and `SplitFeature`.

The `BackendSpannerClient` interface is extended with new methods to fetch moved and split feature details, and the corresponding tests have been refactored to verify each scenario using mock visitors for result assertion.

Split up of #1706