### PR TITLE
feat(data): Add schema and data access for web feature mappings

### DIFF
--- a/infra/storage/spanner/migrations/000022.sql
+++ b/infra/storage/spanner/migrations/000022.sql
@@ -1,0 +1,21 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- DDL statements for the WebFeaturesMappingData table.
+
+CREATE TABLE IF NOT EXISTS WebFeaturesMappingData (
+    WebFeatureID STRING(36) NOT NULL,
+    VendorPositions JSON,
+    CONSTRAINT FK_WebFeaturesMappingData_WebFeatureID FOREIGN KEY (WebFeatureID) REFERENCES WebFeatures(ID) ON DELETE CASCADE,
+) PRIMARY KEY (WebFeatureID);

--- a/lib/gcpspanner/spanneradapters/web_features_mapping_consumer.go
+++ b/lib/gcpspanner/spanneradapters/web_features_mapping_consumer.go
@@ -1,0 +1,65 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"encoding/json"
+
+	"cloud.google.com/go/spanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/webfeaturesmappingtypes"
+)
+
+// WebFeaturesMappingClient is the client for interacting with the web features mapping data in Spanner.
+type WebFeaturesMappingClient interface {
+	SyncWebFeaturesMappingData(ctx context.Context, data []gcpspanner.WebFeaturesMappingData) error
+}
+
+// WebFeaturesMappingConsumer is a consumer for web features mapping data.
+type WebFeaturesMappingConsumer struct {
+	client WebFeaturesMappingClient
+}
+
+// NewWebFeaturesMappingConsumer creates a new WebFeaturesMappingConsumer.
+func NewWebFeaturesMappingConsumer(client WebFeaturesMappingClient) *WebFeaturesMappingConsumer {
+	return &WebFeaturesMappingConsumer{
+		client: client,
+	}
+}
+
+// SyncWebFeaturesMappingData syncs the web features mapping data to Spanner.
+func (a *WebFeaturesMappingConsumer) SyncWebFeaturesMappingData(
+	ctx context.Context,
+	mappings webfeaturesmappingtypes.WebFeaturesMappings,
+) error {
+	data := make([]gcpspanner.WebFeaturesMappingData, 0, len(mappings))
+	for featureID, mapping := range mappings {
+		spannerData := gcpspanner.WebFeaturesMappingData{
+			WebFeatureID:    featureID,
+			VendorPositions: spanner.NullJSON{Value: nil, Valid: false},
+		}
+		if mapping.StandardsPositions != nil {
+			jsonValue, err := json.Marshal(mapping.StandardsPositions)
+			if err != nil {
+				return err
+			}
+			spannerData.VendorPositions = spanner.NullJSON{Value: string(jsonValue), Valid: true}
+		}
+		data = append(data, spannerData)
+	}
+
+	return a.client.SyncWebFeaturesMappingData(ctx, data)
+}

--- a/lib/gcpspanner/spanneradapters/web_features_mapping_consumer_test.go
+++ b/lib/gcpspanner/spanneradapters/web_features_mapping_consumer_test.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package spanneradapters
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/webfeaturesmappingtypes"
+)
+
+// mockWebFeaturesMappingClient is a mock implementation of the WebFeaturesMappingClient interface.
+type mockWebFeaturesMappingClient struct {
+	received []gcpspanner.WebFeaturesMappingData
+}
+
+func (m *mockWebFeaturesMappingClient) SyncWebFeaturesMappingData(
+	_ context.Context, data []gcpspanner.WebFeaturesMappingData) error {
+	m.received = data
+
+	return nil
+}
+
+func TestSyncWebFeaturesMappingData(t *testing.T) {
+	// Create a mock client
+	mockClient := &mockWebFeaturesMappingClient{
+		received: nil,
+	}
+
+	// Create the adapter with the mock client
+	adapter := NewWebFeaturesMappingConsumer(mockClient)
+
+	// Define test cases
+	testCases := []struct {
+		name        string
+		input       webfeaturesmappingtypes.WebFeaturesMappings
+		expected    []gcpspanner.WebFeaturesMappingData
+		expectedErr error
+	}{
+		{
+			name: "success",
+			input: webfeaturesmappingtypes.WebFeaturesMappings{
+				"feature1": {
+					StandardsPositions: []webfeaturesmappingtypes.StandardsPosition{
+						{
+							Vendor:   "vendor1",
+							Position: "position1",
+							URL:      "url1",
+							Concerns: nil,
+						},
+					},
+				},
+			},
+			expected: []gcpspanner.WebFeaturesMappingData{
+				{
+					WebFeatureID: "feature1",
+					VendorPositions: spanner.NullJSON{
+						Value: `[{"vendor":"vendor1","position":"position1","url":"url1"}]`,
+						Valid: true,
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name:        "empty input",
+			input:       webfeaturesmappingtypes.WebFeaturesMappings{},
+			expected:    []gcpspanner.WebFeaturesMappingData{},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset the mock client's received data
+			mockClient.received = nil
+
+			// Call the method
+			err := adapter.SyncWebFeaturesMappingData(context.Background(), tc.input)
+
+			// Check for errors
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("unexpected error. got %v, want %v", err, tc.expectedErr)
+			}
+
+			// Check if the received data matches the expected data
+			if len(mockClient.received) != len(tc.expected) {
+				t.Errorf("unexpected number of items. got %d, want %d", len(mockClient.received), len(tc.expected))
+			}
+			sort.Slice(mockClient.received, func(i, j int) bool {
+				return mockClient.received[i].WebFeatureID < mockClient.received[j].WebFeatureID
+			})
+			sort.Slice(tc.expected, func(i, j int) bool {
+				return tc.expected[i].WebFeatureID < tc.expected[j].WebFeatureID
+			})
+			if !reflect.DeepEqual(mockClient.received, tc.expected) {
+				t.Errorf("unexpected data. got %+v, want %+v", mockClient.received, tc.expected)
+			}
+		})
+	}
+}

--- a/lib/gcpspanner/web_features_mapping_data.go
+++ b/lib/gcpspanner/web_features_mapping_data.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"cloud.google.com/go/spanner"
+)
+
+const webFeaturesMappingDataTable = "WebFeaturesMappingData"
+
+// WebFeaturesMappingData is the struct for ingesting WebFeaturesMappingData.
+// The WebFeatureID field is expected to be the feature key.
+type WebFeaturesMappingData struct {
+	WebFeatureID    string
+	VendorPositions spanner.NullJSON
+}
+
+// spannerWebFeaturesMappingData is the struct for the WebFeaturesMappingData table.
+type spannerWebFeaturesMappingData struct {
+	WebFeatureID    string `spanner:"WebFeatureID"`
+	VendorPositions spanner.NullJSON
+}
+
+// webFeaturesMappingDataMapper is the mapper for the WebFeaturesMappingData table.
+type webFeaturesMappingDataMapper struct{}
+
+func (m webFeaturesMappingDataMapper) Table() string {
+	return webFeaturesMappingDataTable
+}
+
+func (m webFeaturesMappingDataMapper) GetKeyFromExternal(in spannerWebFeaturesMappingData) string {
+	return in.WebFeatureID
+}
+
+func (m webFeaturesMappingDataMapper) GetKeyFromInternal(in spannerWebFeaturesMappingData) string {
+	return in.WebFeatureID
+}
+
+func (m webFeaturesMappingDataMapper) SelectAll() spanner.Statement {
+	return spanner.NewStatement(fmt.Sprintf(`SELECT * FROM %s`, m.Table()))
+}
+
+func (m webFeaturesMappingDataMapper) MergeAndCheckChanged(
+	in spannerWebFeaturesMappingData, existing spannerWebFeaturesMappingData) (spannerWebFeaturesMappingData, bool) {
+	if !in.VendorPositions.Valid && !existing.VendorPositions.Valid {
+		return existing, false
+	}
+	if (in.VendorPositions.Valid && !existing.VendorPositions.Valid) ||
+		(!in.VendorPositions.Valid && existing.VendorPositions.Valid) ||
+		(in.VendorPositions.Value != existing.VendorPositions.Value) {
+		existing.VendorPositions = in.VendorPositions
+
+		return existing, true
+	}
+
+	return existing, false
+}
+
+func (m webFeaturesMappingDataMapper) DeleteMutation(in spannerWebFeaturesMappingData) *spanner.Mutation {
+	return spanner.Delete(webFeaturesMappingDataTable, spanner.Key{in.WebFeatureID})
+}
+
+func (m webFeaturesMappingDataMapper) GetChildDeleteKeyMutations(
+	_ context.Context, _ *Client, _ []spannerWebFeaturesMappingData) ([]ExtraMutationsGroup, error) {
+	return nil, nil
+}
+
+func (m webFeaturesMappingDataMapper) PreDeleteHook(
+	_ context.Context, _ *Client, _ []spannerWebFeaturesMappingData) ([]ExtraMutationsGroup, error) {
+	return nil, nil
+}
+
+// SyncWebFeaturesMappingData syncs the web features mapping data.
+func (c *Client) SyncWebFeaturesMappingData(
+	ctx context.Context,
+	data []WebFeaturesMappingData,
+) error {
+	allFeatures, err := c.FetchAllWebFeatureIDsAndKeys(ctx)
+	if err != nil {
+		return err
+	}
+
+	featureKeyToID := make(map[string]string, len(allFeatures))
+	for _, feature := range allFeatures {
+		featureKeyToID[feature.FeatureKey] = feature.ID
+	}
+
+	spannerData := make([]spannerWebFeaturesMappingData, 0, len(data))
+	for _, d := range data {
+		internalID, ok := featureKeyToID[d.WebFeatureID]
+		if !ok {
+			slog.WarnContext(ctx, "feature key not found, skipping mapping data", "feature_key", d.WebFeatureID)
+
+			continue
+		}
+		spannerData = append(spannerData, spannerWebFeaturesMappingData{
+			WebFeatureID:    internalID,
+			VendorPositions: d.VendorPositions,
+		})
+	}
+
+	s := newEntitySynchronizer[webFeaturesMappingDataMapper](c)
+
+	return s.Sync(ctx, spannerData)
+}

--- a/lib/gcpspanner/web_features_mapping_data_test.go
+++ b/lib/gcpspanner/web_features_mapping_data_test.go
@@ -1,0 +1,168 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/iterator"
+)
+
+func (c *Client) ReadAllWebFeaturesMappingData(ctx context.Context) ([]WebFeaturesMappingData, error) {
+	stmt := spanner.NewStatement(`SELECT * FROM WebFeaturesMappingData`)
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var ret []WebFeaturesMappingData
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+
+			return nil, err
+		}
+		var data WebFeaturesMappingData
+		if err := row.ToStruct(&data); err != nil {
+
+			return nil, err
+		}
+		ret = append(ret, data)
+	}
+
+	return ret, nil
+}
+
+func TestSyncWebFeaturesMappingData(t *testing.T) {
+	ctx := context.Background()
+
+	// Define WebFeature fixtures that correspond to the mapping data.
+	webFeatures := []WebFeature{
+		{FeatureKey: "feature1", Name: "Feature 1", Description: "", DescriptionHTML: ""},
+		{FeatureKey: "feature2", Name: "Feature 2", Description: "", DescriptionHTML: ""},
+		{FeatureKey: "feature3", Name: "Feature 3", Description: "", DescriptionHTML: ""},
+	}
+
+	restartDatabaseContainer(t)
+
+	// Insert WebFeatures to satisfy foreign key constraints.
+	if err := spannerClient.SyncWebFeatures(ctx, webFeatures); err != nil {
+		t.Fatalf("Failed to sync web features: %v", err)
+	}
+
+	initialState := []WebFeaturesMappingData{
+		{
+			WebFeatureID: "feature1",
+			VendorPositions: spanner.NullJSON{
+				Value: `[{"vendor":"mozilla","position":"positive"}]`,
+				Valid: true,
+			},
+		},
+		{
+			WebFeatureID: "feature2",
+			VendorPositions: spanner.NullJSON{
+				Value: `[{"vendor":"webkit","position":"negative"}]`,
+				Valid: true,
+			},
+		},
+	}
+
+	// 1. Setup initial state
+	if err := spannerClient.SyncWebFeaturesMappingData(ctx, initialState); err != nil {
+		t.Fatalf("Failed to set up initial state: %v", err)
+	}
+
+	// 2. Run the sync with the desired state
+	desiredState := []WebFeaturesMappingData{
+		{
+			WebFeatureID: "feature1",
+			VendorPositions: spanner.NullJSON{
+				Value: `[{"vendor":"mozilla","position":"neutral"}]`,
+				Valid: true,
+			},
+		},
+		{
+			WebFeatureID: "feature3",
+			VendorPositions: spanner.NullJSON{
+				Value: `[{"vendor":"w3c","position":"positive"}]`,
+				Valid: true,
+			},
+		},
+	}
+	if err := spannerClient.SyncWebFeaturesMappingData(ctx, desiredState); err != nil {
+		t.Fatalf("SyncWebFeaturesMappingData failed: %v", err)
+	}
+
+	// 3. Verify the final state
+	data, err := spannerClient.ReadAllWebFeaturesMappingData(ctx)
+	if err != nil {
+		t.Fatalf("ReadAllWebFeaturesMappingData failed: %v", err)
+	}
+
+	featureKeyToID := make(map[string]string)
+	// Get the generated IDs.
+	stmt := spanner.NewStatement(`SELECT ID, FeatureKey FROM WebFeatures`)
+	iter := spannerClient.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break // End of results
+		}
+		if err != nil {
+			t.Fatalf("Failed to read web features: %v", err)
+		}
+		var feature SpannerWebFeature
+		if err := row.ToStruct(&feature); err != nil {
+			t.Fatalf("Failed to convert row to SpannerWebFeature: %v", err)
+		}
+		featureKeyToID[feature.FeatureKey] = feature.ID
+	}
+
+	expectedData := []WebFeaturesMappingData{
+		{
+			WebFeatureID: featureKeyToID["feature1"],
+			VendorPositions: spanner.NullJSON{
+				Value: `[{"vendor":"mozilla","position":"neutral"}]`,
+				Valid: true,
+			},
+		},
+		{
+			WebFeatureID: featureKeyToID["feature3"],
+			VendorPositions: spanner.NullJSON{
+				Value: `[{"vendor":"w3c","position":"positive"}]`,
+				Valid: true,
+			},
+		},
+	}
+
+	sortFunc := func(a, b WebFeaturesMappingData) int {
+		return strings.Compare(a.WebFeatureID, b.WebFeatureID)
+	}
+
+	slices.SortFunc(data, sortFunc)
+	slices.SortFunc(expectedData, sortFunc)
+
+	if diff := cmp.Diff(expectedData, data); diff != "" {
+		t.Errorf("data mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/lib/webfeaturesmappingtypes/types.go
+++ b/lib/webfeaturesmappingtypes/types.go
@@ -1,0 +1,28 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webfeaturesmappingtypes
+
+type WebFeaturesMappings map[string]FeatureMapping
+
+type FeatureMapping struct {
+	StandardsPositions []StandardsPosition `json:"standards_positions,omitempty"`
+}
+
+type StandardsPosition struct {
+	Vendor   string   `json:"vendor"`
+	Position string   `json:"position"`
+	URL      string   `json:"url"`
+	Concerns []string `json:"concerns,omitempty"`
+}


### PR DESCRIPTION
This commit introduces the foundational data layer for the new web features mapping workflow.

It includes:
- The Spanner schema migration for the `WebFeatureMapping` table.
- A new `lib/webfeaturesmappingtypes` package defining the intermediate Go types.
- The Spanner mapper (`web_features_mapping_data.go`) for database interactions.
- The consumer adapter (`web_features_mapping_consumer.go`) to be used by the upcoming workflow.
- Comprehensive integration tests for the new data access logic.

Split up of #1955 