### PR TITLE
feat(httpserver): add subscription management methods to server interface

### DIFF
--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -153,6 +153,15 @@ type WPTMetricsStorer interface {
 		userID string, pageSize int, pageToken *string) (*backend.NotificationChannelPage, error)
 	DeleteNotificationChannel(ctx context.Context,
 		userID, channelID string) error
+	CreateSavedSearchSubscription(ctx context.Context, userID string,
+		subscription backend.Subscription) (*backend.SubscriptionResponse, error)
+	DeleteSavedSearchSubscription(ctx context.Context, userID, subscriptionID string) error
+	GetSavedSearchSubscription(ctx context.Context,
+		userID, subscriptionID string) (*backend.SubscriptionResponse, error)
+	ListSavedSearchSubscriptions(ctx context.Context,
+		userID string, pageSize int, pageToken *string) (*backend.SubscriptionPage, error)
+	UpdateSavedSearchSubscription(ctx context.Context, userID, subscriptionID string,
+		req backend.UpdateSubscriptionRequest) (*backend.SubscriptionResponse, error)
 }
 
 type Server struct {

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -245,6 +245,42 @@ type MockDeleteNotificationChannelConfig struct {
 	err               error
 }
 
+type MockCreateSavedSearchSubscriptionConfig struct {
+	expectedUserID       string
+	expectedSubscription backend.Subscription
+	output               *backend.SubscriptionResponse
+	err                  error
+}
+
+type MockDeleteSavedSearchSubscriptionConfig struct {
+	expectedUserID         string
+	expectedSubscriptionID string
+	err                    error
+}
+
+type MockGetSavedSearchSubscriptionConfig struct {
+	expectedUserID         string
+	expectedSubscriptionID string
+	output                 *backend.SubscriptionResponse
+	err                    error
+}
+
+type MockListSavedSearchSubscriptionsConfig struct {
+	expectedUserID    string
+	expectedPageSize  int
+	expectedPageToken *string
+	output            *backend.SubscriptionPage
+	err               error
+}
+
+type MockUpdateSavedSearchSubscriptionConfig struct {
+	expectedUserID         string
+	expectedSubscriptionID string
+	expectedUpdateRequest  backend.UpdateSubscriptionRequest
+	output                 *backend.SubscriptionResponse
+	err                    error
+}
+
 type basicHTTPTestCase[T any] struct {
 	name             string
 	cfg              *T
@@ -274,6 +310,11 @@ type MockWPTMetricsStorer struct {
 	getNotificationChannelCfg                         *MockGetNotificationChannelConfig
 	listNotificationChannelsCfg                       *MockListNotificationChannelsConfig
 	deleteNotificationChannelCfg                      *MockDeleteNotificationChannelConfig
+	createSavedSearchSubscriptionCfg                  *MockCreateSavedSearchSubscriptionConfig
+	deleteSavedSearchSubscriptionCfg                  *MockDeleteSavedSearchSubscriptionConfig
+	getSavedSearchSubscriptionCfg                     *MockGetSavedSearchSubscriptionConfig
+	listSavedSearchSubscriptionsCfg                   *MockListSavedSearchSubscriptionsConfig
+	updateSavedSearchSubscriptionCfg                  *MockUpdateSavedSearchSubscriptionConfig
 	t                                                 *testing.T
 	callCountListMissingOneImplCounts                 int
 	callCountListMissingOneImplFeatures               int
@@ -295,6 +336,11 @@ type MockWPTMetricsStorer struct {
 	callCountGetNotificationChannel                   int
 	callCountListNotificationChannels                 int
 	callCountDeleteNotificationChannel                int
+	callCountCreateSavedSearchSubscription            int
+	callCountDeleteSavedSearchSubscription            int
+	callCountGetSavedSearchSubscription               int
+	callCountListSavedSearchSubscriptions             int
+	callCountUpdateSavedSearchSubscription            int
 }
 
 func (m *MockWPTMetricsStorer) GetIDFromFeatureKey(
@@ -306,6 +352,76 @@ func (m *MockWPTMetricsStorer) GetIDFromFeatureKey(
 	}
 
 	return m.getIDFromFeatureKeyConfig.result, m.getIDFromFeatureKeyConfig.err
+}
+
+func (m *MockWPTMetricsStorer) CreateSavedSearchSubscription(_ context.Context, userID string,
+	subscription backend.Subscription) (*backend.SubscriptionResponse, error) {
+	m.callCountCreateSavedSearchSubscription++
+	if userID != m.createSavedSearchSubscriptionCfg.expectedUserID {
+		m.t.Errorf("unexpected user id %s", userID)
+	}
+	if !reflect.DeepEqual(subscription, m.createSavedSearchSubscriptionCfg.expectedSubscription) {
+		m.t.Errorf("unexpected subscription %+v", subscription)
+	}
+
+	return m.createSavedSearchSubscriptionCfg.output, m.createSavedSearchSubscriptionCfg.err
+}
+
+func (m *MockWPTMetricsStorer) DeleteSavedSearchSubscription(_ context.Context, userID, subscriptionID string) error {
+	m.callCountDeleteSavedSearchSubscription++
+	if userID != m.deleteSavedSearchSubscriptionCfg.expectedUserID {
+		m.t.Errorf("unexpected user id %s", userID)
+	}
+	if subscriptionID != m.deleteSavedSearchSubscriptionCfg.expectedSubscriptionID {
+		m.t.Errorf("unexpected subscription id %s", subscriptionID)
+	}
+
+	return m.deleteSavedSearchSubscriptionCfg.err
+}
+
+func (m *MockWPTMetricsStorer) GetSavedSearchSubscription(_ context.Context,
+	userID, subscriptionID string) (*backend.SubscriptionResponse, error) {
+	m.callCountGetSavedSearchSubscription++
+	if userID != m.getSavedSearchSubscriptionCfg.expectedUserID {
+		m.t.Errorf("unexpected user id %s", userID)
+	}
+	if subscriptionID != m.getSavedSearchSubscriptionCfg.expectedSubscriptionID {
+		m.t.Errorf("unexpected subscription id %s", subscriptionID)
+	}
+
+	return m.getSavedSearchSubscriptionCfg.output, m.getSavedSearchSubscriptionCfg.err
+}
+
+func (m *MockWPTMetricsStorer) ListSavedSearchSubscriptions(_ context.Context,
+	userID string, pageSize int, pageToken *string) (*backend.SubscriptionPage, error) {
+	m.callCountListSavedSearchSubscriptions++
+	if userID != m.listSavedSearchSubscriptionsCfg.expectedUserID {
+		m.t.Errorf("unexpected user id %s", userID)
+	}
+	if pageSize != m.listSavedSearchSubscriptionsCfg.expectedPageSize {
+		m.t.Errorf("unexpected page size %d", pageSize)
+	}
+	if !reflect.DeepEqual(pageToken, m.listSavedSearchSubscriptionsCfg.expectedPageToken) {
+		m.t.Errorf("unexpected page token %+v", pageToken)
+	}
+
+	return m.listSavedSearchSubscriptionsCfg.output, m.listSavedSearchSubscriptionsCfg.err
+}
+
+func (m *MockWPTMetricsStorer) UpdateSavedSearchSubscription(_ context.Context, userID, subscriptionID string,
+	req backend.UpdateSubscriptionRequest) (*backend.SubscriptionResponse, error) {
+	m.callCountUpdateSavedSearchSubscription++
+	if userID != m.updateSavedSearchSubscriptionCfg.expectedUserID {
+		m.t.Errorf("unexpected user id %s", userID)
+	}
+	if subscriptionID != m.updateSavedSearchSubscriptionCfg.expectedSubscriptionID {
+		m.t.Errorf("unexpected subscription id %s", subscriptionID)
+	}
+	if !reflect.DeepEqual(req, m.updateSavedSearchSubscriptionCfg.expectedUpdateRequest) {
+		m.t.Errorf("unexpected update request %+v", req)
+	}
+
+	return m.updateSavedSearchSubscriptionCfg.output, m.updateSavedSearchSubscriptionCfg.err
 }
 
 func (m *MockWPTMetricsStorer) ListMetricsForFeatureIDBrowserAndChannel(_ context.Context,

--- a/lib/backendtypes/types.go
+++ b/lib/backendtypes/types.go
@@ -14,7 +14,12 @@
 
 package backendtypes
 
-import "errors"
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
 
 var (
 	// ErrInvalidPageToken indicates the page token is invalid.
@@ -54,4 +59,30 @@ type UserProfile struct {
 	UserID       string
 	GitHubUserID int64
 	Emails       []string
+}
+
+// AttemptToStoreSubscriptionTrigger attempts to convert the given subscription trigger
+// writable into a subscription trigger response value. If the conversion fails,
+// it logs a warning and returns an empty SubscriptionTriggerResponseValue.
+func AttemptToStoreSubscriptionTrigger(t backend.SubscriptionTriggerWritable) backend.SubscriptionTriggerResponseValue {
+	ret := backend.SubscriptionTriggerResponseValue{}
+	err := ret.FromSubscriptionTriggerWritable(t)
+	if err != nil {
+		slog.Warn("unable to convert trigger from database. skipping", "err", err, "value", t)
+	}
+
+	return ret
+}
+
+// AttemptToStoreSubscriptionTriggerUnknown attempts to convert an unknown subscription trigger
+// into a subscription trigger response value. If the conversion fails,
+// it logs a warning and returns an empty SubscriptionTriggerResponseValue.
+func AttemptToStoreSubscriptionTriggerUnknown() backend.SubscriptionTriggerResponseValue {
+	ret := backend.SubscriptionTriggerResponseValue{}
+	err := ret.FromEnumUnknown(backend.EnumUnknownValue)
+	if err != nil {
+		slog.Warn("unable to convert trigger from database. skipping", "err", err)
+	}
+
+	return ret
 }

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -1341,26 +1341,6 @@ func backendTriggersToSpannerTriggers(backendTriggers []backend.SubscriptionTrig
 	return triggers
 }
 
-func attemptToStoreSubscriptionTrigger(t backend.SubscriptionTriggerWritable) backend.SubscriptionTriggerResponseValue {
-	ret := backend.SubscriptionTriggerResponseValue{}
-	err := ret.FromSubscriptionTriggerWritable(t)
-	if err != nil {
-		slog.Warn("unable to convert trigger from database. skipping", "err", err, "value", t)
-	}
-
-	return ret
-}
-
-func attemptToStoreSubscriptionTriggerUnknown() backend.SubscriptionTriggerResponseValue {
-	ret := backend.SubscriptionTriggerResponseValue{}
-	err := ret.FromEnumUnknown(backend.EnumUnknownValue)
-	if err != nil {
-		slog.Warn("unable to convert trigger from database. skipping", "err", err)
-	}
-
-	return ret
-}
-
 func spannerTriggersToBackendTriggers(spannerTriggers []string) []backend.SubscriptionTriggerResponseItem {
 	triggers := make([]backend.SubscriptionTriggerResponseItem, 0, len(spannerTriggers))
 	for _, trigger := range spannerTriggers {
@@ -1370,13 +1350,13 @@ func spannerTriggersToBackendTriggers(spannerTriggers []string) []backend.Subscr
 			backend.SubscriptionTriggerFeatureBaselineLimitedToNewly,
 			backend.SubscriptionTriggerFeatureBaselineRegressionNewlyToLimited:
 			triggers = append(triggers, backend.SubscriptionTriggerResponseItem{
-				Value:    attemptToStoreSubscriptionTrigger(input),
+				Value:    backendtypes.AttemptToStoreSubscriptionTrigger(input),
 				RawValue: nil,
 			})
 		default:
 			value := trigger
 			triggers = append(triggers, backend.SubscriptionTriggerResponseItem{
-				Value:    attemptToStoreSubscriptionTriggerUnknown(),
+				Value:    backendtypes.AttemptToStoreSubscriptionTriggerUnknown(),
 				RawValue: &value,
 			})
 		}

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -3687,7 +3687,7 @@ func TestCreateSavedSearchSubscription(t *testing.T) {
 				SavedSearchId: savedSearchID,
 				Triggers: []backend.SubscriptionTriggerResponseItem{
 					{
-						Value: attemptToStoreSubscriptionTrigger(
+						Value: backendtypes.AttemptToStoreSubscriptionTrigger(
 							backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
 						RawValue: nil,
 					},
@@ -3814,7 +3814,7 @@ func TestListSavedSearchSubscriptions(t *testing.T) {
 						SavedSearchId: "search1",
 						Triggers: []backend.SubscriptionTriggerResponseItem{
 							{
-								Value: attemptToStoreSubscriptionTrigger(
+								Value: backendtypes.AttemptToStoreSubscriptionTrigger(
 									backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
 								RawValue: nil,
 							},
@@ -3903,7 +3903,7 @@ func TestGetSavedSearchSubscription(t *testing.T) {
 				SavedSearchId: "search1",
 				Triggers: []backend.SubscriptionTriggerResponseItem{
 					{
-						Value: attemptToStoreSubscriptionTrigger(
+						Value: backendtypes.AttemptToStoreSubscriptionTrigger(
 							backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
 						RawValue: nil,
 					},
@@ -4017,7 +4017,7 @@ func TestUpdateSavedSearchSubscription(t *testing.T) {
 				Id: subID,
 				Triggers: []backend.SubscriptionTriggerResponseItem{
 					{
-						Value: attemptToStoreSubscriptionTrigger(
+						Value: backendtypes.AttemptToStoreSubscriptionTrigger(
 							backend.SubscriptionTriggerFeatureBaselineLimitedToNewly),
 						RawValue: nil,
 					},
@@ -4069,7 +4069,7 @@ func TestUpdateSavedSearchSubscription(t *testing.T) {
 				SavedSearchId: "savedsearchid",
 				Triggers: []backend.SubscriptionTriggerResponseItem{
 					{
-						Value: attemptToStoreSubscriptionTrigger(
+						Value: backendtypes.AttemptToStoreSubscriptionTrigger(
 							backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
 						RawValue: nil,
 					},


### PR DESCRIPTION
The spanner adapter layer already implements these methods, so this change adds them to the server interface to expose them at the HTTP server level.

Future work will involve adding HTTP handlers to call these methods.

Other changes:
- Move AttemptToStoreSubscriptionTrigger to the backendtypes package since it was not adapter specific. We will also use it in multiple places.