### PR TITLE
feat(database): Add developer signals for web features

### DIFF
--- a/infra/storage/spanner/migrations/000021.sql
+++ b/infra/storage/spanner/migrations/000021.sql
@@ -1,0 +1,22 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- LatestFeatureDeveloperSignals contains the latest developer signal(s) for a given features.
+-- For now, the only signal for a feature is the thumbs up.
+CREATE TABLE IF NOT EXISTS LatestFeatureDeveloperSignals (
+    WebFeatureID STRING(36) NOT NULL,
+    Votes INT64 NOT NULL,
+    Link STRING(MAX) NOT NULL,
+    FOREIGN KEY (WebFeatureID) REFERENCES WebFeatures(ID) ON DELETE CASCADE,
+) PRIMARY KEY (WebFeatureID);

--- a/infra/storage/spanner/migrations/000021.sql
+++ b/infra/storage/spanner/migrations/000021.sql
@@ -16,7 +16,7 @@
 -- For now, the only signal for a feature is the thumbs up.
 CREATE TABLE IF NOT EXISTS LatestFeatureDeveloperSignals (
     WebFeatureID STRING(36) NOT NULL,
-    Votes INT64 NOT NULL,
+    Upvotes INT64 NOT NULL,
     Link STRING(MAX) NOT NULL,
     FOREIGN KEY (WebFeatureID) REFERENCES WebFeatures(ID) ON DELETE CASCADE,
 ) PRIMARY KEY (WebFeatureID);

--- a/lib/gcpspanner/feature_developer_signals.go
+++ b/lib/gcpspanner/feature_developer_signals.go
@@ -23,13 +23,13 @@ import (
 
 type spannerFeatureDeveloperSignal struct {
 	WebFeatureID string `spanner:"WebFeatureID"`
-	Votes        int64  `spanner:"Votes"`
+	Upvotes      int64  `spanner:"Upvotes"`
 	Link         string `spanner:"Link"`
 }
 
 type FeatureDeveloperSignal struct {
 	WebFeatureKey string `spanner:"WebFeatureKey"`
-	Votes         int64  `spanner:"Votes"`
+	Upvotes       int64  `spanner:"Upvotes"`
 	Link          string `spanner:"Link"`
 }
 
@@ -42,7 +42,7 @@ func (m latestFeatureDeveloperSignalsMapper) SelectAll() spanner.Statement {
 	return spanner.NewStatement(`
 	SELECT
 		WebFeatureID,
-		Votes
+		Upvotes
 	FROM
 		LatestFeatureDeveloperSignals`)
 }
@@ -69,11 +69,11 @@ func (m latestFeatureDeveloperSignalsMapper) MergeAndCheckChanged(
 ) (spannerFeatureDeveloperSignal, bool) {
 	merged := spannerFeatureDeveloperSignal{
 		WebFeatureID: existing.WebFeatureID,
-		Votes:        in.Votes,
+		Upvotes:      in.Upvotes,
 		Link:         in.Link,
 	}
 
-	hasChanged := merged.Votes != existing.Votes || merged.Link != existing.Link
+	hasChanged := merged.Upvotes != existing.Upvotes || merged.Link != existing.Link
 
 	return merged, hasChanged
 }
@@ -100,7 +100,7 @@ func (c *Client) SyncLatestFeatureDeveloperSignals(ctx context.Context, input []
 		}
 		signals = append(signals, spannerFeatureDeveloperSignal{
 			WebFeatureID: *webFeatureID,
-			Votes:        signal.Votes,
+			Upvotes:      signal.Upvotes,
 			Link:         signal.Link,
 		})
 	}
@@ -114,7 +114,7 @@ func (m latestFeatureDeveloperSignalGetAllMapper) SelectAll() spanner.Statement 
 	return spanner.NewStatement(`
 	SELECT
 		wf.FeatureKey AS WebFeatureKey,
-		lfd.Votes,
+		lfd.Upvotes,
 		lfd.Link
 	FROM
 		LatestFeatureDeveloperSignals AS lfd

--- a/lib/gcpspanner/feature_developer_signals.go
+++ b/lib/gcpspanner/feature_developer_signals.go
@@ -1,0 +1,127 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"log/slog"
+
+	"cloud.google.com/go/spanner"
+)
+
+type spannerFeatureDeveloperSignal struct {
+	WebFeatureID string `spanner:"WebFeatureID"`
+	Votes        int64  `spanner:"Votes"`
+	Link         string `spanner:"Link"`
+}
+
+type FeatureDeveloperSignal struct {
+	WebFeatureKey string `spanner:"WebFeatureKey"`
+	Votes         int64  `spanner:"Votes"`
+	Link          string `spanner:"Link"`
+}
+
+const latestFeatureDeveloperSignalsTableName = "LatestFeatureDeveloperSignals"
+
+// latestFeatureDeveloperSignalsMapper implements syncableEntityMapper for LatestFeatureDeveloperSignals.
+type latestFeatureDeveloperSignalsMapper struct{}
+
+func (m latestFeatureDeveloperSignalsMapper) SelectAll() spanner.Statement {
+	return spanner.NewStatement(`
+	SELECT
+		WebFeatureID,
+		Votes
+	FROM
+		LatestFeatureDeveloperSignals`)
+}
+
+func (m latestFeatureDeveloperSignalsMapper) Table() string {
+	return latestFeatureDeveloperSignalsTableName
+}
+
+func (m latestFeatureDeveloperSignalsMapper) DeleteMutation(in spannerFeatureDeveloperSignal) *spanner.Mutation {
+	return spanner.Delete(latestFeatureDeveloperSignalsTableName, spanner.Key{in.WebFeatureID})
+}
+
+func (m latestFeatureDeveloperSignalsMapper) GetKeyFromExternal(in spannerFeatureDeveloperSignal) string {
+	return in.WebFeatureID
+}
+
+func (m latestFeatureDeveloperSignalsMapper) GetKeyFromInternal(in spannerFeatureDeveloperSignal) string {
+	return in.WebFeatureID
+}
+
+func (m latestFeatureDeveloperSignalsMapper) MergeAndCheckChanged(
+	in spannerFeatureDeveloperSignal,
+	existing spannerFeatureDeveloperSignal,
+) (spannerFeatureDeveloperSignal, bool) {
+	merged := spannerFeatureDeveloperSignal{
+		WebFeatureID: existing.WebFeatureID,
+		Votes:        in.Votes,
+		Link:         in.Link,
+	}
+
+	hasChanged := merged.Votes != existing.Votes || merged.Link != existing.Link
+
+	return merged, hasChanged
+}
+
+func (m latestFeatureDeveloperSignalsMapper) GetChildDeleteKeyMutations(
+	_ context.Context, _ *Client, _ []spannerFeatureDeveloperSignal) ([]ExtraMutationsGroup, error) {
+	return nil, nil
+}
+
+func (m latestFeatureDeveloperSignalsMapper) PreDeleteHook(
+	_ context.Context, _ *Client, _ []spannerFeatureDeveloperSignal) ([]ExtraMutationsGroup, error) {
+	return nil, nil
+}
+
+func (c *Client) SyncLatestFeatureDeveloperSignals(ctx context.Context, input []FeatureDeveloperSignal) error {
+	slog.InfoContext(ctx, "Syncing latest feature developer signals", "count", len(input))
+	signals := make([]spannerFeatureDeveloperSignal, 0, len(input))
+	for _, signal := range input {
+		webFeatureID, err := c.GetIDFromFeatureKey(ctx, NewFeatureKeyFilter(signal.WebFeatureKey))
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to get web feature ID", "error", err)
+
+			return err
+		}
+		signals = append(signals, spannerFeatureDeveloperSignal{
+			WebFeatureID: *webFeatureID,
+			Votes:        signal.Votes,
+			Link:         signal.Link,
+		})
+	}
+
+	return newEntitySynchronizer[latestFeatureDeveloperSignalsMapper](c).Sync(ctx, signals)
+}
+
+type latestFeatureDeveloperSignalGetAllMapper struct{}
+
+func (m latestFeatureDeveloperSignalGetAllMapper) SelectAll() spanner.Statement {
+	return spanner.NewStatement(`
+	SELECT
+		wf.FeatureKey AS WebFeatureKey,
+		lfd.Votes,
+		lfd.Link
+	FROM
+		LatestFeatureDeveloperSignals AS lfd
+	JOIN
+		WebFeatures AS wf ON lfd.WebFeatureID = wf.ID`)
+}
+
+func (c *Client) GetAllLatestFeatureDeveloperSignals(ctx context.Context) ([]FeatureDeveloperSignal, error) {
+	return newAllEntityReader[latestFeatureDeveloperSignalGetAllMapper, FeatureDeveloperSignal](c).readAll(ctx)
+}

--- a/lib/gcpspanner/feature_developer_signals_test.go
+++ b/lib/gcpspanner/feature_developer_signals_test.go
@@ -38,12 +38,12 @@ func getSampleFeatureDeveloperSignals() []FeatureDeveloperSignal {
 		{
 			WebFeatureKey: "feature1",
 			Link:          "https://example.com/feature1",
-			Votes:         100,
+			Upvotes:       100,
 		},
 		{
 			WebFeatureKey: "feature2",
 			Link:          "https://example.com/feature2",
-			Votes:         200,
+			Upvotes:       200,
 		},
 	}
 }
@@ -79,13 +79,13 @@ func TestSyncAndGetAllLatestFeatureDeveloperSignals(t *testing.T) {
 	updatedSignals := []FeatureDeveloperSignal{
 		{
 			WebFeatureKey: "feature1",
-			Votes:         150, // Update
+			Upvotes:       150, // Update
 			Link:          "https://example.com/feature1-updated",
 		},
 		// feature2 is deleted
 		{
 			WebFeatureKey: "feature3", // Insert
-			Votes:         300,
+			Upvotes:       300,
 			Link:          "https://example.com/feature3",
 		},
 	}
@@ -109,12 +109,12 @@ func TestSyncAndGetAllLatestFeatureDeveloperSignals(t *testing.T) {
 		{
 			WebFeatureKey: "feature1",
 			Link:          "https://example.com/feature1-updated",
-			Votes:         150,
+			Upvotes:       150,
 		},
 		{
 			WebFeatureKey: "feature3",
 			Link:          "https://example.com/feature3",
-			Votes:         300,
+			Upvotes:       300,
 		},
 	}
 
@@ -127,7 +127,7 @@ func TestSyncAndGetAllLatestFeatureDeveloperSignals(t *testing.T) {
 		{
 			WebFeatureKey: "non-existent-feature",
 			Link:          "https://example.com/non-existent-feature",
-			Votes:         999,
+			Upvotes:       999,
 		},
 	}
 	err = spannerClient.SyncLatestFeatureDeveloperSignals(ctx, signalsWithInvalidFeature)

--- a/lib/gcpspanner/feature_developer_signals_test.go
+++ b/lib/gcpspanner/feature_developer_signals_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"cmp"
+	"context"
+	"slices"
+	"sort"
+	"testing"
+
+	gcmp "github.com/google/go-cmp/cmp"
+)
+
+func setupRequiredTablesForDeveloperSignals(t *testing.T) {
+	ctx := context.Background()
+	sampleFeatures := getSampleFeatures()
+	err := spannerClient.SyncWebFeatures(ctx, sampleFeatures)
+	if err != nil {
+		t.Fatalf("unexpected error during sync. %s", err.Error())
+	}
+}
+
+func getSampleFeatureDeveloperSignals() []FeatureDeveloperSignal {
+	return []FeatureDeveloperSignal{
+		{
+			WebFeatureKey: "feature1",
+			Link:          "https://example.com/feature1",
+			Votes:         100,
+		},
+		{
+			WebFeatureKey: "feature2",
+			Link:          "https://example.com/feature2",
+			Votes:         200,
+		},
+	}
+}
+
+func TestSyncAndGetAllLatestFeatureDeveloperSignals(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+	setupRequiredTablesForDeveloperSignals(t)
+
+	// 1. Initial Sync
+	initialSignals := getSampleFeatureDeveloperSignals()
+	err := spannerClient.SyncLatestFeatureDeveloperSignals(ctx, initialSignals)
+	if err != nil {
+		t.Fatalf("unexpected error during initial sync: %v", err)
+	}
+
+	// 2. Verify initial data with GetAll
+	retrievedSignals, err := spannerClient.GetAllLatestFeatureDeveloperSignals(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error getting all signals: %v", err)
+	}
+
+	sortFn := func(a, b FeatureDeveloperSignal) int {
+		return cmp.Compare(a.WebFeatureKey, b.WebFeatureKey)
+	}
+	slices.SortFunc(retrievedSignals, sortFn)
+
+	if diff := gcmp.Diff(initialSignals, retrievedSignals); diff != "" {
+		t.Errorf("retrieved signals mismatch after initial sync (-want +got):\n%s", diff)
+	}
+
+	// 3. Second Sync (Update, Insert, Delete)
+	updatedSignals := []FeatureDeveloperSignal{
+		{
+			WebFeatureKey: "feature1",
+			Votes:         150, // Update
+			Link:          "https://example.com/feature1-updated",
+		},
+		// feature2 is deleted
+		{
+			WebFeatureKey: "feature3", // Insert
+			Votes:         300,
+			Link:          "https://example.com/feature3",
+		},
+	}
+
+	err = spannerClient.SyncLatestFeatureDeveloperSignals(ctx, updatedSignals)
+	if err != nil {
+		t.Fatalf("unexpected error during second sync: %v", err)
+	}
+
+	// 4. Verify updated data
+	retrievedSignals, err = spannerClient.GetAllLatestFeatureDeveloperSignals(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error getting all signals after update: %v", err)
+	}
+
+	sort.Slice(retrievedSignals, func(i, j int) bool {
+		return retrievedSignals[i].WebFeatureKey < retrievedSignals[j].WebFeatureKey
+	})
+
+	expectedSignalsAfterUpdate := []FeatureDeveloperSignal{
+		{
+			WebFeatureKey: "feature1",
+			Link:          "https://example.com/feature1-updated",
+			Votes:         150,
+		},
+		{
+			WebFeatureKey: "feature3",
+			Link:          "https://example.com/feature3",
+			Votes:         300,
+		},
+	}
+
+	if diff := gcmp.Diff(expectedSignalsAfterUpdate, retrievedSignals); diff != "" {
+		t.Errorf("retrieved signals mismatch after second sync (-want +got):\n%s", diff)
+	}
+
+	// 5. Test Sync with non-existent feature key
+	signalsWithInvalidFeature := []FeatureDeveloperSignal{
+		{
+			WebFeatureKey: "non-existent-feature",
+			Link:          "https://example.com/non-existent-feature",
+			Votes:         999,
+		},
+	}
+	err = spannerClient.SyncLatestFeatureDeveloperSignals(ctx, signalsWithInvalidFeature)
+	if err == nil {
+		t.Error("expected an error when syncing with a non-existent feature key, but got nil")
+	}
+
+	// 6. Verify that the data was not modified by the failed sync
+	retrievedSignalsAfterFailure, err := spannerClient.GetAllLatestFeatureDeveloperSignals(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error getting all signals after failed sync: %v", err)
+	}
+	slices.SortFunc(retrievedSignalsAfterFailure, sortFn)
+
+	if diff := gcmp.Diff(expectedSignalsAfterUpdate, retrievedSignalsAfterFailure); diff != "" {
+		t.Errorf("data should not have changed after a failed sync (-want +got):\n%s", diff)
+	}
+
+	// 7. Test Empty Sync (deletes all)
+	err = spannerClient.SyncLatestFeatureDeveloperSignals(ctx, []FeatureDeveloperSignal{})
+	if err != nil {
+		t.Fatalf("unexpected error during empty sync: %v", err)
+	}
+
+	// 8. Verify all deleted
+	retrievedSignalsAfterEmptySync, err := spannerClient.GetAllLatestFeatureDeveloperSignals(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error getting all signals after empty sync: %v", err)
+	}
+	if len(retrievedSignalsAfterEmptySync) != 0 {
+		t.Errorf("expected 0 signals after empty sync, but got %d", len(retrievedSignalsAfterEmptySync))
+	}
+}


### PR DESCRIPTION
Fixes #1661

This commit introduces the infrastructure to store and manage developer signals for web features, starting with a "thumbs up" count. This provides a mechanism to gather and surface developer feedback and interest directly on web features.

Key changes include:

- **New `LatestFeatureDeveloperSignals` Table:** A new Spanner table is created with a database migration to store the thumbs up count for each feature. It is linked to the `WebFeatures` table with a cascading delete to ensure data integrity. This is to support the data from https://web-platform-dx.github.io/developer-signals/web-features-signals.json

- **Data Access Layer:** The `gcpspanner` package is extended with a `latestFeatureDeveloperSignalsMapper` that implements the `syncableEntityMapper` interface. 

- **Client Methods:** New `SyncLatestFeatureDeveloperSignals` and `GetAllLatestFeatureDeveloperSignals` methods are added to the Spanner client, providing a clear API for ingesting and retrieving signal data.

- **Integration Tests:** An integration test suite is added to validate the new functionality, covering initial data sync, updates, deletions, and error handling for cases like referencing non-existent features.

This lays the groundwork for incorporating more types of developer signals (e.g. thumbsdown) in the future and integrating them into the webstatus.dev platform