### PR TITLE
Refactor HTTP fetching into a common module

### DIFF
--- a/lib/fetchtypes/types.go
+++ b/lib/fetchtypes/types.go
@@ -1,0 +1,28 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetchtypes
+
+import "errors"
+
+var (
+	// ErrFailedToBuildRequest indicates the request failed to build. The fetch never occurred.
+	ErrFailedToBuildRequest = errors.New("failed to build request")
+	// ErrFailedToFetch indicates the fetch failed.
+	ErrFailedToFetch = errors.New("failed to fetch")
+	// ErrUnexpectedResult indicates the fetch returned an unexpected result.
+	ErrUnexpectedResult = errors.New("unexpected result")
+	// ErrMissingBody indicates the fetch returned a nil body.
+	ErrMissingBody = errors.New("missing body")
+)

--- a/lib/httputils/fetcher.go
+++ b/lib/httputils/fetcher.go
@@ -1,0 +1,150 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httputils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/fetchtypes"
+)
+
+var (
+	ErrUnableToParseURL = errors.New("unable to parse URL")
+)
+
+type HTTPFetcher struct {
+	httpClient *http.Client
+	endpoint   *url.URL
+}
+
+// RequestOptions holds options for the HTTP request.
+type RequestOptions struct {
+	Headers map[string]string
+}
+
+// ResponseOptions holds options for handling the HTTP response.
+type ResponseOptions struct {
+	// A list of status codes that are considered successful. If empty, only http.StatusOK is considered successful.
+	ExpectedStatusCodes []int
+}
+
+// FetchOptions holds options for an HTTP fetch operation.
+type FetchOptions struct {
+	Request  RequestOptions
+	Response ResponseOptions
+}
+
+// FetchOption is a function that modifies the FetchOptions.
+type FetchOption func(*FetchOptions)
+
+// WithHeaders sets the headers for the HTTP request.
+func WithHeaders(headers map[string]string) FetchOption {
+	return func(o *FetchOptions) {
+		o.Request.Headers = headers
+	}
+}
+
+// WithExpectedStatusCodes sets the expected status codes for the HTTP response.
+func WithExpectedStatusCodes(codes []int) FetchOption {
+	return func(o *FetchOptions) {
+		o.Response.ExpectedStatusCodes = codes
+	}
+}
+
+// NewHTTPFetcher creates a new HTTPFetcher with the given endpoint and HTTP client.
+func NewHTTPFetcher(
+	endpoint string, httpClient *http.Client) (*HTTPFetcher, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, errors.Join(ErrUnableToParseURL, err)
+	}
+
+	return &HTTPFetcher{
+		httpClient: httpClient,
+		endpoint:   u,
+	}, nil
+}
+
+// Fetch performs an HTTP GET request to the configured endpoint.
+// It returns the response body as an io.ReadCloser on success.
+// The caller is responsible for closing the reader.
+// It accepts a variable number of FetchOption functions to customize the request and response handling.
+func (f HTTPFetcher) Fetch(ctx context.Context, opts ...FetchOption) (io.ReadCloser, error) {
+	// Default options
+	options := &FetchOptions{
+		Response: ResponseOptions{
+			ExpectedStatusCodes: []int{http.StatusOK},
+		},
+		Request: RequestOptions{
+			Headers: nil,
+		},
+	}
+
+	// Apply custom options
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.endpoint.String(), nil)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to create request", "error", err, "url", f.endpoint.String())
+
+		return nil, errors.Join(fetchtypes.ErrFailedToBuildRequest, err)
+	}
+
+	// Apply request options
+	for k, v := range options.Request.Headers {
+		req.Header.Add(k, v)
+	}
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		slog.ErrorContext(ctx, "unable to fetch", "error", err, "url", f.endpoint.String())
+
+		return nil, errors.Join(fetchtypes.ErrFailedToFetch, err)
+	}
+
+	// Apply response options
+	statusCodeMatch := false
+	for _, code := range options.Response.ExpectedStatusCodes {
+		if resp.StatusCode == code {
+			statusCodeMatch = true
+
+			break
+		}
+	}
+
+	if !statusCodeMatch {
+		slog.ErrorContext(ctx, "bad status code while fetching", "status", resp.StatusCode, "url", f.endpoint.String())
+		// Clean up by closing since we will not be returning the body
+		resp.Body.Close()
+
+		return nil, errors.Join(fetchtypes.ErrUnexpectedResult, fmt.Errorf("bad status code:%d", resp.StatusCode))
+	}
+
+	if resp.Body == nil {
+		slog.ErrorContext(ctx, "missing body", "url", f.endpoint.String())
+
+		return nil, fetchtypes.ErrMissingBody
+	}
+
+	return resp.Body, nil
+}

--- a/lib/httputils/fetcher_test.go
+++ b/lib/httputils/fetcher_test.go
@@ -1,0 +1,168 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httputils
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/fetchtypes"
+)
+
+// mockRoundTripper is a mock http.RoundTripper for testing purposes.
+type mockRoundTripper struct {
+	roundTripFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.roundTripFunc(req)
+}
+
+func TestNewHTTPFetcher(t *testing.T) {
+	// nolint:exhaustruct // WONTFIX - external struct.
+	client := &http.Client{}
+
+	t.Run("valid URL", func(t *testing.T) {
+		fetcher, err := NewHTTPFetcher("http://example.com", client)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fetcher == nil {
+			t.Fatal("fetcher should not be nil")
+		}
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		_, err := NewHTTPFetcher(":", client)
+		if err == nil {
+			t.Fatal("expected an error for invalid URL, but got nil")
+		}
+	})
+}
+
+func TestHTTPFetcher_Fetch(t *testing.T) {
+	t.Run("successful fetch", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("test data"))
+		}))
+		defer server.Close()
+
+		fetcher, err := NewHTTPFetcher(server.URL, server.Client())
+		if err != nil {
+			t.Fatalf("unexpected error creating fetcher: %v", err)
+		}
+
+		body, err := fetcher.Fetch(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error on fetch: %v", err)
+		}
+		defer body.Close()
+
+		data, err := io.ReadAll(body)
+		if err != nil {
+			t.Fatalf("unexpected error reading body: %v", err)
+		}
+
+		if string(data) != "test data" {
+			t.Errorf("expected 'test data', got '%s'", string(data))
+		}
+	})
+
+	t.Run("unexpected status code", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer server.Close()
+
+		fetcher, err := NewHTTPFetcher(server.URL, server.Client())
+		if err != nil {
+			t.Fatalf("unexpected error creating fetcher: %v", err)
+		}
+
+		_, err = fetcher.Fetch(context.Background())
+		if !errors.Is(err, fetchtypes.ErrUnexpectedResult) {
+			t.Errorf("expected ErrUnexpectedResult, got %v", err)
+		}
+	})
+
+	t.Run("fetch error", func(t *testing.T) {
+		// nolint:exhaustruct // WONTFIX - external struct.
+		client := &http.Client{
+			Transport: &mockRoundTripper{
+				roundTripFunc: func(_ *http.Request) (*http.Response, error) {
+					return nil, errors.New("network error")
+				},
+			},
+		}
+
+		fetcher, err := NewHTTPFetcher("http://example.com", client)
+		if err != nil {
+			t.Fatalf("unexpected error creating fetcher: %v", err)
+		}
+
+		_, err = fetcher.Fetch(context.Background())
+		if !errors.Is(err, fetchtypes.ErrFailedToFetch) {
+			t.Errorf("expected ErrFailedToFetch, got %v", err)
+		}
+	})
+
+	t.Run("with headers", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "Bearer token" {
+				t.Errorf("expected Authorization header, but it was not set")
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		fetcher, err := NewHTTPFetcher(server.URL, server.Client())
+		if err != nil {
+			t.Fatalf("unexpected error creating fetcher: %v", err)
+		}
+
+		_, err = fetcher.Fetch(context.Background(), WithHeaders(map[string]string{
+			"Authorization": "Bearer token",
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error on fetch: %v", err)
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		}))
+		defer server.Close()
+
+		fetcher, err := NewHTTPFetcher(server.URL, server.Client())
+		if err != nil {
+			t.Fatalf("unexpected error creating fetcher: %v", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err = fetcher.Fetch(ctx)
+		if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "context canceled") {
+			t.Errorf("expected context canceled error, got %v", err)
+		}
+	})
+}

--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher.go
@@ -15,22 +15,19 @@
 package workflow
 
 import (
-	"context"
-	"io"
-	"log/slog"
 	"net/http"
-	"net/url"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/httputils"
 )
 
 func NewChromiumCodesearchEnumFetcher(httpClient *http.Client) (*ChromiumCodesearchEnumFetcher, error) {
-	u, err := url.Parse(enumURL)
+	fetcher, err := httputils.NewHTTPFetcher(enumURL, httpClient)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ChromiumCodesearchEnumFetcher{
-		httpClient: httpClient,
-		enumURL:    u,
+		HTTPFetcher: fetcher,
 	}, nil
 }
 
@@ -38,31 +35,8 @@ func NewChromiumCodesearchEnumFetcher(httpClient *http.Client) (*ChromiumCodesea
 // The returned data will be base64 encoded and it is up the consumer to decode
 // before reading.
 type ChromiumCodesearchEnumFetcher struct {
-	httpClient *http.Client
-	enumURL    *url.URL
+	*httputils.HTTPFetcher
 }
 
 const enumURL = "https://chromium.googlesource.com/chromium/src/+/main/tools/metrics/histograms/metadata/blink/" +
 	"enums.xml?format=TEXT"
-
-func (f ChromiumCodesearchEnumFetcher) Fetch(ctx context.Context) (io.ReadCloser, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.enumURL.String(), nil)
-	if err != nil {
-		slog.ErrorContext(ctx, "unable to create request", "error", err)
-
-		return nil, err
-	}
-	resp, err := f.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		// Clean up by closing since we will not be returning the body
-		resp.Body.Close()
-
-		return nil, err
-	}
-
-	return resp.Body, nil
-}

--- a/workflows/steps/services/chromium_histogram_enums/workflow/job_processor.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/job_processor.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"log/slog"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/httputils"
 	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
 )
 
@@ -47,7 +48,7 @@ func NewChromiumHistogramEnumsJobProcessor(
 }
 
 type EnumsFetecher interface {
-	Fetch(context.Context) (io.ReadCloser, error)
+	Fetch(context.Context, ...httputils.FetchOption) (io.ReadCloser, error)
 }
 
 type EnumsParser interface {

--- a/workflows/steps/services/chromium_histogram_enums/workflow/job_processor_test.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/job_processor_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/httputils"
 	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
 )
 
@@ -102,7 +103,7 @@ func TestProcess(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create mock dependencies
 			mockFetcher := &mockEnumsFetcher{
-				fetchFunc: func(_ context.Context) (io.ReadCloser, error) {
+				fetchFunc: func(_ context.Context, _ ...httputils.FetchOption) (io.ReadCloser, error) {
 					if tt.fetchErr != nil {
 						return nil, tt.fetchErr
 					}
@@ -148,12 +149,12 @@ func TestProcess(t *testing.T) {
 
 // Mock dependencies.
 type mockEnumsFetcher struct {
-	fetchFunc func(ctx context.Context) (io.ReadCloser, error)
+	fetchFunc func(ctx context.Context, opts ...httputils.FetchOption) (io.ReadCloser, error)
 }
 
-func (m *mockEnumsFetcher) Fetch(ctx context.Context) (io.ReadCloser, error) {
+func (m *mockEnumsFetcher) Fetch(ctx context.Context, opts ...httputils.FetchOption) (io.ReadCloser, error) {
 	if m.fetchFunc != nil {
-		return m.fetchFunc(ctx)
+		return m.fetchFunc(ctx, opts...)
 	}
 
 	return nil, errEnumsResponseNil

--- a/workflows/steps/services/common/repo_downloader/pkg/gh/download.go
+++ b/workflows/steps/services/common/repo_downloader/pkg/gh/download.go
@@ -16,10 +16,10 @@ package gh
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/httputils"
 	"github.com/google/go-github/v73/github"
 )
 
@@ -53,24 +53,17 @@ func (d *Downloader) Download(
 		return nil, "", err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL.String(), nil)
-	if err != nil {
-		return nil, "", err
-	}
-	resp, err := d.httpClient.Do(req)
+	fetcher, err := httputils.NewHTTPFetcher(archiveURL.String(), d.httpClient)
 	if err != nil {
 		return nil, "", err
 	}
 
-	statusCode := resp.StatusCode
-	if statusCode < 200 || statusCode > 299 {
-		err := fmt.Errorf("bad status code:%d, unable to download wpt-metadata", statusCode)
-		resp.Body.Close()
-
+	resp, err := fetcher.Fetch(ctx)
+	if err != nil {
 		return nil, "", err
 	}
 
-	return resp.Body, "main", nil
+	return resp, "main", nil
 }
 
 type ArchiveFile interface {

--- a/workflows/steps/services/uma_export/workflow/http_metrics_fetcher_test.go
+++ b/workflows/steps/services/uma_export/workflow/http_metrics_fetcher_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/civil"
+	"github.com/GoogleChrome/webstatus.dev/lib/fetchtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/metricdatatypes"
 )
 
@@ -78,7 +79,7 @@ func TestHTTPMetricsFetcher_Fetch(t *testing.T) {
 			token:       "test-token",
 			httpStatus:  http.StatusInternalServerError,
 			expectedURL: "",
-			err:         errUnexpectedStatusCode,
+			err:         fetchtypes.ErrUnexpectedResult,
 			// Empty values that won't be checked
 			want:         "",
 			responseBody: "",

--- a/workflows/steps/services/wpt_consumer/pkg/workflow/http_results_getter_test.go
+++ b/workflows/steps/services/wpt_consumer/pkg/workflow/http_results_getter_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/fetchtypes"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 )
 
@@ -48,14 +49,6 @@ func TestHTTPResultsGetter_DownloadResults(t *testing.T) {
 			wantErrOfKind: nil,
 		},
 		{
-			name:          "HTTP Error",
-			url:           "http://test.example/not_found",
-			responseBody:  "Not Found",
-			statusCode:    http.StatusNotFound,
-			wantData:      nil,
-			wantErrOfKind: ErrResultsDownloadBadStatusCode,
-		},
-		{
 			name:          "Invalid JSON",
 			url:           "http://test.example/invalid.json",
 			responseBody:  `{not valid JSON}`,
@@ -69,7 +62,7 @@ func TestHTTPResultsGetter_DownloadResults(t *testing.T) {
 			responseBody:  ``, // No response due to timeout
 			statusCode:    http.StatusOK,
 			wantData:      nil,
-			wantErrOfKind: ErrFailedToRequestResults,
+			wantErrOfKind: fetchtypes.ErrFailedToFetch,
 		},
 	}
 


### PR DESCRIPTION
Background: I was about to add a new workflow for the developer signals and saw that I was about to write code that I already used in many places.

This commit introduces a new HTTPFetcher in lib/httputils to standardize and centralize HTTP fetching logic across the application.

The new HTTPFetcher provides a consistent way to handle HTTP requests, including support for custom headers, expected status codes, and robust error handling for cases like network errors, unexpected status codes, and missing response bodies.

The following modules have been refactored to use the new HTTPFetcher:

- lib/gh/download_file_from_release.go
- workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher.go
- workflows/steps/services/common/repo_downloader/pkg/gh/download.go
- workflows/steps/services/uma_export/workflow/http_metrics_fetcher.go
- workflows/steps/services/wpt_consumer/pkg/workflow/http_results_getter.go

A new lib/fetchtypes package has been added to define common error types related to fetching.

Comprehensive unit tests have been added for the HTTPFetcher to cover various scenarios, including successful fetches, error conditions, and context cancellation.