### PR TITLE
feat(httpserver): Add update subscription endpoint

### DIFF
--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -1245,6 +1245,16 @@ func (m *mockServerInterface) CreateSubscription(ctx context.Context,
 	panic("unimplemented")
 }
 
+// UpdateSubscription implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) UpdateSubscription(ctx context.Context,
+	_ backend.UpdateSubscriptionRequestObject) (
+	backend.UpdateSubscriptionResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
 func (m *mockServerInterface) assertCallCount(expectedCallCount int) {
 	if m.callCount != expectedCallCount {
 		m.t.Errorf("expected mock server to be used %d times. only used %d times", expectedCallCount, m.callCount)

--- a/backend/pkg/httpserver/update_subscription.go
+++ b/backend/pkg/httpserver/update_subscription.go
@@ -1,0 +1,139 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+var (
+	errSubscriptionUpdateMaskRequired = errors.New("update_mask is required")
+	errSubscriptionInvalidUpdateMask  = fmt.Errorf("update_mask must be one of the following: %s",
+		getAllSubscriptionUpdateMasksToStringSlice())
+)
+
+func getAllSubscriptionUpdateMasksSet() map[backend.UpdateSubscriptionRequestUpdateMask]any {
+	return map[backend.UpdateSubscriptionRequestUpdateMask]any{
+		backend.UpdateSubscriptionRequestMaskTriggers:  nil,
+		backend.UpdateSubscriptionRequestMaskFrequency: nil,
+	}
+}
+
+func getAllSubscriptionUpdateMasksToStringSlice() []string {
+	allUpdateMasks := getAllSubscriptionUpdateMasksSet()
+	allUpdateMasksSlice := make([]string, 0, len(allUpdateMasks))
+	for updateMask := range allUpdateMasks {
+		allUpdateMasksSlice = append(allUpdateMasksSlice, string(updateMask))
+	}
+	slices.Sort(allUpdateMasksSlice)
+
+	return allUpdateMasksSlice
+}
+
+func validateSubscriptionUpdateMask(updateMask *[]backend.UpdateSubscriptionRequestUpdateMask,
+	required bool, fieldErrors *fieldValidationErrors) {
+	if updateMask == nil || len(*updateMask) == 0 {
+		if required {
+			fieldErrors.addFieldError("update_mask", errSubscriptionUpdateMaskRequired)
+		}
+
+		return
+	}
+
+	set := getAllSubscriptionUpdateMasksSet()
+	for _, updateMask := range *updateMask {
+		if _, ok := set[updateMask]; !ok {
+			fieldErrors.addFieldError("update_mask", errSubscriptionInvalidUpdateMask)
+		}
+	}
+}
+
+func validateSubscriptionUpdate(input *backend.UpdateSubscriptionRequest) *fieldValidationErrors {
+	fieldErrors := &fieldValidationErrors{fieldErrorMap: nil}
+
+	validateSubscriptionUpdateMask(&input.UpdateMask, true, fieldErrors)
+
+	isTriggerRequired := slices.Contains(input.UpdateMask, backend.UpdateSubscriptionRequestMaskTriggers)
+	validateSubscriptionTrigger(input.Triggers, isTriggerRequired, fieldErrors)
+
+	isFrequencyRequired := slices.Contains(input.UpdateMask, backend.UpdateSubscriptionRequestMaskFrequency)
+	validateSubscriptionFrequency(input.Frequency, isFrequencyRequired, fieldErrors)
+
+	if fieldErrors.hasErrors() {
+		return fieldErrors
+	}
+
+	return nil
+}
+
+// nolint:ireturn, revive // Expected ireturn for openapi generation.
+func (s *Server) UpdateSubscription(
+	ctx context.Context,
+	request backend.UpdateSubscriptionRequestObject,
+) (backend.UpdateSubscriptionResponseObject, error) {
+	userCheck := CheckAuthenticatedUser[backend.UpdateSubscriptionResponseObject](ctx, "UpdateSubscription",
+		func(code int, message string) backend.UpdateSubscriptionResponseObject {
+			return backend.UpdateSubscription500JSONResponse(backend.BasicErrorModel{Code: code, Message: message})
+		})
+	if userCheck.User == nil {
+		return userCheck.Response, nil
+	}
+
+	validationErr := validateSubscriptionUpdate(request.Body)
+	if validationErr != nil {
+		return backend.UpdateSubscription400JSONResponse{
+			Code:    http.StatusBadRequest,
+			Message: "input validation errors",
+			Errors:  validationErr.fieldErrorMap,
+		}, nil
+	}
+
+	resp, err := s.wptMetricsStorer.UpdateSavedSearchSubscription(
+		ctx, userCheck.User.ID, request.SubscriptionId, *request.Body)
+	if err != nil {
+		if errors.Is(err, backendtypes.ErrEntityDoesNotExist) {
+			return backend.UpdateSubscription404JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusNotFound,
+					Message: "subscription not found",
+				},
+			), nil
+		} else if errors.Is(err, backendtypes.ErrUserNotAuthorizedForAction) {
+			return backend.UpdateSubscription403JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusForbidden,
+					Message: "user not authorized to update this subscription",
+				},
+			), nil
+		}
+
+		slog.ErrorContext(ctx, "failed to update subscription", "error", err)
+
+		return backend.UpdateSubscription500JSONResponse{
+			Code:    http.StatusInternalServerError,
+			Message: "could not update subscription",
+		}, nil
+	}
+
+	return backend.UpdateSubscription200JSONResponse(*resp), nil
+}

--- a/backend/pkg/httpserver/update_subscription_test.go
+++ b/backend/pkg/httpserver/update_subscription_test.go
@@ -1,0 +1,313 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestUpdateSubscription(t *testing.T) {
+	now := time.Now()
+	testUser := &auth.User{
+		ID:           "test-user",
+		GitHubUserID: nil,
+	}
+
+	testCases := []struct {
+		name                 string
+		cfg                  *MockUpdateSavedSearchSubscriptionConfig
+		expectedCallCount    int
+		authMiddlewareOption testServerOption
+		request              *http.Request
+		expectedResponse     *http.Response
+	}{
+		{
+			name: "success",
+			cfg: &MockUpdateSavedSearchSubscriptionConfig{
+				expectedUserID:         "test-user",
+				expectedSubscriptionID: "sub-id",
+				expectedUpdateRequest: backend.UpdateSubscriptionRequest{
+					Triggers: &[]backend.SubscriptionTriggerWritable{
+						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+					UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
+						backend.UpdateSubscriptionRequestMaskTriggers},
+					Frequency: nil,
+				},
+				output: &backend.SubscriptionResponse{
+					Id:            "sub-id",
+					ChannelId:     "channel-id",
+					SavedSearchId: "search-id",
+					Triggers: []backend.SubscriptionTriggerResponseItem{
+						{
+							Value: backendtypes.AttemptToStoreSubscriptionTrigger(
+								backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
+							RawValue: nil,
+						},
+					},
+					Frequency: "daily",
+					CreatedAt: now,
+					UpdatedAt: now,
+				},
+				err: nil,
+			},
+			expectedCallCount: 1,
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/users/me/subscriptions/sub-id",
+				strings.NewReader(`
+					{
+						"triggers":
+							["feature_any_browser_implementation_complete"],
+						"update_mask": ["triggers"]
+					}`)),
+			expectedResponse: testJSONResponse(http.StatusOK,
+				`{
+					"id":"sub-id",
+					"channel_id":"channel-id",
+					"saved_search_id":"search-id",
+					"triggers": [{"value":"feature_any_browser_implementation_complete"}],
+					"frequency":"daily",
+					"created_at":"`+now.Format(time.RFC3339Nano)+`",
+					"updated_at":"`+now.Format(time.RFC3339Nano)+`"
+				}`),
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+		},
+		{
+			name: "not found",
+			cfg: &MockUpdateSavedSearchSubscriptionConfig{
+				expectedUserID:         "test-user",
+				expectedSubscriptionID: "sub-id",
+				expectedUpdateRequest: backend.UpdateSubscriptionRequest{
+					Triggers: &[]backend.SubscriptionTriggerWritable{
+						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete,
+					},
+					Frequency: nil,
+					UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
+						backend.UpdateSubscriptionRequestMaskTriggers},
+				},
+				output: nil,
+				err:    backendtypes.ErrEntityDoesNotExist,
+			},
+			expectedCallCount: 1,
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/users/me/subscriptions/sub-id",
+				strings.NewReader(`
+				{
+					"triggers": ["feature_any_browser_implementation_complete"],
+					"update_mask": ["triggers"]
+				}`)),
+			expectedResponse: testJSONResponse(http.StatusNotFound, `
+			{
+				"code":404,
+				"message":"subscription not found"
+			}`),
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+		},
+		{
+			name: "bad request - invalid update mask",
+			cfg:  nil,
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/users/me/subscriptions/sub-id",
+				strings.NewReader(`
+				{
+					"triggers": ["feature_any_browser_implementation_complete"],
+					"update_mask": ["invalid_field"]
+				}`)),
+			expectedResponse: testJSONResponse(http.StatusBadRequest, `
+			{
+				"code":400,
+				"message":"input validation errors",
+				"errors":{
+					"update_mask":"update_mask must be one of the following: [frequency triggers]"
+				}
+			}`),
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			expectedCallCount:    0,
+		},
+		{
+			name: "forbidden - user not authorized",
+			cfg: &MockUpdateSavedSearchSubscriptionConfig{
+				expectedUserID:         "test-user",
+				expectedSubscriptionID: "sub-id",
+				expectedUpdateRequest: backend.UpdateSubscriptionRequest{
+					Triggers: &[]backend.SubscriptionTriggerWritable{
+						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+					UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
+						backend.UpdateSubscriptionRequestMaskTriggers},
+					Frequency: nil,
+				},
+				output: nil,
+				err:    backendtypes.ErrUserNotAuthorizedForAction,
+			},
+			expectedCallCount: 1,
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/users/me/subscriptions/sub-id",
+				strings.NewReader(`
+				{
+					"triggers": ["feature_any_browser_implementation_complete"],
+					"update_mask": ["triggers"]
+				}`)),
+			expectedResponse: testJSONResponse(http.StatusForbidden, `
+			{
+				"code":403,
+				"message":"user not authorized to update this subscription"
+			}`),
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+		},
+		{
+			name: "internal server error",
+			cfg: &MockUpdateSavedSearchSubscriptionConfig{
+				expectedUserID:         "test-user",
+				expectedSubscriptionID: "sub-id",
+				expectedUpdateRequest: backend.UpdateSubscriptionRequest{
+					Triggers: &[]backend.SubscriptionTriggerWritable{
+						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+					UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
+						backend.UpdateSubscriptionRequestMaskTriggers},
+					Frequency: nil,
+				},
+				output: nil,
+				err:    fmt.Errorf("database error"),
+			},
+			expectedCallCount: 1,
+			request: httptest.NewRequest(
+				http.MethodPatch,
+				"/v1/users/me/subscriptions/sub-id",
+				strings.NewReader(`
+				{
+					"triggers": ["feature_any_browser_implementation_complete"],
+					"update_mask": ["triggers"]
+				}`)),
+			expectedResponse: testJSONResponse(http.StatusInternalServerError, `
+			{
+				"code":500,
+				"message":"could not update subscription"
+			}`),
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+		},
+	}
+
+	for _, tc := range testCases {
+
+		t.Run(tc.name, func(t *testing.T) {
+			// nolint:exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				updateSavedSearchSubscriptionCfg: tc.cfg,
+				t:                                t,
+			}
+
+			myServer := Server{
+				wptMetricsStorer:        mockStorer,
+				baseURL:                 getTestBaseURL(t),
+				metadataStorer:          nil,
+				operationResponseCaches: nil,
+				userGitHubClientFactory: nil,
+			}
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
+			assertMocksExpectations(t,
+				tc.expectedCallCount,
+				mockStorer.callCountUpdateSavedSearchSubscription,
+				"UpdateSavedSearchSubscription",
+				nil)
+
+		})
+
+	}
+}
+
+func TestValidateSubscriptionUpdate(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input *backend.UpdateSubscriptionRequest
+		want  *fieldValidationErrors
+	}{
+		{
+			name: "valid update",
+			input: &backend.UpdateSubscriptionRequest{
+				Triggers: &[]backend.SubscriptionTriggerWritable{
+					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+				UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
+					backend.UpdateSubscriptionRequestMaskTriggers},
+				Frequency: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "invalid update mask",
+			input: &backend.UpdateSubscriptionRequest{
+				Triggers: &[]backend.SubscriptionTriggerWritable{
+					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+				UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
+					"invalid_field"},
+				Frequency: nil,
+			},
+			want: &fieldValidationErrors{
+				fieldErrorMap: map[string]string{
+					"update_mask": errSubscriptionInvalidUpdateMask.Error(),
+				},
+			},
+		},
+		{
+			name: "missing required triggers",
+			input: &backend.UpdateSubscriptionRequest{
+				Triggers: nil,
+				UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
+					backend.UpdateSubscriptionRequestMaskTriggers},
+				Frequency: nil,
+			},
+			want: &fieldValidationErrors{
+				fieldErrorMap: map[string]string{
+					"triggers": errSubscriptionInvalidTrigger.Error(),
+				},
+			},
+		},
+		{
+			name: "nil update mask",
+			input: &backend.UpdateSubscriptionRequest{
+				Triggers: &[]backend.SubscriptionTriggerWritable{
+					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+				UpdateMask: nil,
+				Frequency:  nil,
+			},
+			want: &fieldValidationErrors{
+				fieldErrorMap: map[string]string{
+					"update_mask": errSubscriptionUpdateMaskRequired.Error(),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := validateSubscriptionUpdate(tc.input)
+			if !reflect.DeepEqual(tc.want, out) {
+				t.Errorf("validateSubscriptionCreation() = %v, want %v", out, tc.want)
+			}
+		})
+	}
+}

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -1119,7 +1119,55 @@ paths:
         schema:
           type: string
     # GET operation to retrieve a specific subscription (to be added in a future PR)
-    # PATCH operation to update a specific subscription (to be added in a future PR)
+    # PATCH operation to update a specific subscription
+    patch:
+      summary: Update a subscription for a saved search
+      operationId: updateSubscription
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSubscriptionRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubscriptionResponse'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExtendedErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
     # DELETE operation to delete a specific subscription (to be added in a future PR)
 components:
   parameters:


### PR DESCRIPTION
This changes adds a new HTTP endpoint to update existing subscriptions. It allows clients to modify the triggers and frequency of their subscriptions. The implementation includes validation of input data and appropriate error handling.