### PR TITLE
refactor(gcpspanner): Migrate WebFeatureChromiumHistogramEnumValue to use Sync

### DIFF
--- a/lib/gcpspanner/daily_chromium_histogram_metrics_test.go
+++ b/lib/gcpspanner/daily_chromium_histogram_metrics_test.go
@@ -303,7 +303,8 @@ func TestStoreAndSyncDailyChromiumHistogramMetric(t *testing.T) {
 	enumIDMap := insertTestChromiumHistogramEnums(ctx, spannerClient, t, sampleEnums)
 	sampleEnumValues := getSampleChromiumHistogramEnumValues(enumIDMap)
 	enumValueLabelToIDMap := insertTestChromiumHistogramEnumValues(ctx, spannerClient, t, sampleEnumValues)
-	spannerClient.createSampleWebFeatureChromiumHistogramEnums(ctx, t, idMap, enumValueLabelToIDMap)
+	sampleWebFeatureEnumValues := getSampleWebFeatureChromiumHistogramEnums(idMap, enumValueLabelToIDMap)
+	insertTestWebFeatureChromiumHistogramEnumValues(ctx, spannerClient, t, sampleWebFeatureEnumValues)
 	sampleMetrics := getSampleDailyChromiumHistogramMetricsToInsert()
 	insertTestDailyChromiumHistogramMetrics(ctx, spannerClient, t, sampleMetrics)
 
@@ -434,7 +435,8 @@ func TestSyncLatestDailyChromiumHistogramMetric_Deletes(t *testing.T) {
 	enumIDMap := insertTestChromiumHistogramEnums(ctx, spannerClient, t, sampleEnums)
 	sampleEnumValues := getSampleChromiumHistogramEnumValues(enumIDMap)
 	enumValueLabelToIDMap := insertTestChromiumHistogramEnumValues(ctx, spannerClient, t, sampleEnumValues)
-	spannerClient.createSampleWebFeatureChromiumHistogramEnums(ctx, t, idMap, enumValueLabelToIDMap)
+	sampleWebFeatureEnumValues := getSampleWebFeatureChromiumHistogramEnums(idMap, enumValueLabelToIDMap)
+	insertTestWebFeatureChromiumHistogramEnumValues(ctx, spannerClient, t, sampleWebFeatureEnumValues)
 	sampleMetrics := getSampleDailyChromiumHistogramMetricsToInsert()
 	insertTestDailyChromiumHistogramMetrics(ctx, spannerClient, t, sampleMetrics)
 

--- a/lib/gcpspanner/web_feature_chromium_histograms.go
+++ b/lib/gcpspanner/web_feature_chromium_histograms.go
@@ -44,29 +44,17 @@ func (m webFeaturesChromiumHistogramEnumSpannerMapper) GetKeyFromExternal(
 	return in.WebFeatureID
 }
 
+func (m webFeaturesChromiumHistogramEnumSpannerMapper) GetKeyFromInternal(
+	in spannerWebFeatureChromiumHistogramEnum) string {
+	return in.WebFeatureID
+}
+
 func (m webFeaturesChromiumHistogramEnumSpannerMapper) Table() string {
 	return webFeatureChromiumHistogramEnumValuesTable
 }
 
-func (m webFeaturesChromiumHistogramEnumSpannerMapper) Merge(
-	_ WebFeatureChromiumHistogramEnumValue,
-	existing spannerWebFeatureChromiumHistogramEnum) spannerWebFeatureChromiumHistogramEnum {
-	return existing
-}
-
-func (m webFeaturesChromiumHistogramEnumSpannerMapper) SelectOne(id string) spanner.Statement {
-	stmt := spanner.NewStatement(fmt.Sprintf(`
-	SELECT
-		WebFeatureID, ChromiumHistogramEnumValueID
-	FROM %s
-	WHERE WebFeatureID = @webFeatureID
-	LIMIT 1`, m.Table()))
-	parameters := map[string]interface{}{
-		"webFeatureID": id,
-	}
-	stmt.Params = parameters
-
-	return stmt
+func (m webFeaturesChromiumHistogramEnumSpannerMapper) SelectAll() spanner.Statement {
+	return spanner.NewStatement(fmt.Sprintf(`SELECT * FROM %s`, m.Table()))
 }
 
 func (m webFeaturesChromiumHistogramEnumSpannerMapper) SelectAllByKeys(id string) spanner.Statement {
@@ -82,9 +70,37 @@ func (m webFeaturesChromiumHistogramEnumSpannerMapper) SelectAllByKeys(id string
 	return stmt
 }
 
-func (c *Client) UpsertWebFeatureChromiumHistogramEnumValue(
-	ctx context.Context, in WebFeatureChromiumHistogramEnumValue) error {
-	return newEntityWriter[webFeaturesChromiumHistogramEnumSpannerMapper](c).upsert(ctx, in)
+func (m webFeaturesChromiumHistogramEnumSpannerMapper) MergeAndCheckChanged(
+	_ WebFeatureChromiumHistogramEnumValue,
+	existing spannerWebFeatureChromiumHistogramEnum) (spannerWebFeatureChromiumHistogramEnum, bool) {
+	// This entity only has key columns, so there's nothing to merge or update.
+	// The synchronizer will handle inserts and deletes based on the key.
+	return existing, false
+}
+
+func (m webFeaturesChromiumHistogramEnumSpannerMapper) DeleteMutation(
+	in spannerWebFeatureChromiumHistogramEnum) *spanner.Mutation {
+	return spanner.Delete(m.Table(), spanner.Key{in.WebFeatureID})
+}
+
+func (m webFeaturesChromiumHistogramEnumSpannerMapper) GetChildDeleteKeyMutations(
+	_ context.Context,
+	_ *Client,
+	_ []spannerWebFeatureChromiumHistogramEnum,
+) ([]ExtraMutationsGroup, error) {
+	return nil, nil
+}
+
+func (m webFeaturesChromiumHistogramEnumSpannerMapper) PreDeleteHook(
+	_ context.Context, _ *Client, _ []spannerWebFeatureChromiumHistogramEnum) ([]ExtraMutationsGroup, error) {
+	return nil, nil
+}
+
+func (c *Client) SyncWebFeatureChromiumHistogramEnumValues(
+	ctx context.Context,
+	in []WebFeatureChromiumHistogramEnumValue,
+) error {
+	return newEntitySynchronizer[webFeaturesChromiumHistogramEnumSpannerMapper](c).Sync(ctx, in)
 }
 
 func (c *Client) getAllWebFeatureChromiumHistogramEnumValuesByFeatureID(

--- a/lib/gcpspanner/web_features_fk_test.go
+++ b/lib/gcpspanner/web_features_fk_test.go
@@ -194,9 +194,11 @@ func (w *webFeatureForeignKeyTestHelpers) insertWebFeatureChromiumHistogramData(
 		t.Errorf("unexpected error during insert. %s", err.Error())
 	}
 
-	err = spannerClient.UpsertWebFeatureChromiumHistogramEnumValue(ctx, WebFeatureChromiumHistogramEnumValue{
-		WebFeatureID:                 *w.featureID,
-		ChromiumHistogramEnumValueID: *enumID,
+	err = spannerClient.SyncWebFeatureChromiumHistogramEnumValues(ctx, []WebFeatureChromiumHistogramEnumValue{
+		{
+			WebFeatureID:                 *w.featureID,
+			ChromiumHistogramEnumValueID: *enumID,
+		},
 	})
 	if err != nil {
 		t.Errorf("unexpected error during insert. %s", err.Error())
@@ -220,15 +222,6 @@ func (w *webFeatureForeignKeyTestHelpers) insertWebFeatureChromiumHistogramData(
 	err = spannerClient.SyncLatestDailyChromiumHistogramMetrics(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error during sync. %s", err.Error())
-	}
-
-	// Insert WebFeatureChromiumHistogramEnumValue
-	err = spannerClient.UpsertWebFeatureChromiumHistogramEnumValue(ctx, WebFeatureChromiumHistogramEnumValue{
-		WebFeatureID:                 *w.featureID,
-		ChromiumHistogramEnumValueID: *enumID,
-	})
-	if err != nil {
-		t.Errorf("unexpected error during insert. %s", err.Error())
 	}
 }
 

--- a/lib/gcpspanner/web_features_test.go
+++ b/lib/gcpspanner/web_features_test.go
@@ -270,11 +270,12 @@ func (s syncWebFeaturesRedirectCase) postFirstSyncSetup(
 	}
 
 	// Associate the enum to feature-a
-	err = spannerClient.UpsertWebFeatureChromiumHistogramEnumValue(ctx,
-		WebFeatureChromiumHistogramEnumValue{
+	err = spannerClient.SyncWebFeatureChromiumHistogramEnumValues(ctx, []WebFeatureChromiumHistogramEnumValue{
+		{
 			WebFeatureID:                 featureKeyToIDMap["feature-a"],
 			ChromiumHistogramEnumValueID: *featureEnumID,
-		})
+		},
+	})
 	if err != nil {
 		t.Fatalf("Failed to upsert web feature chromium histogram enum value: %v", err)
 	}

--- a/util/cmd/load_fake_data/main.go
+++ b/util/cmd/load_fake_data/main.go
@@ -1044,18 +1044,19 @@ func generateWebFeatureChromiumHistogramEnumValues(
 	chromiumHistogramEnumValueToIDMap map[string]string,
 	features []gcpspanner.SpannerWebFeature,
 ) error {
+	values := make([]gcpspanner.WebFeatureChromiumHistogramEnumValue, 0, len(features))
 	for _, feature := range features {
 		webFeatureChromiumHistogramEnumValueEntry := gcpspanner.WebFeatureChromiumHistogramEnumValue{
 			WebFeatureID:                 webFeatureKeyToInternalFeatureID[feature.FeatureKey],
 			ChromiumHistogramEnumValueID: chromiumHistogramEnumValueToIDMap[feature.FeatureKey],
 		}
-		err := client.UpsertWebFeatureChromiumHistogramEnumValue(
-			ctx,
-			webFeatureChromiumHistogramEnumValueEntry,
-		)
-		if err != nil {
-			return err
-		}
+		values = append(values, webFeatureChromiumHistogramEnumValueEntry)
+
+	}
+
+	err := client.SyncWebFeatureChromiumHistogramEnumValues(ctx, values)
+	if err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
This commit refactors the handling of WebFeatureChromiumHistogramEnumValue entities to use the generic entitySynchronizer instead of manual upserts.

The webFeaturesChromiumHistogramEnumSpannerMapper now implements the syncableEntityMapper interface, allowing for more robust and efficient batch synchronization.

The ChromiumHistogramEnumsClient interface and its consumer have been updated to use the new SyncWebFeatureChromiumHistogramEnumValues method.

This change simplifies the data ingestion logic for Chromium histogram enum mappings and aligns it with the project's standard data synchronization pattern.

Fixes #1915