### PR TITLE
fix(localcache): Prevent race condition on cached data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,6 +36,7 @@
     "files.trimTrailingWhitespace": false,
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "go.testFlags": ["-race"],
   "files.exclude": {
     "**/.git": true,
     "**/.svn": true,

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ go-test: clean-up-go-testcontainers go-workspace-setup
 			echo "********* Testing module: $${GO_MODULE} *********" ; \
 			GO_COVERAGE_DIR="$${GO_MODULE}/coverage/unit" ; \
 			mkdir -p $${GO_COVERAGE_DIR} ; \
-			go test -p 1 -cover -covermode=atomic -coverprofile=$${GO_COVERAGE_DIR}/cover.out "$${GO_MODULE}/..." && \
+			go test -race -p 1 -cover -covermode=atomic -coverprofile=$${GO_COVERAGE_DIR}/cover.out "$${GO_MODULE}/..." && \
 			echo "Generating coverage report for $${GO_MODULE}" && \
 			go tool cover --func=$${GO_COVERAGE_DIR}/cover.out && \
 			echo -e "\n\n" || exit 1; \

--- a/workflows/steps/services/wpt_consumer/cmd/job/main.go
+++ b/workflows/steps/services/wpt_consumer/cmd/job/main.go
@@ -89,6 +89,19 @@ func main() {
 	// Worker Pool Setup
 	pool := workerpool.Pool[workflow.JobArguments]{}
 
+	webFeaturesDataCopier := func(in shared.WebFeaturesData) shared.WebFeaturesData {
+		dataCopy := make(shared.WebFeaturesData, len(in))
+		for testName, featuresMap := range in {
+			newFeaturesMap := make(map[string]interface{}, len(featuresMap))
+			for featureKey, featureData := range featuresMap {
+				newFeaturesMap[featureKey] = featureData
+			}
+			dataCopy[testName] = newFeaturesMap
+		}
+
+		return dataCopy
+	}
+
 	processor := workflow.NewWPTJobProcessor(
 		wptfyi.NewHTTPClient(wptFyiHostname),
 		workflow.NewWPTRunsProcessor(
@@ -96,7 +109,7 @@ func main() {
 				workflow.NewHTTPResultsGetter(),
 				workflow.NewCacheableWebFeaturesDataGetter(
 					shared.NewGitHubWebFeaturesClient(ghClient),
-					localcache.NewLocalDataCache[string, shared.WebFeaturesData](),
+					localcache.NewLocalDataCache[string, shared.WebFeaturesData](webFeaturesDataCopier),
 				),
 				spanneradapters.NewWPTWorkflowConsumer(spannerClient),
 			),


### PR DESCRIPTION
Introduces a copier function to the `LocalDataCache` to prevent race conditions when multiple goroutines access and modify cached reference types.

The original problem was that the in-memory `LocalDataCache` could return a direct reference to a cached value (like a map or slice). If multiple goroutines then retrieved this reference and tried to modify it concurrently, it would cause a data race. This was discovered by running tests with the `-race` detector.

This fix addresses the issue by:
1.  Introducing an optional `Copier` function to `NewLocalDataCache`.
2.  If a copier is provided, the `Get` method now returns a deep copy of the cached value, ensuring each goroutine gets its own isolated instance.
3.  The `wpt_consumer` workflow, a consumer of this cache, has been updated to provide a copier for the `WebFeaturesData` type.
4.  A new concurrent test case has been added to `cache_test.go` to explicitly test for this race condition and verify the fix.
5.  The main `Makefile` is updated to always run `go test` with the `-race` flag to proactively catch similar issues in the future.

This issue does not affect the `ValkeyDataCache`, as its data is serialized and deserialized from Valkey, which naturally creates copies and prevents this type of race condition.

Fixes #1807