### PR TITLE
refactor(gcpspanner): Migrate ChromiumHistogramEnumValue to use Sync pattern

### DIFF
--- a/lib/gcpspanner/daily_chromium_histogram_metrics_test.go
+++ b/lib/gcpspanner/daily_chromium_histogram_metrics_test.go
@@ -302,7 +302,16 @@ func TestStoreAndSyncDailyChromiumHistogramMetric(t *testing.T) {
 	sampleEnums := getSampleChromiumHistogramEnums()
 	enumIDMap := insertTestChromiumHistogramEnums(ctx, spannerClient, t, sampleEnums)
 	sampleEnumValues := getSampleChromiumHistogramEnumValues(enumIDMap)
-	enumValueLabelToIDMap := insertTestChromiumHistogramEnumValues(ctx, spannerClient, t, sampleEnumValues)
+	insertTestChromiumHistogramEnumValues(ctx, spannerClient, t, sampleEnumValues)
+	enumValueLabelToIDMap := make(map[string]string)
+	for _, enumValue := range sampleEnumValues {
+		id, err := spannerClient.GetIDFromChromiumHistogramEnumValueKey(
+			ctx, enumValue.ChromiumHistogramEnumID, enumValue.BucketID)
+		if err != nil {
+			t.Fatalf("unexpected error getting enum value id. %s", err.Error())
+		}
+		enumValueLabelToIDMap[enumValue.Label] = *id
+	}
 	sampleWebFeatureEnumValues := getSampleWebFeatureChromiumHistogramEnums(idMap, enumValueLabelToIDMap)
 	insertTestWebFeatureChromiumHistogramEnumValues(ctx, spannerClient, t, sampleWebFeatureEnumValues)
 	sampleMetrics := getSampleDailyChromiumHistogramMetricsToInsert()
@@ -434,7 +443,16 @@ func TestSyncLatestDailyChromiumHistogramMetric_Deletes(t *testing.T) {
 	sampleEnums := getSampleChromiumHistogramEnums()
 	enumIDMap := insertTestChromiumHistogramEnums(ctx, spannerClient, t, sampleEnums)
 	sampleEnumValues := getSampleChromiumHistogramEnumValues(enumIDMap)
-	enumValueLabelToIDMap := insertTestChromiumHistogramEnumValues(ctx, spannerClient, t, sampleEnumValues)
+	insertTestChromiumHistogramEnumValues(ctx, spannerClient, t, sampleEnumValues)
+	enumValueLabelToIDMap := make(map[string]string)
+	for _, enumValue := range sampleEnumValues {
+		id, err := spannerClient.GetIDFromChromiumHistogramEnumValueKey(
+			ctx, enumValue.ChromiumHistogramEnumID, enumValue.BucketID)
+		if err != nil {
+			t.Fatalf("unexpected error getting enum value id. %s", err.Error())
+		}
+		enumValueLabelToIDMap[enumValue.Label] = *id
+	}
 	sampleWebFeatureEnumValues := getSampleWebFeatureChromiumHistogramEnums(idMap, enumValueLabelToIDMap)
 	insertTestWebFeatureChromiumHistogramEnumValues(ctx, spannerClient, t, sampleWebFeatureEnumValues)
 	sampleMetrics := getSampleDailyChromiumHistogramMetricsToInsert()

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -663,8 +663,17 @@ func addSampleChromiumUsageMetricsData(ctx context.Context,
 			Label:                   "feature2",
 		},
 	}
-	chromiumHistogramEnumValueToIDMap := insertTestChromiumHistogramEnumValues(
+	chromiumHistogramEnumValueToIDMap := make(map[string]string)
+	insertTestChromiumHistogramEnumValues(
 		ctx, client, t, sampleChromiumHistogramEnumValues)
+	for _, enumValue := range sampleChromiumHistogramEnumValues {
+		id, err := client.GetIDFromChromiumHistogramEnumValueKey(
+			ctx, enumValue.ChromiumHistogramEnumID, enumValue.BucketID)
+		if err != nil {
+			t.Fatalf("unexpected error getting enum value id. %s", err.Error())
+		}
+		chromiumHistogramEnumValueToIDMap[enumValue.Label] = *id
+	}
 
 	sampleWebFeatureChromiumHistogramEnumValues := []WebFeatureChromiumHistogramEnumValue{
 		{

--- a/lib/gcpspanner/web_feature_chromium_histograms_test.go
+++ b/lib/gcpspanner/web_feature_chromium_histograms_test.go
@@ -109,7 +109,16 @@ func TestSyncWebFeatureChromiumHistogramEnumValues(t *testing.T) {
 	sampleEnums := getSampleChromiumHistogramEnums()
 	enumIDMap := insertTestChromiumHistogramEnums(ctx, spannerClient, t, sampleEnums)
 	sampleEnumValues := getSampleChromiumHistogramEnumValues(enumIDMap)
-	enumValueLabelToIDMap := insertTestChromiumHistogramEnumValues(ctx, spannerClient, t, sampleEnumValues)
+	insertTestChromiumHistogramEnumValues(ctx, spannerClient, t, sampleEnumValues)
+	enumValueLabelToIDMap := make(map[string]string)
+	for _, enumValue := range sampleEnumValues {
+		id, err := spannerClient.GetIDFromChromiumHistogramEnumValueKey(
+			ctx, enumValue.ChromiumHistogramEnumID, enumValue.BucketID)
+		if err != nil {
+			t.Fatalf("unexpected error getting enum value id. %s", err.Error())
+		}
+		enumValueLabelToIDMap[enumValue.Label] = *id
+	}
 	insertTestWebFeatureChromiumHistogramEnumValues(ctx, spannerClient, t,
 		getSampleWebFeatureChromiumHistogramEnums(idMap, enumValueLabelToIDMap))
 

--- a/lib/gcpspanner/web_features_fk_test.go
+++ b/lib/gcpspanner/web_features_fk_test.go
@@ -185,13 +185,20 @@ func (w *webFeatureForeignKeyTestHelpers) insertWebFeatureChromiumHistogramData(
 
 	bucketID := int64(1)
 
-	enumID, err := spannerClient.UpsertChromiumHistogramEnumValue(ctx, ChromiumHistogramEnumValue{
-		ChromiumHistogramEnumID: *id,
-		BucketID:                bucketID,
-		Label:                   "test label",
+	err = spannerClient.SyncChromiumHistogramEnumValues(ctx, []ChromiumHistogramEnumValue{
+		{
+			ChromiumHistogramEnumID: *id,
+			BucketID:                bucketID,
+			Label:                   "test label",
+		},
 	})
 	if err != nil {
-		t.Errorf("unexpected error during insert. %s", err.Error())
+		t.Errorf("unexpected error during sync. %s", err.Error())
+	}
+
+	enumID, err := spannerClient.GetIDFromChromiumHistogramEnumValueKey(ctx, *id, bucketID)
+	if err != nil {
+		t.Errorf("unexpected error during get id. %s", err.Error())
 	}
 
 	err = spannerClient.SyncWebFeatureChromiumHistogramEnumValues(ctx, []WebFeatureChromiumHistogramEnumValue{

--- a/lib/gcpspanner/web_features_test.go
+++ b/lib/gcpspanner/web_features_test.go
@@ -236,13 +236,19 @@ func (s syncWebFeaturesRedirectCase) postFirstSyncSetup(
 	}
 
 	bucketID := int64(100)
-	featureEnumID, err := spannerClient.UpsertChromiumHistogramEnumValue(ctx, ChromiumHistogramEnumValue{
-		ChromiumHistogramEnumID: *enumID,
-		BucketID:                bucketID,
-		Label:                   "FeatureAOrB",
+	err = spannerClient.SyncChromiumHistogramEnumValues(ctx, []ChromiumHistogramEnumValue{
+		{
+			ChromiumHistogramEnumID: *enumID,
+			BucketID:                bucketID,
+			Label:                   "FeatureAOrB",
+		},
 	})
 	if err != nil {
-		t.Fatalf("Failed to insert chromium histogram enum value: %v", err)
+		t.Fatalf("Failed to sync chromium histogram enum value: %v", err)
+	}
+	featureEnumID, err := spannerClient.GetIDFromChromiumHistogramEnumValueKey(ctx, *enumID, bucketID)
+	if err != nil {
+		t.Fatalf("Failed to get chromium histogram enum value id: %v", err)
 	}
 
 	// Insert chromium histogram metrics for feature-a.


### PR DESCRIPTION
This commit refactors the handling of `ChromiumHistogramEnumValue` entities to use the generic `entitySynchronizer` instead of manual upserts. This aligns its data ingestion logic with the project's standard data synchronization pattern, improving efficiency and maintainability.

Key changes include:
- Implemented the `syncableEntityMapper` interface for `chromiumHistogramEnumValueSpannerMapper`.
- Replaced the `UpsertChromiumHistogramEnumValue` method with `SyncChromiumHistogramEnumValues`.
- Updated the `ChromiumHistogramEnumsClient` interface and all call sites (including consumers and tests) to use the new sync method.
- Modified the `MergeAndCheckChanged` method to allow updates to the `Label` field, which will automatically update the `Label_Lowercase` generated column in Spanner.
- Added the `Label_Lowercase` field to the `spannerChromiumHistogramEnumValue` struct with a `spanner:";->"` tag to ensure the Spanner client handles it as a read-only, generated column.


This should be the remaining part for #1915 