### PR TITLE
feat(auth): Add login signal endpoint to track user sessions

### DIFF
--- a/backend/pkg/httpserver/middlewares_test.go
+++ b/backend/pkg/httpserver/middlewares_test.go
@@ -140,6 +140,11 @@ func TestAuthScopePresentWhenSecurityConfigured(t *testing.T) {
 	testAuthScope(t, "/v1/users/me/saved-searches", http.MethodGet, true, testUser)
 }
 
+func TestPingUserAuthScope(t *testing.T) {
+	testUser := &auth.User{ID: "test"}
+	testAuthScope(t, "/v1/users/me/ping", http.MethodPost, true, testUser)
+}
+
 // This test ensures that the third-party OpenAPI library continues to omit
 // Bearer authentication scopes from the request context when the route does
 // not have security schemes configured.

--- a/backend/pkg/httpserver/ping_user.go
+++ b/backend/pkg/httpserver/ping_user.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// PingUser implements backend.StrictServerInterface.
+// nolint: ireturn // Name generated from openapi
+func (s *Server) PingUser(
+	ctx context.Context,
+	_ backend.PingUserRequestObject,
+) (backend.PingUserResponseObject, error) {
+	userCheckResult := CheckAuthenticatedUser(ctx, "PingUser",
+		func(code int, message string) backend.PingUser500JSONResponse {
+			return backend.PingUser500JSONResponse{
+				Code:    code,
+				Message: message,
+			}
+		})
+	if userCheckResult.User == nil {
+		return userCheckResult.Response, nil
+	}
+
+	// TODO: Implement database logic to upsert user profile.
+	return backend.PingUser204Response{}, nil
+}

--- a/backend/pkg/httpserver/ping_user_test.go
+++ b/backend/pkg/httpserver/ping_user_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPingUser(t *testing.T) {
+	testCases := []struct {
+		name             string
+		authMiddleware   func(http.Handler) http.Handler
+		expectedResponse *http.Response
+	}{
+		{
+			name:             "success",
+			authMiddleware:   mockAuthMiddleware(createTestID1User()),
+			expectedResponse: createEmptyBodyResponse(http.StatusNoContent),
+		},
+		{
+			name:           "no user",
+			authMiddleware: mockAuthMiddleware(nil),
+			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
+				"code": 500,
+				"message": "internal server error"
+			}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			authMiddlewareOption := withAuthMiddleware(tc.authMiddleware)
+			myServer := Server{
+				wptMetricsStorer:        nil,
+				metadataStorer:          nil,
+				operationResponseCaches: nil,
+				baseURL:                 getTestBaseURL(t),
+			}
+			req := httptest.NewRequest(http.MethodPost, "/v1/users/me/ping", nil)
+			assertTestServerRequest(t, &myServer, req, tc.expectedResponse, authMiddlewareOption)
+		})
+	}
+}

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -958,6 +958,17 @@ func (m *mockServerInterface) UpdateSavedSearch(ctx context.Context,
 	panic("unimplemented")
 }
 
+// PingUser implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) PingUser(
+	ctx context.Context,
+	_ backend.PingUserRequestObject,
+) (backend.PingUserResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
 // ListMissingOneImplementationFeatures implements backend.StrictServerInterface.
 // nolint: ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListMissingOneImplementationFeatures(ctx context.Context,

--- a/e2e/tests/login.spec.ts
+++ b/e2e/tests/login.spec.ts
@@ -28,6 +28,13 @@ test('matches the screenshot for unauthenticated user', async ({page}) => {
 });
 
 test('can sign in and sign out user', async ({page}) => {
+  // Start waiting for the ping request before logging in.
+  const pingRequestPromise = page.waitForRequest(
+    request =>
+      request.url().endsWith('/v1/users/me/ping') &&
+      request.method() === 'POST',
+  );
+
   await loginAsUser(page, 'test user 1');
   const login = page.locator('webstatus-login');
 
@@ -35,6 +42,10 @@ test('can sign in and sign out user', async ({page}) => {
 
   // Should have the email address
   await expect(login).toContainText(expectedEmail);
+
+  // Wait for the ping request to be made and assert that it happened.
+  const pingRequest = await pingRequestPromise;
+  expect(pingRequest).toBeTruthy();
 
   const header = page.locator('webstatus-header');
   await expect(header).toHaveScreenshot('authenticated-header.png');

--- a/frontend/src/static/js/api/client.ts
+++ b/frontend/src/static/js/api/client.ts
@@ -421,6 +421,21 @@ export class APIClient {
     });
   }
 
+  public async pingUser(token: string): Promise<void> {
+    const options: FetchOptions<
+      FilterKeys<paths['/v1/users/me/ping'], 'post'>
+    > = {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      credentials: temporaryFetchOptions.credentials,
+    };
+    const {error} = await this.client.POST('/v1/users/me/ping', options);
+    if (error) {
+      throw createAPIError(error);
+    }
+  }
+
   public async *getFeatureStatsByBrowserAndChannel(
     featureId: string,
     browser: BrowsersParameter,

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -598,6 +598,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasicErrorModel'
+  /v1/users/me/ping:
+    post:
+      summary: Signal user login and refresh profile
+      description: |
+        Signals to the backend that a user has just authenticated.
+        This allows the backend to perform tasks like creating or updating the user's profile
+        with the latest information from the identity provider (e.g., refreshing their email address).
+
+        This endpoint should be called by clients once, immediately after a successful login.
+      operationId: pingUser
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: No Content
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
   /v1/users/me/saved-searches:
     get:
       summary: List user saved searches


### PR DESCRIPTION
The backend previously had no way to know when a user authenticated. This prevented us from performing one-time actions upon login, such as creating or updating a user's profile with their latest information (e.g., email address).

This change introduces a new `POST /v1/users/me/ping` endpoint. Clients are expected to call this endpoint once immediately after a user successfully authenticates.

The endpoint is named `/ping` rather than `/login` or `/sessions` to reflect that authentication has already been handled by the [client-side identity provider.](https://firebase.google.com/docs/auth/web/github-auth) This endpoint does not create a session but rather serves as a notification that a user has authenticated.

This provides an explicit "login signal" to the backend, allowing it to perform necessary user synchronization tasks without the overhead of refreshing user data on every authenticated request. This is a foundational step for automatically setting up user notification channels.

Fixes #1843