### PR TITLE
feat(spanner): add ID listing and subscription matchmaking methods

### DIFF
--- a/lib/gcpspanner/list_user_saved_searches_test.go
+++ b/lib/gcpspanner/list_user_saved_searches_test.go
@@ -280,3 +280,31 @@ func userSavedSearchesPageEquality(left, right *UserSavedSearchesPage) bool {
 		return userSavedSearchEquality(&a, &b)
 	})
 }
+
+func TestListAllSavedSearchIDs(t *testing.T) {
+	restartDatabaseContainer(t)
+	searches := loadFakeSavedSearches(t)
+
+	t.Run("list all saved search IDs", func(t *testing.T) {
+		ids, err := spannerClient.ListAllSavedSearchIDs(context.Background())
+		if err != nil {
+			t.Errorf("expected nil error. received %s", err)
+		}
+
+		if len(ids) != len(searches) {
+			t.Errorf("expected %d results. received %d", len(searches), len(ids))
+		}
+
+		expectedIDs := make([]string, len(searches))
+		for idx, search := range searches {
+			expectedIDs[idx] = search.ID
+		}
+
+		slices.Sort(ids)
+		slices.Sort(expectedIDs)
+
+		if !slices.Equal(ids, expectedIDs) {
+			t.Errorf("expected IDs %v but received %v", expectedIDs, ids)
+		}
+	})
+}


### PR DESCRIPTION
This commit implements the read queries required for the two main worker phases: batch triggering (Ingestion) and subscriber fan-out (Delivery).

Changes:
- Client: Added `ListAllSavedSearchIDs`. This performs a full ID scan of `SavedSearches`, enabling the Cloud Scheduler batch job to iterate over all entities.
- Client: Added `FindAllActivePushSubscriptions`. This is the "matchmaking" query for the delivery worker. It joins Subscriptions, Channels, and ChannelState to return only active, healthy, push-capable (Email/Webhook) destinations for a specific event.
- Tests: Added integration tests for both methods, verifying correct filtering of disabled channels and frequency mismatches.