### PR TITLE
feat(data): Add adapter for developer signal ingestion

### DIFF
--- a/lib/developersignaltypes/types.go
+++ b/lib/developersignaltypes/types.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package developersignaltypes
+
+// FeatureDeveloperSignal contains information about a developer signal for a feature.
+type FeatureDeveloperSignal struct {
+	Upvotes int64
+	Link    string
+}
+
+// FeatureDeveloperSignals is a map between feature id and developer signal.
+type FeatureDeveloperSignals map[string]FeatureDeveloperSignal

--- a/lib/gcpspanner/spanneradapters/developer_signals_consumer.go
+++ b/lib/gcpspanner/spanneradapters/developer_signals_consumer.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/developersignaltypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+)
+
+// DeveloperSignalsConsumer handles the conversion of the developer signals between the downloaded
+// format in the workflow and the format used by the GCP Spanner client.
+type DeveloperSignalsConsumer struct {
+	client DeveloperSignalsClient
+}
+
+// NewDeveloperSignalsConsumer constructs an adapter for the developer signals service.
+func NewDeveloperSignalsConsumer(client DeveloperSignalsClient) *DeveloperSignalsConsumer {
+	return &DeveloperSignalsConsumer{client: client}
+}
+
+// DeveloperSignalsClient expects a subset of the functionality from lib/gcpspanner that only apply to
+// Developer Signals.
+type DeveloperSignalsClient interface {
+	SyncLatestFeatureDeveloperSignals(ctx context.Context, data []gcpspanner.FeatureDeveloperSignal) error
+}
+
+// SyncLatestFeatureDeveloperSignals handles the conversion of developer signals between the workflow/API input
+// format and the format used by the GCP Spanner client.
+func (c *DeveloperSignalsConsumer) SyncLatestFeatureDeveloperSignals(
+	ctx context.Context, data *developersignaltypes.FeatureDeveloperSignals) error {
+	if data == nil || len(*data) == 0 {
+		return nil
+	}
+
+	signals := make([]gcpspanner.FeatureDeveloperSignal, 0, len(*data))
+	for featureID, signal := range *data {
+		signals = append(signals, gcpspanner.FeatureDeveloperSignal{
+			WebFeatureKey: featureID,
+			Upvotes:       signal.Upvotes,
+			Link:          signal.Link,
+		})
+	}
+
+	return c.client.SyncLatestFeatureDeveloperSignals(ctx, signals)
+
+}

--- a/lib/gcpspanner/spanneradapters/developer_signals_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/developer_signals_consumer_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/developersignaltypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/google/go-cmp/cmp"
+)
+
+type MockDeveloperSignalsClient struct {
+	callHistory   []gcpspanner.FeatureDeveloperSignal
+	shouldFail    bool
+	failWithError error
+}
+
+func (m *MockDeveloperSignalsClient) SyncLatestFeatureDeveloperSignals(
+	_ context.Context,
+	data []gcpspanner.FeatureDeveloperSignal,
+) error {
+	m.callHistory = append(m.callHistory, data...)
+	if m.shouldFail {
+		return m.failWithError
+	}
+
+	return nil
+}
+
+func TestSyncLatestFeatureDeveloperSignals(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         *developersignaltypes.FeatureDeveloperSignals
+		mockClient    *MockDeveloperSignalsClient
+		expectedError error
+		expectedCalls []gcpspanner.FeatureDeveloperSignal
+	}{
+		{
+			name: "Success",
+			input: &developersignaltypes.FeatureDeveloperSignals{
+				"feature1": {Upvotes: 100, Link: "link1"},
+				"feature2": {Upvotes: 200, Link: "link2"},
+			},
+			mockClient:    &MockDeveloperSignalsClient{callHistory: nil, shouldFail: false, failWithError: nil},
+			expectedError: nil,
+			expectedCalls: []gcpspanner.FeatureDeveloperSignal{
+				{WebFeatureKey: "feature1", Upvotes: 100, Link: "link1"},
+				{WebFeatureKey: "feature2", Upvotes: 200, Link: "link2"},
+			},
+		},
+		{
+			name:          "Empty input",
+			input:         &developersignaltypes.FeatureDeveloperSignals{},
+			mockClient:    &MockDeveloperSignalsClient{callHistory: nil, shouldFail: false, failWithError: nil},
+			expectedError: nil,
+			expectedCalls: nil,
+		},
+		{
+			name: "Spanner client error",
+			input: &developersignaltypes.FeatureDeveloperSignals{
+				"feature1": {Upvotes: 100, Link: "link1"},
+			},
+			mockClient: &MockDeveloperSignalsClient{
+				shouldFail:    true,
+				failWithError: errors.New("spanner error"),
+				callHistory:   nil,
+			},
+			expectedError: errors.New("spanner error"),
+			expectedCalls: []gcpspanner.FeatureDeveloperSignal{
+				{WebFeatureKey: "feature1", Upvotes: 100, Link: "link1"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			consumer := NewDeveloperSignalsConsumer(tc.mockClient)
+			err := consumer.SyncLatestFeatureDeveloperSignals(context.Background(), tc.input)
+
+			if !errors.Is(err, tc.expectedError) {
+				if err.Error() != tc.expectedError.Error() {
+					t.Errorf("unexpected error. got %v, want %v", err, tc.expectedError)
+				}
+			}
+
+			// Sort slices for deterministic comparison
+			cmpFunc := func(i, j gcpspanner.FeatureDeveloperSignal) int {
+				if i.WebFeatureKey < j.WebFeatureKey {
+					return -1
+				}
+				if i.WebFeatureKey > j.WebFeatureKey {
+					return 1
+				}
+
+				return 0
+			}
+			slices.SortFunc(tc.mockClient.callHistory, cmpFunc)
+			slices.SortFunc(tc.expectedCalls, cmpFunc)
+
+			if diff := cmp.Diff(tc.expectedCalls, tc.mockClient.callHistory); diff != "" {
+				t.Errorf("unexpected call history (-want +got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit introduces the necessary components to process and store developer signals from an external workflow into the Spanner database.

It adds:
- A new `DeveloperSignalsConsumer` adapter in `spanneradapters` to handle the data transformation.
- A shared `developersignaltypes` package to define a common data structure for signals, decoupling the workflow from the Spanner storage model.
- Unit tests with a mock client to ensure the adapter correctly converts the data.

Fixes: #1783