### PR TITLE
feat(gcpspanner): Implement Notification Channels

### DIFF
--- a/infra/storage/spanner/migrations/000023.sql
+++ b/infra/storage/spanner/migrations/000023.sql
@@ -1,0 +1,34 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- NotificationChannels stores the reusable delivery destinations for a user.
+CREATE TABLE IF NOT EXISTS NotificationChannels (
+    ID STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
+    UserID STRING(MAX) NOT NULL,
+    Name STRING(MAX) NOT NULL,
+    Type STRING(MAX) NOT NULL,
+    Config JSON,
+    CreatedAt TIMESTAMP NOT NULL OPTIONS(allow_commit_timestamp = true),
+    UpdatedAt TIMESTAMP NOT NULL OPTIONS(allow_commit_timestamp = true)
+) PRIMARY KEY (ID);
+
+-- NotificationChannelStates stores the dynamic state and health data.
+CREATE TABLE IF NOT EXISTS NotificationChannelStates (
+    ChannelID STRING(36) NOT NULL,
+    IsDisabledBySystem BOOL,
+    ConsecutiveFailures INT64,
+    CreatedAt TIMESTAMP NOT NULL OPTIONS(allow_commit_timestamp = true),
+    UpdatedAt TIMESTAMP NOT NULL OPTIONS(allow_commit_timestamp = true),
+    CONSTRAINT FK_NotificationChannelState_NotificationChannel FOREIGN KEY (ChannelID) REFERENCES NotificationChannels (ID) ON DELETE CASCADE
+) PRIMARY KEY (ChannelID);

--- a/lib/gcpspanner/client.go
+++ b/lib/gcpspanner/client.go
@@ -536,6 +536,28 @@ func newEntityCreator[
 	return &entityCreator[M, CreateRequest, SpannerStruct]{c}
 }
 
+func (c *entityCreator[M, CreateRequest, SpannerStruct]) create(
+	ctx context.Context,
+	req CreateRequest,
+	opts ...CreateOption) (*string, error) {
+	var id *string
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		newID, err := c.createWithTransaction(ctx, txn, req, opts...)
+		if err != nil {
+			return err
+		}
+		id = newID
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return id, nil
+}
+
 func (c *entityCreator[M, CreateRequest, SpannerStruct]) createWithTransaction(
 	_ context.Context,
 	txn *spanner.ReadWriteTransaction,

--- a/lib/gcpspanner/notification_channel.go
+++ b/lib/gcpspanner/notification_channel.go
@@ -1,0 +1,258 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+const notificationChannelTable = "NotificationChannels"
+
+// EmailConfig represents the JSON structure for an EMAIL notification channel.
+type EmailConfig struct {
+	Address           string  `json:"address,omitempty"`
+	IsVerified        bool    `json:"is_verified,omitempty"`
+	VerificationToken *string `json:"verification_token,omitempty"`
+}
+
+// NotificationChannel represents a user-facing notification channel.
+type NotificationChannel struct {
+	ID          string       `spanner:"ID"`
+	UserID      string       `spanner:"UserID"`
+	Name        string       `spanner:"Name"`
+	Type        string       `spanner:"Type"`
+	EmailConfig *EmailConfig `spanner:"-"`
+	CreatedAt   time.Time    `spanner:"CreatedAt"`
+	UpdatedAt   time.Time    `spanner:"UpdatedAt"`
+}
+
+// spannerNotificationChannel is the internal struct for Spanner mapping.
+type spannerNotificationChannel struct {
+	NotificationChannel
+	Config spanner.NullJSON `spanner:"Config"`
+}
+
+// CreateNotificationChannelRequest is the request to create a channel.
+type CreateNotificationChannelRequest struct {
+	UserID      string
+	Name        string
+	Type        string
+	EmailConfig *EmailConfig
+}
+
+// UpdateNotificationChannelRequest is a request to update a notification channel.
+type UpdateNotificationChannelRequest struct {
+	ID          string
+	UserID      string
+	Name        OptionallySet[string]
+	EmailConfig OptionallySet[*EmailConfig]
+}
+
+// notificationChannelMapper implements the necessary interfaces for the generic helpers.
+type notificationChannelMapper struct{}
+
+func (m notificationChannelMapper) Table() string { return notificationChannelTable }
+
+type updateNotificationChannelMapper struct{ notificationChannelMapper }
+
+func (m updateNotificationChannelMapper) GetKeyFromExternal(in UpdateNotificationChannelRequest) string {
+	return in.ID
+}
+
+func (m notificationChannelMapper) SelectOne(id string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ID, UserID, Name, Type, Config, CreatedAt, UpdatedAt
+	FROM %s
+	WHERE ID = @id
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"id": id,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (m updateNotificationChannelMapper) Merge(
+	req UpdateNotificationChannelRequest, existing spannerNotificationChannel) spannerNotificationChannel {
+	if req.Name.IsSet {
+		existing.Name = req.Name.Value
+	}
+	if req.EmailConfig.IsSet && req.EmailConfig.Value != nil {
+		existing.Config = spanner.NullJSON{Value: *req.EmailConfig.Value, Valid: true}
+	}
+
+	return existing
+}
+
+func (m notificationChannelMapper) NewEntity(
+	id string,
+	req CreateNotificationChannelRequest) (*spannerNotificationChannel, error) {
+	channel := NotificationChannel{
+		ID:          id,
+		UserID:      req.UserID,
+		Name:        req.Name,
+		Type:        req.Type,
+		EmailConfig: req.EmailConfig,
+		CreatedAt:   spanner.CommitTimestamp,
+		UpdatedAt:   spanner.CommitTimestamp,
+	}
+
+	return channel.toSpanner(), nil
+}
+
+// toSpanner converts the public NotificationChannel to the internal spannerNotificationChannel for writing.
+func (c *NotificationChannel) toSpanner() *spannerNotificationChannel {
+	var configData interface{}
+	// This can be extended with a switch on c.Type for other configs.
+	if c.EmailConfig != nil {
+		configData = c.EmailConfig
+	}
+
+	var config spanner.NullJSON
+	if configData != nil {
+		config = spanner.NullJSON{Value: configData, Valid: true}
+	}
+
+	return &spannerNotificationChannel{
+		NotificationChannel: *c,
+		Config:              config,
+	}
+}
+
+// toPublic converts the internal spannerNotificationChannel to the public NotificationChannel for reading.
+func (sc *spannerNotificationChannel) toPublic() (*NotificationChannel, error) {
+	ret := &sc.NotificationChannel
+	if sc.Config.Valid {
+		bytes, err := json.Marshal(sc.Config.Value)
+		if err != nil {
+			return nil, err
+		}
+		var emailConfig EmailConfig
+		if err := json.Unmarshal(bytes, &emailConfig); err != nil {
+			return nil, err
+		}
+		ret.EmailConfig = &emailConfig
+	}
+
+	return ret, nil
+}
+
+func (c *Client) checkNotificationChannelOwnership(
+	ctx context.Context, channelID string, userID string, txn *spanner.ReadWriteTransaction,
+) error {
+	stmt := spanner.Statement{
+		SQL: fmt.Sprintf(`SELECT ID FROM %s WHERE ID = @channelID AND UserID = @userID`, notificationChannelTable),
+		Params: map[string]interface{}{
+			"channelID": channelID,
+			"userID":    userID,
+		},
+	}
+
+	iter := txn.Query(ctx, stmt)
+	defer iter.Stop()
+
+	_, err := iter.Next()
+	if err != nil {
+		// No row found. User does not have a role.
+		if errors.Is(err, iterator.Done) {
+			return errors.Join(ErrMissingRequiredRole, err)
+		}
+		slog.ErrorContext(ctx, "failed to query user role", "error", err)
+
+		return errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	return nil
+}
+
+// CreateNotificationChannel creates a new notification channel.
+func (c *Client) CreateNotificationChannel(
+	ctx context.Context,
+	req CreateNotificationChannelRequest,
+) (*string, error) {
+	return newEntityCreator[notificationChannelMapper](c).create(ctx, req)
+}
+
+// GetNotificationChannel retrieves a notification channel if it belongs to the specified user.
+func (c *Client) GetNotificationChannel(
+	ctx context.Context, channelID string, userID string) (*NotificationChannel, error) {
+	var spannerChannel *spannerNotificationChannel
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		err := c.checkNotificationChannelOwnership(ctx, channelID, userID, txn)
+		if err != nil {
+			return err
+		}
+		spannerChannel, err = newEntityReader[notificationChannelMapper,
+			spannerNotificationChannel, string](c).readRowByKeyWithTransaction(ctx, channelID, txn)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return spannerChannel.toPublic()
+}
+
+// UpdateNotificationChannel updates a notification channel if it belongs to the specified user.
+func (c *Client) UpdateNotificationChannel(
+	ctx context.Context, req UpdateNotificationChannelRequest) error {
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		err := c.checkNotificationChannelOwnership(ctx, req.ID, req.UserID, txn)
+		if err != nil {
+			return err
+		}
+
+		return newEntityWriter[updateNotificationChannelMapper](c).updateWithTransaction(ctx, txn, req)
+	})
+
+	return err
+}
+
+type removeNotificationChannelMapper struct{ notificationChannelMapper }
+
+func (m removeNotificationChannelMapper) DeleteKey(in string) spanner.Key { return spanner.Key{in} }
+
+func (m removeNotificationChannelMapper) GetKeyFromExternal(id string) string { return id }
+
+// DeleteNotificationChannel deletes a notification channel if it belongs to the specified user.
+func (c *Client) DeleteNotificationChannel(
+	ctx context.Context, channelID string, userID string) error {
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		err := c.checkNotificationChannelOwnership(ctx, channelID, userID, txn)
+		if err != nil {
+			return err
+		}
+
+		return newEntityRemover[removeNotificationChannelMapper, spannerNotificationChannel](c).removeWithTransaction(
+			ctx, txn, channelID)
+	})
+
+	return err
+}

--- a/lib/gcpspanner/notification_channel_state.go
+++ b/lib/gcpspanner/notification_channel_state.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+const notificationChannelStateTable = "NotificationChannelStates"
+
+// NotificationChannelState represents a row in the NotificationChannelState table.
+type NotificationChannelState struct {
+	ChannelID           string    `spanner:"ChannelID"`
+	IsDisabledBySystem  bool      `spanner:"IsDisabledBySystem"`
+	ConsecutiveFailures int64     `spanner:"ConsecutiveFailures"`
+	CreatedAt           time.Time `spanner:"CreatedAt"`
+	UpdatedAt           time.Time `spanner:"UpdatedAt"`
+}
+
+// notificationChannelStateMapper implements the necessary interfaces for the generic helpers.
+type notificationChannelStateMapper struct{}
+
+func (m notificationChannelStateMapper) Table() string { return notificationChannelStateTable }
+
+func (m notificationChannelStateMapper) GetKeyFromExternal(in NotificationChannelState) string {
+	return in.ChannelID
+}
+
+func (m notificationChannelStateMapper) SelectOne(key string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+	SELECT
+		ChannelID, IsDisabledBySystem, ConsecutiveFailures, CreatedAt, UpdatedAt
+	FROM %s
+	WHERE ChannelID = @channelId
+	LIMIT 1`, m.Table()))
+	parameters := map[string]interface{}{
+		"channelId": key,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (m notificationChannelStateMapper) Merge(
+	in NotificationChannelState, existing NotificationChannelState) NotificationChannelState {
+	existing.IsDisabledBySystem = in.IsDisabledBySystem
+	existing.ConsecutiveFailures = in.ConsecutiveFailures
+
+	return existing
+}
+
+// UpsertNotificationChannelState inserts or updates a notification channel state.
+func (c *Client) UpsertNotificationChannelState(
+	ctx context.Context, state NotificationChannelState) error {
+	return newEntityWriter[notificationChannelStateMapper](c).upsert(ctx, state)
+}
+
+// GetNotificationChannelState retrieves a notification channel state by its ID.
+func (c *Client) GetNotificationChannelState(
+	ctx context.Context, channelID string) (*NotificationChannelState, error) {
+	return newEntityReader[notificationChannelStateMapper,
+		NotificationChannelState, string](c).readRowByKey(ctx, channelID)
+}

--- a/lib/gcpspanner/notification_channel_state_test.go
+++ b/lib/gcpspanner/notification_channel_state_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+)
+
+func TestNotificationChannelStateOperations(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// We need a channel to associate the state with.
+	userID := uuid.NewString()
+	createReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test Channel",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, createReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel: %v", err)
+	}
+	channelID := *channelIDPtr
+
+	t.Run("Create and Get", func(t *testing.T) {
+		tstate := &NotificationChannelState{
+			ChannelID:           channelID,
+			IsDisabledBySystem:  false,
+			ConsecutiveFailures: 0,
+			CreatedAt:           spanner.CommitTimestamp,
+			UpdatedAt:           spanner.CommitTimestamp,
+		}
+
+		err := spannerClient.UpsertNotificationChannelState(ctx, *tstate)
+		if err != nil {
+			t.Fatalf("UpsertNotificationChannelState (create) failed: %v", err)
+		}
+
+		retrieved, err := spannerClient.GetNotificationChannelState(ctx, channelID)
+		if err != nil {
+			t.Fatalf("GetNotificationChannelState failed: %v", err)
+		}
+		if diff := cmp.Diff(tstate, retrieved,
+			cmpopts.IgnoreFields(NotificationChannelState{
+				ChannelID:           "",
+				IsDisabledBySystem:  false,
+				ConsecutiveFailures: 0,
+				CreatedAt:           spanner.CommitTimestamp,
+				UpdatedAt:           spanner.CommitTimestamp,
+			}, "CreatedAt", "UpdatedAt")); diff != "" {
+			t.Errorf("GetNotificationChannelState mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		// First, ensure a known state exists.
+		initialState := &NotificationChannelState{
+			ChannelID:           channelID,
+			IsDisabledBySystem:  false,
+			ConsecutiveFailures: 1,
+			CreatedAt:           spanner.CommitTimestamp,
+			UpdatedAt:           spanner.CommitTimestamp,
+		}
+		err := spannerClient.UpsertNotificationChannelState(ctx, *initialState)
+		if err != nil {
+			t.Fatalf("pre-test UpsertNotificationChannelState failed: %v", err)
+		}
+
+		// Now, update it.
+		updatedState := &NotificationChannelState{
+			ChannelID:           channelID,
+			IsDisabledBySystem:  true,
+			ConsecutiveFailures: 5,
+			CreatedAt:           spanner.CommitTimestamp,
+			UpdatedAt:           spanner.CommitTimestamp,
+		}
+		err = spannerClient.UpsertNotificationChannelState(ctx, *updatedState)
+		if err != nil {
+			t.Fatalf("UpsertNotificationChannelState (update) failed: %v", err)
+		}
+
+		// Verify the update.
+		retrieved, err := spannerClient.GetNotificationChannelState(ctx, channelID)
+		if err != nil {
+			t.Fatalf("GetNotificationChannelState after update failed: %v", err)
+		}
+		if diff := cmp.Diff(updatedState, retrieved,
+			cmpopts.IgnoreFields(NotificationChannelState{
+				ChannelID:           "",
+				IsDisabledBySystem:  false,
+				ConsecutiveFailures: 0,
+				CreatedAt:           spanner.CommitTimestamp,
+				UpdatedAt:           spanner.CommitTimestamp,
+			}, "CreatedAt", "UpdatedAt")); diff != "" {
+			t.Errorf("GetNotificationChannelState after update mismatch (-want +got):\n%s", diff)
+		}
+	})
+}

--- a/lib/gcpspanner/notification_channel_test.go
+++ b/lib/gcpspanner/notification_channel_test.go
@@ -1,0 +1,149 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+)
+
+func TestNotificationChannelRefactoredOperations(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	userID := uuid.NewString()
+	otherUserID := uuid.NewString()
+
+	baseCreateReq := CreateNotificationChannelRequest{
+		UserID: userID,
+		Name:   "Test Email",
+		Type:   "EMAIL",
+		EmailConfig: &EmailConfig{
+			Address:           "test@example.com",
+			IsVerified:        true,
+			VerificationToken: nil,
+		},
+	}
+
+	// Pre-populate a channel for update/delete tests
+	channelToUpdateIDPtr, err := spannerClient.CreateNotificationChannel(ctx, baseCreateReq)
+	if err != nil {
+		t.Fatalf("failed to pre-populate channel for update/delete tests: %v", err)
+	}
+	channelToUpdateID := *channelToUpdateIDPtr
+
+	channelToDeleteIDPtr, err := spannerClient.CreateNotificationChannel(ctx, baseCreateReq)
+	if err != nil {
+		t.Fatalf("failed to pre-populate channel for delete tests: %v", err)
+	}
+	channelToDeleteID := *channelToDeleteIDPtr
+
+	t.Run("Create and Get", func(t *testing.T) {
+		createReq := CreateNotificationChannelRequest{
+			UserID: userID,
+			Name:   "A new channel",
+			Type:   "EMAIL",
+			EmailConfig: &EmailConfig{
+				Address:           "new@example.com",
+				IsVerified:        false,
+				VerificationToken: nil,
+			},
+		}
+		channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, createReq)
+		if err != nil {
+			t.Fatalf("CreateNotificationChannel failed: %v", err)
+		}
+		channelID := *channelIDPtr
+
+		retrieved, err := spannerClient.GetNotificationChannel(ctx, channelID, userID)
+		if err != nil {
+			t.Fatalf("GetNotificationChannel failed: %v", err)
+		}
+
+		expected := &NotificationChannel{
+			ID:          channelID,
+			UserID:      createReq.UserID,
+			Name:        createReq.Name,
+			Type:        createReq.Type,
+			EmailConfig: createReq.EmailConfig,
+			CreatedAt:   spanner.CommitTimestamp,
+			UpdatedAt:   spanner.CommitTimestamp,
+		}
+
+		if diff := cmp.Diff(expected, retrieved,
+			cmpopts.IgnoreFields(NotificationChannel{
+				ID:          "",
+				UserID:      "",
+				Name:        "",
+				Type:        "",
+				EmailConfig: nil,
+				CreatedAt:   spanner.CommitTimestamp,
+				UpdatedAt:   spanner.CommitTimestamp,
+			}, "CreatedAt", "UpdatedAt")); diff != "" {
+			t.Errorf("GetNotificationChannel mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("Get fails for wrong user", func(t *testing.T) {
+		_, err := spannerClient.GetNotificationChannel(ctx, channelToUpdateID, otherUserID)
+		if err == nil {
+			t.Error("expected an error when getting channel with wrong user ID, but got nil")
+		}
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		updateReq := UpdateNotificationChannelRequest{
+			ID:     channelToUpdateID,
+			UserID: userID,
+			Name:   OptionallySet[string]{Value: "Updated Name", IsSet: true},
+			EmailConfig: OptionallySet[*EmailConfig]{
+				Value: &EmailConfig{Address: "updated@example.com", IsVerified: true, VerificationToken: nil},
+				IsSet: true,
+			},
+		}
+		err := spannerClient.UpdateNotificationChannel(ctx, updateReq)
+		if err != nil {
+			t.Fatalf("UpdateNotificationChannel failed: %v", err)
+		}
+
+		retrieved, err := spannerClient.GetNotificationChannel(ctx, channelToUpdateID, userID)
+		if err != nil {
+			t.Fatalf("GetNotificationChannel after update failed: %v", err)
+		}
+		if retrieved.Name != "Updated Name" {
+			t.Errorf("expected updated name, got %s", retrieved.Name)
+		}
+		if retrieved.EmailConfig == nil || retrieved.EmailConfig.Address != "updated@example.com" {
+			t.Errorf("expected updated email config, got %+v", retrieved.EmailConfig)
+		}
+	})
+
+	t.Run("Delete success", func(t *testing.T) {
+		err := spannerClient.DeleteNotificationChannel(ctx, channelToDeleteID, userID)
+		if err != nil {
+			t.Fatalf("DeleteNotificationChannel failed: %v", err)
+		}
+
+		_, err = spannerClient.GetNotificationChannel(ctx, channelToDeleteID, userID)
+		if err == nil {
+			t.Error("expected an error after getting a deleted channel, but got nil")
+		}
+	})
+}


### PR DESCRIPTION
This commit introduces the Notification Channels feature, including the database schema and the corresponding Go client-side logic for management.

-   **Database Schema (New Migration File):**
    -   **`NotificationChannels` table:** Stores user-defined delivery destinations. <-- Updated by Users
    -   **`NotificationChannelState` table:** Stores dynamic state for each channel. <-- Managed by System
-   **Go Client-Side Implementation (`lib/gcpspanner`):**
    -   **`notification_channel.go`:** Implemented full CRUD functionality for managing notification channels.
    -   **`notification_channel_state.go`:** Implemented `Upsert` and `Get` for managing channel state.
-   **Testing (`lib/gcpspanner`):**
    -   Added comprehensive integration tests for all new functionality.