### PR TITLE
feat(gcpspanner): Implement Notification Channels and Subscriptions with Refactored Helpers

### DIFF
--- a/infra/storage/spanner/migrations/000023.sql
+++ b/infra/storage/spanner/migrations/000023.sql
@@ -1,0 +1,62 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- NotificationChannels stores the reusable delivery destinations for a user.
+CREATE TABLE IF NOT EXISTS NotificationChannels (
+    ID STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
+    UserID STRING(36) NOT NULL,
+    Name STRING(MAX) NOT NULL,
+    Type STRING(MAX) NOT NULL,
+    Config JSON,
+    CreatedAt TIMESTAMP NOT NULL OPTIONS(allow_commit_timestamp = true),
+    UpdatedAt TIMESTAMP NOT NULL OPTIONS(allow_commit_timestamp = true)
+) PRIMARY KEY (ID);
+
+-- NotificationChannelStates stores the dynamic state and health data.
+CREATE TABLE IF NOT EXISTS NotificationChannelStates (
+    ChannelID STRING(36) NOT NULL,
+    IsDisabledBySystem BOOL,
+    ConsecutiveFailures INT64,
+    CreatedAt TIMESTAMP NOT NULL OPTIONS(allow_commit_timestamp = true),
+    UpdatedAt TIMESTAMP NOT NULL OPTIONS(allow_commit_timestamp = true),
+    CONSTRAINT FK_NotificationChannelState_NotificationChannel FOREIGN KEY (ChannelID) REFERENCES NotificationChannels (ID) ON DELETE CASCADE
+) PRIMARY KEY (ChannelID);
+
+-- NotificationChannelDeliveryAttempts stores a log of delivery attempts for a channel.
+CREATE TABLE IF NOT EXISTS NotificationChannelDeliveryAttempts (
+    ID STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
+    ChannelID STRING(36) NOT NULL,
+    AttemptTimestamp TIMESTAMP NOT NULL,
+    Status STRING(MAX) NOT NULL, -- SUCCESS or FAILURE
+    Details JSON,
+    CONSTRAINT FK_NotificationChannelDeliveryAttempt_NotificationChannel FOREIGN KEY (ChannelID) REFERENCES NotificationChannels(ID) ON DELETE CASCADE
+) PRIMARY KEY (ID, ChannelID);
+
+-- Index to get the latest attempts for a channel
+CREATE INDEX IX_NotificationChannelDeliveryAttempt_AttemptTimestamp
+ON NotificationChannelDeliveryAttempts (ChannelID, AttemptTimestamp DESC);
+
+-- SavedSearchSubscriptions links a User to a Saved Search via a Channel.
+CREATE TABLE IF NOT EXISTS SavedSearchSubscriptions (
+    ID STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
+    UserID STRING(36) NOT NULL,
+    ChannelID STRING(36) NOT NULL,
+    SavedSearchID STRING(36) NOT NULL,
+    Triggers ARRAY<STRING(MAX)>,
+    Frequency STRING(MAX),
+    CreatedAt TIMESTAMP NOT NULL OPTIONS(allow_commit_timestamp = true),
+    UpdatedAt TIMESTAMP NOT NULL OPTIONS(allow_commit_timestamp = true),
+    CONSTRAINT FK_SavedSearchSubscription_NotificationChannel FOREIGN KEY (ChannelID) REFERENCES NotificationChannels (ID) ON DELETE CASCADE,
+    CONSTRAINT FK_SavedSearchSubscription_SavedSearches FOREIGN KEY (SavedSearchID) REFERENCES SavedSearches (ID) ON DELETE CASCADE
+) PRIMARY KEY (ID);

--- a/lib/gcpspanner/client.go
+++ b/lib/gcpspanner/client.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"reflect"
 	"slices"
 	"sync"
 	"time"
@@ -29,6 +30,7 @@ import (
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/google/uuid"
 	"google.golang.org/api/iterator"
 	"google.golang.org/grpc/status"
 )
@@ -38,6 +40,9 @@ var ErrQueryReturnedNoResults = errors.New("query returned no results")
 
 // ErrInternalQueryFailure is a catch-all error for now.
 var ErrInternalQueryFailure = errors.New("internal spanner query failure")
+
+// ErrInternalMutationFailure is a generic error for when a spanner mutation fails.
+var ErrInternalMutationFailure = errors.New("internal spanner mutation failure")
 
 // ErrBadClientConfig indicates the the config to setup a Client is invalid.
 var ErrBadClientConfig = errors.New("projectID, instanceID and name must not be empty")
@@ -339,6 +344,81 @@ func encodeFeatureResultOffsetCursor(offset int) string {
 	})
 }
 
+// --- Generic Entity Lister ---
+
+// ListRequest is an interface for list requests that support pagination.
+type ListRequest interface {
+	GetPageToken() *string
+}
+
+// listableEntityMapper is composed for the entityLister.
+type listableEntityMapper[SpannerStruct any, L ListRequest] interface {
+	baseMapper
+	SelectList(req L) spanner.Statement
+	EncodePageToken(item SpannerStruct) string
+}
+
+// entityLister is a basic client for listing any rows from the database with pagination.
+type entityLister[
+	M listableEntityMapper[SpannerStruct, L],
+	SpannerStruct any,
+	L ListRequest,
+] struct {
+	*Client
+}
+
+func newEntityLister[
+	M listableEntityMapper[SpannerStruct, L],
+	SpannerStruct any,
+	L ListRequest,
+](c *Client) *entityLister[M, SpannerStruct, L] {
+	return &entityLister[M, SpannerStruct, L]{c}
+}
+
+func (c *entityLister[M, SpannerStruct, L]) list(
+	ctx context.Context,
+	req L) ([]SpannerStruct, *string, error) {
+	var mapper M
+	stmt := mapper.SelectList(req)
+	txn := c.Single()
+	defer txn.Close()
+	it := txn.Query(ctx, stmt)
+	defer it.Stop()
+
+	var entities []SpannerStruct
+	// Use reflection to get PageSize from the request struct.
+	v := reflect.ValueOf(req)
+	pageSizeField := v.FieldByName("PageSize")
+	var pageSize int
+	if pageSizeField.IsValid() && pageSizeField.Kind() == reflect.Int {
+		pageSize = int(pageSizeField.Int())
+	}
+
+	for {
+		row, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, nil, errors.Join(ErrInternalQueryFailure, err)
+		}
+		var entity SpannerStruct
+		if err := row.ToStruct(&entity); err != nil {
+			return nil, nil, err
+		}
+		entities = append(entities, entity)
+	}
+
+	var nextPageToken *string
+	if pageSize > 0 && len(entities) == pageSize {
+		lastItem := entities[len(entities)-1]
+		token := mapper.EncodePageToken(lastItem)
+		nextPageToken = &token
+	}
+
+	return entities, nextPageToken, nil
+}
+
 // --- Generic Entity Mapper Interfaces ---
 
 // baseMapper provides the table name.
@@ -424,6 +504,71 @@ type removableEntityMapper[ExternalStruct any, SpannerStruct any, Key comparable
 	externalKeyMapper[ExternalStruct, Key]
 	readOneMapper[Key] // To verify the entity exists before deleting.
 	deleteByKeyMapper[Key]
+}
+
+// creatableEntityMapper is composed for the entityCreator.
+type creatableEntityMapper[CreateRequest any, SpannerStruct any] interface {
+	baseMapper
+	NewEntity(id string, req CreateRequest) (SpannerStruct, error)
+}
+
+// entityCreator is a basic client for creating any row in the database.
+type entityCreator[
+	M creatableEntityMapper[CreateRequest, SpannerStruct],
+	CreateRequest any,
+	SpannerStruct any,
+] struct {
+	*Client
+}
+
+func newEntityCreator[
+	M creatableEntityMapper[CreateRequest, SpannerStruct],
+	CreateRequest any,
+	SpannerStruct any,
+](c *Client) *entityCreator[M, CreateRequest, SpannerStruct] {
+	return &entityCreator[M, CreateRequest, SpannerStruct]{c}
+}
+
+func (c *entityCreator[M, CreateRequest, SpannerStruct]) create(
+	ctx context.Context,
+	req CreateRequest) (*string, error) {
+	var id *string
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		newID, err := c.createWithTransaction(ctx, txn, req)
+		if err != nil {
+			return err
+		}
+		id = newID
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return id, nil
+}
+
+func (c *entityCreator[M, CreateRequest, SpannerStruct]) createWithTransaction(
+	_ context.Context,
+	txn *spanner.ReadWriteTransaction,
+	req CreateRequest) (*string, error) {
+	var mapper M
+	id := uuid.NewString()
+	entity, err := mapper.NewEntity(id, req)
+	if err != nil {
+		return nil, err
+	}
+	m, err := spanner.InsertStruct(mapper.Table(), entity)
+	if err != nil {
+		return nil, errors.Join(ErrInternalMutationFailure, err)
+	}
+	err = txn.BufferWrite([]*spanner.Mutation{m})
+	if err != nil {
+		return nil, errors.Join(ErrInternalMutationFailure, err)
+	}
+
+	return &id, nil
 }
 
 // syncableEntityMapper is composed for the entitySynchronizer. It needs

--- a/lib/gcpspanner/notification_channel.go
+++ b/lib/gcpspanner/notification_channel.go
@@ -1,0 +1,245 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/grpc/codes"
+)
+
+const notificationChannelTable = "NotificationChannels"
+
+// EmailConfig represents the JSON structure for an EMAIL notification channel.
+type EmailConfig struct {
+	Address           string  `json:"address,omitempty"`
+	IsVerified        bool    `json:"is_verified,omitempty"`
+	VerificationToken *string `json:"verification_token,omitempty"`
+}
+
+// NotificationChannel represents a user-facing notification channel.
+type NotificationChannel struct {
+	ID          string       `spanner:"ID"`
+	UserID      string       `spanner:"UserID"`
+	Name        string       `spanner:"Name"`
+	Type        string       `spanner:"Type"`
+	EmailConfig *EmailConfig `spanner:"-"`
+	CreatedAt   time.Time    `spanner:"CreatedAt"`
+	UpdatedAt   time.Time    `spanner:"UpdatedAt"`
+}
+
+// spannerNotificationChannel is the internal struct for Spanner mapping.
+type spannerNotificationChannel struct {
+	NotificationChannel
+	Config spanner.NullJSON `spanner:"Config"`
+}
+
+// CreateNotificationChannelRequest is the request to create a channel.
+type CreateNotificationChannelRequest struct {
+	UserID      string
+	Name        string
+	Type        string
+	EmailConfig *EmailConfig
+}
+
+// UpdateNotificationChannelRequest is a request to update a notification channel.
+type UpdateNotificationChannelRequest struct {
+	ID          string
+	UserID      string
+	Name        OptionallySet[string]
+	EmailConfig OptionallySet[*EmailConfig]
+}
+
+// notificationChannelMapper implements the necessary interfaces for the generic helpers.
+type notificationChannelMapper struct{}
+
+type notificationChannelKey struct {
+	ID     string
+	UserID string
+}
+
+func (m notificationChannelMapper) Table() string {
+	return notificationChannelTable
+}
+
+func (m notificationChannelMapper) GetKeyFromExternal(
+	in UpdateNotificationChannelRequest) notificationChannelKey {
+	return notificationChannelKey{
+		ID:     in.ID,
+		UserID: in.UserID,
+	}
+}
+
+func (m notificationChannelMapper) SelectOne(key notificationChannelKey) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ID, UserID, Name, Type, Config, CreatedAt, UpdatedAt
+	FROM %s
+	WHERE ID = @id AND UserID = @userId
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"id":     key.ID,
+		"userId": key.UserID,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (m notificationChannelMapper) Merge(
+	req UpdateNotificationChannelRequest, existing spannerNotificationChannel) (spannerNotificationChannel, error) {
+	if req.Name.IsSet {
+		existing.Name = req.Name.Value
+	}
+	if req.EmailConfig.IsSet && req.EmailConfig.Value != nil {
+		existing.Config = spanner.NullJSON{Value: *req.EmailConfig.Value, Valid: true}
+	}
+
+	return existing, nil
+}
+
+func (m notificationChannelMapper) NewEntity(
+	id string,
+	req CreateNotificationChannelRequest) (*spannerNotificationChannel, error) {
+	channel := NotificationChannel{
+		ID:          id,
+		UserID:      req.UserID,
+		Name:        req.Name,
+		Type:        req.Type,
+		EmailConfig: req.EmailConfig,
+		CreatedAt:   time.Time{},
+		UpdatedAt:   time.Time{},
+	}
+
+	return channel.toSpanner(), nil
+}
+
+// toSpanner converts the public NotificationChannel to the internal spannerNotificationChannel for writing.
+func (c *NotificationChannel) toSpanner() *spannerNotificationChannel {
+	var configData interface{}
+	// This can be extended with a switch on c.Type for other configs.
+	if c.EmailConfig != nil {
+		configData = c.EmailConfig
+	}
+
+	var config spanner.NullJSON
+	if configData != nil {
+		config = spanner.NullJSON{Value: configData, Valid: true}
+	}
+
+	return &spannerNotificationChannel{
+		NotificationChannel: *c,
+		Config:              config,
+	}
+}
+
+// toPublic converts the internal spannerNotificationChannel to the public NotificationChannel for reading.
+func (sc *spannerNotificationChannel) toPublic() (*NotificationChannel, error) {
+	ret := &sc.NotificationChannel
+	if sc.Config.Valid {
+		bytes, err := json.Marshal(sc.Config.Value)
+		if err != nil {
+			return nil, err
+		}
+		var emailConfig EmailConfig
+		if err := json.Unmarshal(bytes, &emailConfig); err != nil {
+			return nil, err
+		}
+		ret.EmailConfig = &emailConfig
+	}
+
+	return ret, nil
+}
+
+// CreateNotificationChannel creates a new notification channel.
+func (c *Client) CreateNotificationChannel(
+	ctx context.Context,
+	req CreateNotificationChannelRequest,
+) (*string, error) {
+	return newEntityCreator[
+		notificationChannelMapper, CreateNotificationChannelRequest, *spannerNotificationChannel](c).create(ctx, req)
+}
+
+// GetNotificationChannel retrieves a notification channel if it belongs to the specified user.
+func (c *Client) GetNotificationChannel(
+	ctx context.Context, channelID string, userID string) (*NotificationChannel, error) {
+	key := notificationChannelKey{ID: channelID, UserID: userID}
+	spannerChannel, err := newEntityReader[notificationChannelMapper,
+		spannerNotificationChannel, notificationChannelKey](c).readRowByKey(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return spannerChannel.toPublic()
+}
+
+// UpdateNotificationChannel updates a notification channel if it belongs to the specified user.
+func (c *Client) UpdateNotificationChannel(
+	ctx context.Context, req UpdateNotificationChannelRequest) error {
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		key := notificationChannelKey{ID: req.ID, UserID: req.UserID}
+		spannerChannel, err := newEntityReader[notificationChannelMapper,
+			spannerNotificationChannel, notificationChannelKey](c).readRowByKeyWithTransaction(ctx, key, txn)
+		if err != nil {
+			return err
+		}
+
+		merged, err := notificationChannelMapper{}.Merge(req, *spannerChannel)
+		if err != nil {
+			return err
+		}
+
+		m, err := spanner.UpdateStruct(notificationChannelTable, merged)
+		if err != nil {
+			return err
+		}
+
+		return txn.BufferWrite([]*spanner.Mutation{m})
+	})
+
+	return err
+}
+
+// DeleteNotificationChannel deletes a notification channel if it belongs to the specified user.
+func (c *Client) DeleteNotificationChannel(
+	ctx context.Context, channelID string, userID string) error {
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		key := spanner.Key{channelID}
+		row, err := txn.ReadRow(ctx, notificationChannelTable, key, []string{"UserID"})
+		if err != nil {
+			if spanner.ErrCode(err) == codes.NotFound {
+				return ErrQueryReturnedNoResults
+			}
+
+			return errors.Join(ErrInternalQueryFailure, err)
+		}
+		var ownerID string
+		if err := row.Column(0, &ownerID); err != nil {
+			return err
+		}
+		if ownerID != userID {
+			return ErrQueryReturnedNoResults
+		}
+
+		return txn.BufferWrite([]*spanner.Mutation{spanner.Delete(notificationChannelTable, key)})
+	})
+
+	return err
+}

--- a/lib/gcpspanner/notification_channel_delivery_attempt.go
+++ b/lib/gcpspanner/notification_channel_delivery_attempt.go
@@ -1,0 +1,209 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+const notificationChannelDeliveryAttemptTable = "NotificationChannelDeliveryAttempts"
+const maxDeliveryAttemptsToKeep = 10
+
+// NotificationChannelDeliveryAttempt represents a row in the NotificationChannelDeliveryAttempt table.
+type NotificationChannelDeliveryAttempt struct {
+	ID               string           `spanner:"ID"`
+	ChannelID        string           `spanner:"ChannelID"`
+	AttemptTimestamp time.Time        `spanner:"AttemptTimestamp"`
+	Status           string           `spanner:"Status"`
+	Details          spanner.NullJSON `spanner:"Details"`
+}
+
+// CreateNotificationChannelDeliveryAttemptRequest is the request to create a delivery attempt.
+type CreateNotificationChannelDeliveryAttemptRequest struct {
+	ChannelID        string
+	AttemptTimestamp time.Time
+	Status           string
+	Details          spanner.NullJSON
+}
+
+// ListNotificationChannelDeliveryAttemptsRequest is the request struct for listing delivery attempts.
+type ListNotificationChannelDeliveryAttemptsRequest struct {
+	ChannelID string
+	PageSize  int
+	PageToken *string
+}
+
+// GetPageToken returns the page token for the request.
+func (r ListNotificationChannelDeliveryAttemptsRequest) GetPageToken() *string {
+	return r.PageToken
+}
+
+type notificationChannelDeliveryAttemptMapper struct{}
+
+func (m notificationChannelDeliveryAttemptMapper) Table() string {
+	return notificationChannelDeliveryAttemptTable
+}
+
+func (m notificationChannelDeliveryAttemptMapper) NewEntity(
+	id string,
+	req CreateNotificationChannelDeliveryAttemptRequest) (NotificationChannelDeliveryAttempt, error) {
+	return NotificationChannelDeliveryAttempt{
+		ID:               id,
+		ChannelID:        req.ChannelID,
+		AttemptTimestamp: req.AttemptTimestamp,
+		Status:           req.Status,
+		Details:          req.Details,
+	}, nil
+}
+
+type deliveryAttemptKey struct {
+	ID        string
+	ChannelID string
+}
+
+func (m notificationChannelDeliveryAttemptMapper) SelectOne(key deliveryAttemptKey) spanner.Statement {
+	stmt := spanner.NewStatement(`
+		SELECT ID, ChannelID, AttemptTimestamp, Status, Details
+		FROM NotificationChannelDeliveryAttempts
+		WHERE ID = @id AND ChannelID = @channelID`)
+	stmt.Params = map[string]interface{}{
+		"id":        key.ID,
+		"channelID": key.ChannelID,
+	}
+
+	return stmt
+}
+
+func (m notificationChannelDeliveryAttemptMapper) SelectList(
+	req ListNotificationChannelDeliveryAttemptsRequest) spanner.Statement {
+	stmt := spanner.NewStatement(`
+		SELECT ID, ChannelID, AttemptTimestamp, Status, Details
+		FROM NotificationChannelDeliveryAttempts
+		WHERE ChannelID = @channelID AND ID > @pageToken
+		ORDER BY ID
+		LIMIT @pageSize`)
+	stmt.Params = map[string]interface{}{
+		"channelID": req.ChannelID,
+		"pageSize":  req.PageSize,
+	}
+	if req.PageToken != nil {
+		stmt.Params["pageToken"] = *req.PageToken
+	} else {
+		stmt.Params["pageToken"] = ""
+	}
+
+	return stmt
+}
+
+// EncodePageToken returns the ID of the delivery attempt as a page token.
+func (m notificationChannelDeliveryAttemptMapper) EncodePageToken(item NotificationChannelDeliveryAttempt) string {
+	return item.ID
+}
+
+// CreateNotificationChannelDeliveryAttempt creates a new delivery attempt log, prunes old ones, and returns its ID.
+func (c *Client) CreateNotificationChannelDeliveryAttempt(
+	ctx context.Context, req CreateNotificationChannelDeliveryAttemptRequest) (*string, error) {
+	var newID *string
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		// 1. Create the new attempt
+		id, err := newEntityCreator[
+			notificationChannelDeliveryAttemptMapper,
+			CreateNotificationChannelDeliveryAttemptRequest,
+			NotificationChannelDeliveryAttempt](c).createWithTransaction(ctx, txn, req)
+		if err != nil {
+			return err
+		}
+		newID = id
+
+		// 2. Count existing attempts for the channel. Note: This count does not include the new attempt just buffered.
+		countStmt := spanner.NewStatement(`
+			SELECT COUNT(*)
+			FROM NotificationChannelDeliveryAttempts
+			WHERE ChannelID = @channelID`)
+		countStmt.Params["channelID"] = req.ChannelID
+		var count int64
+		err = txn.Query(ctx, countStmt).Do(func(r *spanner.Row) error {
+			return r.Column(0, &count)
+		})
+		if err != nil {
+			return err
+		}
+
+		// 3. If the pre-insert count is at the limit, fetch the oldest attempts to delete.
+		if count >= maxDeliveryAttemptsToKeep {
+			// We need to delete enough to make room for the one we are adding.
+			deleteCount := count - maxDeliveryAttemptsToKeep + 1
+			deleteStmt := spanner.NewStatement(`
+				SELECT ID
+				FROM NotificationChannelDeliveryAttempts
+				WHERE ChannelID = @channelID
+				ORDER BY AttemptTimestamp ASC
+				LIMIT @deleteCount`)
+			deleteStmt.Params["channelID"] = req.ChannelID
+			deleteStmt.Params["deleteCount"] = deleteCount
+
+			var mutations []*spanner.Mutation
+			err := txn.Query(ctx, deleteStmt).Do(func(r *spanner.Row) error {
+				var attemptID string
+				if err := r.Column(0, &attemptID); err != nil {
+					return err
+				}
+				mutations = append(mutations,
+					spanner.Delete(notificationChannelDeliveryAttemptTable,
+						spanner.Key{attemptID, req.ChannelID}))
+
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			// 4. Buffer delete mutations
+			if len(mutations) > 0 {
+				return txn.BufferWrite(mutations)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return newID, nil
+}
+
+// GetNotificationChannelDeliveryAttempt retrieves a single delivery attempt.
+func (c *Client) GetNotificationChannelDeliveryAttempt(
+	ctx context.Context, attemptID string, channelID string) (*NotificationChannelDeliveryAttempt, error) {
+	key := deliveryAttemptKey{ID: attemptID, ChannelID: channelID}
+
+	return newEntityReader[notificationChannelDeliveryAttemptMapper,
+		NotificationChannelDeliveryAttempt, deliveryAttemptKey](c).readRowByKey(ctx, key)
+}
+
+// ListNotificationChannelDeliveryAttempts lists all delivery attempts for a channel.
+func (c *Client) ListNotificationChannelDeliveryAttempts(
+	ctx context.Context,
+	req ListNotificationChannelDeliveryAttemptsRequest,
+) ([]NotificationChannelDeliveryAttempt, *string, error) {
+	return newEntityLister[
+		notificationChannelDeliveryAttemptMapper,
+		NotificationChannelDeliveryAttempt,
+		ListNotificationChannelDeliveryAttemptsRequest](c).list(ctx, req)
+}

--- a/lib/gcpspanner/notification_channel_delivery_attempt_test.go
+++ b/lib/gcpspanner/notification_channel_delivery_attempt_test.go
@@ -1,0 +1,204 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/uuid"
+)
+
+func TestCreateNotificationChannelDeliveryAttempt(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// We need a channel to associate the attempt with.
+	userID := uuid.NewString()
+	createReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test Channel",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, createReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel: %v", err)
+	}
+	channelID := *channelIDPtr
+
+	req := CreateNotificationChannelDeliveryAttemptRequest{
+		ChannelID:        channelID,
+		Status:           "SUCCESS",
+		Details:          spanner.NullJSON{Value: map[string]interface{}{"info": "delivered"}, Valid: true},
+		AttemptTimestamp: time.Now(),
+	}
+
+	attemptIDPtr, err := spannerClient.CreateNotificationChannelDeliveryAttempt(ctx, req)
+	if err != nil {
+		t.Fatalf("CreateNotificationChannelDeliveryAttempt failed: %v", err)
+	}
+	if attemptIDPtr == nil {
+		t.Fatal("CreateNotificationChannelDeliveryAttempt did not return an ID")
+	}
+	attemptID := *attemptIDPtr
+
+	// Verify Create by using the Get method.
+	retrieved, err := spannerClient.GetNotificationChannelDeliveryAttempt(ctx, attemptID, channelID)
+	if err != nil {
+		t.Fatalf("failed to read back delivery attempt: %v", err)
+	}
+
+	if retrieved.Status != "SUCCESS" {
+		t.Errorf("expected status to be SUCCESS, got %s", retrieved.Status)
+	}
+
+	if retrieved.AttemptTimestamp.IsZero() {
+		t.Error("expected a non-zero commit timestamp")
+	}
+}
+
+func TestCreateNotificationChannelDeliveryAttemptPruning(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// We need a channel to associate the attempt with.
+	userID := uuid.NewString()
+	createReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test Channel",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, createReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel: %v", err)
+	}
+	channelID := *channelIDPtr
+
+	// Create more attempts than the max to trigger pruning.
+	var idsToDelete []string
+	var idToKeep string
+	for i := 0; i < maxDeliveryAttemptsToKeep+2; i++ {
+		// The sleep is a simple way to ensure distinct AttemptTimestamps for ordering.
+		time.Sleep(1 * time.Millisecond)
+		req := CreateNotificationChannelDeliveryAttemptRequest{
+			ChannelID:        channelID,
+			Status:           "SUCCESS",
+			Details:          spanner.NullJSON{Value: nil, Valid: false},
+			AttemptTimestamp: time.Now(),
+		}
+		idPtr, err := spannerClient.CreateNotificationChannelDeliveryAttempt(ctx, req)
+		if err != nil {
+			t.Fatalf("CreateNotificationChannelDeliveryAttempt (pruning test) failed: %v", err)
+		}
+		id := *idPtr
+		if i < 2 { // The first two should be deleted.
+			idsToDelete = append(idsToDelete, id)
+		}
+		if i == 5 { // This one should be kept.
+			idToKeep = id
+		}
+	}
+
+	// 1. Verify that the number of attempts is now capped at the max.
+	// List all attempts for the channel.
+	listReq := ListNotificationChannelDeliveryAttemptsRequest{
+		ChannelID: channelID,
+		PageSize:  10, // Arbitrary large number to get all.
+		PageToken: nil,
+	}
+	attempts, _, err := spannerClient.ListNotificationChannelDeliveryAttempts(ctx, listReq)
+	if err != nil {
+		t.Fatalf("ListNotificationChannelDeliveryAttempts failed: %v", err)
+	}
+	if len(attempts) != maxDeliveryAttemptsToKeep {
+		t.Errorf("expected %d attempts, got %d", maxDeliveryAttemptsToKeep, len(attempts))
+	}
+	// 2. Verify that the OLDEST attempts were the ones deleted.
+	for _, id := range idsToDelete {
+		_, err := spannerClient.GetNotificationChannelDeliveryAttempt(ctx, id, channelID)
+		if err == nil {
+			t.Errorf("expected attempt with ID %s to be deleted, but it was found", id)
+		}
+	}
+
+	// 3. Verify that a NEWER attempt was kept.
+	_, err = spannerClient.GetNotificationChannelDeliveryAttempt(ctx, idToKeep, channelID)
+	if err != nil {
+		t.Errorf("expected attempt with ID %s to be kept, but it was not found", idToKeep)
+	}
+}
+
+func TestCreateNotificationChannelDeliveryAttemptConcurrency(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// We need a channel to associate the attempt with.
+	userID := uuid.NewString()
+	createReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test Channel",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	concurrentChannelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, createReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel for concurrency test: %v", err)
+	}
+	concurrentChannelID := *concurrentChannelIDPtr
+
+	var wg sync.WaitGroup
+	concurrentAttempts := 5
+	attemptsPerRoutine := 3 // Total attempts = 15, which is > maxDeliveryAttemptsToKeep
+
+	for i := 0; i < concurrentAttempts; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < attemptsPerRoutine; j++ {
+				req := CreateNotificationChannelDeliveryAttemptRequest{
+					ChannelID:        concurrentChannelID,
+					Status:           "SUCCESS",
+					Details:          spanner.NullJSON{Value: nil, Valid: false},
+					AttemptTimestamp: time.Now(),
+				}
+				_, err := spannerClient.CreateNotificationChannelDeliveryAttempt(context.Background(), req)
+				if err != nil {
+					// Using t.Errorf in a goroutine is safer than t.Fatalf.
+					t.Errorf("CreateNotificationChannelDeliveryAttempt in goroutine failed: %v", err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// List all attempts for the channel.
+	listReq := ListNotificationChannelDeliveryAttemptsRequest{
+		ChannelID: concurrentChannelID,
+		PageSize:  10, // Arbitrary large number to get all.
+		PageToken: nil,
+	}
+	attempts, _, err := spannerClient.ListNotificationChannelDeliveryAttempts(ctx, listReq)
+	if err != nil {
+		t.Fatalf("ListNotificationChannelDeliveryAttempts (concurrency test) failed: %v", err)
+	}
+	if len(attempts) != maxDeliveryAttemptsToKeep {
+		t.Errorf("expected %d attempts, got %d", maxDeliveryAttemptsToKeep, len(attempts))
+	}
+}

--- a/lib/gcpspanner/notification_channel_state.go
+++ b/lib/gcpspanner/notification_channel_state.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+const notificationChannelStateTable = "NotificationChannelStates"
+
+// NotificationChannelState represents a row in the NotificationChannelState table.
+type NotificationChannelState struct {
+	ChannelID           string    `spanner:"ChannelID"`
+	IsDisabledBySystem  bool      `spanner:"IsDisabledBySystem"`
+	ConsecutiveFailures int64     `spanner:"ConsecutiveFailures"`
+	CreatedAt           time.Time `spanner:"CreatedAt"`
+	UpdatedAt           time.Time `spanner:"UpdatedAt"`
+}
+
+// notificationChannelStateMapper implements the necessary interfaces for the generic helpers.
+type notificationChannelStateMapper struct{}
+
+func (m notificationChannelStateMapper) Table() string {
+	return notificationChannelStateTable
+}
+
+func (m notificationChannelStateMapper) GetKeyFromExternal(in NotificationChannelState) string {
+	return in.ChannelID
+}
+
+func (m notificationChannelStateMapper) SelectOne(key string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ChannelID, IsDisabledBySystem, ConsecutiveFailures, CreatedAt, UpdatedAt
+	FROM %s
+	WHERE ChannelID = @channelId
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"channelId": key,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (m notificationChannelStateMapper) Merge(
+	in NotificationChannelState, existing NotificationChannelState) NotificationChannelState {
+	existing.IsDisabledBySystem = in.IsDisabledBySystem
+	existing.ConsecutiveFailures = in.ConsecutiveFailures
+
+	return existing
+}
+
+// UpsertNotificationChannelState inserts or updates a notification channel state.
+func (c *Client) UpsertNotificationChannelState(
+	ctx context.Context, state NotificationChannelState) error {
+	return newEntityWriter[notificationChannelStateMapper](c).upsert(ctx, state)
+}
+
+// GetNotificationChannelState retrieves a notification channel state by its ID.
+func (c *Client) GetNotificationChannelState(
+	ctx context.Context, channelID string) (*NotificationChannelState, error) {
+	return newEntityReader[notificationChannelStateMapper,
+		NotificationChannelState, string](c).readRowByKey(ctx, channelID)
+}

--- a/lib/gcpspanner/notification_channel_state_test.go
+++ b/lib/gcpspanner/notification_channel_state_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+)
+
+func TestNotificationChannelStateOperations(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// We need a channel to associate the state with.
+	userID := uuid.NewString()
+	createReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test Channel",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, createReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel: %v", err)
+	}
+	channelID := *channelIDPtr
+
+	t.Run("Create and Get", func(t *testing.T) {
+		tstate := &NotificationChannelState{
+			ChannelID:           channelID,
+			IsDisabledBySystem:  false,
+			ConsecutiveFailures: 0,
+			CreatedAt:           time.Time{},
+			UpdatedAt:           time.Time{},
+		}
+
+		err := spannerClient.UpsertNotificationChannelState(ctx, *tstate)
+		if err != nil {
+			t.Fatalf("UpsertNotificationChannelState (create) failed: %v", err)
+		}
+
+		retrieved, err := spannerClient.GetNotificationChannelState(ctx, channelID)
+		if err != nil {
+			t.Fatalf("GetNotificationChannelState failed: %v", err)
+		}
+		if diff := cmp.Diff(tstate, retrieved,
+			cmpopts.IgnoreFields(NotificationChannelState{
+				ChannelID:           "",
+				IsDisabledBySystem:  false,
+				ConsecutiveFailures: 0,
+				CreatedAt:           time.Time{},
+				UpdatedAt:           time.Time{},
+			}, "CreatedAt", "UpdatedAt")); diff != "" {
+			t.Errorf("GetNotificationChannelState mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		// First, ensure a known state exists.
+		initialState := &NotificationChannelState{
+			ChannelID:           channelID,
+			IsDisabledBySystem:  false,
+			ConsecutiveFailures: 1,
+			CreatedAt:           time.Time{},
+			UpdatedAt:           time.Time{},
+		}
+		err := spannerClient.UpsertNotificationChannelState(ctx, *initialState)
+		if err != nil {
+			t.Fatalf("pre-test UpsertNotificationChannelState failed: %v", err)
+		}
+
+		// Now, update it.
+		updatedState := &NotificationChannelState{
+			ChannelID:           channelID,
+			IsDisabledBySystem:  true,
+			ConsecutiveFailures: 5,
+			CreatedAt:           time.Time{},
+			UpdatedAt:           time.Time{},
+		}
+		err = spannerClient.UpsertNotificationChannelState(ctx, *updatedState)
+		if err != nil {
+			t.Fatalf("UpsertNotificationChannelState (update) failed: %v", err)
+		}
+
+		// Verify the update.
+		retrieved, err := spannerClient.GetNotificationChannelState(ctx, channelID)
+		if err != nil {
+			t.Fatalf("GetNotificationChannelState after update failed: %v", err)
+		}
+		if diff := cmp.Diff(updatedState, retrieved,
+			cmpopts.IgnoreFields(NotificationChannelState{
+				ChannelID:           "",
+				IsDisabledBySystem:  false,
+				ConsecutiveFailures: 0,
+				CreatedAt:           time.Time{},
+				UpdatedAt:           time.Time{},
+			}, "CreatedAt", "UpdatedAt")); diff != "" {
+			t.Errorf("GetNotificationChannelState after update mismatch (-want +got):\n%s", diff)
+		}
+	})
+}

--- a/lib/gcpspanner/notification_channel_test.go
+++ b/lib/gcpspanner/notification_channel_test.go
@@ -1,0 +1,149 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+)
+
+func TestNotificationChannelRefactoredOperations(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	userID := uuid.NewString()
+	otherUserID := uuid.NewString()
+
+	baseCreateReq := CreateNotificationChannelRequest{
+		UserID: userID,
+		Name:   "Test Email",
+		Type:   "EMAIL",
+		EmailConfig: &EmailConfig{
+			Address:           "test@example.com",
+			IsVerified:        true,
+			VerificationToken: nil,
+		},
+	}
+
+	// Pre-populate a channel for update/delete tests
+	channelToUpdateIDPtr, err := spannerClient.CreateNotificationChannel(ctx, baseCreateReq)
+	if err != nil {
+		t.Fatalf("failed to pre-populate channel for update/delete tests: %v", err)
+	}
+	channelToUpdateID := *channelToUpdateIDPtr
+
+	channelToDeleteIDPtr, err := spannerClient.CreateNotificationChannel(ctx, baseCreateReq)
+	if err != nil {
+		t.Fatalf("failed to pre-populate channel for delete tests: %v", err)
+	}
+	channelToDeleteID := *channelToDeleteIDPtr
+
+	t.Run("Create and Get", func(t *testing.T) {
+		createReq := CreateNotificationChannelRequest{
+			UserID: userID,
+			Name:   "A new channel",
+			Type:   "EMAIL",
+			EmailConfig: &EmailConfig{
+				Address:           "new@example.com",
+				IsVerified:        false,
+				VerificationToken: nil,
+			},
+		}
+		channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, createReq)
+		if err != nil {
+			t.Fatalf("CreateNotificationChannel failed: %v", err)
+		}
+		channelID := *channelIDPtr
+
+		retrieved, err := spannerClient.GetNotificationChannel(ctx, channelID, userID)
+		if err != nil {
+			t.Fatalf("GetNotificationChannel failed: %v", err)
+		}
+
+		expected := &NotificationChannel{
+			ID:          channelID,
+			UserID:      createReq.UserID,
+			Name:        createReq.Name,
+			Type:        createReq.Type,
+			EmailConfig: createReq.EmailConfig,
+			CreatedAt:   time.Time{},
+			UpdatedAt:   time.Time{},
+		}
+
+		if diff := cmp.Diff(expected, retrieved,
+			cmpopts.IgnoreFields(NotificationChannel{
+				ID:          "",
+				UserID:      "",
+				Name:        "",
+				Type:        "",
+				EmailConfig: nil,
+				CreatedAt:   time.Time{},
+				UpdatedAt:   time.Time{},
+			}, "CreatedAt", "UpdatedAt")); diff != "" {
+			t.Errorf("GetNotificationChannel mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("Get fails for wrong user", func(t *testing.T) {
+		_, err := spannerClient.GetNotificationChannel(ctx, channelToUpdateID, otherUserID)
+		if err == nil {
+			t.Error("expected an error when getting channel with wrong user ID, but got nil")
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		updateReq := UpdateNotificationChannelRequest{
+			ID:     channelToUpdateID,
+			UserID: userID,
+			Name:   OptionallySet[string]{Value: "Updated Name", IsSet: true},
+			EmailConfig: OptionallySet[*EmailConfig]{
+				Value: &EmailConfig{Address: "updated@example.com", IsVerified: true, VerificationToken: nil},
+				IsSet: true,
+			},
+		}
+		err := spannerClient.UpdateNotificationChannel(ctx, updateReq)
+		if err != nil {
+			t.Fatalf("UpdateNotificationChannel failed: %v", err)
+		}
+
+		retrieved, err := spannerClient.GetNotificationChannel(ctx, channelToUpdateID, userID)
+		if err != nil {
+			t.Fatalf("GetNotificationChannel after update failed: %v", err)
+		}
+		if retrieved.Name != "Updated Name" {
+			t.Errorf("expected updated name, got %s", retrieved.Name)
+		}
+		if retrieved.EmailConfig == nil || retrieved.EmailConfig.Address != "updated@example.com" {
+			t.Errorf("expected updated email config, got %+v", retrieved.EmailConfig)
+		}
+	})
+
+	t.Run("Delete success", func(t *testing.T) {
+		err := spannerClient.DeleteNotificationChannel(ctx, channelToDeleteID, userID)
+		if err != nil {
+			t.Fatalf("DeleteNotificationChannel failed: %v", err)
+		}
+
+		_, err = spannerClient.GetNotificationChannel(ctx, channelToDeleteID, userID)
+		if err == nil {
+			t.Error("expected an error after getting a deleted channel, but got nil")
+		}
+	})
+}

--- a/lib/gcpspanner/saved_search_subscription.go
+++ b/lib/gcpspanner/saved_search_subscription.go
@@ -1,0 +1,299 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/grpc/codes"
+)
+
+const savedSearchSubscriptionTable = "SavedSearchSubscriptions"
+
+// SavedSearchSubscription represents a row in the SavedSearchSubscription table.
+type SavedSearchSubscription struct {
+	ID            string    `spanner:"ID"`
+	UserID        string    `spanner:"UserID"`
+	ChannelID     string    `spanner:"ChannelID"`
+	SavedSearchID string    `spanner:"SavedSearchID"`
+	Triggers      []string  `spanner:"Triggers"`
+	Frequency     string    `spanner:"Frequency"`
+	CreatedAt     time.Time `spanner:"CreatedAt"`
+	UpdatedAt     time.Time `spanner:"UpdatedAt"`
+}
+
+// CreateSavedSearchSubscriptionRequest is the request to create a subscription.
+type CreateSavedSearchSubscriptionRequest struct {
+	UserID        string
+	ChannelID     string
+	SavedSearchID string
+	Triggers      []string
+	Frequency     string
+}
+
+// UpdateSavedSearchSubscriptionRequest is a request to update a saved search subscription.
+type UpdateSavedSearchSubscriptionRequest struct {
+	ID        string
+	UserID    string
+	Triggers  OptionallySet[[]string]
+	Frequency OptionallySet[string]
+}
+
+// ListSavedSearchSubscriptionsRequest is a request to list saved search subscriptions.
+type ListSavedSearchSubscriptionsRequest struct {
+	UserID    string
+	PageSize  int
+	PageToken *string
+}
+
+// GetPageToken returns the page token for the request.
+func (r ListSavedSearchSubscriptionsRequest) GetPageToken() *string {
+	return r.PageToken
+}
+
+type baseSavedSearchSubscriptionMapper struct{}
+
+func (m baseSavedSearchSubscriptionMapper) Table() string {
+	return savedSearchSubscriptionTable
+}
+
+// savedSearchSubscriptionMapper implements the necessary interfaces for the generic helpers.
+type savedSearchSubscriptionMapper struct {
+	baseSavedSearchSubscriptionMapper
+}
+
+func (m savedSearchSubscriptionMapper) GetKeyFromExternal(
+	in UpdateSavedSearchSubscriptionRequest) string {
+	return in.ID
+}
+
+func (m savedSearchSubscriptionMapper) SelectOne(key string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ID, UserID, ChannelID, SavedSearchID, Triggers, Frequency, CreatedAt, UpdatedAt
+	FROM %s
+	WHERE ID = @id
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"id": key,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (m savedSearchSubscriptionMapper) SelectList(req ListSavedSearchSubscriptionsRequest) spanner.Statement {
+	query := fmt.Sprintf(`
+		SELECT ID, UserID, ChannelID, SavedSearchID, Triggers, Frequency, CreatedAt, UpdatedAt
+		FROM %s
+		WHERE UserID = @userID`, m.Table())
+	params := map[string]interface{}{
+		"userID": req.UserID,
+	}
+
+	if req.GetPageToken() != nil && *req.GetPageToken() != "" {
+		query += " AND ID > @pageToken"
+		params["pageToken"] = *req.GetPageToken()
+	}
+
+	query += " ORDER BY ID LIMIT @pageSize"
+	params["pageSize"] = req.PageSize
+
+	stmt := spanner.NewStatement(query)
+	stmt.Params = params
+
+	return stmt
+}
+
+func (m savedSearchSubscriptionMapper) Merge(
+	req UpdateSavedSearchSubscriptionRequest, existing SavedSearchSubscription) SavedSearchSubscription {
+	if req.Triggers.IsSet {
+		existing.Triggers = req.Triggers.Value
+	}
+	if req.Frequency.IsSet {
+		existing.Frequency = req.Frequency.Value
+	}
+
+	return existing
+}
+
+// EncodePageToken returns the ID of the subscription as a page token.
+func (m savedSearchSubscriptionMapper) EncodePageToken(item SavedSearchSubscription) string {
+	return item.ID
+}
+
+func (m savedSearchSubscriptionMapper) NewEntity(
+	id string,
+	req CreateSavedSearchSubscriptionRequest) (SavedSearchSubscription, error) {
+	return SavedSearchSubscription{
+		ID:            id,
+		UserID:        req.UserID,
+		ChannelID:     req.ChannelID,
+		SavedSearchID: req.SavedSearchID,
+		Triggers:      req.Triggers,
+		Frequency:     req.Frequency,
+		CreatedAt:     time.Time{},
+		UpdatedAt:     time.Time{},
+	}, nil
+}
+
+func (c *Client) checkForSavedSearchSubscriptionOwnership(
+	ctx context.Context,
+	txn *spanner.ReadWriteTransaction,
+	userID string,
+	channelID string) error {
+	// Check channel ownership
+	channelKey := spanner.Key{channelID}
+	channelRow, err := txn.ReadRow(ctx, notificationChannelTable, channelKey, []string{"UserID"})
+	if err != nil {
+		if spanner.ErrCode(err) == codes.NotFound {
+			return fmt.Errorf("notification channel %s not found", channelID)
+		}
+
+		return err
+	}
+	var channelOwnerID string
+	if err := channelRow.Column(0, &channelOwnerID); err != nil {
+		return err
+	}
+	if channelOwnerID != userID {
+		return fmt.Errorf("user %s does not own notification channel %s", userID, channelID)
+	}
+
+	return nil
+}
+
+// CreateSavedSearchSubscription creates a new saved search subscription.
+func (c *Client) CreateSavedSearchSubscription(
+	ctx context.Context,
+	req CreateSavedSearchSubscriptionRequest,
+) (*string, error) {
+	var id *string
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		err := c.checkForSavedSearchSubscriptionOwnership(ctx, txn, req.UserID, req.ChannelID)
+		if err != nil {
+			return err
+		}
+		newID, err := newEntityCreator[
+			savedSearchSubscriptionMapper,
+			CreateSavedSearchSubscriptionRequest,
+			SavedSearchSubscription](c).createWithTransaction(ctx, txn, req)
+		if err != nil {
+			return err
+		}
+		id = newID
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return id, nil
+}
+
+// GetSavedSearchSubscription retrieves a subscription if it belongs to the specified user.
+func (c *Client) GetSavedSearchSubscription(
+	ctx context.Context, subscriptionID string, userID string) (*SavedSearchSubscription, error) {
+	var ret *SavedSearchSubscription
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		// Read the subscription first to get the savedSearchID and channelID
+		sub, err := newEntityReader[savedSearchSubscriptionMapper,
+			SavedSearchSubscription, string](c).readRowByKeyWithTransaction(ctx, subscriptionID, txn)
+		if err != nil {
+			return err
+		}
+
+		err = c.checkForSavedSearchSubscriptionOwnership(ctx, txn, userID, sub.ChannelID)
+		if err != nil {
+			return err
+		}
+		ret = sub
+
+		return nil
+	})
+
+	return ret, err
+}
+
+// UpdateSavedSearchSubscription updates a subscription if it belongs to the specified user.
+func (c *Client) UpdateSavedSearchSubscription(
+	ctx context.Context, req UpdateSavedSearchSubscriptionRequest) error {
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		// Read the subscription first to get the savedSearchID and channelID
+		sub, err := newEntityReader[savedSearchSubscriptionMapper,
+			SavedSearchSubscription, string](c).readRowByKeyWithTransaction(ctx, req.ID, txn)
+		if err != nil {
+			return err
+		}
+
+		err = c.checkForSavedSearchSubscriptionOwnership(ctx, txn, req.UserID, sub.ChannelID)
+		if err != nil {
+			return err
+		}
+
+		return newEntityWriter[savedSearchSubscriptionMapper](c).updateWithTransaction(ctx, txn, req)
+	})
+
+	return err
+}
+
+// removeUserSavedSearchMapper implements removableEntityMapper.
+type removeSavedSearchSubscriptionMapper struct {
+	baseSavedSearchSubscriptionMapper
+}
+
+func (m removeSavedSearchSubscriptionMapper) DeleteKey(key string) spanner.Key {
+	return spanner.Key{key}
+}
+func (m removeSavedSearchSubscriptionMapper) GetKeyFromExternal(in string) string { return in }
+
+func (m removeSavedSearchSubscriptionMapper) SelectOne(key string) spanner.Statement {
+	return savedSearchSubscriptionMapper{baseSavedSearchSubscriptionMapper: baseSavedSearchSubscriptionMapper{}}.
+		SelectOne(key)
+}
+
+// DeleteSavedSearchSubscription deletes a subscription if it belongs to the specified user.
+func (c *Client) DeleteSavedSearchSubscription(
+	ctx context.Context, subscriptionID string, userID string) error {
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		// Read the subscription first to get the savedSearchID and channelID
+		sub, err := newEntityReader[savedSearchSubscriptionMapper,
+			SavedSearchSubscription, string](c).readRowByKeyWithTransaction(ctx, subscriptionID, txn)
+		if err != nil {
+			return err
+		}
+
+		err = c.checkForSavedSearchSubscriptionOwnership(ctx, txn, userID, sub.ChannelID)
+		if err != nil {
+			return err
+		}
+
+		return newEntityRemover[removeSavedSearchSubscriptionMapper, string](c).
+			removeWithTransaction(ctx, txn, subscriptionID)
+	})
+
+	return err
+}
+
+// ListSavedSearchSubscriptions retrieves a list of subscriptions for a user with pagination.
+func (c *Client) ListSavedSearchSubscriptions(
+	ctx context.Context, req ListSavedSearchSubscriptionsRequest) ([]SavedSearchSubscription, *string, error) {
+	return newEntityLister[savedSearchSubscriptionMapper,
+		SavedSearchSubscription, ListSavedSearchSubscriptionsRequest](c).list(ctx, req)
+}

--- a/lib/gcpspanner/saved_search_subscription_test.go
+++ b/lib/gcpspanner/saved_search_subscription_test.go
@@ -1,0 +1,344 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+)
+
+func TestCreateAndGetSavedSearchSubscription(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	userID := uuid.NewString()
+
+	// Pre-populate dependencies
+	channelReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, channelReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel: %v", err)
+	}
+	channelID := *channelIDPtr
+
+	savedSearchIDPtr, err := spannerClient.CreateNewUserSavedSearch(ctx, CreateUserSavedSearchRequest{
+		Name:        "Test Search",
+		Query:       "is:widely",
+		OwnerUserID: userID,
+		Description: nil,
+	})
+	if err != nil {
+		t.Fatalf("failed to create saved search: %v", err)
+	}
+	savedSearchID := *savedSearchIDPtr
+
+	createReq := CreateSavedSearchSubscriptionRequest{
+		UserID:        userID,
+		ChannelID:     channelID,
+		SavedSearchID: savedSearchID,
+		Triggers:      []string{"spec.links"},
+		Frequency:     "DAILY",
+	}
+	subIDPtr, err := spannerClient.CreateSavedSearchSubscription(ctx, createReq)
+	if err != nil {
+		t.Fatalf("CreateSavedSearchSubscription failed: %v", err)
+	}
+	subID := *subIDPtr
+
+	retrieved, err := spannerClient.GetSavedSearchSubscription(ctx, subID, userID)
+	if err != nil {
+		t.Fatalf("GetSavedSearchSubscription failed: %v", err)
+	}
+	expected := &SavedSearchSubscription{
+		ID:            subID,
+		UserID:        createReq.UserID,
+		ChannelID:     createReq.ChannelID,
+		SavedSearchID: createReq.SavedSearchID,
+		Triggers:      createReq.Triggers,
+		Frequency:     createReq.Frequency,
+		CreatedAt:     time.Time{},
+		UpdatedAt:     time.Time{},
+	}
+	if diff := cmp.Diff(expected, retrieved,
+		cmpopts.IgnoreFields(SavedSearchSubscription{
+			ID:            "",
+			UserID:        "",
+			ChannelID:     "",
+			SavedSearchID: "",
+			Triggers:      nil,
+			Frequency:     "",
+			CreatedAt:     time.Time{},
+			UpdatedAt:     time.Time{},
+		}, "CreatedAt", "UpdatedAt")); diff != "" {
+		t.Errorf("GetSavedSearchSubscription mismatch (-want +got):\n%s", diff)
+	}
+}
+func TestGetSavedSearchSubscriptionFailsForWrongUser(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	userID := uuid.NewString()
+	otherUserID := uuid.NewString()
+
+	// Pre-populate dependencies
+	channelReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, channelReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel: %v", err)
+	}
+	channelID := *channelIDPtr
+
+	savedSearchIDPtr, err := spannerClient.CreateNewUserSavedSearch(ctx, CreateUserSavedSearchRequest{
+		Name:        "Test Search",
+		Query:       "is:widely",
+		OwnerUserID: userID,
+		Description: nil,
+	})
+	if err != nil {
+		t.Fatalf("failed to create saved search: %v", err)
+	}
+	savedSearchID := *savedSearchIDPtr
+
+	baseCreateReq := CreateSavedSearchSubscriptionRequest{
+		UserID:        userID,
+		ChannelID:     channelID,
+		SavedSearchID: savedSearchID,
+		Triggers:      []string{"baseline.status"},
+		Frequency:     "IMMEDIATE",
+	}
+
+	subToUpdateIDPtr, err := spannerClient.CreateSavedSearchSubscription(ctx, baseCreateReq)
+	if err != nil {
+		t.Fatalf("failed to pre-populate subscription for update tests: %v", err)
+	}
+	subToUpdateID := *subToUpdateIDPtr
+
+	_, err = spannerClient.GetSavedSearchSubscription(ctx, subToUpdateID, otherUserID)
+	if err == nil {
+		t.Error("expected an error when getting subscription with wrong user ID, but got nil")
+	}
+}
+
+func TestUpdateSavedSearchSubscription(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	userID := uuid.NewString()
+
+	// Pre-populate dependencies
+	channelReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, channelReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel: %v", err)
+	}
+	channelID := *channelIDPtr
+
+	savedSearchIDPtr, err := spannerClient.CreateNewUserSavedSearch(ctx, CreateUserSavedSearchRequest{
+		Name:        "Test Search",
+		Query:       "is:widely",
+		OwnerUserID: userID,
+		Description: nil,
+	})
+	if err != nil {
+		t.Fatalf("failed to create saved search: %v", err)
+	}
+	savedSearchID := *savedSearchIDPtr
+
+	baseCreateReq := CreateSavedSearchSubscriptionRequest{
+		UserID:        userID,
+		ChannelID:     channelID,
+		SavedSearchID: savedSearchID,
+		Triggers:      []string{"baseline.status"},
+		Frequency:     "IMMEDIATE",
+	}
+
+	subToUpdateIDPtr, err := spannerClient.CreateSavedSearchSubscription(ctx, baseCreateReq)
+	if err != nil {
+		t.Fatalf("failed to pre-populate subscription for update tests: %v", err)
+	}
+	subToUpdateID := *subToUpdateIDPtr
+
+	updateReq := UpdateSavedSearchSubscriptionRequest{
+		ID:        subToUpdateID,
+		UserID:    userID,
+		Triggers:  OptionallySet[[]string]{Value: []string{"developer_signals.upvotes"}, IsSet: true},
+		Frequency: OptionallySet[string]{Value: "WEEKLY_DIGEST", IsSet: true},
+	}
+	err = spannerClient.UpdateSavedSearchSubscription(ctx, updateReq)
+	if err != nil {
+		t.Fatalf("UpdateSavedSearchSubscription failed: %v", err)
+	}
+
+	retrieved, err := spannerClient.GetSavedSearchSubscription(ctx, subToUpdateID, userID)
+	if err != nil {
+		t.Fatalf("GetSavedSearchSubscription after update failed: %v", err)
+	}
+	if retrieved.Frequency != "WEEKLY_DIGEST" {
+		t.Errorf("expected updated frequency, got %s", retrieved.Frequency)
+	}
+}
+
+func TestDeleteSavedSearchSubscription(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	userID := uuid.NewString()
+
+	// Pre-populate dependencies
+	channelReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, channelReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel: %v", err)
+	}
+	channelID := *channelIDPtr
+
+	savedSearchIDPtr, err := spannerClient.CreateNewUserSavedSearch(ctx, CreateUserSavedSearchRequest{
+		Name:        "Test Search",
+		Query:       "is:widely",
+		OwnerUserID: userID,
+		Description: nil,
+	})
+	if err != nil {
+		t.Fatalf("failed to create saved search: %v", err)
+	}
+	savedSearchID := *savedSearchIDPtr
+
+	baseCreateReq := CreateSavedSearchSubscriptionRequest{
+		UserID:        userID,
+		ChannelID:     channelID,
+		SavedSearchID: savedSearchID,
+		Triggers:      []string{"baseline.status"},
+		Frequency:     "IMMEDIATE",
+	}
+
+	subToDeleteIDPtr, err := spannerClient.CreateSavedSearchSubscription(ctx, baseCreateReq)
+	if err != nil {
+		t.Fatalf("failed to pre-populate subscription for delete tests: %v", err)
+	}
+	subToDeleteID := *subToDeleteIDPtr
+
+	err = spannerClient.DeleteSavedSearchSubscription(ctx, subToDeleteID, userID)
+	if err != nil {
+		t.Fatalf("DeleteSavedSearchSubscription failed: %v", err)
+	}
+
+	_, err = spannerClient.GetSavedSearchSubscription(ctx, subToDeleteID, userID)
+	if err == nil {
+		t.Error("expected an error after getting a deleted subscription, but got nil")
+	}
+}
+
+func TestListSavedSearchSubscriptions(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	userID := uuid.NewString()
+
+	// Pre-populate dependencies
+	channelReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, channelReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel: %v", err)
+	}
+	channelID := *channelIDPtr
+
+	savedSearchIDPtr, err := spannerClient.CreateNewUserSavedSearch(ctx, CreateUserSavedSearchRequest{
+		Name:        "Test Search",
+		Query:       "is:widely",
+		OwnerUserID: userID,
+		Description: nil,
+	})
+	if err != nil {
+		t.Fatalf("failed to create saved search: %v", err)
+	}
+	savedSearchID := *savedSearchIDPtr
+
+	baseCreateReq := CreateSavedSearchSubscriptionRequest{
+		UserID:        userID,
+		ChannelID:     channelID,
+		SavedSearchID: savedSearchID,
+		Triggers:      []string{"baseline.status"},
+		Frequency:     "IMMEDIATE",
+	}
+
+	// Create a few subscriptions to list
+	for i := 0; i < 3; i++ {
+		_, err := spannerClient.CreateSavedSearchSubscription(ctx, baseCreateReq)
+		if err != nil {
+			t.Fatalf("failed to create subscription for list test: %v", err)
+		}
+	}
+
+	// List first page
+	listReq1 := ListSavedSearchSubscriptionsRequest{
+		UserID:    userID,
+		PageSize:  2,
+		PageToken: nil,
+	}
+	results1, nextPageToken1, err := spannerClient.ListSavedSearchSubscriptions(ctx, listReq1)
+	if err != nil {
+		t.Fatalf("ListSavedSearchSubscriptions page 1 failed: %v", err)
+	}
+	if len(results1) != 2 {
+		t.Errorf("expected 2 results on page 1, got %d", len(results1))
+	}
+	if nextPageToken1 == nil {
+		t.Fatal("expected a next page token on page 1, got nil")
+	}
+
+	// List second page
+	listReq2 := ListSavedSearchSubscriptionsRequest{
+		UserID:    userID,
+		PageSize:  2,
+		PageToken: nextPageToken1,
+	}
+	results2, _, err := spannerClient.ListSavedSearchSubscriptions(ctx, listReq2)
+	if err != nil {
+		t.Fatalf("ListSavedSearchSubscriptions page 2 failed: %v", err)
+	}
+	if len(results2) < 1 {
+		t.Errorf("expected at least 1 result on page 2, got %d", len(results2))
+	}
+}


### PR DESCRIPTION
This commit introduces the foundational database schema and Go client-side logic for Notification Channels and Saved Search Subscriptions. It also includes a significant refactoring of the generic Spanner helpers to create a more robust and consistent data access layer.

### 1. Refactoring of Generic Spanner Helpers

-   **`client.go`:**
    -   **`entityCreator`:** Refactored to return `*string` for the new entity ID, providing a consistent way to retrieve the ID after creation.
    -   **`entityLister`:** Refactored to use a generic, interface-driven approach for cursor-based pagination, returning `([]T, *string, error)`.
    -   **`entityRemover`:** Refactored to be key-based, simplifying deletion logic and improving flexibility.
-   All existing callers of these helpers were updated to align with the new patterns.

### 2. Database Schema

A new database migration was added to create the necessary tables:

-   **`NotificationChannels` table:** Stores user-defined delivery destinations (e.g., email).
-   **`NotificationChannelState` table:** Stores dynamic state for each channel, such as `IsDisabledBySystem`.
-   **`NotificationChannelDeliveryAttempts` table:** Logs individual delivery attempts. It has a composite primary key `(ID, ChannelID)` and a foreign key to `NotificationChannels`.
-   **`SavedSearchSubscriptions` table:** Links a `UserID`, `SavedSearchID`, and `ChannelID`. Includes `Triggers` and `Frequency` columns.

### 3. Go Client-Side Implementation

-   **`notification_channel.go`:** Implemented full CRUD functionality for managing notification channels.
-   **`notification_channel_delivery_attempt.go`:** Implemented `Create` and `List` functionality for delivery attempts, including logic to automatically prune old attempts.
-   **`notification_channel_state.go`:** Implemented `Upsert` and `Get` for managing channel state.
-   **`saved_search_subscription.go`:** Implemented full CRUD and `List` functionality for saved search subscriptions, including ownership checks.
-   All new methods utilize the refactored generic helpers, adhering to the new patterns for returning `*string` IDs and handling pagination.

### 4. Testing

-   Added comprehensive integration tests for all new CRUD and List operations for Notification Channels, Delivery Attempts, and Saved Search Subscriptions.
-   Updated all tests to align with the refactored generic helpers, correctly handling pointer-based IDs and pagination tokens.