### PR TITLE
feat(gcpspanner): Implement Notification Channel Delivery Attempts

### DIFF
--- a/infra/storage/spanner/migrations/000024.sql
+++ b/infra/storage/spanner/migrations/000024.sql
@@ -1,0 +1,27 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- NotificationChannelDeliveryAttempts stores a log of delivery attempts for a channel.
+CREATE TABLE IF NOT EXISTS NotificationChannelDeliveryAttempts (
+    ID STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
+    ChannelID STRING(36) NOT NULL,
+    AttemptTimestamp TIMESTAMP NOT NULL,
+    Status STRING(MAX) NOT NULL, -- SUCCESS or FAILURE
+    Details JSON,
+    CONSTRAINT FK_NotificationChannelDeliveryAttempt_NotificationChannel FOREIGN KEY (ChannelID) REFERENCES NotificationChannels(ID) ON DELETE CASCADE
+) PRIMARY KEY (ID, ChannelID);
+
+-- Index to get the latest attempts for a channel
+CREATE INDEX IX_NotificationChannelDeliveryAttempt_AttemptTimestamp
+ON NotificationChannelDeliveryAttempts (ChannelID, AttemptTimestamp DESC);

--- a/lib/gcpspanner/notification_channel_delivery_attempt.go
+++ b/lib/gcpspanner/notification_channel_delivery_attempt.go
@@ -1,0 +1,223 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+const notificationChannelDeliveryAttemptTable = "NotificationChannelDeliveryAttempts"
+const maxDeliveryAttemptsToKeep = 10
+
+// NotificationChannelDeliveryAttempt represents a row in the NotificationChannelDeliveryAttempt table.
+type NotificationChannelDeliveryAttempt struct {
+	ID               string                                   `spanner:"ID"`
+	ChannelID        string                                   `spanner:"ChannelID"`
+	AttemptTimestamp time.Time                                `spanner:"AttemptTimestamp"`
+	Status           NotificationChannelDeliveryAttemptStatus `spanner:"Status"`
+	Details          spanner.NullJSON                         `spanner:"Details"`
+}
+
+type NotificationChannelDeliveryAttemptStatus string
+
+const (
+	// DeliveryAttemptStatusSuccess indicates that the delivery attempt was successful.
+	DeliveryAttemptStatusSuccess NotificationChannelDeliveryAttemptStatus = "SUCCESS"
+	// DeliveryAttemptStatusFailure indicates that the delivery attempt failed.
+	DeliveryAttemptStatusFailure NotificationChannelDeliveryAttemptStatus = "FAILURE"
+)
+
+// CreateNotificationChannelDeliveryAttemptRequest is the request to create a delivery attempt.
+type CreateNotificationChannelDeliveryAttemptRequest struct {
+	ChannelID        string
+	AttemptTimestamp time.Time
+	Status           NotificationChannelDeliveryAttemptStatus
+	Details          spanner.NullJSON
+}
+
+// ListNotificationChannelDeliveryAttemptsRequest is the request struct for listing delivery attempts.
+type ListNotificationChannelDeliveryAttemptsRequest struct {
+	ChannelID string
+	PageSize  int
+	PageToken *string
+}
+
+// GetPageSize returns the page size for the request.
+func (r ListNotificationChannelDeliveryAttemptsRequest) GetPageSize() int {
+	return r.PageSize
+}
+
+type notificationChannelDeliveryAttemptMapper struct{}
+
+func (m notificationChannelDeliveryAttemptMapper) Table() string {
+	return notificationChannelDeliveryAttemptTable
+}
+
+func (m notificationChannelDeliveryAttemptMapper) NewEntity(
+	id string,
+	req CreateNotificationChannelDeliveryAttemptRequest) (NotificationChannelDeliveryAttempt, error) {
+	return NotificationChannelDeliveryAttempt{
+		ID:               id,
+		ChannelID:        req.ChannelID,
+		AttemptTimestamp: req.AttemptTimestamp,
+		Status:           req.Status,
+		Details:          req.Details,
+	}, nil
+}
+
+type deliveryAttemptKey struct {
+	ID        string
+	ChannelID string
+}
+
+func (m notificationChannelDeliveryAttemptMapper) SelectOne(key deliveryAttemptKey) spanner.Statement {
+	stmt := spanner.NewStatement(`
+		SELECT ID, ChannelID, AttemptTimestamp, Status, Details
+		FROM NotificationChannelDeliveryAttempts
+		WHERE ID = @id AND ChannelID = @channelID`)
+	stmt.Params = map[string]interface{}{
+		"id":        key.ID,
+		"channelID": key.ChannelID,
+	}
+
+	return stmt
+}
+
+func (m notificationChannelDeliveryAttemptMapper) SelectList(
+	req ListNotificationChannelDeliveryAttemptsRequest) spanner.Statement {
+	var pageFilter string
+	params := map[string]interface{}{
+		"channelID": req.ChannelID,
+		"pageSize":  req.PageSize,
+	}
+	if req.PageToken != nil {
+		cursor, err := decodeCursor[notificationChannelDeliveryAttemptCursor](*req.PageToken)
+		if err == nil {
+			params["lastID"] = cursor.LastID
+			pageFilter = " AND ID > @lastID"
+		}
+	}
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+		SELECT ID, ChannelID, AttemptTimestamp, Status, Details
+		FROM NotificationChannelDeliveryAttempts
+		WHERE ChannelID = @channelID %s
+		ORDER BY AttemptTimestamp, ID
+		LIMIT @pageSize`, pageFilter))
+	stmt.Params = params
+
+	return stmt
+}
+
+type notificationChannelDeliveryAttemptCursor struct {
+	LastID string `json:"last_id"`
+}
+
+// EncodePageToken returns the ID of the delivery attempt as a page token.
+func (m notificationChannelDeliveryAttemptMapper) EncodePageToken(item NotificationChannelDeliveryAttempt) string {
+	return encodeCursor(notificationChannelDeliveryAttemptCursor{
+		LastID: item.ID,
+	})
+}
+
+// CreateNotificationChannelDeliveryAttempt creates a new delivery attempt log, prunes old ones, and returns its ID.
+func (c *Client) CreateNotificationChannelDeliveryAttempt(
+	ctx context.Context, req CreateNotificationChannelDeliveryAttemptRequest) (*string, error) {
+	var newID *string
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		// 1. Create the new attempt
+		id, err := newEntityCreator[notificationChannelDeliveryAttemptMapper](c).createWithTransaction(ctx, txn, req)
+		if err != nil {
+			return err
+		}
+		newID = id
+
+		// 2. Count existing attempts for the channel. Note: This count does not include the new attempt just buffered.
+		countStmt := spanner.NewStatement(`
+			SELECT COUNT(*)
+			FROM NotificationChannelDeliveryAttempts
+			WHERE ChannelID = @channelID`)
+		countStmt.Params["channelID"] = req.ChannelID
+		var count int64
+		err = txn.Query(ctx, countStmt).Do(func(r *spanner.Row) error {
+			return r.Column(0, &count)
+		})
+		if err != nil {
+			return err
+		}
+
+		// 3. If the pre-insert count is at the limit, fetch the oldest attempts to delete.
+		if count >= maxDeliveryAttemptsToKeep {
+			// We need to delete enough to make room for the one we are adding.
+			deleteCount := count - maxDeliveryAttemptsToKeep + 1
+			deleteStmt := spanner.NewStatement(`
+				SELECT ID
+				FROM NotificationChannelDeliveryAttempts
+				WHERE ChannelID = @channelID
+				ORDER BY AttemptTimestamp ASC
+				LIMIT @deleteCount`)
+			deleteStmt.Params["channelID"] = req.ChannelID
+			deleteStmt.Params["deleteCount"] = deleteCount
+
+			var mutations []*spanner.Mutation
+			err := txn.Query(ctx, deleteStmt).Do(func(r *spanner.Row) error {
+				var attemptID string
+				if err := r.Column(0, &attemptID); err != nil {
+					return err
+				}
+				mutations = append(mutations,
+					spanner.Delete(notificationChannelDeliveryAttemptTable,
+						spanner.Key{attemptID, req.ChannelID}))
+
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			// 4. Buffer delete mutations
+			if len(mutations) > 0 {
+				return txn.BufferWrite(mutations)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return newID, nil
+}
+
+// GetNotificationChannelDeliveryAttempt retrieves a single delivery attempt.
+func (c *Client) GetNotificationChannelDeliveryAttempt(
+	ctx context.Context, attemptID string, channelID string) (*NotificationChannelDeliveryAttempt, error) {
+	key := deliveryAttemptKey{ID: attemptID, ChannelID: channelID}
+
+	return newEntityReader[notificationChannelDeliveryAttemptMapper,
+		NotificationChannelDeliveryAttempt, deliveryAttemptKey](c).readRowByKey(ctx, key)
+}
+
+// ListNotificationChannelDeliveryAttempts lists all delivery attempts for a channel.
+func (c *Client) ListNotificationChannelDeliveryAttempts(
+	ctx context.Context,
+	req ListNotificationChannelDeliveryAttemptsRequest,
+) ([]NotificationChannelDeliveryAttempt, *string, error) {
+	return newEntityLister[notificationChannelDeliveryAttemptMapper](c).list(ctx, req)
+}

--- a/lib/gcpspanner/notification_channel_delivery_attempt_test.go
+++ b/lib/gcpspanner/notification_channel_delivery_attempt_test.go
@@ -1,0 +1,204 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/uuid"
+)
+
+func TestCreateNotificationChannelDeliveryAttempt(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// We need a channel to associate the attempt with.
+	userID := uuid.NewString()
+	createReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test Channel",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, createReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel: %v", err)
+	}
+	channelID := *channelIDPtr
+
+	req := CreateNotificationChannelDeliveryAttemptRequest{
+		ChannelID:        channelID,
+		Status:           "SUCCESS",
+		Details:          spanner.NullJSON{Value: map[string]interface{}{"info": "delivered"}, Valid: true},
+		AttemptTimestamp: time.Now(),
+	}
+
+	attemptIDPtr, err := spannerClient.CreateNotificationChannelDeliveryAttempt(ctx, req)
+	if err != nil {
+		t.Fatalf("CreateNotificationChannelDeliveryAttempt failed: %v", err)
+	}
+	if attemptIDPtr == nil {
+		t.Fatal("CreateNotificationChannelDeliveryAttempt did not return an ID")
+	}
+	attemptID := *attemptIDPtr
+
+	// Verify Create by using the Get method.
+	retrieved, err := spannerClient.GetNotificationChannelDeliveryAttempt(ctx, attemptID, channelID)
+	if err != nil {
+		t.Fatalf("failed to read back delivery attempt: %v", err)
+	}
+
+	if retrieved.Status != "SUCCESS" {
+		t.Errorf("expected status to be SUCCESS, got %s", retrieved.Status)
+	}
+
+	if retrieved.AttemptTimestamp.IsZero() {
+		t.Error("expected a non-zero commit timestamp")
+	}
+}
+
+func TestCreateNotificationChannelDeliveryAttemptPruning(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// We need a channel to associate the attempt with.
+	userID := uuid.NewString()
+	createReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test Channel",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	channelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, createReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel: %v", err)
+	}
+	channelID := *channelIDPtr
+
+	// Create more attempts than the max to trigger pruning.
+	var idsToDelete []string
+	var idToKeep string
+	for i := 0; i < maxDeliveryAttemptsToKeep+2; i++ {
+		// The sleep is a simple way to ensure distinct AttemptTimestamps for ordering.
+		time.Sleep(1 * time.Millisecond)
+		req := CreateNotificationChannelDeliveryAttemptRequest{
+			ChannelID:        channelID,
+			Status:           "SUCCESS",
+			Details:          spanner.NullJSON{Value: nil, Valid: false},
+			AttemptTimestamp: time.Now(),
+		}
+		idPtr, err := spannerClient.CreateNotificationChannelDeliveryAttempt(ctx, req)
+		if err != nil {
+			t.Fatalf("CreateNotificationChannelDeliveryAttempt (pruning test) failed: %v", err)
+		}
+		id := *idPtr
+		if i < 2 { // The first two should be deleted.
+			idsToDelete = append(idsToDelete, id)
+		}
+		if i == 5 { // This one should be kept.
+			idToKeep = id
+		}
+	}
+
+	// 1. Verify that the number of attempts is now capped at the max.
+	// List all attempts for the channel.
+	listReq := ListNotificationChannelDeliveryAttemptsRequest{
+		ChannelID: channelID,
+		PageSize:  10, // Arbitrary large number to get all.
+		PageToken: nil,
+	}
+	attempts, _, err := spannerClient.ListNotificationChannelDeliveryAttempts(ctx, listReq)
+	if err != nil {
+		t.Fatalf("ListNotificationChannelDeliveryAttempts failed: %v", err)
+	}
+	if len(attempts) != maxDeliveryAttemptsToKeep {
+		t.Errorf("expected %d attempts, got %d", maxDeliveryAttemptsToKeep, len(attempts))
+	}
+	// 2. Verify that the OLDEST attempts were the ones deleted.
+	for _, id := range idsToDelete {
+		_, err := spannerClient.GetNotificationChannelDeliveryAttempt(ctx, id, channelID)
+		if err == nil {
+			t.Errorf("expected attempt with ID %s to be deleted, but it was found", id)
+		}
+	}
+
+	// 3. Verify that a NEWER attempt was kept.
+	_, err = spannerClient.GetNotificationChannelDeliveryAttempt(ctx, idToKeep, channelID)
+	if err != nil {
+		t.Errorf("expected attempt with ID %s to be kept, but it was not found", idToKeep)
+	}
+}
+
+func TestCreateNotificationChannelDeliveryAttemptConcurrency(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// We need a channel to associate the attempt with.
+	userID := uuid.NewString()
+	createReq := CreateNotificationChannelRequest{
+		UserID:      userID,
+		Name:        "Test Channel",
+		Type:        "EMAIL",
+		EmailConfig: &EmailConfig{Address: "test@example.com", IsVerified: true, VerificationToken: nil},
+	}
+	concurrentChannelIDPtr, err := spannerClient.CreateNotificationChannel(ctx, createReq)
+	if err != nil {
+		t.Fatalf("failed to create notification channel for concurrency test: %v", err)
+	}
+	concurrentChannelID := *concurrentChannelIDPtr
+
+	var wg sync.WaitGroup
+	concurrentAttempts := 5
+	attemptsPerRoutine := 3 // Total attempts = 15, which is > maxDeliveryAttemptsToKeep
+
+	for i := 0; i < concurrentAttempts; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < attemptsPerRoutine; j++ {
+				req := CreateNotificationChannelDeliveryAttemptRequest{
+					ChannelID:        concurrentChannelID,
+					Status:           "SUCCESS",
+					Details:          spanner.NullJSON{Value: nil, Valid: false},
+					AttemptTimestamp: time.Now(),
+				}
+				_, err := spannerClient.CreateNotificationChannelDeliveryAttempt(context.Background(), req)
+				if err != nil {
+					// Using t.Errorf in a goroutine is safer than t.Fatalf.
+					t.Errorf("CreateNotificationChannelDeliveryAttempt in goroutine failed: %v", err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// List all attempts for the channel.
+	listReq := ListNotificationChannelDeliveryAttemptsRequest{
+		ChannelID: concurrentChannelID,
+		PageSize:  10, // Arbitrary large number to get all.
+		PageToken: nil,
+	}
+	attempts, _, err := spannerClient.ListNotificationChannelDeliveryAttempts(ctx, listReq)
+	if err != nil {
+		t.Fatalf("ListNotificationChannelDeliveryAttempts (concurrency test) failed: %v", err)
+	}
+	if len(attempts) != maxDeliveryAttemptsToKeep {
+		t.Errorf("expected %d attempts, got %d", maxDeliveryAttemptsToKeep, len(attempts))
+	}
+}


### PR DESCRIPTION
This commit introduces the Notification Channel Delivery Attempts feature in the GCP Spanner library. It includes the ability to create and list delivery attempts associated with notification channels.

For now, each channel will only keep track of the last 10 delivery attempts (we will adjust this number in the future).

This is similar to GitHub webhooks delivery attempts.

-   **Database Schema (New Migration File):**
    -   **`NotificationChannelDeliveryAttempts` table:** Logs individual delivery attempts with a composite primary key `(ID, ChannelID)`.
-   **Go Client-Side Implementation (`lib/gcpspanner`):**
    -   **`notification_channel_delivery_attempt.go`:** Implemented `Create` and `List` functionality for delivery attempts, including logic to automatically prune old attempts.
-   **Testing (`lib/gcpspanner`):**
    -   Added comprehensive integration tests for all new functionality.