### PR TITLE
feat(api): Add endpoints for notification channels

### DIFF
--- a/backend/pkg/httpserver/delete_notification_channel.go
+++ b/backend/pkg/httpserver/delete_notification_channel.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// DeleteNotificationChannel handles the DELETE request to /v1/users/me/notification-channels/{channel_id}.
+// nolint:ireturn, revive // Expected ireturn for openapi generation.
+func (s *Server) DeleteNotificationChannel(
+	ctx context.Context,
+	req backend.DeleteNotificationChannelRequestObject,
+) (backend.DeleteNotificationChannelResponseObject, error) {
+	userCheckResult := CheckAuthenticatedUser(ctx, "DeleteNotificationChannel",
+		func(code int, message string) backend.DeleteNotificationChannel500JSONResponse {
+			return backend.DeleteNotificationChannel500JSONResponse{
+				Code:    code,
+				Message: message,
+			}
+		})
+	if userCheckResult.User == nil {
+		return userCheckResult.Response, nil
+	}
+
+	err := s.wptMetricsStorer.DeleteNotificationChannel(ctx, userCheckResult.User.ID, req.ChannelId)
+	if err != nil {
+		if errors.Is(err, backendtypes.ErrEntityDoesNotExist) || errors.Is(err, backendtypes.ErrUserNotAuthorizedForAction) {
+			return backend.DeleteNotificationChannel404JSONResponse{
+				Code:    http.StatusNotFound,
+				Message: "Notification channel not found or not owned by user",
+			}, nil
+		}
+
+		return backend.DeleteNotificationChannel500JSONResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "Could not delete notification channel",
+		}, nil
+	}
+
+	return backend.DeleteNotificationChannel204Response{}, nil
+}

--- a/backend/pkg/httpserver/delete_notification_channel_test.go
+++ b/backend/pkg/httpserver/delete_notification_channel_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+)
+
+func TestDeleteNotificationChannel(t *testing.T) {
+	testUser := &auth.User{
+		ID:           "listUserID1",
+		GitHubUserID: nil,
+	}
+	testCases := []struct {
+		name                 string
+		cfg                  *MockDeleteNotificationChannelConfig
+		expectedCallCount    int
+		authMiddlewareOption testServerOption
+		request              *http.Request
+		expectedResponse     *http.Response
+	}{
+		{
+			name: "success",
+			cfg: &MockDeleteNotificationChannelConfig{
+				expectedUserID:    "listUserID1",
+				expectedChannelID: "channel1",
+				err:               nil,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request:              httptest.NewRequest(http.MethodDelete, "/v1/users/me/notification-channels/channel1", nil),
+			expectedResponse:     createEmptyBodyResponse(http.StatusNoContent),
+		},
+		{
+			name: "not found",
+			cfg: &MockDeleteNotificationChannelConfig{
+				expectedUserID:    "listUserID1",
+				expectedChannelID: "channel1",
+				err:               backendtypes.ErrEntityDoesNotExist,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request:              httptest.NewRequest(http.MethodDelete, "/v1/users/me/notification-channels/channel1", nil),
+			expectedResponse: testJSONResponse(404, `
+			{
+				"code":404,
+				"message":"Notification channel not found or not owned by user"
+			}`),
+		},
+		{
+			name: "500 error",
+			cfg: &MockDeleteNotificationChannelConfig{
+				expectedUserID:    "listUserID1",
+				expectedChannelID: "channel1",
+				err:               errTest,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request:              httptest.NewRequest(http.MethodDelete, "/v1/users/me/notification-channels/channel1", nil),
+			expectedResponse: testJSONResponse(500, `
+			{
+				"code":500,
+				"message":"Could not delete notification channel"
+			}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint:exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				deleteNotificationChannelCfg: tc.cfg,
+				t:                            t,
+			}
+			myServer := Server{
+				wptMetricsStorer:        mockStorer,
+				baseURL:                 getTestBaseURL(t),
+				metadataStorer:          nil,
+				operationResponseCaches: nil,
+				userGitHubClientFactory: nil,
+			}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+				[]testServerOption{tc.authMiddlewareOption}...)
+			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountDeleteNotificationChannel,
+				"DeleteNotificationChannel", nil)
+		})
+	}
+}

--- a/backend/pkg/httpserver/get_notification_channel.go
+++ b/backend/pkg/httpserver/get_notification_channel.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// GetNotificationChannel handles the GET request to /v1/users/me/notification-channels/{channel_id}.
+// nolint:ireturn, revive // Expected ireturn for openapi generation.
+func (s *Server) GetNotificationChannel(
+	ctx context.Context,
+	req backend.GetNotificationChannelRequestObject,
+) (backend.GetNotificationChannelResponseObject, error) {
+	userCheckResult := CheckAuthenticatedUser(ctx, "GetNotificationChannel",
+		func(code int, message string) backend.GetNotificationChannel500JSONResponse {
+			return backend.GetNotificationChannel500JSONResponse{
+				Code:    code,
+				Message: message,
+			}
+		})
+	if userCheckResult.User == nil {
+		return userCheckResult.Response, nil
+	}
+
+	channel, err := s.wptMetricsStorer.GetNotificationChannel(ctx, userCheckResult.User.ID, req.ChannelId)
+	if err != nil {
+		if errors.Is(err, backendtypes.ErrEntityDoesNotExist) || errors.Is(err, backendtypes.ErrUserNotAuthorizedForAction) {
+			return backend.GetNotificationChannel404JSONResponse{
+				Code:    http.StatusNotFound,
+				Message: "Notification channel not found or not owned by user",
+			}, nil
+		}
+
+		return backend.GetNotificationChannel500JSONResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "Could not retrieve notification channel",
+		}, nil
+	}
+
+	return backend.GetNotificationChannel200JSONResponse(*channel), nil
+}

--- a/backend/pkg/httpserver/get_notification_channel_test.go
+++ b/backend/pkg/httpserver/get_notification_channel_test.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestGetNotificationChannel(t *testing.T) {
+	testUser := &auth.User{
+		ID:           "listUserID1",
+		GitHubUserID: nil,
+	}
+	testCases := []struct {
+		name                 string
+		cfg                  *MockGetNotificationChannelConfig
+		expectedCallCount    int
+		authMiddlewareOption testServerOption
+		request              *http.Request
+		expectedResponse     *http.Response
+	}{
+		{
+			name: "success",
+			cfg: &MockGetNotificationChannelConfig{
+				expectedUserID:    "listUserID1",
+				expectedChannelID: "channel1",
+				output: &backend.NotificationChannelResponse{
+
+					Id:        "channel1",
+					Name:      "My Email",
+					Type:      backend.NotificationChannelResponseTypeEmail,
+					Value:     "test@example.com",
+					Status:    backend.NotificationChannelStatusEnabled,
+					CreatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+				err: nil,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request:              httptest.NewRequest(http.MethodGet, "/v1/users/me/notification-channels/channel1", nil),
+			expectedResponse: testJSONResponse(200, `
+{
+	"id": "channel1",
+	"name": "My Email",
+	"type": "email",
+	"value": "test@example.com",
+	"status": "enabled",
+	"created_at":"2000-01-01T00:00:00Z",
+	"updated_at":"2000-01-01T00:00:00Z"
+}`),
+		},
+		{
+			name: "not found",
+			cfg: &MockGetNotificationChannelConfig{
+				expectedUserID:    "listUserID1",
+				expectedChannelID: "channel1",
+				output:            nil,
+				err:               backendtypes.ErrEntityDoesNotExist,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request:              httptest.NewRequest(http.MethodGet, "/v1/users/me/notification-channels/channel1", nil),
+			expectedResponse: testJSONResponse(404, `
+			{
+				"code":404,
+				"message":"Notification channel not found or not owned by user"
+			}`),
+		},
+		{
+			name: "500 error",
+			cfg: &MockGetNotificationChannelConfig{
+				expectedUserID:    "listUserID1",
+				expectedChannelID: "channel1",
+				output:            nil,
+				err:               errTest,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request:              httptest.NewRequest(http.MethodGet, "/v1/users/me/notification-channels/channel1", nil),
+			expectedResponse: testJSONResponse(500, `
+			{
+				"code":500,
+				"message":"Could not retrieve notification channel"
+			}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint:exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				getNotificationChannelCfg: tc.cfg,
+				t:                         t,
+			}
+			myServer := Server{
+				wptMetricsStorer:        mockStorer,
+				baseURL:                 getTestBaseURL(t),
+				metadataStorer:          nil,
+				operationResponseCaches: nil,
+				userGitHubClientFactory: nil,
+			}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+				[]testServerOption{tc.authMiddlewareOption}...)
+			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountGetNotificationChannel,
+				"GetNotificationChannel", nil)
+		})
+	}
+}

--- a/backend/pkg/httpserver/list_notification_channels.go
+++ b/backend/pkg/httpserver/list_notification_channels.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// ListNotificationChannels handles the GET request to /v1/users/me/notification-channels.
+// nolint:ireturn, revive // Expected ireturn for openapi generation.
+func (s *Server) ListNotificationChannels(
+	ctx context.Context,
+	req backend.ListNotificationChannelsRequestObject,
+) (backend.ListNotificationChannelsResponseObject, error) {
+	userCheckResult := CheckAuthenticatedUser(ctx, "ListNotificationChannels",
+		func(code int, message string) backend.ListNotificationChannels500JSONResponse {
+			return backend.ListNotificationChannels500JSONResponse{
+				Code:    code,
+				Message: message,
+			}
+		})
+	if userCheckResult.User == nil {
+		return userCheckResult.Response, nil
+	}
+
+	pageSize := getPageSizeOrDefault(req.Params.PageSize)
+
+	channels, err := s.wptMetricsStorer.ListNotificationChannels(
+		ctx, userCheckResult.User.ID, pageSize, req.Params.PageToken)
+
+	if err != nil {
+		if errors.Is(err, backendtypes.ErrInvalidPageToken) {
+			return backend.ListNotificationChannels400JSONResponse{
+				Code:    http.StatusBadRequest,
+				Message: "Invalid page token",
+			}, nil
+		}
+
+		return backend.ListNotificationChannels500JSONResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "Could not list notification channels",
+		}, nil
+	}
+
+	return backend.ListNotificationChannels200JSONResponse(*channels), nil
+}

--- a/backend/pkg/httpserver/list_notification_channels_test.go
+++ b/backend/pkg/httpserver/list_notification_channels_test.go
@@ -1,0 +1,148 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestListNotificationChannels(t *testing.T) {
+	testUser := &auth.User{
+		ID:           "listUserID1",
+		GitHubUserID: nil,
+	}
+	testCases := []struct {
+		name                 string
+		cfg                  *MockListNotificationChannelsConfig
+		expectedCallCount    int
+		authMiddlewareOption testServerOption
+		request              *http.Request
+		expectedResponse     *http.Response
+	}{
+		{
+			name: "success",
+			cfg: &MockListNotificationChannelsConfig{
+				expectedUserID:    "listUserID1",
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				output: &backend.NotificationChannelPage{
+					Metadata: nil,
+					Data: &[]backend.NotificationChannelResponse{
+						{
+							Id:        "channel1",
+							Name:      "My Email",
+							Type:      backend.NotificationChannelResponseTypeEmail,
+							Value:     "test@example.com",
+							Status:    backend.NotificationChannelStatusEnabled,
+							CreatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+							UpdatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+				err: nil,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request:              httptest.NewRequest(http.MethodGet, "/v1/users/me/notification-channels", nil),
+			expectedResponse: testJSONResponse(200, `
+{
+	"data":[
+		{
+			"id": "channel1",
+			"name": "My Email",
+			"type": "email",
+			"value": "test@example.com",
+			"status": "enabled",
+			"created_at":"2000-01-01T00:00:00Z",
+			"updated_at":"2000-01-01T00:00:00Z"
+		}
+	]
+}`),
+		},
+		{
+			name: "500 case",
+			cfg: &MockListNotificationChannelsConfig{
+				expectedUserID:    "listUserID1",
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				output:            nil,
+				err:               errTest,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request:              httptest.NewRequest(http.MethodGet, "/v1/users/me/notification-channels", nil),
+			expectedResponse: testJSONResponse(500, `
+			{
+				"code":500,
+				"message":"Could not list notification channels"
+			}`),
+		},
+		{
+			name: "400 case - invalid page token",
+			cfg: &MockListNotificationChannelsConfig{
+				expectedUserID:    "listUserID1",
+				expectedPageSize:  100,
+				expectedPageToken: badPageToken,
+				output:            nil,
+				err:               backendtypes.ErrInvalidPageToken,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodGet, "/v1/users/me/notification-channels?page_token="+*badPageToken, nil),
+			expectedResponse: testJSONResponse(400, `{"code":400,"message":"Invalid page token"}`),
+		},
+		{
+			name:                 "unauthenticated",
+			cfg:                  nil,
+			expectedCallCount:    0,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(nil)),
+			request:              httptest.NewRequest(http.MethodGet, "/v1/users/me/notification-channels", nil),
+			expectedResponse: testJSONResponse(500, `
+			{
+				"code": 500,
+				"message": "internal server error"
+			}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint:exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				listNotificationChannelsCfg: tc.cfg,
+				t:                           t,
+			}
+			myServer := Server{
+				wptMetricsStorer:        mockStorer,
+				baseURL:                 getTestBaseURL(t),
+				metadataStorer:          nil,
+				operationResponseCaches: nil,
+				userGitHubClientFactory: nil,
+			}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+				[]testServerOption{tc.authMiddlewareOption}...)
+			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListNotificationChannels,
+				"ListNotificationChannels", nil)
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -147,6 +147,12 @@ type WPTMetricsStorer interface {
 	) error
 	SyncUserProfileInfo(ctx context.Context,
 		userProfile backendtypes.UserProfile) error
+	GetNotificationChannel(ctx context.Context,
+		userID, channelID string) (*backend.NotificationChannelResponse, error)
+	ListNotificationChannels(ctx context.Context,
+		userID string, pageSize int, pageToken *string) (*backend.NotificationChannelPage, error)
+	DeleteNotificationChannel(ctx context.Context,
+		userID, channelID string) error
 }
 
 type Server struct {

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -224,6 +224,27 @@ type MockSyncUserProfileInfoConfig struct {
 	err                 error
 }
 
+type MockGetNotificationChannelConfig struct {
+	expectedChannelID string
+	expectedUserID    string
+	output            *backend.NotificationChannelResponse
+	err               error
+}
+
+type MockListNotificationChannelsConfig struct {
+	expectedUserID    string
+	expectedPageSize  int
+	expectedPageToken *string
+	output            *backend.NotificationChannelPage
+	err               error
+}
+
+type MockDeleteNotificationChannelConfig struct {
+	expectedChannelID string
+	expectedUserID    string
+	err               error
+}
+
 type basicHTTPTestCase[T any] struct {
 	name             string
 	cfg              *T
@@ -250,6 +271,9 @@ type MockWPTMetricsStorer struct {
 	putUserSavedSearchBookmarkCfg                     *MockPutUserSavedSearchBookmarkConfig
 	removeUserSavedSearchBookmarkCfg                  *MockRemoveUserSavedSearchBookmarkConfig
 	syncUserProfileInfoCfg                            *MockSyncUserProfileInfoConfig
+	getNotificationChannelCfg                         *MockGetNotificationChannelConfig
+	listNotificationChannelsCfg                       *MockListNotificationChannelsConfig
+	deleteNotificationChannelCfg                      *MockDeleteNotificationChannelConfig
 	t                                                 *testing.T
 	callCountListMissingOneImplCounts                 int
 	callCountListMissingOneImplFeatures               int
@@ -268,6 +292,9 @@ type MockWPTMetricsStorer struct {
 	callCountPutUserSavedSearchBookmark               int
 	callCountRemoveUserSavedSearchBookmark            int
 	callCountSyncUserProfileInfo                      int
+	callCountGetNotificationChannel                   int
+	callCountListNotificationChannels                 int
+	callCountDeleteNotificationChannel                int
 }
 
 func (m *MockWPTMetricsStorer) GetIDFromFeatureKey(
@@ -653,6 +680,65 @@ func (m *MockWPTMetricsStorer) RemoveUserSavedSearchBookmark(
 	return m.removeUserSavedSearchBookmarkCfg.err
 }
 
+func (m *MockWPTMetricsStorer) GetNotificationChannel(
+	_ context.Context,
+	userID, channelID string,
+) (*backend.NotificationChannelResponse, error) {
+	m.callCountGetNotificationChannel++
+
+	if userID != m.getNotificationChannelCfg.expectedUserID ||
+		channelID != m.getNotificationChannelCfg.expectedChannelID {
+		m.t.Errorf("Incorrect arguments - Expected: ( %s %s ), Got: ( %s %s )",
+			m.getNotificationChannelCfg.expectedUserID,
+			m.getNotificationChannelCfg.expectedChannelID,
+			userID,
+			channelID)
+	}
+
+	return m.getNotificationChannelCfg.output, m.getNotificationChannelCfg.err
+}
+
+func (m *MockWPTMetricsStorer) ListNotificationChannels(
+	_ context.Context,
+	userID string,
+	pageSize int,
+	pageToken *string,
+) (*backend.NotificationChannelPage, error) {
+	m.callCountListNotificationChannels++
+
+	if userID != m.listNotificationChannelsCfg.expectedUserID ||
+		pageSize != m.listNotificationChannelsCfg.expectedPageSize ||
+		!reflect.DeepEqual(pageToken, m.listNotificationChannelsCfg.expectedPageToken) {
+		m.t.Errorf("Incorrect arguments - Expected: ( %s %d %v ), Got: ( %s %d %v )",
+			m.listNotificationChannelsCfg.expectedUserID,
+			m.listNotificationChannelsCfg.expectedPageSize,
+			m.listNotificationChannelsCfg.expectedPageToken,
+			userID,
+			pageSize,
+			pageToken)
+	}
+
+	return m.listNotificationChannelsCfg.output, m.listNotificationChannelsCfg.err
+}
+
+func (m *MockWPTMetricsStorer) DeleteNotificationChannel(
+	_ context.Context,
+	userID, channelID string,
+) error {
+	m.callCountDeleteNotificationChannel++
+
+	if userID != m.deleteNotificationChannelCfg.expectedUserID ||
+		channelID != m.deleteNotificationChannelCfg.expectedChannelID {
+		m.t.Errorf("Incorrect arguments - Expected: ( %s %s ), Got: ( %s %s )",
+			m.deleteNotificationChannelCfg.expectedUserID,
+			m.deleteNotificationChannelCfg.expectedChannelID,
+			userID,
+			channelID)
+	}
+
+	return m.deleteNotificationChannelCfg.err
+}
+
 func TestGetPageSizeOrDefault(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -973,6 +1059,39 @@ func (m *mockServerInterface) RemoveUserSavedSearchBookmark(ctx context.Context,
 // nolint: ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) UpdateSavedSearch(ctx context.Context,
 	_ backend.UpdateSavedSearchRequestObject) (backend.UpdateSavedSearchResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
+// DeleteNotificationChannel implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) DeleteNotificationChannel(
+	ctx context.Context,
+	_ backend.DeleteNotificationChannelRequestObject,
+) (backend.DeleteNotificationChannelResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
+// GetNotificationChannel implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) GetNotificationChannel(
+	ctx context.Context,
+	_ backend.GetNotificationChannelRequestObject,
+) (backend.GetNotificationChannelResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
+// ListNotificationChannels implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) ListNotificationChannels(
+	ctx context.Context,
+	_ backend.ListNotificationChannelsRequestObject,
+) (backend.ListNotificationChannelsResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
 	m.callCount++
 	panic("unimplemented")

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -649,6 +649,134 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasicErrorModel'
+  /v1/users/me/notification-channels:
+    get:
+      summary: List user notification channels
+      operationId: listNotificationChannels
+      parameters:
+        - $ref: '#/components/parameters/paginationTokenParam'
+        - $ref: '#/components/parameters/paginationSizeParam'
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationChannelPage'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+  /v1/users/me/notification-channels/{channel_id}:
+    parameters:
+      - name: channel_id
+        in: path
+        description: Notification Channel ID
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get notification channel by ID
+      operationId: getNotificationChannel
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationChannelResponse'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found (channel does not exist or user does not own it)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+    delete:
+      summary: Delete notification channel
+      operationId: deleteNotificationChannel
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: No Content (successful deletion)
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found (channel does not exist or user does not own it)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
   /v1/users/me/saved-searches:
     get:
       summary: List user saved searches


### PR DESCRIPTION
This commit introduces API endpoints for managing user notification channels, addressing the initial scope outlined in issue #1844.

The following endpoints have been added under the `/v1/users/me/` prefix, requiring user authentication:

- `GET /notification-channels`: Lists all notification channels for the authenticated user.
- `GET /notification-channels/{channel_id}`: Retrieves a single notification channel by its ID.
- `DELETE /notification-channels/{channel_id}`: Deletes a specific notification channel.

Key changes include:
- Updating the OpenAPI specification to define the new endpoints.
- Implementing the corresponding HTTP handlers in `backend/pkg/httpserver`.
- Adding the necessary methods to the `WPTMetricsStorer` interface and its mock implementation.
- Including unit tests for the new handlers to ensure correctness and error handling.

This implementation lays the groundwork for future enhancements, such as creating and updating notification channels.

Fixes #1844