### PR TITLE
feat(api): add discouraged feature information

### DIFF
--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -73,11 +73,12 @@ func TestGetFeature(t *testing.T) {
 							Version: valuePtr("100"),
 						},
 					},
-					FeatureId: "feature1",
-					Name:      "feature 1",
-					Spec:      nil,
-					Usage:     nil,
-					Wpt:       nil,
+					Discouraged: nil,
+					FeatureId:   "feature1",
+					Name:        "feature 1",
+					Spec:        nil,
+					Usage:       nil,
+					Wpt:         nil,
 				})),
 				err: nil,
 			},
@@ -176,6 +177,14 @@ func TestGetFeature(t *testing.T) {
 						Upvotes: valuePtr(int64(10)),
 						Link:    valuePtr("https://example.com"),
 					},
+					Discouraged: &backend.FeatureDiscouragedInfo{
+						AccordingTo: &[]backend.FeatureDiscouragedAccordingTo{
+							{Link: "https://example.com/discouraged"},
+						},
+						Alternatives: &[]backend.FeatureDiscouragedAlternative{
+							{Id: "alternative"},
+						},
+					},
 					BrowserImplementations: &map[string]backend.BrowserImplementation{
 						"chrome": {
 							Status:  valuePtr(backend.Available),
@@ -207,6 +216,10 @@ func TestGetFeature(t *testing.T) {
 							`"browser_implementations":` +
 							`{"chrome":{"date":"1999-01-01","status":"available","version":"100"}},` +
 							`"developer_signals":{"link":"https://example.com","upvotes":10},` +
+							`"discouraged":{` +
+							`"according_to":[{"link":"https://example.com/discouraged"}],` +
+							`"alternatives":[{"id":"alternative"}]` +
+							`},` +
 							`"feature_id":"feature1","name":"feature 1"}`,
 					),
 					CacheCfg: getDefaultCacheConfig(),
@@ -228,6 +241,9 @@ func TestGetFeature(t *testing.T) {
 		}
 	},
 	"developer_signals":{"link":"https://example.com","upvotes":10},
+	"discouraged":{
+		"according_to":[{"link":"https://example.com/discouraged"}],"alternatives":[{"id":"alternative"}]
+	},
 	"feature_id":"feature1",
 	"name":"feature 1"
 }`,
@@ -246,6 +262,10 @@ func TestGetFeature(t *testing.T) {
 							`"browser_implementations":` +
 							`{"chrome":{"date":"1999-01-01","status":"available","version":"100"}},` +
 							`"developer_signals":{"link":"https://example.com","upvotes":10},` +
+							`"discouraged":{` +
+							`"according_to":[{"link":"https://example.com/discouraged"}],` +
+							`"alternatives":[{"id":"alternative"}]` +
+							`},` +
 							`"feature_id":"feature1","name":"feature 1"}`,
 					),
 					Err: nil,
@@ -268,6 +288,9 @@ func TestGetFeature(t *testing.T) {
 		}
 	},
 	"developer_signals":{"link":"https://example.com","upvotes":10},
+	"discouraged":{
+		"according_to":[{"link":"https://example.com/discouraged"}],"alternatives":[{"id":"alternative"}]
+	},
 	"feature_id":"feature1",
 	"name":"feature 1"
 }`,

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -85,6 +85,7 @@ func TestListFeatures(t *testing.T) {
 								},
 							},
 							DeveloperSignals: nil,
+							Discouraged:      nil,
 						},
 					},
 				},
@@ -256,6 +257,14 @@ func TestListFeatures(t *testing.T) {
 								Upvotes: valuePtr(int64(24)),
 								Link:    valuePtr("https://example.com"),
 							},
+							Discouraged: &backend.FeatureDiscouragedInfo{
+								AccordingTo: &[]backend.FeatureDiscouragedAccordingTo{
+									{Link: "https://example.com/discouraged"},
+								},
+								Alternatives: &[]backend.FeatureDiscouragedAlternative{
+									{Id: "alternative"},
+								},
+							},
 						},
 					},
 				},
@@ -278,6 +287,10 @@ func TestListFeatures(t *testing.T) {
 							`"browser_implementations":` +
 							`{"chrome":{"date":"1999-01-01","status":"available","version":"101"}},` +
 							`"developer_signals":{"link":"https://example.com","upvotes":24},` +
+							`"discouraged":{` +
+							`"according_to":[{"link":"https://example.com/discouraged"}],` +
+							`"alternatives":[{"id":"alternative"}]` +
+							`},` +
 							`"feature_id":"feature1","name":"feature 1"}],` +
 							`"metadata":{"next_page_token":"next-page-token","total":100}}`,
 					),
@@ -304,6 +317,9 @@ func TestListFeatures(t *testing.T) {
 			"developer_signals":{
 				"link":"https://example.com",
 				"upvotes":24
+			},
+			"discouraged":{
+				"according_to":[{"link":"https://example.com/discouraged"}],"alternatives":[{"id":"alternative"}]
 			},
 			"feature_id":"feature1",
 			"name":"feature 1"
@@ -335,6 +351,10 @@ func TestListFeatures(t *testing.T) {
 							`"browser_implementations":` +
 							`{"chrome":{"date":"1999-01-01","status":"available","version":"101"}},` +
 							`"developer_signals":{"link":"https://example.com","upvotes":24},` +
+							`"discouraged":{` +
+							`"according_to":[{"link":"https://example.com/discouraged"}],` +
+							`"alternatives":[{"id":"alternative"}]` +
+							`},` +
 							`"feature_id":"feature1","name":"feature 1"}],` +
 							`"metadata":{"next_page_token":"next-page-token","total":100}}`,
 					),
@@ -362,6 +382,9 @@ func TestListFeatures(t *testing.T) {
 			"developer_signals":{
 				"link":"https://example.com",
 				"upvotes":24
+			},
+			"discouraged":{
+				"according_to":[{"link":"https://example.com/discouraged"}],"alternatives":[{"id":"alternative"}]
 			},
 			"feature_id":"feature1",
 			"name":"feature 1"

--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -331,6 +331,7 @@ FROM WebFeatures wf
 LEFT OUTER JOIN FeatureBaselineStatus fbs ON wf.ID = fbs.WebFeatureID
 LEFT OUTER JOIN ExcludedFeatureKeys efk ON wf.FeatureKey = efk.FeatureKey
 LEFT OUTER JOIN FeatureSpecs fs ON wf.ID = fs.WebFeatureID
+LEFT OUTER JOIN FeatureDiscouragedDetails fdd ON wf.ID = fdd.WebFeatureID
 LEFT OUTER JOIN LatestFeatureDeveloperSignals lfds ON wf.ID = lfds.WebFeatureID
 LEFT OUTER JOIN (
 	SELECT
@@ -446,6 +447,8 @@ SELECT
 	fbs.LowDate,
 	fbs.HighDate,
 	fs.Links AS SpecLinks,
+	fdd.AccordingTo,
+	fdd.Alternatives,
 	chromium_usage_metrics.ChromiumUsage,
 	lfds.Upvotes AS DeveloperSignalUpvotes,
 	lfds.Link AS DeveloperSignalLink,
@@ -511,6 +514,8 @@ SELECT
 	fbs.LowDate,
 	fbs.HighDate,
 	fs.Links AS SpecLinks,
+	fdd.AccordingTo,
+	fdd.Alternatives,
 	chromium_usage_metrics.ChromiumUsage,
 	lfds.Upvotes AS DeveloperSignalUpvotes,
 	lfds.Link AS DeveloperSignalLink,

--- a/lib/gcpspanner/feature_search.go
+++ b/lib/gcpspanner/feature_search.go
@@ -42,6 +42,8 @@ type SpannerFeatureResult struct {
 	LowDate                *time.Time                    `spanner:"LowDate"`
 	HighDate               *time.Time                    `spanner:"HighDate"`
 	SpecLinks              []string                      `spanner:"SpecLinks"`
+	AccordingTo            []string                      `spanner:"AccordingTo"`
+	Alternatives           []string                      `spanner:"Alternatives"`
 	ChromiumUsage          *big.Rat                      `spanner:"ChromiumUsage"`
 	DeveloperSignalUpvotes *int64                        `spanner:"DeveloperSignalUpvotes"`
 	DeveloperSignalLink    *string                       `spanner:"DeveloperSignalLink"`
@@ -88,6 +90,8 @@ type FeatureResult struct {
 	LowDate                *time.Time              `spanner:"LowDate"`
 	HighDate               *time.Time              `spanner:"HighDate"`
 	SpecLinks              []string                `spanner:"SpecLinks"`
+	AccordingTo            []string                `spanner:"AccordingTo"`
+	Alternatives           []string                `spanner:"Alternatives"`
 	ChromiumUsage          *big.Rat                `spanner:"ChromiumUsage"`
 	DeveloperSignalUpvotes *int64                  `spanner:"DeveloperSignalUpvotes"`
 	DeveloperSignalLink    *string                 `spanner:"DeveloperSignalLink"`
@@ -232,6 +236,14 @@ func (c *Client) getFeatureResult(
 			result.SpecLinks = nil
 		}
 
+		if len(result.AccordingTo) == 0 {
+			result.AccordingTo = nil
+		}
+
+		if len(result.Alternatives) == 0 {
+			result.Alternatives = nil
+		}
+
 		actualResult := FeatureResult{
 			FeatureKey:             result.FeatureKey,
 			Name:                   result.Name,
@@ -242,6 +254,8 @@ func (c *Client) getFeatureResult(
 			LowDate:                result.LowDate,
 			HighDate:               result.HighDate,
 			SpecLinks:              result.SpecLinks,
+			AccordingTo:            result.AccordingTo,
+			Alternatives:           result.Alternatives,
 			ChromiumUsage:          result.ChromiumUsage,
 			DeveloperSignalUpvotes: result.DeveloperSignalUpvotes,
 			DeveloperSignalLink:    result.DeveloperSignalLink,

--- a/lib/gcpspanner/get_feature.go
+++ b/lib/gcpspanner/get_feature.go
@@ -83,6 +83,8 @@ func (c *Client) GetFeature(
 		ChromiumUsage:          result.ChromiumUsage,
 		DeveloperSignalUpvotes: result.DeveloperSignalUpvotes,
 		DeveloperSignalLink:    result.DeveloperSignalLink,
+		AccordingTo:            result.AccordingTo,
+		Alternatives:           result.Alternatives,
 	}
 
 	return &actualResult, nil

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -849,6 +849,10 @@ func (s *Backend) convertFeatureResult(featureResult *gcpspanner.FeatureResult) 
 			Upvotes: featureResult.DeveloperSignalUpvotes,
 			Link:    featureResult.DeveloperSignalLink,
 		}),
+		Discouraged: convertDiscouragedDetails(
+			featureResult.Alternatives,
+			featureResult.AccordingTo,
+		),
 	}
 
 	if len(featureResult.ExperimentalMetrics) > 0 {
@@ -886,6 +890,39 @@ func (s *Backend) convertFeatureResult(featureResult *gcpspanner.FeatureResult) 
 		ret.Spec = &backend.FeatureSpecInfo{
 			Links: &links,
 		}
+	}
+
+	return ret
+}
+
+func convertDiscouragedDetails(alternatives, accordingTo []string) *backend.FeatureDiscouragedInfo {
+	if len(alternatives) == 0 && len(accordingTo) == 0 {
+		return nil
+	}
+
+	ret := &backend.FeatureDiscouragedInfo{
+		Alternatives: nil,
+		AccordingTo:  nil,
+	}
+
+	if len(alternatives) > 0 {
+		alternativeInfo := make([]backend.FeatureDiscouragedAlternative, 0, len(alternatives))
+		for idx := range alternatives {
+			alternativeInfo = append(alternativeInfo, backend.FeatureDiscouragedAlternative{
+				Id: alternatives[idx],
+			})
+		}
+		ret.Alternatives = &alternativeInfo
+	}
+
+	if len(accordingTo) > 0 {
+		accordingToInfo := make([]backend.FeatureDiscouragedAccordingTo, 0, len(accordingTo))
+		for idx := range accordingTo {
+			accordingToInfo = append(accordingToInfo, backend.FeatureDiscouragedAccordingTo{
+				Link: accordingTo[idx],
+			})
+		}
+		ret.AccordingTo = &accordingToInfo
 	}
 
 	return ret

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -1193,6 +1193,14 @@ func TestFeaturesSearch(t *testing.T) {
 							ChromiumUsage:          big.NewRat(91, 100),
 							DeveloperSignalUpvotes: valuePtr(int64(9)),
 							DeveloperSignalLink:    valuePtr("http://example.com"),
+							AccordingTo: []string{
+								"accordingto1",
+								"accordingto2",
+							},
+							Alternatives: []string{
+								"alternative1",
+								"alternative2",
+							},
 						},
 						{
 							Name:       "feature 2",
@@ -1249,6 +1257,11 @@ func TestFeaturesSearch(t *testing.T) {
 							ChromiumUsage:          big.NewRat(10, 100),
 							DeveloperSignalUpvotes: nil,
 							DeveloperSignalLink:    nil,
+							AccordingTo: []string{
+								"accordingto3",
+								"accordingto4",
+							},
+							Alternatives: nil,
 						},
 					},
 				},
@@ -1315,6 +1328,24 @@ func TestFeaturesSearch(t *testing.T) {
 						DeveloperSignals: &backend.FeatureDeveloperSignals{
 							Upvotes: valuePtr[int64](9),
 							Link:    valuePtr("http://example.com"),
+						},
+						Discouraged: &backend.FeatureDiscouragedInfo{
+							AccordingTo: &[]backend.FeatureDiscouragedAccordingTo{
+								{
+									Link: "accordingto1",
+								},
+								{
+									Link: "accordingto2",
+								},
+							},
+							Alternatives: &[]backend.FeatureDiscouragedAlternative{
+								{
+									Id: "alternative1",
+								},
+								{
+									Id: "alternative2",
+								},
+							},
 						},
 					},
 					{
@@ -1383,6 +1414,17 @@ func TestFeaturesSearch(t *testing.T) {
 							},
 						},
 						DeveloperSignals: nil,
+						Discouraged: &backend.FeatureDiscouragedInfo{
+							AccordingTo: &[]backend.FeatureDiscouragedAccordingTo{
+								{
+									Link: "accordingto3",
+								},
+								{
+									Link: "accordingto4",
+								},
+							},
+							Alternatives: nil,
+						},
 					},
 				},
 			},
@@ -1583,6 +1625,11 @@ func TestGetFeature(t *testing.T) {
 					ChromiumUsage:          nil,
 					DeveloperSignalUpvotes: valuePtr(int64(4)),
 					DeveloperSignalLink:    valuePtr("http://example.com"),
+					Alternatives: []string{
+						"alternative1",
+						"alternative2",
+					},
+					AccordingTo: []string{"according1", "according2"},
 				},
 				returnedError: nil,
 			},
@@ -1642,6 +1689,24 @@ func TestGetFeature(t *testing.T) {
 						DeveloperSignals: &backend.FeatureDeveloperSignals{
 							Upvotes: valuePtr[int64](4),
 							Link:    valuePtr("http://example.com"),
+						},
+						Discouraged: &backend.FeatureDiscouragedInfo{
+							Alternatives: &[]backend.FeatureDiscouragedAlternative{
+								{
+									Id: "alternative1",
+								},
+								{
+									Id: "alternative2",
+								},
+							},
+							AccordingTo: &[]backend.FeatureDiscouragedAccordingTo{
+								{
+									Link: "according1",
+								},
+								{
+									Link: "according2",
+								},
+							},
 						},
 					}),
 				}
@@ -3073,6 +3138,8 @@ func TestConvertFeatureResult(t *testing.T) {
 				ChromiumUsage:          big.NewRat(8, 100),
 				DeveloperSignalUpvotes: nil,
 				DeveloperSignalLink:    nil,
+				AccordingTo:            nil,
+				Alternatives:           nil,
 			},
 
 			expectedFeature: &backend.Feature{
@@ -3094,6 +3161,7 @@ func TestConvertFeatureResult(t *testing.T) {
 				Wpt:                    nil,
 				BrowserImplementations: nil,
 				DeveloperSignals:       nil,
+				Discouraged:            nil,
 			},
 		},
 	}

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -1142,6 +1142,31 @@ components:
         link:
           type: string
           description: Link to the issue tracking developer signal for a feature.
+    FeatureDiscouragedInfo:
+      type: object
+      properties:
+        according_to:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureDiscouragedAccordingTo'
+        alternatives:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureDiscouragedAlternative'
+    FeatureDiscouragedAccordingTo:
+      type: object
+      properties:
+        link:
+          type: string
+      required:
+        - link
+    FeatureDiscouragedAlternative:
+      type: object
+      properties:
+        id:
+          type: string
+      required:
+        - id
     FeaturePage:
       type: object
       properties:
@@ -1366,6 +1391,8 @@ components:
             The absence of this object means the feature does not have an active issue
             in https://github.com/web-platform-dx/developer-signals.
           $ref: '#/components/schemas/FeatureDeveloperSignals'
+        discouraged:
+          $ref: '#/components/schemas/FeatureDiscouragedInfo'
       required:
         - feature_id
         - name


### PR DESCRIPTION
This commit introduces the ability to surface information about discouraged web features through the API.

The `Feature` object in the API response now includes an optional `discouraged` field. This field contains details on why a feature is discouraged, including links to the source (`according_to`) and a list of suggested `alternatives`.

Implementation details:
- The `openapi.yaml` specification has been updated with the new `FeatureDiscouragedInfo` schema.
- The core Spanner feature query now joins the `FeatureDiscouragedDetails` table to retrieve this information.
- Data models, adapters, and tests have been updated throughout the backend to support and validate the new data.