### PR TITLE
feat(infra): Shorten workflow names to accommodate service account limits

### DIFF
--- a/infra/ingestion/workflows.tf
+++ b/infra/ingestion/workflows.tf
@@ -261,7 +261,7 @@ module "web_features_mapping_workflow" {
     google.public_project   = google.public_project
   }
   regions                       = var.regions
-  short_name                    = "web-features-mapping"
+  short_name                    = "feature-map"
   full_name                     = "Web Features Mapping Workflow"
   deletion_protection           = var.deletion_protection
   project_id                    = var.spanner_datails.project_id

--- a/infra/modules/single_stage_go_workflow/variables.tf
+++ b/infra/modules/single_stage_go_workflow/variables.tf
@@ -51,7 +51,11 @@ variable "timeout_seconds" {
 
 variable "short_name" {
   type        = string
-  description = "short name to describe resources. Typically 10 characters or less"
+  description = "short name to describe resources."
+  validation {
+    condition     = length(var.short_name) <= 13
+    error_message = "Short name must be 13 characters or less."
+  }
 }
 
 variable "full_name" {


### PR DESCRIPTION
Shortens the 'short_name' of the web-features-mapping workflow to 'feature-map'.

Also adds validation to the 'single_stage_go_workflow' module to enforce a maximum length of 13 characters for the 'short_name'.

This is necessary because the service account name is generated from the short_name and includes the environment, and service account names have a limited length.