### PR TITLE
feat(gh): Introduce UserGitHubClient and pagination helpers

### DIFF
--- a/lib/gh/client.go
+++ b/lib/gh/client.go
@@ -24,6 +24,11 @@ type RepoClient interface {
 	GetLatestRelease(ctx context.Context, owner, repo string) (*github.RepositoryRelease, *github.Response, error)
 }
 
+type UsersClient interface {
+	ListEmails(ctx context.Context, opts *github.ListOptions) ([]*github.UserEmail, *github.Response, error)
+	Get(ctx context.Context, user string) (*github.User, *github.Response, error)
+}
+
 type Client struct {
 	repoClient RepoClient
 }
@@ -40,4 +45,21 @@ func NewClient(token string) *Client {
 	}
 
 	return c
+}
+
+// UserGitHubClient is a client that receives a token from a user that has installed our GitHub App.
+// It uses that token to make requests on behalf of that user to verify things about them.
+// It is different from the regular Client which is used for internal operations.
+type UserGitHubClient struct {
+	usersClient UsersClient
+}
+
+// NewUserGitHubClient creates a new UserGitHubClient with the given token.
+// Assumes that the token is not empty.
+func NewUserGitHubClient(token string) *UserGitHubClient {
+	c := github.NewClient(nil).WithAuthToken(token)
+
+	return &UserGitHubClient{
+		usersClient: c.Users,
+	}
 }

--- a/lib/gh/get_current_user.go
+++ b/lib/gh/get_current_user.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+// ErrFieldUnexpectedlyNil is returned when a field that is expected to be non-nil is found to be nil.
+// A lot of GitHub API fields are pointers, so we need to check for nil values.
+var ErrFieldUnexpectedlyNil = errors.New("expected field to be non-nil")
+
+type GitHubUser struct {
+	ID       int64
+	Username string
+}
+
+func (c *UserGitHubClient) GetCurrentUser(ctx context.Context) (*GitHubUser, error) {
+	// An empty string for the user parameter fetches the authenticated user.
+	user, _, err := c.usersClient.Get(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if user.ID == nil {
+		slog.ErrorContext(ctx, "missing user id after get user request", "user", user)
+
+		return nil, ErrFieldUnexpectedlyNil
+	}
+
+	if user.Login == nil {
+		slog.ErrorContext(ctx, "missing user login after get user request", "user", user)
+
+		return nil, ErrFieldUnexpectedlyNil
+	}
+
+	return &GitHubUser{
+		ID:       *user.ID,
+		Username: *user.Login,
+	}, nil
+}

--- a/lib/gh/get_current_user_test.go
+++ b/lib/gh/get_current_user_test.go
@@ -1,0 +1,148 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-github/v75/github"
+)
+
+// MockUsersClient is a mock implementation of the UsersClient interface.
+type MockUsersClient struct {
+	GetFunc        func(ctx context.Context, user string) (*github.User, *github.Response, error)
+	ListEmailsFunc func(ctx context.Context, opts *github.ListOptions) ([]*github.UserEmail, *github.Response, error)
+}
+
+func (m *MockUsersClient) Get(ctx context.Context, user string) (*github.User, *github.Response, error) {
+	if m.GetFunc == nil {
+		panic("GetFunc not set")
+	}
+
+	return m.GetFunc(ctx, user)
+}
+
+func (m *MockUsersClient) ListEmails(ctx context.Context, opts *github.ListOptions) (
+	[]*github.UserEmail, *github.Response, error) {
+	if m.ListEmailsFunc == nil {
+		panic("ListEmailsFunc not set")
+	}
+
+	return m.ListEmailsFunc(ctx, opts)
+}
+
+var errTestAPI = errors.New("api error")
+
+func createTestGithubResponse(nextPage int) *github.Response {
+	// nolint:exhaustruct
+	return &github.Response{
+		// nolint:exhaustruct
+		Response: &http.Response{StatusCode: http.StatusOK},
+		NextPage: nextPage,
+	}
+}
+
+func createTestGitHubUser(id int64, login string) *github.User {
+	// nolint:exhaustruct
+	return &github.User{
+		ID:    valuePtr(id),
+		Login: valuePtr(login),
+	}
+}
+
+func TestUserGitHubClient_GetCurrentUser(t *testing.T) {
+	type mockGetCurrentUserConfig struct {
+		user *github.User
+		err  error
+	}
+	tests := []struct {
+		name          string
+		cfg           *mockGetCurrentUserConfig
+		expectedUser  *GitHubUser
+		expectedError error
+	}{
+		{
+			name: "Success",
+			cfg: &mockGetCurrentUserConfig{
+				user: createTestGitHubUser(12345, "testuser"),
+				err:  nil,
+			},
+			expectedUser: &GitHubUser{
+				ID:       12345,
+				Username: "testuser",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "API Error",
+			cfg: &mockGetCurrentUserConfig{
+				user: nil,
+				err:  errTestAPI,
+			},
+			expectedUser:  nil,
+			expectedError: errTestAPI,
+		},
+		{
+			name: "Nil ID",
+			cfg: &mockGetCurrentUserConfig{
+				// nolint:exhaustruct
+				user: &github.User{ // Keep this inline to test nil ID specifically
+					ID:    nil,
+					Login: valuePtr("testuser"),
+				},
+				err: nil,
+			},
+			expectedUser:  nil,
+			expectedError: ErrFieldUnexpectedlyNil,
+		},
+		{
+			name: "Nil Login",
+			cfg: &mockGetCurrentUserConfig{
+				// nolint:exhaustruct
+				user: &github.User{ // Keep this inline to test nil Login specifically
+					ID:    valuePtr(int64(12345)),
+					Login: nil,
+				},
+				err: nil,
+			},
+			expectedUser:  nil,
+			expectedError: ErrFieldUnexpectedlyNil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockUsersClient{
+				GetFunc: func(_ context.Context, _ string) (*github.User, *github.Response, error) {
+					return tt.cfg.user, createTestGithubResponse(0), tt.cfg.err
+				}, ListEmailsFunc: nil,
+			}
+			appClient := &UserGitHubClient{usersClient: mockClient}
+
+			user, err := appClient.GetCurrentUser(context.Background())
+
+			if !errors.Is(err, tt.expectedError) {
+				t.Errorf("GetCurrentUser() error = %v, wantErr %v", err, tt.expectedError)
+			}
+			if !reflect.DeepEqual(user, tt.expectedUser) {
+				t.Errorf("GetCurrentUser() = %v, want %v", user, tt.expectedUser)
+			}
+		})
+	}
+}

--- a/lib/gh/list_current_user_emails.go
+++ b/lib/gh/list_current_user_emails.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+
+	"github.com/google/go-github/v75/github"
+)
+
+type UserEmail struct {
+	Email    string
+	Verified bool
+}
+
+func (c *UserGitHubClient) ListEmails(ctx context.Context) ([]*UserEmail, error) {
+	var emails []*UserEmail
+	p := newPaginator(c.usersClient.ListEmails, func(item *github.UserEmail) (*UserEmail, bool) {
+		if item == nil || item.Email == nil {
+			return nil, false
+		}
+		var verified bool
+		if item.Verified != nil {
+			verified = *item.Verified
+		}
+
+		return &UserEmail{
+			Email:    *item.Email,
+			Verified: verified,
+		}, true
+	})
+	for p.HasNextPage() {
+		page, err := p.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		emails = append(emails, page...)
+	}
+
+	return emails, nil
+}

--- a/lib/gh/list_current_user_emails_test.go
+++ b/lib/gh/list_current_user_emails_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-github/v75/github"
+)
+
+func TestUserGitHubClient_ListEmails(t *testing.T) {
+	type mockListEmailsConfig struct {
+		emails []*github.UserEmail
+		err    error
+	}
+	tests := []struct {
+		name           string
+		cfg            *mockListEmailsConfig
+		expectedEmails []*UserEmail
+		expectedError  error
+	}{
+		{
+			name: "Success - Single Page",
+			cfg: &mockListEmailsConfig{
+				emails: []*github.UserEmail{
+					{Email: valuePtr("test1@example.com"), Verified: valuePtr(true)},
+					{Email: valuePtr("test2@example.com"), Verified: valuePtr(false)},
+				},
+				err: nil,
+			},
+			expectedEmails: []*UserEmail{
+				{Email: "test1@example.com", Verified: true},
+				{Email: "test2@example.com", Verified: false},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "API Error",
+			cfg: &mockListEmailsConfig{
+				emails: nil,
+				err:    errTestAPI,
+			},
+			expectedEmails: nil,
+			expectedError:  errTestAPI,
+		},
+		{
+			name: "Nil Email in list",
+			cfg: &mockListEmailsConfig{
+				emails: []*github.UserEmail{
+					{Email: valuePtr("test1@example.com"), Verified: valuePtr(true)},
+					nil,
+				},
+				err: nil,
+			},
+			expectedEmails: []*UserEmail{
+				{Email: "test1@example.com", Verified: true},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Nil Email Address",
+			cfg: &mockListEmailsConfig{
+				emails: []*github.UserEmail{
+					{Email: nil, Verified: valuePtr(true)},
+				},
+				err: nil,
+			},
+			expectedEmails: nil,
+			expectedError:  nil,
+		},
+		{
+			name: "Nil Verified Status",
+			cfg: &mockListEmailsConfig{
+				emails: []*github.UserEmail{
+					{Email: valuePtr("test@example.com"), Verified: nil},
+				},
+				err: nil,
+			},
+			expectedEmails: []*UserEmail{
+				{Email: "test@example.com", Verified: false},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockUsersClient{
+				ListEmailsFunc: func(_ context.Context, _ *github.ListOptions) ([]*github.UserEmail, *github.Response, error) {
+					return tt.cfg.emails, createTestGithubResponse(0), tt.cfg.err
+				},
+				GetFunc: nil,
+			}
+			appClient := &UserGitHubClient{usersClient: mockClient}
+
+			emails, err := appClient.ListEmails(context.Background())
+
+			if !errors.Is(err, tt.expectedError) {
+				t.Errorf("ListEmails() error = %v, wantErr %v", err, tt.expectedError)
+			}
+			if !reflect.DeepEqual(emails, tt.expectedEmails) {
+				t.Errorf("ListEmails() = %v, want %v", emails, tt.expectedEmails)
+			}
+		})
+	}
+}

--- a/lib/gh/paginator.go
+++ b/lib/gh/paginator.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+
+	"github.com/google/go-github/v75/github"
+)
+
+// paginator is a generic structure for handling pagination.
+type paginator[T any, LibStruct any] struct {
+	listFunc    func(ctx context.Context, opts *github.ListOptions) ([]LibStruct, *github.Response, error)
+	convert     func(item LibStruct) (T, bool)
+	currentPage int
+	perPage     int
+}
+
+// NextPage fetches the next page of items.
+func (p *paginator[T, LibStruct]) NextPage(ctx context.Context) ([]T, error) {
+	opts := &github.ListOptions{
+		Page:    p.currentPage,
+		PerPage: p.perPage,
+	}
+
+	items, resp, err := p.listFunc(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.NextPage == 0 {
+		p.currentPage = 0
+	} else {
+		p.currentPage = resp.NextPage
+	}
+
+	convertedItems := make([]T, 0, len(items))
+	for _, item := range items {
+		convertedItem, success := p.convert(item)
+		if !success {
+			continue
+		}
+		convertedItems = append(convertedItems, convertedItem)
+	}
+
+	return convertedItems, nil
+}
+
+// newPaginator creates a new Paginator instance.
+func newPaginator[T any, LibStruct any](
+	listFunc func(ctx context.Context, opts *github.ListOptions) ([]LibStruct, *github.Response, error),
+	convert func(item LibStruct) (T, bool)) *paginator[T, LibStruct] {
+	return &paginator[T, LibStruct]{
+		listFunc:    listFunc,
+		currentPage: 1,
+		perPage:     100,
+		convert:     convert,
+	}
+}
+
+// HasNextPage checks if there are more pages to fetch.
+func (p *paginator[T, LibStruct]) HasNextPage() bool {
+	return p.currentPage != 0
+}

--- a/lib/gh/paginator_test.go
+++ b/lib/gh/paginator_test.go
@@ -1,0 +1,150 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-github/v75/github"
+)
+
+func TestPaginator(t *testing.T) {
+	type TestItem struct {
+		Value string
+	}
+
+	type LibTestItem struct {
+		Name *string
+	}
+
+	convertFunc := func(item LibTestItem) (TestItem, bool) {
+		if item.Name == nil {
+			// nolint:exhaustruct
+			return TestItem{}, false
+		}
+
+		return TestItem{Value: *item.Name}, true
+	}
+
+	var errOnSecondPage = errors.New("api error on second page")
+
+	tests := []struct {
+		name          string
+		listFunc      func(ctx context.Context, opts *github.ListOptions) ([]LibTestItem, *github.Response, error)
+		expectedItems []TestItem
+		expectedError error
+		expectedPages int
+	}{
+		{
+			name: "Single page success",
+			listFunc: func(_ context.Context, _ *github.ListOptions) ([]LibTestItem, *github.Response, error) {
+				return []LibTestItem{{
+					Name: valuePtr("item1"),
+				}}, createTestGithubResponse(0), nil
+			},
+			expectedItems: []TestItem{{"item1"}},
+			expectedError: nil,
+			expectedPages: 1,
+		},
+		{
+			name: "Multi-page success",
+			listFunc: func(_ context.Context, opts *github.ListOptions) ([]LibTestItem, *github.Response, error) {
+				if opts.Page == 1 {
+					return []LibTestItem{{
+						Name: valuePtr("itemA"),
+					}}, createTestGithubResponse(2), nil
+				}
+
+				return []LibTestItem{{
+					Name: valuePtr("itemB"),
+				}}, createTestGithubResponse(0), nil
+			},
+			expectedItems: []TestItem{{"itemA"}, {"itemB"}},
+			expectedError: nil,
+			expectedPages: 2,
+		},
+		{
+			name: "API error on first page",
+			listFunc: func(_ context.Context, _ *github.ListOptions) ([]LibTestItem, *github.Response, error) {
+				return nil, nil, errTestAPI
+			},
+			expectedItems: nil,
+			expectedError: errTestAPI,
+			expectedPages: 1,
+		},
+		{
+			name: "API error on second page",
+			listFunc: func(_ context.Context, opts *github.ListOptions) ([]LibTestItem, *github.Response, error) {
+				if opts.Page == 1 {
+					return []LibTestItem{{
+						Name: valuePtr("itemA"),
+					}}, createTestGithubResponse(2), nil
+				}
+
+				return nil, nil, errOnSecondPage
+			},
+			expectedItems: nil,
+			expectedError: errOnSecondPage,
+			expectedPages: 2,
+		},
+		{
+			name: "Conversion skips item",
+			listFunc: func(_ context.Context, _ *github.ListOptions) ([]LibTestItem, *github.Response, error) {
+				return []LibTestItem{
+					{Name: valuePtr("valid")},
+					{Name: nil},
+					{Name: valuePtr("another_valid")},
+				}, createTestGithubResponse(0), nil
+			},
+			expectedItems: []TestItem{{"valid"}, {"another_valid"}},
+			expectedError: nil,
+			expectedPages: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPaginator(tt.listFunc, convertFunc)
+			var actualItems []TestItem
+			var actualError error
+			pagesFetched := 0
+
+			for p.HasNextPage() {
+				pagesFetched++
+				pageItems, err := p.NextPage(context.Background())
+				if err != nil {
+					actualError = err
+					actualItems = nil // Discard partial results on error.
+
+					break
+				}
+				actualItems = append(actualItems, pageItems...)
+			}
+
+			if !errors.Is(actualError, tt.expectedError) {
+				t.Errorf("Paginator error = %v, wantErr %v", actualError, tt.expectedError)
+			}
+			if !reflect.DeepEqual(actualItems, tt.expectedItems) {
+				t.Errorf("Paginator items = %v, want %v", actualItems, tt.expectedItems)
+			}
+			if pagesFetched != tt.expectedPages {
+				t.Errorf("Paginator fetched %d pages, want %d", pagesFetched, tt.expectedPages)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit also introduces:
- `UsersClient` interface for GitHub user-related API calls.
- `GetCurrentUser` function for retrieving authenticated user details.
- `ListEmails` function for fetching user email addresses with pagination.
- A generic `paginator` to handle multi-page API responses.

Accompanying unit tests are added for all new functionalities.