### PR TITLE
feat(auth): Extract GitHub user ID from Firebase token

### DIFF
--- a/backend/pkg/httpserver/create_saved_search_test.go
+++ b/backend/pkg/httpserver/create_saved_search_test.go
@@ -38,7 +38,8 @@ func createStringOfNLength(n int) string {
 
 func TestCreateSavedSearch(t *testing.T) {
 	testUser := &auth.User{
-		ID: "testID1",
+		ID:           "testID1",
+		GitHubUserID: nil,
 	}
 	testCases := []struct {
 		name                            string

--- a/backend/pkg/httpserver/list_user_saved_searches_test.go
+++ b/backend/pkg/httpserver/list_user_saved_searches_test.go
@@ -27,7 +27,8 @@ import (
 
 func TestListUserSavedSearches(t *testing.T) {
 	testUser := &auth.User{
-		ID: "listUserID1",
+		ID:           "listUserID1",
+		GitHubUserID: nil,
 	}
 	testCases := []struct {
 		name                 string

--- a/backend/pkg/httpserver/middlewares_test.go
+++ b/backend/pkg/httpserver/middlewares_test.go
@@ -27,7 +27,8 @@ import (
 
 func createTestID1User() *auth.User {
 	return &auth.User{
-		ID: "testID1",
+		ID:           "testID1",
+		GitHubUserID: valuePtr("123456"),
 	}
 }
 
@@ -136,13 +137,8 @@ func testAuthScope(t *testing.T, path string, method string, shouldBePresent boo
 // Bearer authentication scopes to the request context when the route has
 // security schemes configured.
 func TestAuthScopePresentWhenSecurityConfigured(t *testing.T) {
-	testUser := &auth.User{ID: "test"}
+	testUser := &auth.User{ID: "test", GitHubUserID: valuePtr("id2")}
 	testAuthScope(t, "/v1/users/me/saved-searches", http.MethodGet, true, testUser)
-}
-
-func TestPingUserAuthScope(t *testing.T) {
-	testUser := &auth.User{ID: "test"}
-	testAuthScope(t, "/v1/users/me/ping", http.MethodPost, true, testUser)
 }
 
 // This test ensures that the third-party OpenAPI library continues to omit

--- a/backend/pkg/httpserver/update_saved_search_test.go
+++ b/backend/pkg/httpserver/update_saved_search_test.go
@@ -28,7 +28,8 @@ import (
 
 func TestUpdateSavedSearch(t *testing.T) {
 	testUser := &auth.User{
-		ID: "testID1",
+		ID:           "testID1",
+		GitHubUserID: nil,
 	}
 	// Common Request Bodies and Mock Settings
 	updateAllFieldsRequestBody := `{

--- a/lib/auth/gcip_authenticator.go
+++ b/lib/auth/gcip_authenticator.go
@@ -16,6 +16,7 @@ package auth
 
 import (
 	"context"
+	"log/slog"
 
 	firebaseauth "firebase.google.com/go/v4/auth"
 )
@@ -39,6 +40,30 @@ func NewGCIPAuthenticator(client UserAuthClient) *GCIPAuthenticator {
 	}
 }
 
+func extractGitHubUserIDFromToken(token *firebaseauth.Token) (*string, bool) {
+	if token.Firebase.Identities == nil {
+		return nil, false
+	}
+
+	rawGithubIdentities, ok := token.Firebase.Identities["github.com"]
+	if !ok {
+		return nil, false
+	}
+
+	// Have to convert to []interface{} first.
+	// Cannot directly convert to []string.
+	githubIDs, ok := rawGithubIdentities.([]interface{})
+	if !ok || len(githubIDs) == 0 {
+		return nil, false
+	}
+
+	if githubID, ok := githubIDs[0].(string); ok {
+		return &githubID, true
+	}
+
+	return nil, false
+}
+
 // Authenticate authenticates a user using the provided ID token.
 func (a GCIPAuthenticator) Authenticate(ctx context.Context, idToken string) (*User, error) {
 	// Verify the ID token using the Firebase Auth client.
@@ -47,8 +72,15 @@ func (a GCIPAuthenticator) Authenticate(ctx context.Context, idToken string) (*U
 		return nil, err
 	}
 
+	gitHubUserID, found := extractGitHubUserIDFromToken(token)
+	if !found {
+		slog.WarnContext(ctx, "github user ID not found in token", "identities", token.Firebase.Identities,
+			"uid", token.UID)
+	}
+
 	// Create a new user object using the user's ID from the token.
 	return &User{
-		ID: token.UID,
+		ID:           token.UID,
+		GitHubUserID: gitHubUserID,
 	}, nil
 }

--- a/lib/auth/gcip_authenticator_test.go
+++ b/lib/auth/gcip_authenticator_test.go
@@ -23,6 +23,20 @@ import (
 	firebaseauth "firebase.google.com/go/v4/auth"
 )
 
+func createTestFirebaseToken(uid string, githubID *string) *firebaseauth.Token {
+	identities := map[string]interface{}{}
+	if githubID != nil {
+		identities["github.com"] = []interface{}{*githubID}
+	}
+	// nolint:exhaustruct
+	return &firebaseauth.Token{
+		UID: uid,
+		Firebase: firebaseauth.FirebaseInfo{
+			Identities: identities,
+		},
+	}
+}
+
 // TestGCIPAuthenticator tests the GCIPAuthenticator functions.
 func TestGCIPAuthenticator(t *testing.T) {
 	tests := []struct {
@@ -36,10 +50,9 @@ func TestGCIPAuthenticator(t *testing.T) {
 			name:    "Successful authentication",
 			idToken: "valid_id_token",
 			mockVerifyFn: func(_ context.Context, _ string) (*firebaseauth.Token, error) {
-				// nolint:exhaustruct // WONTFIX -third part struct used for testing
-				return &firebaseauth.Token{UID: "123"}, nil
+				return createTestFirebaseToken("123", valuePtr("id2")), nil
 			},
-			expectedUser:  &User{ID: "123"},
+			expectedUser:  &User{ID: "123", GitHubUserID: valuePtr("id2")},
 			expectedError: false,
 		},
 		{
@@ -50,6 +63,15 @@ func TestGCIPAuthenticator(t *testing.T) {
 			},
 			expectedUser:  nil,
 			expectedError: true,
+		},
+		{
+			name:    "Missing GitHub user ID",
+			idToken: "invalid_id_token",
+			mockVerifyFn: func(_ context.Context, _ string) (*firebaseauth.Token, error) {
+				return createTestFirebaseToken("123", nil), nil
+			},
+			expectedUser:  &User{ID: "123", GitHubUserID: nil},
+			expectedError: false,
 		},
 	}
 
@@ -76,6 +98,78 @@ func TestGCIPAuthenticator(t *testing.T) {
 			// Check if the user matches the expected value.
 			if !reflect.DeepEqual(tc.expectedUser, user) {
 				t.Errorf("Expected user to be '%+v', got '%+v'", tc.expectedUser, user)
+			}
+		})
+	}
+}
+
+func TestExtractGitHubUserIDFromToken(t *testing.T) {
+	tests := []struct {
+		name          string
+		token         *firebaseauth.Token
+		expectedID    *string
+		expectedFound bool
+	}{
+		{
+			name:          "Success",
+			token:         createTestFirebaseToken("test", valuePtr("12345")),
+			expectedID:    valuePtr("12345"),
+			expectedFound: true,
+		},
+		{
+			name: "Nil Identities",
+			// nolint:exhaustruct
+			// Keep inline for specific nil case
+			token:         &firebaseauth.Token{Firebase: firebaseauth.FirebaseInfo{Identities: nil}},
+			expectedID:    nil,
+			expectedFound: false,
+		},
+		{
+			name: "Missing github.com identity",
+			// nolint:exhaustruct
+			token: &firebaseauth.Token{Firebase: firebaseauth.FirebaseInfo{
+				Identities: map[string]interface{}{"google.com": []interface{}{"some-id"}},
+			}},
+			expectedID:    nil,
+			expectedFound: false,
+		},
+		{
+			name: "Non-slice identity",
+			// nolint:exhaustruct
+			token: &firebaseauth.Token{Firebase: firebaseauth.FirebaseInfo{
+				Identities: map[string]interface{}{"github.com": "not-a-slice"},
+			}},
+			expectedID:    nil,
+			expectedFound: false,
+		},
+		{
+			name: "Empty identity slice",
+			// nolint:exhaustruct
+			token: &firebaseauth.Token{Firebase: firebaseauth.FirebaseInfo{
+				Identities: map[string]interface{}{"github.com": []interface{}{}},
+			}},
+			expectedID:    nil,
+			expectedFound: false,
+		},
+		{
+			name: "Non-string identity",
+			// nolint:exhaustruct
+			token: &firebaseauth.Token{Firebase: firebaseauth.FirebaseInfo{
+				Identities: map[string]interface{}{"github.com": []interface{}{12345}},
+			}},
+			expectedID:    nil,
+			expectedFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := extractGitHubUserIDFromToken(tt.token)
+			if found != tt.expectedFound {
+				t.Errorf("extractGitHubUserIDFromToken() found = %v, want %v", found, tt.expectedFound)
+			}
+			if !reflect.DeepEqual(got, tt.expectedID) {
+				t.Errorf("extractGitHubUserIDFromToken() got = %v, want %v", got, tt.expectedID)
 			}
 		})
 	}

--- a/lib/auth/types.go
+++ b/lib/auth/types.go
@@ -14,7 +14,26 @@
 
 package auth
 
+import "strconv"
+
 // User contains the details of an authenticated user.
 type User struct {
 	ID string
+	// GitHubUserID is the string representation of the GitHub user's integer ID,
+	// as returned by Firebase Auth.
+	//
+	// It is a pointer because it may be nil if the user is authenticated but not
+	// linked to GitHub, or if the ID hasn't been verified against the GitHub API yet.
+	// Verification is deferred until needed to keep most authenticated calls fast.
+	GitHubUserID *string
+}
+
+// HasGitHubID checks if the authenticated user matches a specific GitHub integer ID.
+// It handles the necessary string-to-int64 conversion safely.
+func (u User) HasGitHubUserID(in int64) bool {
+	if u.GitHubUserID == nil {
+		return false
+	}
+
+	return *u.GitHubUserID == strconv.FormatInt(in, 10)
 }

--- a/lib/auth/types_test.go
+++ b/lib/auth/types_test.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import "testing"
+
+func TestUser_HasGitHubUserID(t *testing.T) {
+	tests := []struct {
+		name           string
+		user           User
+		inputID        int64
+		expectedResult bool
+	}{
+		{
+			name: "Matching ID",
+			user: User{
+				ID:           "user1",
+				GitHubUserID: valuePtr("12345"),
+			},
+			inputID:        12345,
+			expectedResult: true,
+		},
+		{
+			name: "Non-matching ID",
+			user: User{
+				ID:           "user1",
+				GitHubUserID: valuePtr("12345"),
+			},
+			inputID:        54321,
+			expectedResult: false,
+		},
+		{
+			name: "Nil GitHubUserID",
+			user: User{
+				ID:           "user1",
+				GitHubUserID: nil,
+			},
+			inputID:        12345,
+			expectedResult: false,
+		},
+		{
+			name: "Zero ID",
+			user: User{
+				ID:           "user1",
+				GitHubUserID: valuePtr("0"),
+			},
+			inputID:        0,
+			expectedResult: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.user.HasGitHubUserID(tt.inputID); got != tt.expectedResult {
+				t.Errorf("User.HasGitHubUserID() = %v, want %v", got, tt.expectedResult)
+			}
+		})
+	}
+}
+
+// valuePtr is a helper function to get a pointer to a value.
+func valuePtr[T any](v T) *T {
+	return &v
+}

--- a/lib/httpmiddlewares/bearertokenauth_test.go
+++ b/lib/httpmiddlewares/bearertokenauth_test.go
@@ -179,7 +179,8 @@ func TestBearerTokenAuthenticationMiddleware(t *testing.T) {
 				}
 
 				return &auth.User{
-					ID: testID,
+					ID:           testID,
+					GitHubUserID: nil,
 				}, nil
 			},
 			mockErrorFn: func(_ context.Context, _ int, _ http.ResponseWriter, _ error) {
@@ -188,7 +189,8 @@ func TestBearerTokenAuthenticationMiddleware(t *testing.T) {
 			expectedStatusCode: http.StatusOK,
 			expectedBody:       "next handler was called",
 			expectedUser: &auth.User{
-				ID: testID,
+				ID:           testID,
+				GitHubUserID: nil,
 			},
 		},
 	}


### PR DESCRIPTION
This commit introduces the capability to extract a user's GitHub ID from their Firebase authentication token.

- Adds `extractGitHubUserIDFromToken` to parse the GitHub user ID from the token's `identities` claim.
- Updates the `auth.User` struct to include a `GitHubUserID` field.
- Implements the `HasGitHubUserID` method on the `User` struct for safe comparison of GitHub IDs.
- Adds comprehensive unit tests for the new extraction logic and the `HasGitHubUserID` method.
- Updates existing tests to reflect the changes in the `auth.User` struct.