### PR TITLE
refactor: Use sync for browser feature availabilities

### DIFF
--- a/lib/gcpspanner/browser_availabilities_test.go
+++ b/lib/gcpspanner/browser_availabilities_test.go
@@ -17,6 +17,7 @@ package gcpspanner
 import (
 	"context"
 	"errors"
+	"maps"
 	"slices"
 	"testing"
 
@@ -24,42 +25,27 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-func getSampleBrowserAvailabilities() []struct {
-	FeatureKey string
-	BrowserFeatureAvailability
-} {
-	return []struct {
-		FeatureKey string
-		BrowserFeatureAvailability
-	}{
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{
+func getSampleBrowserAvailabilities() map[string][]BrowserFeatureAvailability {
+	return map[string][]BrowserFeatureAvailability{
+		"feature1": {
+			{
 				BrowserName:    "fooBrowser",
 				BrowserVersion: "0.0.0",
 			},
-			FeatureKey: "feature1",
-		},
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{
+			{
 				BrowserName:    "barBrowser",
 				BrowserVersion: "0.0.0",
 			},
-			FeatureKey: "feature1",
 		},
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{
+		"feature2": {
+			{
 				BrowserName:    "barBrowser",
 				BrowserVersion: "2.0.0",
 			},
-			FeatureKey: "feature2",
-		},
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{
+			{
 				BrowserName:    "fooBrowser",
 				BrowserVersion: "1.0.0",
 			},
-
-			FeatureKey: "feature2",
 		},
 	}
 }
@@ -86,7 +72,7 @@ func setupRequiredTablesForBrowserFeatureAvailability(
 // Helper method to get all the Availabilities in a stable order.
 func (c *Client) ReadAllAvailabilities(ctx context.Context, _ *testing.T) ([]BrowserFeatureAvailability, error) {
 	stmt := spanner.NewStatement(
-		"SELECT * FROM BrowserFeatureAvailabilities ORDER BY BrowserVersion ASC, BrowserName ASC")
+		"SELECT BrowserName, BrowserVersion FROM BrowserFeatureAvailabilities ORDER BY BrowserVersion ASC, BrowserName ASC")
 	iter := c.Single().Query(ctx, stmt)
 	defer iter.Stop()
 
@@ -99,27 +85,25 @@ func (c *Client) ReadAllAvailabilities(ctx context.Context, _ *testing.T) ([]Bro
 		if err != nil {
 			return nil, errors.Join(ErrInternalQueryFailure, err)
 		}
-		var availability spannerBrowserFeatureAvailability
+		var availability BrowserFeatureAvailability
 		if err := row.ToStruct(&availability); err != nil {
 			return nil, errors.Join(ErrInternalQueryFailure, err)
 		}
-		ret = append(ret, availability.BrowserFeatureAvailability)
+		ret = append(ret, availability)
 	}
 
 	return ret, nil
 }
 
-func TestUpsertBrowserFeatureAvailability(t *testing.T) {
+func TestSyncBrowserFeatureAvailabilities(t *testing.T) {
 	restartDatabaseContainer(t)
 	ctx := context.Background()
 	setupRequiredTablesForBrowserFeatureAvailability(ctx, spannerClient, t)
 	sampleAvailabilities := getSampleBrowserAvailabilities()
-	for _, availability := range sampleAvailabilities {
-		err := spannerClient.UpsertBrowserFeatureAvailability(
-			ctx, availability.FeatureKey, availability.BrowserFeatureAvailability)
-		if err != nil {
-			t.Errorf("unexpected error during insert. %s", err.Error())
-		}
+	err := spannerClient.SyncBrowserFeatureAvailabilities(
+		ctx, sampleAvailabilities)
+	if err != nil {
+		t.Errorf("unexpected error during insert. %s", err.Error())
 	}
 
 	expectedPage := []BrowserFeatureAvailability{
@@ -151,10 +135,19 @@ func TestUpsertBrowserFeatureAvailability(t *testing.T) {
 	}
 
 	// Update the availability info for feature1 on barBrowser to a later version
-	err = spannerClient.UpsertBrowserFeatureAvailability(ctx, "feature1", BrowserFeatureAvailability{
-		BrowserName:    "barBrowser",
-		BrowserVersion: "1.0.0",
-	})
+	updatedAvailabilities := maps.Clone(sampleAvailabilities)
+	updatedAvailabilities["feature1"] = []BrowserFeatureAvailability{
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "0.0.0",
+		},
+		{
+			BrowserName:    "barBrowser",
+			BrowserVersion: "1.0.0",
+		},
+	}
+
+	err = spannerClient.SyncBrowserFeatureAvailabilities(ctx, updatedAvailabilities)
 	if err != nil {
 		t.Errorf("unexpected error during update. %s", err.Error())
 	}

--- a/lib/gcpspanner/browser_feature_count_test.go
+++ b/lib/gcpspanner/browser_feature_count_test.go
@@ -61,67 +61,31 @@ func loadDataForListBrowserFeatureCountMetric(ctx context.Context, t *testing.T,
 		}
 	}
 
-	browserFeatureAvailabilities := []struct {
-		FeatureKey string
-		BrowserFeatureAvailability
-	}{
-		// Chrome Availabilities
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "chrome", BrowserVersion: "100"},
-			FeatureKey:                 "FeatureX",
-		}, // Available from Chrome 100
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "chrome", BrowserVersion: "100"},
-			FeatureKey:                 "FeatureY",
-		}, // Available from Chrome 100
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "chrome", BrowserVersion: "101"},
-			FeatureKey:                 "FeatureZ",
-		}, // Available from Chrome 101
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "chrome", BrowserVersion: "101"},
-			FeatureKey:                 "FeatureV",
-		}, // Available from Chrome 101
-
-		// Firefox Availabilities
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "firefox", BrowserVersion: "80"},
-			FeatureKey:                 "FeatureY",
-		}, // Available from Firefox 80
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "firefox", BrowserVersion: "81"},
-			FeatureKey:                 "FeatureW",
-		}, // Available from Firefox 81
-
-		// Chrome Android Availabilities
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{
-				BrowserName:    "chrome_android",
-				BrowserVersion: "100",
-			},
-			FeatureKey: "FeatureX",
-		}, // Available from Chrome Android 102
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{
-				BrowserName:    "chrome_android",
-				BrowserVersion: "101",
-			},
-			FeatureKey: "FeatureV",
-		}, // Available from Chrome Android 102
-
-		// Firefox Android Availabilities
-		{
-			BrowserFeatureAvailability: BrowserFeatureAvailability{
-				BrowserName: "firefox_android", BrowserVersion: "80"},
-			FeatureKey: "FeatureV",
-		}, // Available from Firefox Android 80
+	browserFeatureAvailabilities := map[string][]BrowserFeatureAvailability{
+		"FeatureX": {
+			{BrowserName: "chrome", BrowserVersion: "100"},
+			{BrowserName: "chrome_android", BrowserVersion: "100"},
+		},
+		"FeatureY": {
+			{BrowserName: "chrome", BrowserVersion: "100"},
+			{BrowserName: "firefox", BrowserVersion: "80"},
+		},
+		"FeatureZ": {
+			{BrowserName: "chrome", BrowserVersion: "101"},
+		},
+		"FeatureV": {
+			{BrowserName: "chrome", BrowserVersion: "101"},
+			{BrowserName: "chrome_android", BrowserVersion: "101"},
+			{BrowserName: "firefox_android", BrowserVersion: "80"},
+		},
+		"FeatureW": {
+			{BrowserName: "firefox", BrowserVersion: "81"},
+		},
 	}
-	for _, availability := range browserFeatureAvailabilities {
-		err := client.UpsertBrowserFeatureAvailability(ctx,
-			availability.FeatureKey, availability.BrowserFeatureAvailability)
-		if err != nil {
-			t.Errorf("unexpected error during insert. %s", err.Error())
-		}
+
+	err := client.SyncBrowserFeatureAvailabilities(ctx, browserFeatureAvailabilities)
+	if err != nil {
+		t.Errorf("unexpected error during insert. %s", err.Error())
 	}
 }
 

--- a/lib/gcpspanner/browser_feature_support_event_test.go
+++ b/lib/gcpspanner/browser_feature_support_event_test.go
@@ -80,12 +80,14 @@ func setupTablesForPrecalculateBrowserFeatureSupportEvents(
 			BrowserFeatureAvailability: BrowserFeatureAvailability{BrowserName: "Firefox", BrowserVersion: "112"},
 		},
 	}
+	syncAvailabilities := make(map[string][]BrowserFeatureAvailability)
 	for _, availability := range availabilities {
-		err := spannerClient.UpsertBrowserFeatureAvailability(ctx, availability.WebFeatureKey,
-			availability.BrowserFeatureAvailability)
-		if err != nil {
-			t.Fatalf("Failed to insert BrowserFeatureAvailability: %v", err)
-		}
+		syncAvailabilities[availability.WebFeatureKey] = append(
+			syncAvailabilities[availability.WebFeatureKey], availability.BrowserFeatureAvailability)
+	}
+	err := spannerClient.SyncBrowserFeatureAvailabilities(ctx, syncAvailabilities)
+	if err != nil {
+		t.Fatalf("Failed to sync BrowserFeatureAvailability: %v", err)
 	}
 
 	return features, featureKeyToID

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -164,11 +164,14 @@ func setupRequiredTablesForFeaturesSearch(ctx context.Context,
 			FeatureKey: "feature3",
 		},
 	}
+	syncAvailabilities := make(map[string][]BrowserFeatureAvailability)
 	for _, availability := range sampleBrowserAvailabilities {
-		err := client.UpsertBrowserFeatureAvailability(ctx, availability.FeatureKey, availability.BrowserFeatureAvailability)
-		if err != nil {
-			t.Errorf("unexpected error during insert of availabilities. %s", err.Error())
-		}
+		syncAvailabilities[availability.FeatureKey] = append(
+			syncAvailabilities[availability.FeatureKey], availability.BrowserFeatureAvailability)
+	}
+	err = client.SyncBrowserFeatureAvailabilities(ctx, syncAvailabilities)
+	if err != nil {
+		t.Errorf("unexpected error during insert of availabilities. %s", err.Error())
 	}
 
 	//nolint: dupl // Okay to duplicate for tests

--- a/lib/gcpspanner/missing_one_implementation_feature_list_test.go
+++ b/lib/gcpspanner/missing_one_implementation_feature_list_test.go
@@ -127,14 +127,16 @@ func loadDataForListMissingOneImplFeatureList(ctx context.Context, t *testing.T,
 			FeatureKey:                 "FeatureX",
 		}, // Available from bazBrowser 2.0
 	}
+	syncAvailabilities := make(map[string][]BrowserFeatureAvailability)
 	for _, availability := range browserFeatureAvailabilities {
-		err := client.UpsertBrowserFeatureAvailability(ctx,
-			availability.FeatureKey, availability.BrowserFeatureAvailability)
-		if err != nil {
-			t.Errorf("unexpected error during insert. %s", err.Error())
-		}
+		syncAvailabilities[availability.FeatureKey] = append(
+			syncAvailabilities[availability.FeatureKey], availability.BrowserFeatureAvailability)
 	}
-	err := spannerClient.PrecalculateBrowserFeatureSupportEvents(ctx,
+	err := client.SyncBrowserFeatureAvailabilities(ctx, syncAvailabilities)
+	if err != nil {
+		t.Errorf("unexpected error during insert. %s", err.Error())
+	}
+	err = spannerClient.PrecalculateBrowserFeatureSupportEvents(ctx,
 		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Errorf("unexpected error during pre-calculate. %s", err.Error())

--- a/lib/gcpspanner/missing_one_implementation_test.go
+++ b/lib/gcpspanner/missing_one_implementation_test.go
@@ -132,14 +132,17 @@ func loadDataForListMissingOneImplCounts(ctx context.Context, t *testing.T, clie
 			FeatureKey:                 "FeatureX",
 		}, // Available from bazBrowser 2.0
 	}
+	syncAvailabilities := make(map[string][]BrowserFeatureAvailability)
 	for _, availability := range browserFeatureAvailabilities {
-		err := client.UpsertBrowserFeatureAvailability(ctx,
-			availability.FeatureKey, availability.BrowserFeatureAvailability)
-		if err != nil {
-			t.Errorf("unexpected error during insert. %s", err.Error())
-		}
+		syncAvailabilities[availability.FeatureKey] = append(
+			syncAvailabilities[availability.FeatureKey], availability.BrowserFeatureAvailability)
 	}
-	err := spannerClient.PrecalculateBrowserFeatureSupportEvents(ctx,
+	err := client.SyncBrowserFeatureAvailabilities(ctx, syncAvailabilities)
+	if err != nil {
+		t.Errorf("unexpected error during insert. %s", err.Error())
+	}
+
+	err = spannerClient.PrecalculateBrowserFeatureSupportEvents(ctx,
 		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC), time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Errorf("unexpected error during pre-calculate. %s", err.Error())

--- a/lib/gcpspanner/web_features_fk_test.go
+++ b/lib/gcpspanner/web_features_fk_test.go
@@ -116,10 +116,14 @@ func (w *webFeatureForeignKeyTestHelpers) insertBrowserFeatureAvailability(ctx c
 	}
 
 	// Insert BrowserFeatureAvailability
-	err = spannerClient.UpsertBrowserFeatureAvailability(ctx, w.testWebFeature().FeatureKey, BrowserFeatureAvailability{
-		BrowserName:    "fooBrowser",
-		BrowserVersion: "0.0.0",
-	})
+	availabilities := make(map[string][]BrowserFeatureAvailability)
+	availabilities[w.testWebFeature().FeatureKey] = []BrowserFeatureAvailability{
+		{
+			BrowserName:    "fooBrowser",
+			BrowserVersion: "0.0.0",
+		},
+	}
+	err = spannerClient.SyncBrowserFeatureAvailabilities(ctx, availabilities)
 	if err != nil {
 		t.Errorf("unexpected error during insert. %s", err.Error())
 	}


### PR DESCRIPTION
This commit refactors the code to use a new sync method for updating browser feature availabilities. The new method, SyncBrowserFeatureAvailabilities, allows for batch updates, which improves performance by reducing the number of database calls. And also helps in the cases when a feature's availability regresses for a browser.

The following changes were made:
- Replaced UpsertBrowserFeatureAvailability with SyncBrowserFeatureAvailabilities in all the test files.
- Updated the main logic to use the new sync method.
- Updated the data loading scripts to use the new sync method.