### PR TITLE
feat: Add support for moved and split web features

### DIFF
--- a/infra/storage/spanner/migrations/000020.sql
+++ b/infra/storage/spanner/migrations/000020.sql
@@ -1,0 +1,31 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE TABLE IF NOT EXISTS MovedWebFeatures (
+    ID STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
+    OriginalFeatureKey STRING(64) NOT NULL, -- From web features repo.
+    TargetWebFeatureID STRING(36) NOT NULL, -- From web features repo.
+    -- Additional lowercase columns for case-insensitive search
+    OriginalFeatureKey_Lowercase STRING(64) AS (LOWER(OriginalFeatureKey)) STORED,
+    CONSTRAINT FK_MovedWebFeaturesTargetWebFeatureID FOREIGN KEY (TargetWebFeatureID) REFERENCES WebFeatures(ID) ON DELETE CASCADE,
+) PRIMARY KEY (ID);
+
+CREATE TABLE IF NOT EXISTS SplitWebFeatures (
+    ID STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
+    OriginalFeatureKey STRING(64) NOT NULL, -- From web features repo.
+    TargetWebFeatureID STRING(36) NOT NULL, -- From web features repo.
+    -- Additional lowercase columns for case-insensitive search
+    OriginalFeatureKey_Lowercase STRING(64) AS (LOWER(OriginalFeatureKey)) STORED,
+    CONSTRAINT FK_SplitWebFeatures_TargetWebFeatureID FOREIGN KEY (TargetWebFeatureID) REFERENCES WebFeatures(ID) ON DELETE CASCADE,
+) PRIMARY KEY (ID);

--- a/lib/gcpspanner/moved_web_features_test.go
+++ b/lib/gcpspanner/moved_web_features_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestSyncMovedWebFeatures(t *testing.T) {
+	ctx := context.Background()
+
+	type testCase struct {
+		name          string
+		initial       []MovedWebFeature
+		sync          []MovedWebFeature
+		expected      []MovedWebFeature
+		expectedError error
+	}
+
+	testCases := []testCase{
+		{
+			name:    "initial sync",
+			initial: []MovedWebFeature{},
+			sync: []MovedWebFeature{
+				{OriginalFeatureKey: "feature-a", NewFeatureKey: "feature-b"},
+				{OriginalFeatureKey: "feature-c", NewFeatureKey: "feature-d"},
+			},
+			expected: []MovedWebFeature{
+				{OriginalFeatureKey: "feature-a", NewFeatureKey: "feature-b"},
+				{OriginalFeatureKey: "feature-c", NewFeatureKey: "feature-d"},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "delete",
+			initial: []MovedWebFeature{
+				{OriginalFeatureKey: "feature-a", NewFeatureKey: "feature-b"},
+				{OriginalFeatureKey: "feature-c", NewFeatureKey: "feature-d"},
+			},
+			sync: []MovedWebFeature{
+				{OriginalFeatureKey: "feature-a", NewFeatureKey: "feature-b"},
+			},
+			expected: []MovedWebFeature{
+				{OriginalFeatureKey: "feature-a", NewFeatureKey: "feature-b"},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "add and delete",
+			initial: []MovedWebFeature{
+				{OriginalFeatureKey: "feature-a", NewFeatureKey: "feature-b"},
+			},
+			sync: []MovedWebFeature{
+				{OriginalFeatureKey: "feature-c", NewFeatureKey: "feature-d"},
+			},
+			expected: []MovedWebFeature{
+				{OriginalFeatureKey: "feature-c", NewFeatureKey: "feature-d"},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			restartDatabaseContainer(t)
+
+			// Setup initial web features.
+			err := spannerClient.SyncWebFeatures(ctx, []WebFeature{
+				{FeatureKey: "feature-b", Name: "Feature B", Description: "", DescriptionHTML: ""},
+				{FeatureKey: "feature-d", Name: "Feature D", Description: "", DescriptionHTML: ""},
+			})
+			if err != nil {
+				t.Fatalf("failed to sync web features: %v", err)
+			}
+
+			// Setup initial moved features.
+			if len(tc.initial) > 0 {
+				err = spannerClient.SyncMovedWebFeatures(ctx, tc.initial)
+				if err != nil {
+					t.Fatalf("failed to sync initial moved features: %v", err)
+				}
+			}
+
+			// Perform the sync to test.
+			err = spannerClient.SyncMovedWebFeatures(ctx, tc.sync)
+			if !errors.Is(err, tc.expectedError) {
+				t.Fatalf("expected error %v, got %v", tc.expectedError, err)
+			}
+
+			// Verify the result.
+			result, err := spannerClient.GetAllMovedWebFeatures(ctx)
+			if err != nil {
+				t.Fatalf("failed to get all moved features: %v", err)
+			}
+
+			sortFunc := func(a, b MovedWebFeature) bool {
+				return a.OriginalFeatureKey < b.OriginalFeatureKey
+			}
+			if diff := cmp.Diff(tc.expected, result, cmpopts.SortSlices(sortFunc)); diff != "" {
+				t.Errorf("unexpected result (-want +got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestGetMovedWebFeatureDetailsByOriginalFeatureKey(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// Setup initial web features.
+	err := spannerClient.SyncWebFeatures(ctx, []WebFeature{
+		{FeatureKey: "feature-b", Name: "Feature B", Description: "", DescriptionHTML: ""},
+	})
+	if err != nil {
+		t.Fatalf("failed to sync web features: %v", err)
+	}
+
+	// Setup moved feature.
+	movedFeature := MovedWebFeature{OriginalFeatureKey: "feature-a", NewFeatureKey: "feature-b"}
+	err = spannerClient.SyncMovedWebFeatures(ctx, []MovedWebFeature{movedFeature})
+	if err != nil {
+		t.Fatalf("failed to sync moved features: %v", err)
+	}
+
+	// Test found case.
+	result, err := spannerClient.GetMovedWebFeatureDetailsByOriginalFeatureKey(ctx, "feature-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The target feature ID is returned, not the key. Let's get the ID to compare.
+	targetID, err := spannerClient.GetIDFromFeatureKey(ctx, NewFeatureKeyFilter("feature-b"))
+	if err != nil {
+		t.Fatalf("failed to get target ID: %v", err)
+	}
+	expected := &MovedWebFeature{OriginalFeatureKey: "feature-a", NewFeatureKey: *targetID}
+
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("unexpected result (-want +got): %s", diff)
+	}
+
+	// Test not found case.
+	_, err = spannerClient.GetMovedWebFeatureDetailsByOriginalFeatureKey(ctx, "non-existent-feature")
+	if !errors.Is(err, ErrQueryReturnedNoResults) {
+		t.Errorf("expected error %v, got %v", ErrQueryReturnedNoResults, err)
+	}
+}

--- a/lib/gcpspanner/split_web_features.go
+++ b/lib/gcpspanner/split_web_features.go
@@ -14,28 +14,134 @@
 
 package gcpspanner
 
-import "context"
+import (
+	"context"
+	"log/slog"
+
+	"cloud.google.com/go/spanner"
+)
+
+const splitWebFeaturesTable = "SplitWebFeatures"
 
 type SplitWebFeature struct {
 	OriginalFeatureKey string   `spanner:"OriginalFeatureKey"`
 	TargetFeatureKeys  []string `spanner:"TargetFeatureKeys"`
 }
 
+type spannerNewSplitWebFeature struct {
+	OriginalFeatureKey string `spanner:"OriginalFeatureKey"`
+	TargetWebFeatureID string `spanner:"TargetWebFeatureID"`
+}
+
+type spannerSplitWebFeature struct {
+	ID                 string `spanner:"ID"`
+	OriginalFeatureKey string `spanner:"OriginalFeatureKey"`
+	TargetWebFeatureID string `spanner:"TargetWebFeatureID"`
+}
+
+type splitWebFeatureMapper struct{}
+
+func (m splitWebFeatureMapper) SelectAll() spanner.Statement {
+	return spanner.NewStatement(
+		`SELECT
+			ID,
+			OriginalFeatureKey,
+			TargetWebFeatureID
+		FROM SplitWebFeatures`)
+}
+
+func (m splitWebFeatureMapper) MergeAndCheckChanged(
+	_ spannerNewSplitWebFeature, existing spannerSplitWebFeature) (spannerSplitWebFeature, bool) {
+	// Right now, we treat these as immutable for now. Differences should yield a different entity
+	return existing, false
+}
+
+func (m splitWebFeatureMapper) PreDeleteHook(
+	_ context.Context,
+	_ *Client,
+	_ []spannerSplitWebFeature,
+) ([]ExtraMutationsGroup, error) {
+	return nil, nil
+}
+
+func (m splitWebFeatureMapper) GetKeyFromExternal(in spannerNewSplitWebFeature) splitWebFeatureKey {
+	return splitWebFeatureKey(in)
+}
+
+func (m splitWebFeatureMapper) GetKeyFromInternal(in spannerSplitWebFeature) splitWebFeatureKey {
+	return splitWebFeatureKey{
+		OriginalFeatureKey: in.OriginalFeatureKey,
+		TargetWebFeatureID: in.TargetWebFeatureID,
+	}
+}
+
+func (m splitWebFeatureMapper) GetChildDeleteKeyMutations(
+	_ context.Context, _ *Client, _ []spannerSplitWebFeature) ([]ExtraMutationsGroup, error) {
+	return nil, nil
+}
+
+func (m splitWebFeatureMapper) Table() string {
+	return splitWebFeaturesTable
+}
+
+func (m splitWebFeatureMapper) DeleteMutation(in spannerSplitWebFeature) *spanner.Mutation {
+	return spanner.Delete(splitWebFeaturesTable, spanner.Key{in.ID})
+}
+
+type splitWebFeatureKey struct {
+	OriginalFeatureKey string
+	TargetWebFeatureID string
+}
+
 // SyncSplitWebFeatures reconciles the SplitWebFeatures table with the provided list of features.
 // It will insert new details for split web features, update existing ones, and delete any split web features
 // that are in the database but not in the provided list.
-func (c *Client) SyncSplitWebFeatures(_ context.Context, _ []SplitWebFeature) error {
-	// TODO. Will implement once the tables are created.
-	// https://github.com/GoogleChrome/webstatus.dev/issues/1669
-	return nil
+func (c *Client) SyncSplitWebFeatures(ctx context.Context, splitWebFeatures []SplitWebFeature) error {
+	slog.InfoContext(ctx, "Starting split web features synchronization")
+	spannerSplitWebFeatures := []spannerNewSplitWebFeature{}
+	for _, splitWebFeatures := range splitWebFeatures {
+		for _, targetFeatureKey := range splitWebFeatures.TargetFeatureKeys {
+			// Get the web feature id from the target feature key.
+			targetWebFeatureID, err := c.GetIDFromFeatureKey(ctx, NewFeatureKeyFilter(targetFeatureKey))
+			if err != nil {
+				return err
+			}
+			spannerSplitWebFeatures = append(spannerSplitWebFeatures, spannerNewSplitWebFeature{
+				OriginalFeatureKey: splitWebFeatures.OriginalFeatureKey,
+				TargetWebFeatureID: *targetWebFeatureID,
+			})
+		}
+	}
+
+	synchronizer := newEntitySynchronizer[splitWebFeatureMapper](c)
+
+	return synchronizer.Sync(ctx, spannerSplitWebFeatures)
+}
+
+type splitWebFeatureByOriginalKeyMapper struct{}
+
+func (m splitWebFeatureByOriginalKeyMapper) SelectOne(featureKey string) spanner.Statement {
+	stmt := spanner.NewStatement(
+		`SELECT
+			swf.OriginalFeatureKey,
+			ARRAY_AGG(wf.FeatureKey) AS TargetFeatureKeys
+		FROM
+			SplitWebFeatures AS swf
+		JOIN
+			WebFeatures AS wf ON swf.TargetWebFeatureID = wf.ID
+		WHERE
+			swf.OriginalFeatureKey = @OriginalFeatureKey
+		GROUP BY
+			swf.OriginalFeatureKey`)
+	stmt.Params["OriginalFeatureKey"] = featureKey
+
+	return stmt
 }
 
 // GetSplitWebFeatureByOriginalFeatureKey returns the details about the split feature.
 // If details are not found for the feature key, it returns ErrQueryReturnedNoResults.
 // Other errors should be investigated and handled appropriately.
 func (c *Client) GetSplitWebFeatureByOriginalFeatureKey(
-	_ context.Context, _ string) (*SplitWebFeature, error) {
-	// TODO. Will implement once the tables are created.
-	// https://github.com/GoogleChrome/webstatus.dev/issues/1669
-	return nil, ErrQueryReturnedNoResults
+	ctx context.Context, featureKey string) (*SplitWebFeature, error) {
+	return newEntityReader[splitWebFeatureByOriginalKeyMapper, SplitWebFeature, string](c).readRowByKey(ctx, featureKey)
 }

--- a/lib/gcpspanner/split_web_features_test.go
+++ b/lib/gcpspanner/split_web_features_test.go
@@ -1,0 +1,200 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type splitWebFeaturesTestCase struct {
+	name          string
+	initial       []SplitWebFeature
+	sync          []SplitWebFeature
+	expected      []SplitWebFeature
+	expectedError error
+}
+
+func TestSyncSplitWebFeatures(t *testing.T) {
+	testCases := []splitWebFeaturesTestCase{
+		{
+			name:    "initial sync",
+			initial: []SplitWebFeature{},
+			sync: []SplitWebFeature{
+				{OriginalFeatureKey: "feature-a", TargetFeatureKeys: []string{"feature-b", "feature-c"}},
+			},
+			expected: []SplitWebFeature{
+				{OriginalFeatureKey: "feature-a", TargetFeatureKeys: []string{"feature-b", "feature-c"}},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "delete one target",
+			initial: []SplitWebFeature{
+				{OriginalFeatureKey: "feature-a", TargetFeatureKeys: []string{"feature-b", "feature-c"}},
+			},
+			sync: []SplitWebFeature{
+				{OriginalFeatureKey: "feature-a", TargetFeatureKeys: []string{"feature-b"}},
+			},
+			expected: []SplitWebFeature{
+				{OriginalFeatureKey: "feature-a", TargetFeatureKeys: []string{"feature-b"}},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "add one target",
+			initial: []SplitWebFeature{
+				{OriginalFeatureKey: "feature-a", TargetFeatureKeys: []string{"feature-b"}},
+			},
+			sync: []SplitWebFeature{
+				{OriginalFeatureKey: "feature-a", TargetFeatureKeys: []string{"feature-b", "feature-c"}},
+			},
+			expected: []SplitWebFeature{
+				{OriginalFeatureKey: "feature-a", TargetFeatureKeys: []string{"feature-b", "feature-c"}},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "delete original feature",
+			initial: []SplitWebFeature{
+				{OriginalFeatureKey: "feature-a", TargetFeatureKeys: []string{"feature-b", "feature-c"}},
+			},
+			sync:          []SplitWebFeature{},
+			expected:      []SplitWebFeature{},
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runSplitWebFeaturesTestCase(t, tc)
+		})
+	}
+}
+
+func runSplitWebFeaturesTestCase(t *testing.T, tc splitWebFeaturesTestCase) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// Setup initial web features.
+	err := spannerClient.SyncWebFeatures(ctx, []WebFeature{
+		{FeatureKey: "feature-b", Name: "Feature B", Description: "", DescriptionHTML: ""},
+		{FeatureKey: "feature-c", Name: "Feature C", Description: "", DescriptionHTML: ""},
+	})
+	if err != nil {
+		t.Fatalf("failed to sync web features: %v", err)
+	}
+
+	// Setup initial split features.
+	if len(tc.initial) > 0 {
+		err = spannerClient.SyncSplitWebFeatures(ctx, tc.initial)
+		if err != nil {
+			t.Fatalf("failed to sync initial split features: %v", err)
+		}
+	}
+
+	// Perform the sync to test.
+	err = spannerClient.SyncSplitWebFeatures(ctx, tc.sync)
+	if !errors.Is(err, tc.expectedError) {
+		t.Fatalf("expected error %v, got %v", tc.expectedError, err)
+	}
+
+	// Verify the result.
+	var originalKeys []string
+	if len(tc.expected) > 0 {
+		for _, f := range tc.expected {
+			originalKeys = append(originalKeys, f.OriginalFeatureKey)
+		}
+	} else if len(tc.initial) > 0 {
+		// If we expect empty, check the original keys from the initial state
+		for _, f := range tc.initial {
+			originalKeys = append(originalKeys, f.OriginalFeatureKey)
+		}
+	}
+
+	result := make([]SplitWebFeature, 0, len(originalKeys))
+	for _, key := range originalKeys {
+		feature, err := spannerClient.GetSplitWebFeatureByOriginalFeatureKey(ctx, key)
+		if err != nil {
+			// If we expect no results, this is okay.
+			if errors.Is(err, ErrQueryReturnedNoResults) && len(tc.expected) == 0 {
+				continue
+			}
+			t.Fatalf("failed to get split feature %s: %v", key, err)
+		}
+		result = append(result, *feature)
+	}
+
+	for i := range result {
+		sortFeatureKeys(result[0].TargetFeatureKeys)
+		sortFeatureKeys(tc.expected[0].TargetFeatureKeys)
+		if diff := cmp.Diff(
+			tc.expected[i].TargetFeatureKeys,
+			result[i].TargetFeatureKeys); diff != "" {
+			t.Errorf("unexpected target keys for %s (-want +got): %s", result[i].OriginalFeatureKey, diff)
+		}
+	}
+}
+
+func TestGetSplitWebFeatureByOriginalFeatureKey(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// Setup initial web features.
+	err := spannerClient.SyncWebFeatures(ctx, []WebFeature{
+		{FeatureKey: "feature-b", Name: "Feature B", Description: "", DescriptionHTML: ""},
+		{FeatureKey: "feature-c", Name: "Feature C", Description: "", DescriptionHTML: ""},
+	})
+	if err != nil {
+		t.Fatalf("failed to sync web features: %v", err)
+	}
+
+	// Setup split feature.
+	splitFeature := SplitWebFeature{OriginalFeatureKey: "feature-a", TargetFeatureKeys: []string{"feature-b", "feature-c"}}
+	err = spannerClient.SyncSplitWebFeatures(ctx, []SplitWebFeature{splitFeature})
+	if err != nil {
+		t.Fatalf("failed to sync split features: %v", err)
+	}
+
+	// Test found case.
+	result, err := spannerClient.GetSplitWebFeatureByOriginalFeatureKey(ctx, "feature-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sortFeatureKeys(splitFeature.TargetFeatureKeys)
+	sortFeatureKeys(result.TargetFeatureKeys)
+	if diff := cmp.Diff(
+		splitFeature.TargetFeatureKeys, result.TargetFeatureKeys); diff != "" {
+		t.Errorf("unexpected target keys (-want +got): %s", diff)
+	}
+	if result.OriginalFeatureKey != "feature-a" {
+		t.Errorf("expected original feature key 'feature-a', got '%s'", result.OriginalFeatureKey)
+	}
+
+	// Test not found case.
+	_, err = spannerClient.GetSplitWebFeatureByOriginalFeatureKey(ctx, "non-existent-feature")
+	if !errors.Is(err, ErrQueryReturnedNoResults) {
+		t.Errorf("expected error %v, got %v", ErrQueryReturnedNoResults, err)
+	}
+}
+
+func sortFeatureKeys(keys []string) {
+	slices.Sort(keys)
+}

--- a/lib/gcpspanner/web_features.go
+++ b/lib/gcpspanner/web_features.go
@@ -425,6 +425,10 @@ func (c *Client) GetIDFromFeatureKey(ctx context.Context, filter *FeatureIDFilte
 	return newEntityWriterWithIDRetrieval[webFeatureSpannerMapper, string](c).getIDByKey(ctx, filter.featureKey)
 }
 
+func (c *Client) GetWebFeatureByID(ctx context.Context, id string) (*SpannerWebFeature, error) {
+	return newEntityReader[webFeatureSpannerMapper, SpannerWebFeature, string](c).readRowByKey(ctx, id)
+}
+
 func (c *Client) fetchAllWebFeatureIDsWithTransaction(
 	ctx context.Context, txn *spanner.ReadOnlyTransaction) ([]string, error) {
 	return fetchSingleColumnValuesWithTransaction[string](ctx, txn, webFeaturesTable, "ID")


### PR DESCRIPTION
This commit introduces the capability to handle web features that have been moved (renamed) or split into multiple new features. This is essential for maintaining historical data integrity and providing a seamless user experience when feature definitions evolve.

Key changes include:

- **Database Schema:**
  - Adds `MovedWebFeatures` and `SplitWebFeatures` tables to the Spanner schema to track these changes.

- **DB Client:**
  - Implements `SyncMovedWebFeatures` and `SyncSplitWebFeatures` to synchronize the database with the latest feature definitions from the `web-features` repository.
  - Provides new data access methods (`GetMovedWebFeatureDetailsByOriginalFeatureKey`, `GetSplitWebFeatureByOriginalFeatureKey`, `GetAllMovedWebFeatures`) to query the new tables.
  - Introduces a generic `entityAllReader` in the Spanner client for more efficient data retrieval.

- **Testing:**
  - Adds comprehensive integration tests for the new moved and split feature logic, ensuring correct synchronization and data retrieval.