### PR TITLE
feat(httpserver): add create subscription endpoint

### DIFF
--- a/backend/pkg/httpserver/create_subscription.go
+++ b/backend/pkg/httpserver/create_subscription.go
@@ -1,0 +1,184 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// The exhaustive linter is configured to check that this map is complete.
+func getAllSubscriptionTriggersSet() map[backend.SubscriptionTriggerWritable]any {
+	return map[backend.SubscriptionTriggerWritable]any{
+		backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete: nil,
+		backend.SubscriptionTriggerFeatureBaselineLimitedToNewly:           nil,
+		backend.SubscriptionTriggerFeatureBaselineRegressionNewlyToLimited: nil,
+	}
+}
+
+func getAllSubscriptionTriggersToStringSlice() []string {
+	allTriggers := getAllSubscriptionTriggersSet()
+	allTriggersSlice := make([]string, 0, len(allTriggers))
+	for trigger := range allTriggers {
+		allTriggersSlice = append(allTriggersSlice, string(trigger))
+	}
+	slices.Sort(allTriggersSlice)
+
+	return allTriggersSlice
+}
+
+var (
+	errSubscriptionInvalidTrigger = fmt.Errorf("triggers must be one of the following: %s",
+		getAllSubscriptionTriggersToStringSlice())
+	errSubscriptionInvalidFrequency = fmt.Errorf("frequency must be one of the following: %s",
+		getAllSubscriptionFrequenciesToStringSlice())
+	errSubscriptionChannelIDRequired     = errors.New("channel_id is required")
+	errSubscriptionSavedSearchIDRequired = errors.New("saved_search_id is required")
+)
+
+func validateSubscriptionTrigger(trigger *[]backend.SubscriptionTriggerWritable,
+	required bool, fieldErrors *fieldValidationErrors) {
+	if trigger == nil {
+		if required {
+			fieldErrors.addFieldError("triggers", errSubscriptionInvalidTrigger)
+		}
+
+		return
+	}
+
+	set := getAllSubscriptionTriggersSet()
+	for _, trigger := range *trigger {
+		if _, ok := set[trigger]; !ok {
+			fieldErrors.addFieldError("triggers", errSubscriptionInvalidTrigger)
+		}
+	}
+}
+
+// The exhaustive linter is configured to check that this map is complete.
+func getAllSubscriptionFrequenciesSet() map[backend.SubscriptionFrequency]any {
+	return map[backend.SubscriptionFrequency]any{
+		backend.SubscriptionFrequencyDaily: nil,
+	}
+}
+
+func getAllSubscriptionFrequenciesToStringSlice() []string {
+	allFrequencies := getAllSubscriptionFrequenciesSet()
+	allFrequenciesSlice := make([]string, 0, len(allFrequencies))
+	for frequency := range allFrequencies {
+		allFrequenciesSlice = append(allFrequenciesSlice, string(frequency))
+	}
+	slices.Sort(allFrequenciesSlice)
+
+	return allFrequenciesSlice
+}
+
+func validateSubscriptionFrequency(frequency *backend.SubscriptionFrequency,
+	required bool, fieldErrors *fieldValidationErrors) {
+	if frequency == nil {
+		if required {
+			fieldErrors.addFieldError("frequency", errSubscriptionInvalidFrequency)
+		}
+
+		return
+	}
+
+	set := getAllSubscriptionFrequenciesSet()
+	if _, ok := set[*frequency]; !ok {
+		fieldErrors.addFieldError("frequency", errSubscriptionInvalidFrequency)
+	}
+}
+
+func validateSubscriptionChannelID(channelID string, fieldErrors *fieldValidationErrors) {
+	if channelID == "" {
+		fieldErrors.addFieldError("channel_id", errSubscriptionChannelIDRequired)
+
+		return
+	}
+}
+
+func validateSubscriptionSavedSearchID(savedSearchID string, fieldErrors *fieldValidationErrors) {
+	if savedSearchID == "" {
+		fieldErrors.addFieldError("saved_search_id", errSubscriptionSavedSearchIDRequired)
+
+		return
+	}
+}
+
+func validateSubscriptionCreation(input *backend.Subscription) *fieldValidationErrors {
+	fieldErrors := &fieldValidationErrors{fieldErrorMap: nil}
+
+	validateSubscriptionTrigger(&input.Triggers, true, fieldErrors)
+
+	validateSubscriptionFrequency(&input.Frequency, true, fieldErrors)
+
+	validateSubscriptionChannelID(input.ChannelId, fieldErrors)
+
+	validateSubscriptionSavedSearchID(input.SavedSearchId, fieldErrors)
+
+	if fieldErrors.hasErrors() {
+		return fieldErrors
+	}
+
+	return nil
+}
+
+// nolint:ireturn, revive // Expected ireturn for openapi generation.
+func (s *Server) CreateSubscription(
+	ctx context.Context,
+	request backend.CreateSubscriptionRequestObject,
+) (backend.CreateSubscriptionResponseObject, error) {
+	userCheck := CheckAuthenticatedUser[backend.CreateSubscriptionResponseObject](ctx, "CreateSubscription",
+		func(code int, message string) backend.CreateSubscriptionResponseObject {
+			return backend.CreateSubscription500JSONResponse(backend.BasicErrorModel{Code: code, Message: message})
+		})
+	if userCheck.User == nil {
+		return userCheck.Response, nil
+	}
+	validationErr := validateSubscriptionCreation(request.Body)
+	if validationErr != nil {
+		return backend.CreateSubscription400JSONResponse{
+			Code:    http.StatusBadRequest,
+			Message: "input validation errors",
+			Errors:  validationErr.fieldErrorMap,
+		}, nil
+	}
+
+	resp, err := s.wptMetricsStorer.CreateSavedSearchSubscription(ctx, userCheck.User.ID, *request.Body)
+	if err != nil {
+		if errors.Is(err, backendtypes.ErrUserNotAuthorizedForAction) {
+			return backend.CreateSubscription403JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusForbidden,
+					Message: "user not authorized to create this subscription using the specified channel",
+				},
+			), nil
+		}
+		slog.ErrorContext(ctx, "failed to create subscription", "error", err)
+
+		return backend.CreateSubscription500JSONResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "could not create subscription",
+		}, nil
+	}
+
+	return backend.CreateSubscription201JSONResponse(*resp), nil
+}

--- a/backend/pkg/httpserver/create_subscription_test.go
+++ b/backend/pkg/httpserver/create_subscription_test.go
@@ -1,0 +1,291 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestCreateSubscription(t *testing.T) {
+	now := time.Now()
+	testUser := &auth.User{
+		ID:           "test-user",
+		GitHubUserID: nil,
+	}
+
+	testCases := []struct {
+		name                 string
+		cfg                  *MockCreateSavedSearchSubscriptionConfig
+		expectedCallCount    int
+		authMiddlewareOption testServerOption
+		request              *http.Request
+		expectedResponse     *http.Response
+	}{
+		{
+			name: "success",
+			cfg: &MockCreateSavedSearchSubscriptionConfig{
+				expectedUserID: "test-user",
+				expectedSubscription: backend.Subscription{
+					ChannelId:     "channel-id",
+					SavedSearchId: "search-id",
+					Triggers: []backend.SubscriptionTriggerWritable{
+						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+					Frequency: "daily",
+				},
+				output: &backend.SubscriptionResponse{
+					Id:            "sub-id",
+					ChannelId:     "channel-id",
+					SavedSearchId: "search-id",
+					Triggers: []backend.SubscriptionTriggerResponseItem{
+						{
+							Value: backendtypes.AttemptToStoreSubscriptionTrigger(
+								backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
+							RawValue: nil,
+						},
+					},
+					Frequency: "daily",
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				err: nil,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/users/me/subscriptions",
+				strings.NewReader(`{
+					"channel_id": "channel-id",
+					"saved_search_id": "search-id",
+					"triggers": ["feature_any_browser_implementation_complete"],
+					"frequency": "daily"
+				}`),
+			),
+			expectedResponse: testJSONResponse(http.StatusCreated, `{
+				"id":"sub-id",
+				"channel_id":"channel-id",
+				"saved_search_id":"search-id",
+				"triggers": [{"value":"feature_any_browser_implementation_complete"}],
+				"frequency":"daily",
+				"created_at":"`+now.Format(time.RFC3339Nano)+`",
+				"updated_at":"`+now.Format(time.RFC3339Nano)+`"
+			}`),
+		},
+		{
+			name:                 "bad request - missing channel id",
+			cfg:                  nil,
+			expectedCallCount:    0,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/users/me/subscriptions",
+				strings.NewReader(`{
+					"saved_search_id": "search-id",
+					"triggers": ["feature_any_browser_implementation_complete"],
+					"frequency": "daily"
+				}`),
+			),
+			expectedResponse: testJSONResponse(http.StatusBadRequest, `
+			{
+				"code":400,
+				"message":"input validation errors",
+				"errors":{
+					"channel_id":"channel_id is required"
+				}
+			}`),
+		},
+		{
+			name: "forbidden - user not authorized",
+			cfg: &MockCreateSavedSearchSubscriptionConfig{
+				expectedUserID: "test-user",
+				expectedSubscription: backend.Subscription{
+					ChannelId:     "channel-id",
+					SavedSearchId: "search-id",
+					Triggers: []backend.SubscriptionTriggerWritable{
+						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+					Frequency: "daily",
+				},
+				output: nil,
+				err:    backendtypes.ErrUserNotAuthorizedForAction,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/users/me/subscriptions",
+				strings.NewReader(`{
+					"channel_id": "channel-id",
+					"saved_search_id": "search-id",
+					"triggers": ["feature_any_browser_implementation_complete"],
+					"frequency": "daily"
+				}`)),
+			expectedResponse: testJSONResponse(http.StatusForbidden, `{
+				"code":403,
+				"message":"user not authorized to create this subscription using the specified channel"
+			}`),
+		},
+		{
+			name: "internal server error",
+			cfg: &MockCreateSavedSearchSubscriptionConfig{
+				expectedUserID: "test-user",
+				expectedSubscription: backend.Subscription{
+					ChannelId:     "channel-id",
+					SavedSearchId: "search-id",
+					Triggers: []backend.SubscriptionTriggerWritable{
+						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+					Frequency: "daily",
+				},
+				output: nil,
+				err:    fmt.Errorf("database error"),
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/users/me/subscriptions",
+				strings.NewReader(`{
+					"channel_id": "channel-id",
+					"saved_search_id": "search-id",
+					"triggers": ["feature_any_browser_implementation_complete"],
+					"frequency": "daily"
+				}`)),
+			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
+				"code":500,
+				"message":"could not create subscription"
+			}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint:exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				createSavedSearchSubscriptionCfg: tc.cfg,
+				t:                                t,
+			}
+			myServer := Server{
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
+				operationResponseCaches: nil,
+				baseURL:                 getTestBaseURL(t),
+			}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
+			assertMocksExpectations(t,
+				tc.expectedCallCount,
+				mockStorer.callCountCreateSavedSearchSubscription,
+				"CreateSavedSearchSubscription",
+				nil)
+		})
+	}
+}
+
+func TestValidateSubscriptionCreation(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input *backend.Subscription
+		want  *fieldValidationErrors
+	}{
+		{
+			name: "valid subscription",
+			input: &backend.Subscription{
+				ChannelId:     "channel-id",
+				SavedSearchId: "search-id",
+				Triggers: []backend.SubscriptionTriggerWritable{
+					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+				Frequency: backend.SubscriptionFrequencyDaily,
+			},
+			want: nil,
+		},
+		{
+			name: "invalid channel id",
+			input: &backend.Subscription{
+				ChannelId:     "",
+				SavedSearchId: "searchid",
+				Triggers: []backend.SubscriptionTriggerWritable{
+					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+				Frequency: backend.SubscriptionFrequencyDaily,
+			},
+			want: &fieldValidationErrors{
+				fieldErrorMap: map[string]string{
+					"channel_id": errSubscriptionChannelIDRequired.Error(),
+				},
+			},
+		},
+		{
+			name: "invalid saved search id",
+			input: &backend.Subscription{
+				ChannelId:     "channelid",
+				SavedSearchId: "",
+				Triggers: []backend.SubscriptionTriggerWritable{
+					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+				Frequency: backend.SubscriptionFrequencyDaily,
+			},
+			want: &fieldValidationErrors{
+				fieldErrorMap: map[string]string{
+					"saved_search_id": errSubscriptionSavedSearchIDRequired.Error(),
+				},
+			},
+		},
+		{
+			name: "invalid trigger",
+			input: &backend.Subscription{
+				ChannelId:     "channelid",
+				SavedSearchId: "searchid",
+				Triggers: []backend.SubscriptionTriggerWritable{
+					"invalid_trigger"},
+				Frequency: backend.SubscriptionFrequencyDaily,
+			},
+			want: &fieldValidationErrors{
+				fieldErrorMap: map[string]string{
+					"triggers": errSubscriptionInvalidTrigger.Error(),
+				},
+			},
+		},
+		{
+			name: "invalid frequency",
+			input: &backend.Subscription{
+				ChannelId:     "channelid",
+				SavedSearchId: "searchid",
+				Triggers: []backend.SubscriptionTriggerWritable{
+					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+				Frequency: "invalid_frequency",
+			},
+			want: &fieldValidationErrors{
+				fieldErrorMap: map[string]string{
+					"frequency": errSubscriptionInvalidFrequency.Error(),
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := validateSubscriptionCreation(tc.input)
+			if !reflect.DeepEqual(tc.want, out) {
+				t.Errorf("validateSubscriptionCreation() = %v, want %v", out, tc.want)
+			}
+		})
+	}
+}

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -1235,6 +1235,16 @@ func (m *mockServerInterface) ListMissingOneImplementationFeatures(ctx context.C
 	panic("unimplemented")
 }
 
+// CreateSubscription implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) CreateSubscription(ctx context.Context,
+	_ backend.CreateSubscriptionRequestObject) (
+	backend.CreateSubscriptionResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
 func (m *mockServerInterface) assertCallCount(expectedCallCount int) {
 	if m.callCount != expectedCallCount {
 		m.t.Errorf("expected mock server to be used %d times. only used %d times", expectedCallCount, m.callCount)

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -1065,7 +1065,49 @@ paths:
                 $ref: '#/components/schemas/BasicErrorModel'
   /v1/users/me/subscriptions:
     description: Operations for managing user subscriptions to saved searches.
-    # POST operation to create a new subscription (to be added in a future PR)
+    # POST operation to create a new subscription
+    post:
+      summary: Create a subscription for a saved search
+      operationId: createSubscription
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Subscription'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubscriptionResponse'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExtendedErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
     # GET operation to list user's subscriptions (to be added in a future PR)
   /v1/users/me/subscriptions/{subscription_id}:
     description: Operations for managing a specific user subscription.
@@ -1649,7 +1691,6 @@ components:
           description: >
             The original, raw value from the database. Only present if the 'value'
             is 'unknown', allowing clients to identify and manage deprecated triggers.
-          nullable: true
       required:
         - value
     SubscriptionBase:


### PR DESCRIPTION
This change adds a new HTTP endpoint to create saved search subscriptions.

It validates the incoming request, ensuring that the subscription triggers are valid, the frequency is supported, and that the saved search ID and channel ID are provided. The endpoint interacts with the backend server
interface to create the subscription and returns the created subscription in the response.