### PR TITLE
feat(metrics): Store all UMA metrics regardless of feature mapping

### DIFF
--- a/lib/gcpspanner/client.go
+++ b/lib/gcpspanner/client.go
@@ -59,12 +59,6 @@ var (
 	// ErrUsageMetricUpsertNoHistogramFound indicates that the chromium histogram metric
 	// was not found when attempting to upsert a usage metric.
 	ErrUsageMetricUpsertNoHistogramFound = errors.New("histogram not found when upserting usage metric")
-
-	// ErrUsageMetricUpsertNoHistogramEnumFound indicates that the chromium histogram enum
-	// was not found when attempting to upsert a usage metric. This typically occurs when
-	// the histogram name associated with the metric is not found, possibly due to
-	// a draft or obsolete feature for which the corresponding enum ID has not been created.
-	ErrUsageMetricUpsertNoHistogramEnumFound = errors.New("histogram enum not found when upserting usage metric")
 )
 
 // entitySynchronizer specific errors.

--- a/lib/gcpspanner/daily_chromium_histogram_metrics.go
+++ b/lib/gcpspanner/daily_chromium_histogram_metrics.go
@@ -19,12 +19,10 @@ import (
 	"errors"
 	"log/slog"
 	"math/big"
-	"time"
 
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
 	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
-	"google.golang.org/api/iterator"
 )
 
 const dailyChromiumHistogramMetricsTable = "DailyChromiumHistogramMetrics"
@@ -46,179 +44,162 @@ type spannerDailyChromiumHistogramMetric struct {
 	ChromiumHistogramEnumValueID string `spanner:"ChromiumHistogramEnumValueID"`
 }
 
-// getLatestDailyChromiumMetricDate retrieves the Date of the latest usage stats for the given feature.
-func getLatestDailyChromiumMetricDate(
-	ctx context.Context,
-	txn *spanner.ReadWriteTransaction,
-	chromiumHistogramEnumValueID string) (*civil.Date, error) {
-	stmt := spanner.NewStatement(`
-        SELECT
-			dchm.Day as Date
-        FROM LatestDailyChromiumHistogramMetrics l
-        JOIN DailyChromiumHistogramMetrics dchm
-		ON l.ChromiumHistogramEnumValueID = dchm.ChromiumHistogramEnumValueID
-        WHERE l.ChromiumHistogramEnumValueID = @chromiumHistogramEnumValueID`)
-
-	stmt.Params = map[string]interface{}{
-		"chromiumHistogramEnumValueID": chromiumHistogramEnumValueID,
-	}
-
-	iter := txn.Query(ctx, stmt)
-	defer iter.Stop()
-
-	row, err := iter.Next()
-	if err != nil {
-		if errors.Is(err, iterator.Done) {
-			// No row found, return zero time
-			zeroTime := time.Time{}
-			zeroDate := civil.DateOf(zeroTime)
-
-			return &zeroDate, errors.Join(ErrQueryReturnedNoResults, err)
-		}
-		slog.ErrorContext(ctx, "error querying for latest run time", "error", err)
-
-		return nil, err
-	}
-
-	var date civil.Date
-	if err := row.Columns(&date); err != nil {
-		slog.ErrorContext(ctx, "error extracting date", "error", err)
-
-		return nil, err
-	}
-
-	return &date, nil
-}
-
-func getWebFeatureIDByChromiumHistogramEnumValueID(
-	ctx context.Context,
-	txn *spanner.ReadWriteTransaction,
-	chromiumHistogramEnumValueID string) (*string, error) {
-	stmt := spanner.NewStatement(`
-		SELECT
-			WebFeatureID
-		FROM WebFeatureChromiumHistogramEnumValues
-		WHERE chromiumHistogramEnumValueID = @chromiumHistogramEnumValueID`)
-
-	stmt.Params = map[string]interface{}{
-		"chromiumHistogramEnumValueID": chromiumHistogramEnumValueID,
-	}
-
-	iter := txn.Query(ctx, stmt)
-	defer iter.Stop()
-
-	row, err := iter.Next()
-	if err != nil {
-		if errors.Is(err, iterator.Done) {
-			return nil, errors.Join(ErrQueryReturnedNoResults, err)
-		}
-		slog.ErrorContext(ctx, "error querying for web feature ID", "error", err)
-
-		return nil, err
-	}
-	var featureID string
-	if err := row.Columns(&featureID); err != nil {
-		slog.ErrorContext(ctx, "error extracting date", "error", err)
-
-		return nil, err
-	}
-
-	return &featureID, nil
-}
-
-// shouldUpsertLatestDailyChromiumUsageMetric determines whether the latest metric should be upserted based on
-// date comparison.
-func shouldUpsertLatestDailyChromiumUsageMetric(existingDate *civil.Date, newDate civil.Date) bool {
-	return existingDate == nil || existingDate.IsZero() || newDate.After(*existingDate)
-}
-
-// UpsertDailyChromiumHistogramMetric upserts a daily chromium histogram metric.
-//
-// Errors:
-//   - ErrQueryReturnedNoResults: If the histogram key or value ID is not found.
-//   - ErrInternalQueryFailure: If any internal query fails during the process.
-//   - ErrUsageMetricUpsertNoFeatureIDFound: If no feature ID is found while
-//     attempting to upsert the latest daily chromium usage metric.
-//   - ErrUsageMetricUpsertNoHistogramFound: If the histogram is not found
-//   - ErrUsageMetricUpsertNoHistogramEnumFound: If a particular enum in the histogram is not found.
-func (c *Client) UpsertDailyChromiumHistogramMetric(
+// StoreDailyChromiumHistogramMetrics stores a slice of daily chromium histogram metrics in a bulk insert.
+func (c *Client) StoreDailyChromiumHistogramMetrics(
 	ctx context.Context,
 	histogramName metricdatatypes.HistogramName,
-	bucketID int64,
-	metric DailyChromiumHistogramMetric) error {
-	// TODO: When we have a generic way to do batch upserts, change this to accept an array of metrics.
+	metrics map[int64]DailyChromiumHistogramMetric) error {
 	chromiumHistogramEnumID, err := c.GetIDFromChromiumHistogramKey(ctx, string(histogramName))
 	if err != nil {
 		slog.ErrorContext(ctx, "unable to find histogram key id from histogram name", "name", string(histogramName))
 
 		return errors.Join(err, ErrUsageMetricUpsertNoHistogramFound)
 	}
-	chromiumHistogramEnumValueID, err := c.GetIDFromChromiumHistogramEnumValueKey(
-		ctx, *chromiumHistogramEnumID, bucketID)
-	if err != nil {
-		if errors.Is(err, ErrQueryReturnedNoResults) {
-			slog.WarnContext(ctx, "unable to find histogram value id. likely a draft or obsolete feature. will skip",
-				"id", *chromiumHistogramEnumID,
-				"bucketID", bucketID)
 
-			return errors.Join(err, ErrUsageMetricUpsertNoHistogramEnumFound)
+	producerFn := func(metricChan chan<- spannerDailyChromiumHistogramMetric) {
+		for bucketID, metric := range metrics {
+			chromiumHistogramEnumValueID, err := c.GetIDFromChromiumHistogramEnumValueKey(
+				ctx, *chromiumHistogramEnumID, bucketID)
+			if err != nil {
+				slog.WarnContext(ctx, "unable to find histogram value id. likely a draft or obsolete feature. will skip",
+					"id", *chromiumHistogramEnumID,
+					"bucketID", bucketID)
+
+				continue
+			}
+			metricChan <- spannerDailyChromiumHistogramMetric{
+				DailyChromiumHistogramMetric: metric,
+				ChromiumHistogramEnumValueID: *chromiumHistogramEnumValueID,
+			}
 		}
+	}
 
-		slog.ErrorContext(ctx, "unable to find histogram value id",
-			"id", *chromiumHistogramEnumID,
-			"bucketID", bucketID)
+	toMutationFn := func(m spannerDailyChromiumHistogramMetric) (*spanner.Mutation, error) {
+		return spanner.InsertOrUpdateStruct(dailyChromiumHistogramMetricsTable, m)
+	}
 
+	return runConcurrentBatch(ctx, c, producerFn, dailyChromiumHistogramMetricsTable, toMutationFn)
+}
+
+// Implements the syncableEntityMapper interface for WebFeature and SpannerLatestDailyChromiumHistogramMetric.
+type latestDailyChromiumHistogramMetricMapper struct{}
+
+// Key for the latestDailyChromiumHistogramMetricMapper.
+type latestDailyChromiumHistogramMetricKey struct {
+	WebFeatureID                 string
+	ChromiumHistogramEnumValueID string
+}
+
+// Table returns the name of the Spanner table.
+func (m latestDailyChromiumHistogramMetricMapper) Table() string {
+	return LatestDailyChromiumHistogramMetricsTable
+}
+
+// SelectAll returns a statement to select all LatestDailyChromiumHistogramMetrics.
+func (m latestDailyChromiumHistogramMetricMapper) SelectAll() spanner.Statement {
+	return spanner.NewStatement(`
+		SELECT
+			WebFeatureID, ChromiumHistogramEnumValueID, Day
+		FROM LatestDailyChromiumHistogramMetrics`)
+}
+
+// GetKeyFromExternal returns the business key from an external struct.
+func (m latestDailyChromiumHistogramMetricMapper) GetKeyFromExternal(
+	in SpannerLatestDailyChromiumHistogramMetric) latestDailyChromiumHistogramMetricKey {
+	return latestDailyChromiumHistogramMetricKey{in.WebFeatureID, in.ChromiumHistogramEnumValueID}
+}
+
+// GetKeyFromInternal returns the business key from an internal Spanner struct.
+func (m latestDailyChromiumHistogramMetricMapper) GetKeyFromInternal(
+	in SpannerLatestDailyChromiumHistogramMetric) latestDailyChromiumHistogramMetricKey {
+	return latestDailyChromiumHistogramMetricKey{in.WebFeatureID, in.ChromiumHistogramEnumValueID}
+}
+
+// MergeAndCheckChanged will merge the entity and return if the entity has changed.
+func (m latestDailyChromiumHistogramMetricMapper) MergeAndCheckChanged(
+	in SpannerLatestDailyChromiumHistogramMetric,
+	existing SpannerLatestDailyChromiumHistogramMetric,
+) (SpannerLatestDailyChromiumHistogramMetric, bool) {
+	merged := SpannerLatestDailyChromiumHistogramMetric{
+		WebFeatureID:                 existing.WebFeatureID,
+		ChromiumHistogramEnumValueID: existing.ChromiumHistogramEnumValueID,
+		Day:                          in.Day,
+	}
+
+	hasChanged := merged.Day != existing.Day
+
+	return merged, hasChanged
+}
+
+// GetChildDeleteKeyMutations is a no-op for this table.
+func (m latestDailyChromiumHistogramMetricMapper) GetChildDeleteKeyMutations(
+	_ context.Context,
+	_ *Client,
+	_ []SpannerLatestDailyChromiumHistogramMetric,
+) ([]ChildDeleteKeyMutations, error) {
+	return nil, nil
+}
+
+// DeleteMutation creates a Spanner delete mutation.
+func (m latestDailyChromiumHistogramMetricMapper) DeleteMutation(
+	in SpannerLatestDailyChromiumHistogramMetric) *spanner.Mutation {
+	return spanner.Delete(LatestDailyChromiumHistogramMetricsTable,
+		spanner.Key{in.WebFeatureID, in.ChromiumHistogramEnumValueID})
+}
+
+// SyncLatestDailyChromiumHistogramMetrics reconciles the LatestDailyChromiumHistogramMetrics table.
+func (c *Client) SyncLatestDailyChromiumHistogramMetrics(ctx context.Context) error {
+	slog.InfoContext(ctx, "Starting latest daily chromium histogram metrics synchronization")
+	synchronizer := newEntitySynchronizer[latestDailyChromiumHistogramMetricMapper,
+		SpannerLatestDailyChromiumHistogramMetric,
+		SpannerLatestDailyChromiumHistogramMetric,
+		latestDailyChromiumHistogramMetricKey](c)
+
+	desiredState, err := c.getDesiredLatestDailyChromiumHistogramMetrics(ctx)
+	if err != nil {
 		return err
 	}
 
-	_, err = c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
-		var mutations []*spanner.Mutation
-		m0, err := spanner.InsertOrUpdateStruct(
-			dailyChromiumHistogramMetricsTable,
-			spannerDailyChromiumHistogramMetric{
-				DailyChromiumHistogramMetric: metric,
-				ChromiumHistogramEnumValueID: *chromiumHistogramEnumValueID,
-			})
-		if err != nil {
+	return synchronizer.Sync(ctx, desiredState)
+}
+
+func (c *Client) getDesiredLatestDailyChromiumHistogramMetrics(
+	ctx context.Context) ([]SpannerLatestDailyChromiumHistogramMetric, error) {
+	txn := c.ReadOnlyTransaction()
+	defer txn.Close()
+
+	stmt := spanner.NewStatement(`
+		WITH LatestMetrics AS (
+			SELECT
+				ChromiumHistogramEnumValueID,
+				MAX(Day) AS MaxDay
+			FROM DailyChromiumHistogramMetrics
+			GROUP BY ChromiumHistogramEnumValueID
+		)
+		SELECT
+			w.WebFeatureID,
+			w.ChromiumHistogramEnumValueID,
+			l.MaxDay AS Day
+		FROM WebFeatureChromiumHistogramEnumValues w
+		JOIN LatestMetrics l ON w.ChromiumHistogramEnumValueID = l.ChromiumHistogramEnumValueID
+	`)
+
+	iter := txn.Query(ctx, stmt)
+	defer iter.Stop()
+
+	var desiredState []SpannerLatestDailyChromiumHistogramMetric
+	err := iter.Do(func(r *spanner.Row) error {
+		var metric SpannerLatestDailyChromiumHistogramMetric
+		if err := r.ToStruct(&metric); err != nil {
 			return err
 		}
-		mutations = append(mutations, m0)
-
-		existingDate, err := getLatestDailyChromiumMetricDate(ctx, txn, *chromiumHistogramEnumValueID)
-		if err != nil {
-			if !errors.Is(err, ErrQueryReturnedNoResults) { // Handle errors other than "not found"
-				return errors.Join(ErrInternalQueryFailure, err)
-			}
-		}
-
-		if shouldUpsertLatestDailyChromiumUsageMetric(existingDate, metric.Day) {
-			featureID, err := getWebFeatureIDByChromiumHistogramEnumValueID(ctx, txn, *chromiumHistogramEnumValueID)
-			if err != nil {
-				if errors.Is(err, ErrQueryReturnedNoResults) {
-					return errors.Join(err, ErrUsageMetricUpsertNoFeatureIDFound)
-				}
-
-				return errors.Join(ErrInternalQueryFailure, err)
-			}
-			m1, err := spanner.InsertOrUpdateStruct(
-				LatestDailyChromiumHistogramMetricsTable,
-				SpannerLatestDailyChromiumHistogramMetric{
-					WebFeatureID:                 *featureID,
-					ChromiumHistogramEnumValueID: *chromiumHistogramEnumValueID,
-					Day:                          metric.Day,
-				})
-			if err != nil {
-				return errors.Join(ErrInternalQueryFailure, err)
-			}
-			mutations = append(mutations, m1)
-		}
-		err = txn.BufferWrite(mutations)
-		if err != nil {
-			return errors.Join(ErrInternalQueryFailure, err)
-		}
+		desiredState = append(desiredState, metric)
 
 		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
 
-	return err
+	return desiredState, nil
 }

--- a/lib/gcpspanner/daily_chromium_histogram_metrics_test.go
+++ b/lib/gcpspanner/daily_chromium_histogram_metrics_test.go
@@ -8,7 +8,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES, OR CONDITIONS OF ANY KIND, either express or implied.
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
@@ -405,13 +405,6 @@ func TestStoreAndSyncDailyChromiumHistogramMetric(t *testing.T) {
 				bucketID:      0,
 				expectedError: ErrUsageMetricUpsertNoHistogramFound,
 			},
-			// This test case is no longer valid because we don't check for the enum value at this level.
-			// {
-			// 	name:          "bad histogram bucket id",
-			// 	histogram:     metricdatatypes.WebDXFeatureEnum,
-			// 	bucketID:      0,
-			// 	expectedError: ErrUsageMetricUpsertNoHistogramEnumFound,
-			// },
 		}
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
@@ -465,7 +458,8 @@ func TestSyncLatestDailyChromiumHistogramMetric_Deletes(t *testing.T) {
 
 	// 3. Trigger a deletion by calling the high-level DeleteWebFeature function.
 	// This should handle the cascade correctly, as verified in other tests.
-	featureIDToDelete := idMap["ViewTransitions"]
+	// feature2 matches to ViewTransitions enum label.
+	featureIDToDelete := idMap["feature2"]
 	err = spannerClient.DeleteWebFeature(ctx, featureIDToDelete)
 	if err != nil {
 		t.Fatalf("failed to delete WebFeature: %s", err.Error())

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -8,7 +8,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES, OR CONDITIONS OF ANY KIND, either express or implied.
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -8,7 +8,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// WITHOUT WARRANTIES, OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
@@ -711,6 +711,11 @@ func addSampleChromiumUsageMetricsData(ctx context.Context,
 		},
 	}
 	insertTestDailyChromiumHistogramMetrics(ctx, client, t, sampleDailyChromiumHistogramMetrics)
+
+	err := client.SyncLatestDailyChromiumHistogramMetrics(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error during sync. %s", err.Error())
+	}
 }
 
 func defaultSorting() Sortable {
@@ -1730,7 +1735,7 @@ func testFeatureAvailableBrowserDateFilters(ctx context.Context, t *testing.T, c
 				Keyword: searchtypes.KeywordAND,
 				Term:    nil,
 				Children: []*searchtypes.SearchNode{
-					{ // startDateNode
+					{
 						Keyword: searchtypes.KeywordNone,
 						Term: &searchtypes.SearchTerm{
 							Identifier: searchtypes.IdentifierAvailableBrowserDate,
@@ -1758,7 +1763,7 @@ func testFeatureAvailableBrowserDateFilters(ctx context.Context, t *testing.T, c
 							},
 						},
 					},
-					{ // endDateNode
+					{
 						Keyword: searchtypes.KeywordNone,
 						Term: &searchtypes.SearchTerm{
 							Identifier: searchtypes.IdentifierAvailableBrowserDate,

--- a/lib/gcpspanner/web_features_fk_test.go
+++ b/lib/gcpspanner/web_features_fk_test.go
@@ -197,17 +197,24 @@ func (w *webFeatureForeignKeyTestHelpers) insertWebFeatureChromiumHistogramData(
 		t.Errorf("unexpected error during insert. %s", err.Error())
 	}
 
-	err = spannerClient.UpsertDailyChromiumHistogramMetric(ctx,
-		metricdatatypes.HistogramName(histogramName), bucketID, DailyChromiumHistogramMetric{
-			Day: civil.Date{
-				Year:  2000,
-				Day:   1,
-				Month: time.January,
+	err = spannerClient.StoreDailyChromiumHistogramMetrics(
+		ctx,
+		metricdatatypes.HistogramName(histogramName),
+		map[int64]DailyChromiumHistogramMetric{
+			bucketID: {
+				Day: civil.Date{
+					Year: 2000, Day: 1, Month: time.January,
+				},
+				Rate: *big.NewRat(91, 100),
 			},
-			Rate: *big.NewRat(91, 100),
 		})
 	if err != nil {
 		t.Errorf("unexpected error during insert. %s", err.Error())
+	}
+
+	err = spannerClient.SyncLatestDailyChromiumHistogramMetrics(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error during sync. %s", err.Error())
 	}
 
 	// Insert WebFeatureChromiumHistogramEnumValue

--- a/util/cmd/load_fake_data/main.go
+++ b/util/cmd/load_fake_data/main.go
@@ -912,15 +912,16 @@ func generateChromiumHistogramMetrics(
 				usage = big.NewRat(r.Int63n(10000), 10000) // Generate usage between 0-100%
 			}
 
-			err := client.UpsertDailyChromiumHistogramMetric(
+			err := client.StoreDailyChromiumHistogramMetrics(
 				ctx,
-				metricdatatypes.WebDXFeatureEnum,
-				int64(i+1),
-				gcpspanner.DailyChromiumHistogramMetric{
-					Day:  civil.DateOf(currDate),
-					Rate: *usage,
+				metricdatatypes.WebDXFeatureEnum, map[int64]gcpspanner.DailyChromiumHistogramMetric{
+					int64(i + 1): {
+						Day:  civil.DateOf(currDate),
+						Rate: *usage,
+					},
 				},
 			)
+
 			if err != nil {
 				return metricsCount, err
 			}

--- a/util/cmd/load_fake_data/main.go
+++ b/util/cmd/load_fake_data/main.go
@@ -935,6 +935,11 @@ func generateChromiumHistogramMetrics(
 		}
 	}
 
+	err := client.SyncLatestDailyChromiumHistogramMetrics(ctx)
+	if err != nil {
+		return metricsCount, err
+	}
+
 	return metricsCount, nil
 }
 


### PR DESCRIPTION
Previously, the UMA metric consumer would only store histogram metrics that could be successfully mapped to an existing web feature ID. This meant that metrics for new or unmapped features were discarded.

This change modifies the data ingestion logic to ensure all metrics are saved:

1.  All histogram metrics for a given day are now unconditionally saved to the `DailyChromiumHistogramMetrics` table.
2.  A separate step then attempts to associate these metrics with known web features in the `FeatureChromiumHistogramMetrics` table.
3.  The `LatestFeatureChromiumHistogramMetrics` table is now updated using a synchronization operation, ensuring it accurately reflects the latest data and handles removals correctly.

This separation makes the data ingestion more robust, preventing data loss and allowing feature mappings to be corrected in the future without losing historical metric data.

Fixes #1731 