### PR TITLE
feat(infra): Add web_features_mapping_consumer workflow infra

### DIFF
--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -82,6 +82,11 @@ wpt_region_schedules = {
   "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
 }
 
+web_features_mapping_region_schedules = {
+  "us-central1"  = "0 23 * * *" # Daily at 11:00 PM
+  "europe-west1" = "0 11 * * *" # Daily at 11:00 AM
+}
+
 firebase_api_key_location = "prod-firebase-app-api-key"
 
 auth_github_config_locations = {

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -83,6 +83,11 @@ wpt_region_schedules = {
   "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
 }
 
+web_features_mapping_region_schedules = {
+  "us-central1"  = "0 23 * * *" # Daily at 11:00 PM
+  "europe-west1" = "0 11 * * *" # Daily at 11:00 AM
+}
+
 firebase_api_key_location = "staging-firebase-app-api-key"
 
 auth_github_config_locations = {

--- a/infra/ingestion/variables.tf
+++ b/infra/ingestion/variables.tf
@@ -82,6 +82,9 @@ variable "web_features_region_schedules" {
   type = map(string)
 }
 
+variable "web_features_mapping_region_schedules" {
+  type = map(string)
+}
 
 variable "deletion_protection" {
   type = bool

--- a/infra/ingestion/workflows.tf
+++ b/infra/ingestion/workflows.tf
@@ -253,3 +253,39 @@ module "developer_signals_workflow" {
     }
   ]
 }
+
+module "web_features_mapping_workflow" {
+  source = "../modules/single_stage_go_workflow"
+  providers = {
+    google.internal_project = google.internal_project
+    google.public_project   = google.public_project
+  }
+  regions                       = var.regions
+  short_name                    = "web-features-mapping"
+  full_name                     = "Web Features Mapping Workflow"
+  deletion_protection           = var.deletion_protection
+  project_id                    = var.spanner_datails.project_id
+  timeout_seconds               = 60 * 10 # 10 minutes
+  image_name                    = "web_features_mapping_consumer_image"
+  spanner_details               = var.spanner_datails
+  notification_channel_ids      = var.notification_channel_ids
+  env_id                        = var.env_id
+  region_schedules              = var.web_features_mapping_region_schedules
+  docker_repository_url         = var.docker_repository_details.url
+  go_module_path                = "workflows/steps/services/web_features_mapping_consumer"
+  does_process_write_to_spanner = true
+  env_vars = [
+    {
+      name  = "PROJECT_ID"
+      value = var.spanner_datails.project_id
+    },
+    {
+      name  = "SPANNER_DATABASE"
+      value = var.spanner_datails.database
+    },
+    {
+      name  = "SPANNER_INSTANCE"
+      value = var.spanner_datails.instance
+    }
+  ]
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -79,22 +79,23 @@ module "ingestion" {
     google.public_project   = google.public_project
   }
 
-  env_id                             = var.env_id
-  docker_repository_details          = module.storage.docker_repository_details
-  deletion_protection                = var.deletion_protection
-  regions                            = keys(var.region_information)
-  secret_ids                         = var.secret_ids
-  datastore_info                     = module.storage.datastore_info
-  spanner_datails                    = module.storage.spanner_info
-  projects                           = var.projects
-  depends_on                         = [module.services]
-  wpt_region_schedules               = var.wpt_region_schedules
-  bcd_region_schedules               = var.bcd_region_schedules
-  uma_region_schedules               = var.uma_region_schedules
-  chromium_region_schedules          = var.chromium_region_schedules
-  web_features_region_schedules      = var.web_features_region_schedules
-  developer_signals_region_schedules = var.developer_signals_region_schedules
-  notification_channel_ids           = var.notification_channel_ids
+  env_id                                = var.env_id
+  docker_repository_details             = module.storage.docker_repository_details
+  deletion_protection                   = var.deletion_protection
+  regions                               = keys(var.region_information)
+  secret_ids                            = var.secret_ids
+  datastore_info                        = module.storage.datastore_info
+  spanner_datails                       = module.storage.spanner_info
+  projects                              = var.projects
+  depends_on                            = [module.services]
+  wpt_region_schedules                  = var.wpt_region_schedules
+  bcd_region_schedules                  = var.bcd_region_schedules
+  uma_region_schedules                  = var.uma_region_schedules
+  chromium_region_schedules             = var.chromium_region_schedules
+  web_features_region_schedules         = var.web_features_region_schedules
+  developer_signals_region_schedules    = var.developer_signals_region_schedules
+  web_features_mapping_region_schedules = var.web_features_mapping_region_schedules
+  notification_channel_ids              = var.notification_channel_ids
 }
 
 module "backend" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -154,6 +154,10 @@ variable "web_features_region_schedules" {
   type = map(string)
 }
 
+variable "web_features_mapping_region_schedules" {
+  type = map(string)
+}
+
 
 variable "firebase_api_key_location" {
   description = "Location of the firebase api key in secret manager"


### PR DESCRIPTION
This commit adds the necessary infrastructure to support the new `web_features_mapping_consumer` workflow.

It includes updates to Terraform variables and workflow definitions to deploy and run the new data ingestion job.

Depends on #1958 

Split up of #1955 