### PR TITLE
feat: Handle moved features during data ingestion

### DIFF
--- a/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/chromium_historgram_enum_consumer_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/jsonschema/web_platform_dx__web_features"
 	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
 )
 
@@ -31,8 +32,9 @@ type mockChromiumHistogramEnumsClient struct {
 		gcpspanner.ChromiumHistogramEnumValue) (*string, error)
 	upsertWebFeatureChromiumHistogramEnumValue func(context.Context,
 		gcpspanner.WebFeatureChromiumHistogramEnumValue) error
-	getIDFromFeatureKey func(context.Context, *gcpspanner.FeatureIDFilter) (*string, error)
-	fetchAllFeatureKeys func(context.Context) ([]string, error)
+	getIDFromFeatureKey    func(context.Context, *gcpspanner.FeatureIDFilter) (*string, error)
+	fetchAllFeatureKeys    func(context.Context) ([]string, error)
+	getAllMovedWebFeatures func(ctx context.Context) ([]gcpspanner.MovedWebFeature, error)
 }
 
 func (m *mockChromiumHistogramEnumsClient) UpsertChromiumHistogramEnum(ctx context.Context,
@@ -58,6 +60,11 @@ func (m *mockChromiumHistogramEnumsClient) GetIDFromFeatureKey(ctx context.Conte
 func (m *mockChromiumHistogramEnumsClient) FetchAllFeatureKeys(
 	ctx context.Context) ([]string, error) {
 	return m.fetchAllFeatureKeys(ctx)
+}
+
+func (m *mockChromiumHistogramEnumsClient) GetAllMovedWebFeatures(
+	ctx context.Context) ([]gcpspanner.MovedWebFeature, error) {
+	return m.getAllMovedWebFeatures(ctx)
 }
 
 func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
@@ -89,6 +96,9 @@ func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
 					_ gcpspanner.WebFeatureChromiumHistogramEnumValue) error {
 					return nil
 				},
+				getAllMovedWebFeatures: func(_ context.Context) ([]gcpspanner.MovedWebFeature, error) {
+					return nil, nil
+				},
 			},
 			data: metricdatatypes.HistogramMapping{
 				metricdatatypes.WebDXFeatureEnum: []metricdatatypes.HistogramEnumValue{
@@ -107,6 +117,7 @@ func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
 				upsertChromiumHistogramEnumValue:           nil,
 				upsertWebFeatureChromiumHistogramEnumValue: nil,
 				getIDFromFeatureKey:                        nil,
+				getAllMovedWebFeatures:                     nil,
 			},
 			data: metricdatatypes.HistogramMapping{
 				metricdatatypes.WebDXFeatureEnum: []metricdatatypes.HistogramEnumValue{
@@ -128,6 +139,9 @@ func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
 				upsertChromiumHistogramEnumValue:           nil,
 				upsertWebFeatureChromiumHistogramEnumValue: nil,
 				getIDFromFeatureKey:                        nil,
+				getAllMovedWebFeatures: func(_ context.Context) ([]gcpspanner.MovedWebFeature, error) {
+					return nil, nil
+				},
 			},
 			data: metricdatatypes.HistogramMapping{
 				metricdatatypes.WebDXFeatureEnum: []metricdatatypes.HistogramEnumValue{
@@ -152,6 +166,9 @@ func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
 				},
 				upsertWebFeatureChromiumHistogramEnumValue: nil,
 				getIDFromFeatureKey:                        nil,
+				getAllMovedWebFeatures: func(_ context.Context) ([]gcpspanner.MovedWebFeature, error) {
+					return nil, nil
+				},
 			},
 			data: metricdatatypes.HistogramMapping{
 				metricdatatypes.WebDXFeatureEnum: []metricdatatypes.HistogramEnumValue{
@@ -179,6 +196,9 @@ func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
 					return nil, errors.New("test error")
 				},
 				upsertWebFeatureChromiumHistogramEnumValue: nil,
+				getAllMovedWebFeatures: func(_ context.Context) ([]gcpspanner.MovedWebFeature, error) {
+					return nil, nil
+				},
 			},
 			data: metricdatatypes.HistogramMapping{
 				metricdatatypes.WebDXFeatureEnum: []metricdatatypes.HistogramEnumValue{
@@ -208,6 +228,9 @@ func TestChromiumHistogramEnumConsumer_SaveHistogramEnums(t *testing.T) {
 				upsertWebFeatureChromiumHistogramEnumValue: func(_ context.Context,
 					_ gcpspanner.WebFeatureChromiumHistogramEnumValue) error {
 					return errors.New("test error")
+				},
+				getAllMovedWebFeatures: func(_ context.Context) ([]gcpspanner.MovedWebFeature, error) {
+					return nil, nil
 				},
 			},
 			data: metricdatatypes.HistogramMapping{
@@ -264,5 +287,227 @@ func TestCreateEnumToFeatureKeyMap(t *testing.T) {
 	got := createEnumToFeatureKeyMap(featureKeys)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("createEnumToFeatureKeyMap()\ngot:  (%+v)\nwant: (%+v)\n", got, want)
+	}
+}
+
+func TestMigrateMovedFeatures(t *testing.T) {
+	testCases := []struct {
+		name                         string
+		histogramsToEnumMap          map[metricdatatypes.HistogramName]map[int64]*string
+		histogramsToAllFeatureKeySet map[metricdatatypes.HistogramName]map[string]metricdatatypes.HistogramEnumValue
+		movedFeatures                map[string]web_platform_dx__web_features.FeatureMovedData
+		expectedHistogramsToEnumMap  map[metricdatatypes.HistogramName]map[int64]*string
+		expectedErr                  error
+	}{
+		{
+			name: "successful migration",
+			histogramsToEnumMap: map[metricdatatypes.HistogramName]map[int64]*string{
+				metricdatatypes.WebDXFeatureEnum: {
+					1: valuePtr("old-feature"),
+				},
+			},
+			histogramsToAllFeatureKeySet: map[metricdatatypes.HistogramName]map[string]metricdatatypes.HistogramEnumValue{
+				metricdatatypes.WebDXFeatureEnum: {
+					"old-feature": {Value: 1, Label: "old-feature"},
+				},
+			},
+			movedFeatures: map[string]web_platform_dx__web_features.FeatureMovedData{
+				"old-feature": {RedirectTarget: "new-feature", Kind: web_platform_dx__web_features.Moved},
+			},
+			expectedHistogramsToEnumMap: map[metricdatatypes.HistogramName]map[int64]*string{
+				metricdatatypes.WebDXFeatureEnum: {
+					1: valuePtr("new-feature"),
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "conflict with existing feature",
+			histogramsToEnumMap: map[metricdatatypes.HistogramName]map[int64]*string{
+				metricdatatypes.WebDXFeatureEnum: {
+					1: valuePtr("old-feature"),
+					2: valuePtr("new-feature"),
+				},
+			},
+			histogramsToAllFeatureKeySet: map[metricdatatypes.HistogramName]map[string]metricdatatypes.HistogramEnumValue{
+				metricdatatypes.WebDXFeatureEnum: {
+					"old-feature": {Value: 1, Label: "old-feature"},
+					"new-feature": {Value: 2, Label: "new-feature"},
+				},
+			},
+			movedFeatures: map[string]web_platform_dx__web_features.FeatureMovedData{
+				"old-feature": {RedirectTarget: "new-feature", Kind: web_platform_dx__web_features.Moved},
+			},
+			expectedHistogramsToEnumMap: nil,
+			expectedErr:                 ErrConflictMigratingFeatureKey,
+		},
+		{
+			name: "no migration needed",
+			histogramsToEnumMap: map[metricdatatypes.HistogramName]map[int64]*string{
+				metricdatatypes.WebDXFeatureEnum: {
+					1: valuePtr("feature-a"),
+				},
+			},
+			histogramsToAllFeatureKeySet: map[metricdatatypes.HistogramName]map[string]metricdatatypes.HistogramEnumValue{
+				metricdatatypes.WebDXFeatureEnum: {
+					"feature-a": {Value: 1, Label: "feature-a"},
+				},
+			},
+			movedFeatures: map[string]web_platform_dx__web_features.FeatureMovedData{},
+			expectedHistogramsToEnumMap: map[metricdatatypes.HistogramName]map[int64]*string{
+				metricdatatypes.WebDXFeatureEnum: {
+					1: valuePtr("feature-a"),
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "multiple migrations",
+			histogramsToEnumMap: map[metricdatatypes.HistogramName]map[int64]*string{
+				metricdatatypes.WebDXFeatureEnum: {
+					1: valuePtr("old-a"),
+					2: valuePtr("feature-c"),
+				},
+				"hist2": {
+					3: valuePtr("old-b"),
+				},
+			},
+			histogramsToAllFeatureKeySet: map[metricdatatypes.HistogramName]map[string]metricdatatypes.HistogramEnumValue{
+				metricdatatypes.WebDXFeatureEnum: {
+					"old-a":     {Value: 1, Label: "old-a"},
+					"feature-c": {Value: 2, Label: "feature-c"},
+				},
+				"hist2": {
+					"old-b": {Value: 3, Label: "old-b"},
+				},
+			},
+			movedFeatures: map[string]web_platform_dx__web_features.FeatureMovedData{
+				"old-a": {RedirectTarget: "new-a", Kind: web_platform_dx__web_features.Moved},
+				"old-b": {RedirectTarget: "new-b", Kind: web_platform_dx__web_features.Moved},
+			},
+			expectedHistogramsToEnumMap: map[metricdatatypes.HistogramName]map[int64]*string{
+				metricdatatypes.WebDXFeatureEnum: {
+					1: valuePtr("new-a"),
+					2: valuePtr("feature-c"),
+				},
+				"hist2": {
+					3: valuePtr("new-b"),
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:                         "empty data",
+			histogramsToEnumMap:          map[metricdatatypes.HistogramName]map[int64]*string{},
+			histogramsToAllFeatureKeySet: map[metricdatatypes.HistogramName]map[string]metricdatatypes.HistogramEnumValue{},
+			movedFeatures: map[string]web_platform_dx__web_features.FeatureMovedData{
+				"a": {RedirectTarget: "b", Kind: web_platform_dx__web_features.Moved},
+			},
+			expectedHistogramsToEnumMap: map[metricdatatypes.HistogramName]map[int64]*string{},
+			expectedErr:                 nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := migrateMovedFeatures(
+				context.Background(), tc.histogramsToEnumMap, tc.histogramsToAllFeatureKeySet, tc.movedFeatures)
+
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("expected error %v, got %v", tc.expectedErr, err)
+			}
+
+			if tc.expectedErr == nil && !reflect.DeepEqual(tc.histogramsToEnumMap, tc.expectedHistogramsToEnumMap) {
+				t.Errorf("expected data %v, got %v", tc.expectedHistogramsToEnumMap, tc.histogramsToEnumMap)
+			}
+		})
+	}
+}
+
+var errTestDatabaseError = errors.New("test database error")
+
+func TestChromiumHistogramEnumConsumer_GetAllMovedWebFeatures(t *testing.T) {
+	testCases := []struct {
+		name          string
+		mockClient    *mockChromiumHistogramEnumsClient
+		expected      map[string]web_platform_dx__web_features.FeatureMovedData
+		expectedError error
+	}{
+		{
+			name: "Success",
+			mockClient: &mockChromiumHistogramEnumsClient{
+				fetchAllFeatureKeys:                        nil,
+				upsertChromiumHistogramEnum:                nil,
+				upsertChromiumHistogramEnumValue:           nil,
+				upsertWebFeatureChromiumHistogramEnumValue: nil,
+				getIDFromFeatureKey:                        nil,
+				getAllMovedWebFeatures: func(_ context.Context) ([]gcpspanner.MovedWebFeature, error) {
+					return []gcpspanner.MovedWebFeature{
+						{
+							OriginalFeatureKey: "feature1",
+							NewFeatureKey:      "new-feature1",
+						},
+						{
+							OriginalFeatureKey: "feature2",
+							NewFeatureKey:      "new-feature2",
+						},
+					}, nil
+				},
+			},
+			expected: map[string]web_platform_dx__web_features.FeatureMovedData{
+				"feature1": {
+					RedirectTarget: "new-feature1",
+					Kind:           web_platform_dx__web_features.Moved,
+				},
+				"feature2": {
+					RedirectTarget: "new-feature2",
+					Kind:           web_platform_dx__web_features.Moved,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Database error",
+			mockClient: &mockChromiumHistogramEnumsClient{
+				fetchAllFeatureKeys:                        nil,
+				upsertChromiumHistogramEnum:                nil,
+				upsertChromiumHistogramEnumValue:           nil,
+				upsertWebFeatureChromiumHistogramEnumValue: nil,
+				getIDFromFeatureKey:                        nil,
+				getAllMovedWebFeatures: func(_ context.Context) ([]gcpspanner.MovedWebFeature, error) {
+					return nil, errTestDatabaseError
+				},
+			},
+			expected:      nil,
+			expectedError: errTestDatabaseError,
+		},
+		{
+			name: "Empty result",
+			mockClient: &mockChromiumHistogramEnumsClient{
+				fetchAllFeatureKeys:                        nil,
+				upsertChromiumHistogramEnum:                nil,
+				upsertChromiumHistogramEnumValue:           nil,
+				upsertWebFeatureChromiumHistogramEnumValue: nil,
+				getIDFromFeatureKey:                        nil,
+				getAllMovedWebFeatures: func(_ context.Context) ([]gcpspanner.MovedWebFeature, error) {
+					return []gcpspanner.MovedWebFeature{}, nil
+				},
+			},
+			expected:      map[string]web_platform_dx__web_features.FeatureMovedData{},
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			consumer := &ChromiumHistogramEnumConsumer{client: tc.mockClient}
+			result, err := consumer.GetAllMovedWebFeatures(context.Background())
+			if !errors.Is(tc.expectedError, err) {
+				t.Errorf("Unexpected error. Expected %v, got %v", tc.expectedError, err)
+			}
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Unexpected result. Expected %v, got %v", tc.expected, result)
+			}
+		})
 	}
 }

--- a/lib/gcpspanner/spanneradapters/wptconsumertypes/types.go
+++ b/lib/gcpspanner/spanneradapters/wptconsumertypes/types.go
@@ -40,6 +40,10 @@ var ErrUnableToStoreWPTRun = errors.New("unable to store wpt run data")
 // unable to save the wpt run feature metrics.
 var ErrUnableToStoreWPTRunFeatureMetrics = errors.New("unable to store wpt run feature metrics")
 
+// ErrUnableToGetAllMovedWebFeatures indicates that the storage layer was unable
+// to get all moved web features.
+var ErrUnableToGetAllMovedWebFeatures = errors.New("unable to get all moved web features")
+
 // BrowserName is an enumeration of the supported browsers for WPT runs.
 type BrowserName string
 


### PR DESCRIPTION
This change introduces logic to handle features that have been marked as "moved" to a new feature key.

During data ingestion for WPT and Chromium histograms, if a feature has been moved, this change ensures that the metrics are associated with the new, redirected feature key. This allows for future ingestions to be correctly attributed while upstream sources (like WPT test annotations or Chromium mojom files) are being updated.

These checks are implemented at different layers depending on the data source:

- For WPT, the migration happens in the workflow layer before scoring. This allows the scores to be calculated with the corrected feature keys.
- For Chromium histograms, the migration happens in the spanner adapter layer. This is because the full list of feature keys is not available until this layer, where it is fetched from the database.

The implementation also introduces a check to prevent conflicts where both the old and new feature keys are present in the source data. When this conflict occurs, an error is logged with the message "conflict migrating feature key", which will be used for alerting in GCP.

We can also add alerting for these messages too:
- "migrating feature key for histogram"
- "migrating feature key for test"

These will let us know to update the upstream sources