### PR TITLE
feat(spanner): add SavedSearchNotificationEvents table and publish logic

### DIFF
--- a/infra/storage/spanner/migrations/000027.sql
+++ b/infra/storage/spanner/migrations/000027.sql
@@ -1,0 +1,38 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- SavedSearchNotificationEvents
+-- The append-only log of all generated events ("The Fact Table").
+CREATE TABLE IF NOT EXISTS SavedSearchNotificationEvents (
+    EventId STRING(36) NOT NULL DEFAULT (GENERATE_UUID()),
+    SavedSearchId STRING(36) NOT NULL,
+    SnapshotType STRING(MAX) NOT NULL,
+    Timestamp TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+    EventType STRING(MAX) NOT NULL, -- Enum: IMMEDIATE_DIFF, WEEKLY_DIGEST, etc.
+    Reason STRING(MAX) NOT NULL,    -- Enum: DATA_UPDATED, QUERY_EDITED, etc.
+    BlobPath STRING(MAX) NOT NULL,
+    Summary JSON,
+    DiffKind STRING(MAX),           -- e.g., "SavedSearchDiffList"
+    DataVersion STRING(MAX),        -- e.g., "v1"
+
+    CONSTRAINT FK_Events_State
+        FOREIGN KEY (SavedSearchId, SnapshotType)
+        REFERENCES SavedSearchState (SavedSearchId, SnapshotType) ON DELETE CASCADE
+
+) PRIMARY KEY (EventId);
+
+
+-- This index prevents full table scans during RSS polling.
+CREATE INDEX IF NOT EXISTS SavedSearchNotificationEvents_BySearchAndType
+ON SavedSearchNotificationEvents (SavedSearchId, EventType, Timestamp DESC);

--- a/lib/gcpspanner/saved_search_notification_events.go
+++ b/lib/gcpspanner/saved_search_notification_events.go
@@ -1,0 +1,137 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+const savedSearchNotificationEventsTable = "SavedSearchNotificationEvents"
+
+type SavedSearchNotificationEvent struct {
+	ID            string                  `spanner:"EventId"`
+	SavedSearchID string                  `spanner:"SavedSearchId"`
+	SnapshotType  SavedSearchSnapshotType `spanner:"SnapshotType"`
+	Timestamp     time.Time               `spanner:"Timestamp"`
+	EventType     string                  `spanner:"EventType"`
+	Reason        string                  `spanner:"Reason"`
+	BlobPath      string                  `spanner:"BlobPath"`
+	Summary       spanner.NullJSON        `spanner:"Summary"`
+	DiffKind      *string                 `spanner:"DiffKind"`
+	DataVersion   string                  `spanner:"DataVersion"`
+}
+
+type SavedSearchNotificationCreateRequest struct {
+	SavedSearchID string                  `spanner:"SavedSearchId"`
+	SnapshotType  SavedSearchSnapshotType `spanner:"SnapshotType"`
+	Timestamp     time.Time               `spanner:"Timestamp"`
+	EventType     string                  `spanner:"EventType"`
+	Reason        string                  `spanner:"Reason"`
+	BlobPath      string                  `spanner:"BlobPath"`
+	Summary       spanner.NullJSON        `spanner:"Summary"`
+	DiffKind      *string                 `spanner:"DiffKind"`
+	DataVersion   string                  `spanner:"DataVersion"`
+}
+
+func (c *Client) GetSavedSearchNotificationEvent(
+	ctx context.Context, eventID string) (*SavedSearchNotificationEvent, error) {
+	r := newEntityReader[savedSearchNotificationEventMapper, SavedSearchNotificationEvent, string](c)
+
+	return r.readRowByKey(ctx, eventID)
+}
+
+// savedSearchNotificationEventMapper implements the necessary interfaces for the generic helpers.
+type savedSearchNotificationEventMapper struct{}
+
+func (m savedSearchNotificationEventMapper) Table() string {
+	return savedSearchNotificationEventsTable
+}
+
+func (m savedSearchNotificationEventMapper) SelectOne(EventID string) spanner.Statement {
+	return spanner.Statement{
+		SQL:    "SELECT * FROM SavedSearchNotificationEvents WHERE EventId = @EventId",
+		Params: map[string]any{"EventId": EventID},
+	}
+}
+
+func (m savedSearchNotificationEventMapper) NewEntity(id string, req SavedSearchNotificationCreateRequest) (
+	SavedSearchNotificationEvent, error) {
+	return SavedSearchNotificationEvent{
+		ID:            id,
+		SavedSearchID: req.SavedSearchID,
+		SnapshotType:  req.SnapshotType,
+		Timestamp:     req.Timestamp,
+		EventType:     req.EventType,
+		Reason:        req.Reason,
+		BlobPath:      req.BlobPath,
+		Summary:       req.Summary,
+		DiffKind:      req.DiffKind,
+		DataVersion:   req.DataVersion,
+	}, nil
+}
+
+// PublishSavedSearchNotificationEvent records a new saved search notification event.
+// This saves the event and updates the state pointer, but explicitly KEEPS the lock.
+// The worker is expected to call ReleaseLock via defer.
+func (c *Client) PublishSavedSearchNotificationEvent(ctx context.Context,
+	event SavedSearchNotificationCreateRequest, newStatePath, workerID string) (*string, error) {
+	var id *string
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		// Check Lock & Update State (Using ReadInspectMutateWithTransaction)
+		key := savedSearchStateKey{SavedSearchID: event.SavedSearchID,
+			SnapshotType: SavedSearchSnapshotType(event.SnapshotType)}
+
+		err := newEntityMutator[savedSearchStateMapper, SavedSearchState](c).readInspectMutateWithTransaction(ctx, key,
+			func(_ context.Context, existing *SavedSearchState) (*spanner.Mutation, error) {
+				if existing == nil {
+					return nil, ErrQueryReturnedNoResults
+				}
+				// Fencing Check: Verify I still own the lock before committing
+				if existing.WorkerLockID == nil || *existing.WorkerLockID != workerID {
+					return nil, ErrAlreadyLocked
+				}
+
+				// Update Logic: Set New Path + KEEP Lock
+				// We update the BlobPath but explicitly copy the lock identity from the existing row.
+				newState := SavedSearchState{
+					SavedSearchID:          event.SavedSearchID,
+					SnapshotType:           event.SnapshotType,
+					LastKnownStateBlobPath: &newStatePath,
+					WorkerLockID:           existing.WorkerLockID,        // KEEP LOCK
+					WorkerLockExpiresAt:    existing.WorkerLockExpiresAt, // KEEP EXPIRY
+				}
+
+				return spanner.InsertOrUpdateStruct(savedSearchStateTableName, newState)
+			}, txn)
+
+		if err != nil {
+			return err
+		}
+
+		// Insert Event
+		newID, err := newEntityCreator[savedSearchNotificationEventMapper](c).createWithTransaction(ctx, txn, event)
+		if err != nil {
+			return err
+		}
+		id = newID
+
+		return nil
+	})
+
+	return id, err
+}

--- a/lib/gcpspanner/saved_search_notification_events_test.go
+++ b/lib/gcpspanner/saved_search_notification_events_test.go
@@ -1,0 +1,299 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+)
+
+// createSavedSearchForNotificationTests creates a saved search for testing notification events.
+func createSavedSearchForNotificationTests(ctx context.Context, t *testing.T) string {
+	t.Helper()
+	id, err := spannerClient.CreateNewUserSavedSearch(ctx, CreateUserSavedSearchRequest{
+		Name:        "test search for notifications",
+		Query:       "group:notification-test",
+		OwnerUserID: "owner-notification-1",
+		Description: nil,
+	})
+	if err != nil {
+		t.Fatalf("CreateNewUserSavedSearch() returned unexpected error: %v", err)
+	}
+
+	return *id
+}
+
+// setupLockAndInitialState acquires a lock and sets an initial state for testing.
+func setupLockAndInitialState(
+	ctx context.Context,
+	t *testing.T,
+	savedSearchID, snapshotType, workerID, initialBlobPath string,
+	ttl time.Duration,
+	fixedTime time.Time,
+) {
+	t.Helper()
+	spannerClient.setTimeNowForTesting(func() time.Time { return fixedTime })
+
+	_, err := spannerClient.TryAcquireSavedSearchStateWorkerLock(ctx, savedSearchID,
+		SavedSearchSnapshotType(snapshotType), workerID, ttl)
+	if err != nil {
+		t.Fatalf("setup: TryAcquireSavedSearchStateWorkerLock failed: %v", err)
+	}
+	err = spannerClient.UpdateSavedSearchStateLastKnownStateBlobPath(ctx, savedSearchID,
+		SavedSearchSnapshotType(snapshotType), initialBlobPath)
+	if err != nil {
+		t.Fatalf("setup: UpdateSavedSearchStateLastKnownStateBlobPath failed: %v", err)
+	}
+}
+
+// assertPublishedEvent checks if the published event matches the expected event.
+func assertPublishedEvent(
+	ctx context.Context,
+	t *testing.T,
+	expectedEvent SavedSearchNotificationEvent,
+) {
+	t.Helper()
+	retrievedEvent, err := spannerClient.GetSavedSearchNotificationEvent(ctx, expectedEvent.ID)
+	if err != nil {
+		t.Fatalf("GetSavedSearchNotificationEvent() failed: %v", err)
+	}
+	// Ignore timestamp as it's set by the server.
+	if diff := cmp.Diff(expectedEvent, *retrievedEvent, cmp.FilterPath(func(p cmp.Path) bool {
+		return p.String() == "Timestamp"
+	}, cmp.Ignore())); diff != "" {
+		t.Errorf("retrieved event mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// assertStateAndLockKept checks if the state was updated and the lock was preserved.
+func assertStateAndLockKept(
+	ctx context.Context,
+	t *testing.T,
+	savedSearchID, snapshotType, newStatePath, workerID string,
+	expectedExpiration time.Time,
+) {
+	t.Helper()
+	state, err := spannerClient.GetSavedSearchState(ctx, savedSearchID, SavedSearchSnapshotType(snapshotType))
+	if err != nil {
+		t.Fatalf("GetSavedSearchState() after publish failed: %v", err)
+	}
+	if state.LastKnownStateBlobPath == nil || *state.LastKnownStateBlobPath != newStatePath {
+		t.Errorf("LastKnownStateBlobPath mismatch: got %v, want %s", state.LastKnownStateBlobPath, newStatePath)
+	}
+	if state.WorkerLockID == nil || *state.WorkerLockID != workerID {
+		t.Errorf("WorkerLockID should have been kept, but mismatch: got %v, want %s", state.WorkerLockID, workerID)
+	}
+	if state.WorkerLockExpiresAt == nil || !state.WorkerLockExpiresAt.Equal(expectedExpiration) {
+		t.Errorf("WorkerLockExpiresAt should have been kept, but mismatch: got %v, want %v",
+			state.WorkerLockExpiresAt, expectedExpiration)
+	}
+}
+
+// assertStateUnchanged checks if the state of SavedSearchState remained unchanged.
+func assertStateUnchanged(
+	ctx context.Context,
+	t *testing.T,
+	savedSearchID, snapshotType, expectedBlobPath, expectedWorkerID string,
+	expectedExpiration time.Time,
+) {
+	t.Helper()
+	state, err := spannerClient.GetSavedSearchState(ctx, savedSearchID, SavedSearchSnapshotType(snapshotType))
+	if err != nil {
+		t.Fatalf("GetSavedSearchState() failed: %v", err)
+	}
+	if state.LastKnownStateBlobPath == nil || *state.LastKnownStateBlobPath != expectedBlobPath {
+		t.Errorf("LastKnownStateBlobPath changed unexpectedly: got %v, want %s",
+			state.LastKnownStateBlobPath, expectedBlobPath)
+	}
+	if state.WorkerLockID == nil || *state.WorkerLockID != expectedWorkerID {
+		t.Errorf("WorkerLockID changed unexpectedly: got %v, want %s", state.WorkerLockID, expectedWorkerID)
+	}
+	if state.WorkerLockExpiresAt == nil || !state.WorkerLockExpiresAt.Equal(expectedExpiration) {
+		t.Errorf("WorkerLockExpiresAt changed unexpectedly: got %v, want %v",
+			state.WorkerLockExpiresAt, expectedExpiration)
+	}
+}
+
+func TestPublishSavedSearchNotificationEvent(t *testing.T) {
+	ctx := context.Background()
+
+	// Shared test data
+	snapshotType := "compat-stats"
+	workerID := "worker-1"
+	ttl := 10 * time.Minute
+	initialBlobPath := "path/initial"
+	newStatePath := "path/new"
+
+	// Fixed time for deterministic tests
+	fixedTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	initialExpiration := fixedTime.Add(ttl)
+
+	testCases := []struct {
+		name              string
+		setup             func(t *testing.T, savedSearchID string)
+		event             func(savedSearchID string) SavedSearchNotificationCreateRequest
+		newStatePath      string
+		workerID          string
+		expectedErr       error
+		assertAfterAction func(t *testing.T, savedSearchID string, eventID *string)
+	}{
+		{
+			name: "success - publish event and update state, keeping lock",
+			setup: func(t *testing.T, savedSearchID string) {
+				t.Helper()
+				setupLockAndInitialState(ctx, t, savedSearchID, snapshotType, workerID, initialBlobPath, ttl, fixedTime)
+			},
+			event: func(savedSearchID string) SavedSearchNotificationCreateRequest {
+				return SavedSearchNotificationCreateRequest{
+					SavedSearchID: savedSearchID,
+					SnapshotType:  SavedSearchSnapshotType(snapshotType),
+					Timestamp:     spanner.CommitTimestamp,
+					EventType:     "IMMEDIATE_DIFF",
+					Reason:        "DATA_UPDATED",
+					BlobPath:      newStatePath,
+					DataVersion:   "v1",
+					Summary: spanner.NullJSON{
+						Value: nil,
+						Valid: false,
+					},
+					DiffKind: nil,
+				}
+			},
+			newStatePath: newStatePath,
+			workerID:     workerID,
+			expectedErr:  nil,
+			assertAfterAction: func(t *testing.T, savedSearchID string, eventID *string) {
+				t.Helper()
+				assertPublishedEvent(ctx, t, SavedSearchNotificationEvent{
+					ID:            *eventID,
+					SavedSearchID: savedSearchID,
+					SnapshotType:  SavedSearchSnapshotType(snapshotType),
+					Timestamp:     spanner.CommitTimestamp,
+					EventType:     "IMMEDIATE_DIFF",
+					Reason:        "DATA_UPDATED",
+					BlobPath:      newStatePath,
+					DataVersion:   "v1",
+					Summary: spanner.NullJSON{
+						Value: nil,
+						Valid: false,
+					},
+					DiffKind: nil,
+				})
+				assertStateAndLockKept(ctx, t, savedSearchID, snapshotType, newStatePath, workerID, initialExpiration)
+			},
+		},
+		{
+			name: "fail - lock not owned by worker",
+			setup: func(t *testing.T, savedSearchID string) {
+				t.Helper()
+				setupLockAndInitialState(ctx, t, savedSearchID, snapshotType, workerID, initialBlobPath, ttl, fixedTime)
+			},
+			event: func(savedSearchID string) SavedSearchNotificationCreateRequest {
+				return SavedSearchNotificationCreateRequest{
+					SavedSearchID: savedSearchID,
+					SnapshotType:  SavedSearchSnapshotType(snapshotType),
+					Timestamp:     spanner.CommitTimestamp,
+					EventType:     "IMMEDIATE_DIFF",
+					Reason:        "DATA_UPDATED",
+					BlobPath:      newStatePath,
+					DataVersion:   "v1",
+					Summary: spanner.NullJSON{
+						Value: nil,
+						Valid: false,
+					},
+					DiffKind: nil,
+				}
+			},
+			newStatePath: newStatePath,
+			workerID:     "wrong-worker-id",
+			expectedErr:  ErrAlreadyLocked,
+			assertAfterAction: func(t *testing.T, savedSearchID string, _ *string) {
+				t.Helper()
+				assertStateUnchanged(ctx, t, savedSearchID, snapshotType, initialBlobPath, workerID, initialExpiration)
+				// No event should be published
+				_, err := spannerClient.GetSavedSearchNotificationEvent(ctx, uuid.NewString() /* arbitrary ID */)
+				if !errors.Is(err, ErrQueryReturnedNoResults) {
+					t.Errorf("expected no event to be published, but got %v", err)
+				}
+			},
+		},
+		{
+			name:  "fail - saved search state does not exist",
+			setup: noopSavedSearchStateHelper,
+			event: func(_ string) SavedSearchNotificationCreateRequest {
+				return SavedSearchNotificationCreateRequest{
+					SavedSearchID: "non-existent-search",
+					SnapshotType:  SavedSearchSnapshotType(snapshotType),
+					Timestamp:     spanner.CommitTimestamp,
+					EventType:     "IMMEDIATE_DIFF",
+					Reason:        "DATA_UPDATED",
+					BlobPath:      newStatePath,
+					DataVersion:   "v1",
+					Summary: spanner.NullJSON{
+						Value: nil,
+						Valid: false,
+					},
+					DiffKind: nil,
+				}
+			},
+			newStatePath: newStatePath,
+			workerID:     workerID,
+			expectedErr:  ErrQueryReturnedNoResults,
+			assertAfterAction: func(t *testing.T, _ string, _ *string) {
+				t.Helper()
+				// No event should be published
+				_, err := spannerClient.GetSavedSearchNotificationEvent(ctx, uuid.NewString() /* arbitrary ID */)
+				if !errors.Is(err, ErrQueryReturnedNoResults) {
+					t.Errorf("expected no event to be published, but got %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			restartDatabaseContainer(t)
+			savedSearchID := createSavedSearchForNotificationTests(ctx, t)
+
+			tc.setup(t, savedSearchID)
+			event := tc.event(savedSearchID)
+
+			eventID, err := spannerClient.PublishSavedSearchNotificationEvent(ctx, event, tc.newStatePath, tc.workerID)
+
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("PublishSavedSearchNotificationEvent() error = %v, want %v", err, tc.expectedErr)
+			}
+
+			tc.assertAfterAction(t, savedSearchID, eventID)
+		})
+	}
+}
+
+func TestGetSavedSearchNotificationEvent_NotFound(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// Test case for when the event is not found
+	_, err := spannerClient.GetSavedSearchNotificationEvent(ctx, "non-existent-event-id")
+	if !errors.Is(err, ErrQueryReturnedNoResults) {
+		t.Errorf("expected ErrQueryReturnedNoResults, got %v", err)
+	}
+}


### PR DESCRIPTION
This commit implements the persistence layer for notification events, acting as the "fact table" for the delivery pipeline. It includes the schema migration and the transactional logic required to atomically commit an event while updating the ingestion state.

Changes:
- Infrastructure: Added migration 000027.sql creating `SavedSearchNotificationEvents` with `ON DELETE CASCADE` and an index for RSS polling efficiency.
- Client: Implemented `PublishSavedSearchNotificationEvent`. This method performs a complex multi-table transaction that:
    1. Verifies the worker still holds the lock (fencing).
    2. Updates `SavedSearchState` with the new BlobPath while *explicitly preserving* the lock (to be released later via defer).
    3. Inserts the new event record.
- Client: Implemented `GetSavedSearchNotificationEvent` for retrieving event details.
- Tests: Added integration tests covering successful event publishing, lock ownership verification, and atomic state updates.