### PR TITLE
chore: run npm audit fix to address vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8827,9 +8827,9 @@
       "license": "MIT"
     },
     "node_modules/koa": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.2.tgz",
-      "integrity": "sha512-+CCssgnrWKx9aI3OeZwroa/ckG4JICxvIFnSiOUyl2Uv+UTI+xIw0FfFrWS7cQFpoePpr9o8csss7KzsTzNL8Q==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.3.tgz",
+      "integrity": "sha512-zPPuIt+ku1iCpFBRwseMcPYQ1cJL8l60rSmKeOuGfOXyE6YnTBmf2aEFNL2HQGrD0cPcLO/t+v9RTgC+fwEh/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
This fixes this alert: https://github.com/GoogleChrome/webstatus.dev/security/dependabot/96