### PR TITLE
feat(backend): refactor event schema for blob-based diffs and multi-reasons

### DIFF
--- a/infra/storage/spanner/migrations/000028.sql
+++ b/infra/storage/spanner/migrations/000028.sql
@@ -1,0 +1,31 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- 1. DiffBlobPath: Points to the GCS object containing the structured FeatureDiff.
+--    Replaces the idea of storing the raw JSON in the DB.
+--    Example: "gs://bucket/events/{event_id}/diff.json"
+--    This is similar to the existing BlobPath column which stores the summary blob path.
+--    The blob is self documenting and contains the vesion and kind information within it.
+ALTER TABLE SavedSearchNotificationEvents ADD COLUMN DiffBlobPath STRING(MAX);
+
+-- 2. Drop columns that are redundantly handled by the Blob Envelope (metadata inside the blob)
+ALTER TABLE SavedSearchNotificationEvents DROP COLUMN DiffKind;
+ALTER TABLE SavedSearchNotificationEvents DROP COLUMN DataVersion;
+
+-- 3. Change 'Reason' column to 'Reasons' ARRAY to support multiple reasons per event.
+-- The original 'Reason' column was a single string, which couldn't handle the
+-- "Both" scenario (Data Updated + Query Edited).
+-- We replace it with an ARRAY so we can tag an event with multiple reasons.
+ALTER TABLE SavedSearchNotificationEvents DROP COLUMN Reason;
+ALTER TABLE SavedSearchNotificationEvents ADD COLUMN Reasons ARRAY<STRING(MAX)>;

--- a/lib/gcpspanner/saved_search_notification_events.go
+++ b/lib/gcpspanner/saved_search_notification_events.go
@@ -29,11 +29,10 @@ type SavedSearchNotificationEvent struct {
 	SnapshotType  SavedSearchSnapshotType `spanner:"SnapshotType"`
 	Timestamp     time.Time               `spanner:"Timestamp"`
 	EventType     string                  `spanner:"EventType"`
-	Reason        string                  `spanner:"Reason"`
+	Reasons       []string                `spanner:"Reasons"`
 	BlobPath      string                  `spanner:"BlobPath"`
+	DiffBlobPath  string                  `spanner:"DiffBlobPath"`
 	Summary       spanner.NullJSON        `spanner:"Summary"`
-	DiffKind      *string                 `spanner:"DiffKind"`
-	DataVersion   string                  `spanner:"DataVersion"`
 }
 
 type SavedSearchNotificationCreateRequest struct {
@@ -41,11 +40,10 @@ type SavedSearchNotificationCreateRequest struct {
 	SnapshotType  SavedSearchSnapshotType `spanner:"SnapshotType"`
 	Timestamp     time.Time               `spanner:"Timestamp"`
 	EventType     string                  `spanner:"EventType"`
-	Reason        string                  `spanner:"Reason"`
+	Reasons       []string                `spanner:"Reasons"`
 	BlobPath      string                  `spanner:"BlobPath"`
+	DiffBlobPath  string                  `spanner:"DiffBlobPath"`
 	Summary       spanner.NullJSON        `spanner:"Summary"`
-	DiffKind      *string                 `spanner:"DiffKind"`
-	DataVersion   string                  `spanner:"DataVersion"`
 }
 
 func (c *Client) GetSavedSearchNotificationEvent(
@@ -77,11 +75,10 @@ func (m savedSearchNotificationEventMapper) NewEntity(id string, req SavedSearch
 		SnapshotType:  req.SnapshotType,
 		Timestamp:     req.Timestamp,
 		EventType:     req.EventType,
-		Reason:        req.Reason,
+		Reasons:       req.Reasons,
 		BlobPath:      req.BlobPath,
 		Summary:       req.Summary,
-		DiffKind:      req.DiffKind,
-		DataVersion:   req.DataVersion,
+		DiffBlobPath:  req.DiffBlobPath,
 	}, nil
 }
 

--- a/lib/gcpspanner/saved_search_notification_events_test.go
+++ b/lib/gcpspanner/saved_search_notification_events_test.go
@@ -141,6 +141,7 @@ func TestPublishSavedSearchNotificationEvent(t *testing.T) {
 	ttl := 10 * time.Minute
 	initialBlobPath := "path/initial"
 	newStatePath := "path/new"
+	newDiffBlobPath := "path/diff/new"
 
 	// Fixed time for deterministic tests
 	fixedTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
@@ -167,14 +168,13 @@ func TestPublishSavedSearchNotificationEvent(t *testing.T) {
 					SnapshotType:  SavedSearchSnapshotType(snapshotType),
 					Timestamp:     spanner.CommitTimestamp,
 					EventType:     "IMMEDIATE_DIFF",
-					Reason:        "DATA_UPDATED",
+					Reasons:       []string{"DATA_UPDATED", "QUERY_CHANGED"},
 					BlobPath:      newStatePath,
-					DataVersion:   "v1",
+					DiffBlobPath:  newDiffBlobPath,
 					Summary: spanner.NullJSON{
 						Value: nil,
 						Valid: false,
 					},
-					DiffKind: nil,
 				}
 			},
 			newStatePath: newStatePath,
@@ -188,14 +188,13 @@ func TestPublishSavedSearchNotificationEvent(t *testing.T) {
 					SnapshotType:  SavedSearchSnapshotType(snapshotType),
 					Timestamp:     spanner.CommitTimestamp,
 					EventType:     "IMMEDIATE_DIFF",
-					Reason:        "DATA_UPDATED",
+					Reasons:       []string{"DATA_UPDATED", "QUERY_CHANGED"},
 					BlobPath:      newStatePath,
-					DataVersion:   "v1",
+					DiffBlobPath:  newDiffBlobPath,
 					Summary: spanner.NullJSON{
 						Value: nil,
 						Valid: false,
 					},
-					DiffKind: nil,
 				})
 				assertStateAndLockKept(ctx, t, savedSearchID, snapshotType, newStatePath, workerID, initialExpiration)
 			},
@@ -212,14 +211,13 @@ func TestPublishSavedSearchNotificationEvent(t *testing.T) {
 					SnapshotType:  SavedSearchSnapshotType(snapshotType),
 					Timestamp:     spanner.CommitTimestamp,
 					EventType:     "IMMEDIATE_DIFF",
-					Reason:        "DATA_UPDATED",
+					Reasons:       []string{"DATA_UPDATED"},
 					BlobPath:      newStatePath,
-					DataVersion:   "v1",
+					DiffBlobPath:  newDiffBlobPath,
 					Summary: spanner.NullJSON{
 						Value: nil,
 						Valid: false,
 					},
-					DiffKind: nil,
 				}
 			},
 			newStatePath: newStatePath,
@@ -244,14 +242,13 @@ func TestPublishSavedSearchNotificationEvent(t *testing.T) {
 					SnapshotType:  SavedSearchSnapshotType(snapshotType),
 					Timestamp:     spanner.CommitTimestamp,
 					EventType:     "IMMEDIATE_DIFF",
-					Reason:        "DATA_UPDATED",
+					Reasons:       []string{"DATA_UPDATED"},
 					BlobPath:      newStatePath,
-					DataVersion:   "v1",
+					DiffBlobPath:  newDiffBlobPath,
 					Summary: spanner.NullJSON{
 						Value: nil,
 						Valid: false,
 					},
-					DiffKind: nil,
 				}
 			},
 			newStatePath: newStatePath,


### PR DESCRIPTION
Updates the `SavedSearchNotificationEvents` table to support the new architecture where detailed diffs are stored as self-describing blobs in GCS, and events can have multiple triggers.

Schema Changes (Migration 000028):
- Add `DiffBlobPath` to point to the structured diff in GCS (replaces embedded JSON).
- Drop `DiffKind` and `DataVersion` as metadata is now encapsulated in the Blob Envelope.
- Replace single `Reason` string with `Reasons` ARRAY<STRING> to support concurrent causes (e.g., Data Updated + Query Changed).

Library (`lib/gcpspanner`):
- Update `SavedSearchNotificationEvent` struct to use `[]string` for Reasons.
- Update entity mapping logic to support the new schema fields.
- Update tests to verify multi-reason persistence and diff blob paths.

We simply drop the old fields because we are not using this table yet in production, so no data migration is necessary.