### PR TITLE
fix(frontend): Display developer signals with zero upvotes

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
@@ -380,6 +380,26 @@ describe('webstatus-feature-page', () => {
       expect(icon?.getAttribute('name')).to.equal('hand-thumbs-up');
     });
 
+    it('renders the developer signal when the upvotes are zero', async () => {
+      const signal = {upvotes: 0, link: 'http://example.com'};
+      const actual = element.renderDeveloperSignal(signal);
+      render(actual, hostElement);
+      const host = await fixture(hostElement);
+      const tooltip = host.querySelector('sl-tooltip');
+      const button = host.querySelector('sl-button');
+
+      expect(tooltip).to.not.be.null;
+      expect(button).to.not.be.null;
+
+      expect(tooltip?.getAttribute('content')).to.equal(
+        '0 developer upvotes. Need this feature across browsers? Click this and upvote it on GitHub.',
+      );
+      expect(button?.getAttribute('aria-label')).to.equal(
+        '0 developer upvotes',
+      );
+      expect(button?.textContent?.trim()).to.equal('0');
+    });
+
     it('renders the developer signal button with compact number', async () => {
       const signal = {upvotes: 12345, link: 'http://example.com'};
       const actual = element.renderDeveloperSignal(signal);

--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -384,7 +384,7 @@ export class FeaturePage extends BaseChartsPage {
   renderDeveloperSignal(
     signal?: components['schemas']['FeatureDeveloperSignals'],
   ): TemplateResult {
-    if (!signal?.link || !signal?.upvotes) {
+    if (signal?.link === undefined || signal?.upvotes === undefined) {
       return html`${nothing}`;
     }
 


### PR DESCRIPTION
The previous logic did not render the developer signal component if the number of upvotes was zero, because it was treated as a falsy value.

This change corrects the condition to explicitly check for `undefined` instead, allowing the component to be rendered correctly when there are zero upvotes.

A new unit test is added to verify this behavior.