### PR TITLE
feat(ingestion): Add terraform for developer signals workflow

### DIFF
--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -62,6 +62,11 @@ web_features_region_schedules = {
   "europe-west1" = "0 8 * * *"  # Daily at 8:00 AM
 }
 
+developer_signals_region_schedules = {
+  "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
+  "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
+}
+
 chromium_region_schedules = {
   "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
   "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -63,6 +63,11 @@ web_features_region_schedules = {
   "europe-west1" = "0 8 * * *"  # Daily at 8:00 AM
 }
 
+developer_signals_region_schedules = {
+  "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
+  "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
+}
+
 chromium_region_schedules = {
   "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
   "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM

--- a/infra/ingestion/variables.tf
+++ b/infra/ingestion/variables.tf
@@ -72,6 +72,10 @@ variable "chromium_region_schedules" {
   type = map(string)
 }
 
+variable "developer_signals_region_schedules" {
+  type = map(string)
+}
+
 variable "uma_region_schedules" {
   type = map(string)
 }

--- a/infra/ingestion/workflows.tf
+++ b/infra/ingestion/workflows.tf
@@ -213,3 +213,37 @@ module "uma_export_workflow" {
   ]
 }
 
+module "developer_signals_workflow" {
+  source = "../modules/single_stage_go_workflow"
+  providers = {
+    google.internal_project = google.internal_project
+    google.public_project   = google.public_project
+  }
+  regions                       = var.regions
+  short_name                    = "dev-signals" # Needs to be short enough to create a service account
+  full_name                     = "Developer Signals Workflow"
+  deletion_protection           = var.deletion_protection
+  project_id                    = var.spanner_datails.project_id
+  timeout_seconds               = 60 * 10 # 5 minutes
+  image_name                    = "developer_signals_consumer_image"
+  spanner_details               = var.spanner_datails
+  env_id                        = var.env_id
+  region_schedules              = var.developer_signals_region_schedules
+  docker_repository_url         = var.docker_repository_details.url
+  go_module_path                = "workflows/steps/services/developer_signals_consumer"
+  does_process_write_to_spanner = true
+  env_vars = [
+    {
+      name  = "PROJECT_ID"
+      value = var.spanner_datails.project_id
+    },
+    {
+      name  = "SPANNER_DATABASE"
+      value = var.spanner_datails.database
+    },
+    {
+      name  = "SPANNER_INSTANCE"
+      value = var.spanner_datails.instance
+    }
+  ]
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -79,21 +79,22 @@ module "ingestion" {
     google.public_project   = google.public_project
   }
 
-  env_id                        = var.env_id
-  docker_repository_details     = module.storage.docker_repository_details
-  deletion_protection           = var.deletion_protection
-  regions                       = keys(var.region_information)
-  buckets                       = module.storage.buckets
-  secret_ids                    = var.secret_ids
-  datastore_info                = module.storage.datastore_info
-  spanner_datails               = module.storage.spanner_info
-  projects                      = var.projects
-  depends_on                    = [module.services]
-  wpt_region_schedules          = var.wpt_region_schedules
-  bcd_region_schedules          = var.bcd_region_schedules
-  uma_region_schedules          = var.uma_region_schedules
-  chromium_region_schedules     = var.chromium_region_schedules
-  web_features_region_schedules = var.web_features_region_schedules
+  env_id                             = var.env_id
+  docker_repository_details          = module.storage.docker_repository_details
+  deletion_protection                = var.deletion_protection
+  regions                            = keys(var.region_information)
+  buckets                            = module.storage.buckets
+  secret_ids                         = var.secret_ids
+  datastore_info                     = module.storage.datastore_info
+  spanner_datails                    = module.storage.spanner_info
+  projects                           = var.projects
+  depends_on                         = [module.services]
+  wpt_region_schedules               = var.wpt_region_schedules
+  bcd_region_schedules               = var.bcd_region_schedules
+  uma_region_schedules               = var.uma_region_schedules
+  chromium_region_schedules          = var.chromium_region_schedules
+  web_features_region_schedules      = var.web_features_region_schedules
+  developer_signals_region_schedules = var.developer_signals_region_schedules
 }
 
 module "backend" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -134,6 +134,10 @@ variable "bcd_region_schedules" {
   type = map(string)
 }
 
+variable "developer_signals_region_schedules" {
+  type = map(string)
+}
+
 variable "wpt_region_schedules" {
   type = map(string)
 }


### PR DESCRIPTION
This commit introduces the necessary Terraform infrastructure for the new "Developer Signals" data ingestion workflow.

The changes include:
- A new `developer_signals_workflow` module in `infra/ingestion/workflows.tf` to define the Cloud Run job.
- New variables in `infra/ingestion/variables.tf` and `infra/variables.tf` for the workflow's region-based schedules.
  - The schedule ensures it happens after the web feature workflow.
- Configuration of the production and staging schedules in the respective `.tfvars` files.

During the next deployment, it will deploy the jobs.

Fixes #1663