### PR TITLE
Add missing deletion_protection variable for terraform resource

### DIFF
--- a/infra/modules/single_stage_go_workflow/main.tf
+++ b/infra/modules/single_stage_go_workflow/main.tf
@@ -65,12 +65,13 @@ resource "google_cloud_run_v2_job_iam_member" "job_status" {
 }
 
 resource "google_workflows_workflow" "workflow" {
-  for_each        = module.job.regional_job_map
-  provider        = google.internal_project
-  name            = "${var.env_id}-${var.short_name}-${each.key}"
-  region          = each.key
-  description     = "${var.full_name}. Env id: ${var.env_id}"
-  service_account = google_service_account.service_account.id
+  for_each            = module.job.regional_job_map
+  provider            = google.internal_project
+  name                = "${var.env_id}-${var.short_name}-${each.key}"
+  region              = each.key
+  description         = "${var.full_name}. Env id: ${var.env_id}"
+  service_account     = google_service_account.service_account.id
+  deletion_protection = var.deletion_protection
   source_contents = templatefile(
     "${path.root}/modules/single_stage_go_workflow/workflows.yaml.tftpl",
     {


### PR DESCRIPTION
Some GCP terraform resources have an optional property named deletion_protection.

With it, terraform will not delete it. It defaults to true for staging and prod. But false when deploying your own [copy](https://github.com/GoogleChrome/webstatus.dev/blob/main/DEPLOYMENT.md#deploying-your-own-copy).

When I was cleaning up old dev environments, I could not cleanly delete them because this particular resource had deletion_protection set to true by default. This change uses the global variable which allows us to explicitly tell if we want that given resource to have deletion_protection.