### PR TITLE
feat(workers): implement feature comparison logic [2/4]

### DIFF
--- a/workers/event_producer/pkg/differ/comparator.go
+++ b/workers/event_producer/pkg/differ/comparator.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package differ
+
+import "github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+
+func calculateDiff(oldMap, newMap map[string]ComparableFeature) *FeatureDiff {
+	diff := new(FeatureDiff)
+
+	for id, newF := range newMap {
+		oldF, exists := oldMap[id]
+		if !exists {
+			diff.Added = append(diff.Added, FeatureAdded{
+				ID: id, Name: newF.Name.Value, Reason: ReasonNewMatch,
+			})
+
+			continue
+		}
+
+		if mod, changed := compareFeature(oldF, newF); changed {
+			diff.Modified = append(diff.Modified, mod)
+		}
+	}
+
+	for id, oldF := range oldMap {
+		if _, exists := newMap[id]; !exists {
+			diff.Removed = append(diff.Removed, FeatureRemoved{
+				ID: id, Name: oldF.Name.Value, Reason: ReasonUnmatched,
+			})
+		}
+	}
+
+	return diff
+}
+
+func compareFeature(oldF, newF ComparableFeature) (FeatureModified, bool) {
+	mod := FeatureModified{
+		ID:             newF.ID,
+		Name:           newF.Name.Value,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+	}
+	hasMods := false
+
+	// 1. Name Change
+	if oldF.Name.IsSet && oldF.Name.Value != newF.Name.Value {
+		mod.NameChange = &Change[string]{From: oldF.Name.Value, To: newF.Name.Value}
+		hasMods = true
+	}
+
+	// 2. Baseline Status
+	if oldF.BaselineStatus.IsSet && oldF.BaselineStatus.Value != newF.BaselineStatus.Value {
+		mod.BaselineChange = &Change[backend.BaselineInfoStatus]{From: oldF.BaselineStatus.Value,
+			To: newF.BaselineStatus.Value}
+		hasMods = true
+	}
+
+	// 3. Browser Implementations
+	// We check each field individually using a helper.
+	// This ensures we respect the IsSet flag for each browser independently.
+	if mod.BrowserChanges == nil {
+		mod.BrowserChanges = make(map[backend.SupportedBrowsers]*Change[string])
+	}
+
+	checkBrowser := func(key backend.SupportedBrowsers, oldB, newB OptionallySet[string]) {
+		if oldB.IsSet && oldB.Value != newB.Value {
+			mod.BrowserChanges[key] = &Change[string]{From: oldB.Value, To: newB.Value}
+			hasMods = true
+		}
+	}
+
+	// Note for future devs:
+	// The 'exhaustive' linter checks that this map literal contains every key from the enum.
+	// If we add a new browser, the linter will fail and let us know we should start calculating for that browser too.
+	browserMap := map[backend.SupportedBrowsers]struct {
+		Old OptionallySet[string]
+		New OptionallySet[string]
+	}{
+		backend.Chrome:         {oldF.BrowserImpls.Chrome, newF.BrowserImpls.Chrome},
+		backend.ChromeAndroid:  {oldF.BrowserImpls.ChromeAndroid, newF.BrowserImpls.ChromeAndroid},
+		backend.Edge:           {oldF.BrowserImpls.Edge, newF.BrowserImpls.Edge},
+		backend.Firefox:        {oldF.BrowserImpls.Firefox, newF.BrowserImpls.Firefox},
+		backend.FirefoxAndroid: {oldF.BrowserImpls.FirefoxAndroid, newF.BrowserImpls.FirefoxAndroid},
+		backend.Safari:         {oldF.BrowserImpls.Safari, newF.BrowserImpls.Safari},
+		backend.SafariIos:      {oldF.BrowserImpls.SafariIos, newF.BrowserImpls.SafariIos},
+	}
+
+	// EXECUTE: Iterate over the map.
+	for key, data := range browserMap {
+		checkBrowser(key, data.Old, data.New)
+	}
+
+	return mod, hasMods
+}

--- a/workers/event_producer/pkg/differ/comparator_test.go
+++ b/workers/event_producer/pkg/differ/comparator_test.go
@@ -1,0 +1,270 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package differ
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func newBaseFeature(id, name, status string) ComparableFeature {
+	return ComparableFeature{
+		ID:             id,
+		Name:           OptionallySet[string]{Value: name, IsSet: true},
+		BaselineStatus: OptionallySet[backend.BaselineInfoStatus]{Value: backend.BaselineInfoStatus(status), IsSet: true},
+		BrowserImpls: BrowserImplementations{
+			Chrome:         unsetOptionalSet[string](),
+			ChromeAndroid:  unsetOptionalSet[string](),
+			Edge:           unsetOptionalSet[string](),
+			Firefox:        unsetOptionalSet[string](),
+			FirefoxAndroid: unsetOptionalSet[string](),
+			Safari:         unsetOptionalSet[string](),
+			SafariIos:      unsetOptionalSet[string](),
+		},
+	}
+}
+
+func TestCalculateDiff(t *testing.T) {
+	tests := []struct {
+		name         string
+		oldMap       map[string]ComparableFeature
+		newMap       map[string]ComparableFeature
+		wantAdded    int
+		wantRemoved  int
+		wantModified int
+	}{
+		{
+			name:         "No Changes",
+			oldMap:       map[string]ComparableFeature{"1": newBaseFeature("1", "A", "limited")},
+			newMap:       map[string]ComparableFeature{"1": newBaseFeature("1", "A", "limited")},
+			wantAdded:    0,
+			wantRemoved:  0,
+			wantModified: 0,
+		},
+		{
+			name:         "Addition",
+			oldMap:       map[string]ComparableFeature{},
+			newMap:       map[string]ComparableFeature{"2": newBaseFeature("2", "A", "limited")},
+			wantAdded:    1,
+			wantRemoved:  0,
+			wantModified: 0,
+		},
+		{
+			name:         "Removal",
+			oldMap:       map[string]ComparableFeature{"1": newBaseFeature("1", "A", "limited")},
+			newMap:       map[string]ComparableFeature{},
+			wantAdded:    0,
+			wantRemoved:  1,
+			wantModified: 0,
+		},
+		{
+			name: "Modification",
+			oldMap: map[string]ComparableFeature{
+				"1": newBaseFeature("1", "A", "limited"),
+			},
+			newMap: map[string]ComparableFeature{
+				"1": newBaseFeature("1", "A", "widely"),
+			},
+			wantAdded:    0,
+			wantRemoved:  0,
+			wantModified: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diff := calculateDiff(tc.oldMap, tc.newMap)
+			if len(diff.Added) != tc.wantAdded {
+				t.Errorf("Added count: got %d, want %d", len(diff.Added), tc.wantAdded)
+			}
+			if len(diff.Removed) != tc.wantRemoved {
+				t.Errorf("Removed count: got %d, want %d", len(diff.Removed), tc.wantRemoved)
+			}
+			if len(diff.Modified) != tc.wantModified {
+				t.Errorf("Modified count: got %d, want %d", len(diff.Modified), tc.wantModified)
+			}
+		})
+	}
+}
+
+func TestCompareFeature_Fields(t *testing.T) {
+	tests := []struct {
+		name      string
+		oldF      ComparableFeature
+		newF      ComparableFeature
+		wantMod   bool
+		checkDiff func(t *testing.T, m FeatureModified)
+	}{
+		{
+			name:    "Name Change",
+			oldF:    newBaseFeature("1", "Old Name", "limited"),
+			newF:    newBaseFeature("1", "New Name", "limited"),
+			wantMod: true,
+			checkDiff: func(t *testing.T, m FeatureModified) {
+				if m.NameChange == nil {
+					t.Fatal("NameChange is nil")
+				}
+				if m.NameChange.From != "Old Name" || m.NameChange.To != "New Name" {
+					t.Errorf("NameChange mismatch: %v", m.NameChange)
+				}
+			},
+		},
+		{
+			name:    "Baseline Change",
+			oldF:    newBaseFeature("1", "A", "limited"),
+			newF:    newBaseFeature("1", "A", "widely"),
+			wantMod: true,
+			checkDiff: func(t *testing.T, m FeatureModified) {
+				if m.BaselineChange == nil {
+					t.Fatal("BaselineChange is nil")
+				}
+				if m.BaselineChange.From != backend.Limited || m.BaselineChange.To != backend.Widely {
+					t.Errorf("BaselineChange mismatch: %v", m.BaselineChange)
+				}
+			},
+		},
+		{
+			name: "Browser Implementation Change",
+			oldF: func() ComparableFeature {
+				f := newBaseFeature("1", "A", "limited")
+				f.BrowserImpls.Chrome = OptionallySet[string]{Value: "unavailable", IsSet: true}
+
+				return f
+			}(),
+			newF: func() ComparableFeature {
+				f := newBaseFeature("1", "A", "limited")
+				f.BrowserImpls.Chrome = OptionallySet[string]{Value: "available", IsSet: true}
+
+				return f
+			}(),
+			wantMod: true,
+			checkDiff: func(t *testing.T, m FeatureModified) {
+				if len(m.BrowserChanges) == 0 {
+					t.Fatal("BrowserChanges is empty")
+				}
+				if chg, ok := m.BrowserChanges[backend.Chrome]; !ok || chg.To != "available" {
+					t.Errorf("Chrome change mismatch: %v", chg)
+				}
+			},
+		},
+		{
+			name: "Browser Implementation Schema Evolution (Missing in Old)",
+			oldF: func() ComparableFeature {
+				f := newBaseFeature("1", "A", "limited")
+				f.BrowserImpls.Chrome = OptionallySet[string]{Value: "", IsSet: false} // Missing
+
+				return f
+			}(),
+			newF: func() ComparableFeature {
+				f := newBaseFeature("1", "A", "limited")
+				f.BrowserImpls.Chrome = OptionallySet[string]{Value: "available", IsSet: true} // Present
+
+				return f
+			}(),
+			wantMod:   false, // Should NOT detect change
+			checkDiff: func(_ *testing.T, _ FeatureModified) {},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mod, changed := compareFeature(tc.oldF, tc.newF)
+			if changed != tc.wantMod {
+				t.Errorf("compareFeature() changed = %v, want %v", changed, tc.wantMod)
+			}
+			if changed && tc.checkDiff != nil {
+				tc.checkDiff(t, mod)
+			}
+		})
+	}
+}
+
+func unsetOptionalSet[T any]() OptionallySet[T] {
+	var value T
+
+	return OptionallySet[T]{
+		Value: value,
+		IsSet: false,
+	}
+}
+
+// TestSchemaEvolution_QuietRollout demonstrates exactly how the system behaves
+// when a new field is added to the code but missing from GCS blobs.
+func TestSchemaEvolution_QuietRollout(t *testing.T) {
+	// 1. Simulate an "Old Blob" (V1)
+	// Missing "browserImplementations" entirely.
+	legacyJSON := `{
+		"id": "feat-123",
+		"name": "My Feature",
+		"baselineStatus": "limited"
+	}`
+
+	// 2. Unmarshal into Current Struct
+	var oldFeature ComparableFeature
+	if err := json.Unmarshal([]byte(legacyJSON), &oldFeature); err != nil {
+		t.Fatalf("Failed to unmarshal legacy json: %v", err)
+	}
+
+	// Verify IsSet=false for the missing fields inside the struct
+	if oldFeature.BrowserImpls.Chrome.IsSet {
+		t.Fatal("Expected Chrome.IsSet to be false for legacy blob")
+	}
+
+	// 3. Create "New Live Data" (V2)
+	// We populate the struct manually to simulate a live fetch
+	newFeature := ComparableFeature{
+		ID:             "feat-123",
+		Name:           OptionallySet[string]{Value: "My Feature", IsSet: true},
+		BaselineStatus: OptionallySet[backend.BaselineInfoStatus]{Value: "limited", IsSet: true},
+		BrowserImpls: BrowserImplementations{
+			Chrome:         OptionallySet[string]{Value: "available", IsSet: true},
+			ChromeAndroid:  unsetOptionalSet[string](),
+			Edge:           unsetOptionalSet[string](),
+			Firefox:        unsetOptionalSet[string](),
+			FirefoxAndroid: unsetOptionalSet[string](),
+			Safari:         unsetOptionalSet[string](),
+			SafariIos:      unsetOptionalSet[string](),
+		},
+	}
+
+	// 4. Run Comparison
+	mod, changed := compareFeature(oldFeature, newFeature)
+
+	// 5. Assert "Quiet Rollout"
+	// Even though Old.Chrome was unset and New.Chrome is "available",
+	// the comparator should skip it because Old.Chrome.IsSet is false.
+	if changed {
+		t.Errorf("Quiet Rollout Failed! Expected no changes, but got: %+v", mod)
+	}
+
+	// 6. Assert Mixed Update Safety
+	// Modify an existing field to ensure it is still caught.
+	newFeature.BaselineStatus.Value = "newly" // Real update!
+
+	mod, changed = compareFeature(oldFeature, newFeature)
+
+	if !changed {
+		t.Error("Mixed Update Failed! Expected baseline change to trigger alert.")
+	}
+	if mod.BaselineChange == nil {
+		t.Error("Expected BaselineChange to be populated.")
+	}
+	// The new field should STILL be ignored
+	if _, ok := mod.BrowserChanges[backend.Chrome]; ok {
+		t.Error("Expected BrowserChanges[chrome] to still be ignored (Quiet Rollout).")
+	}
+}


### PR DESCRIPTION
**For more information about the differ, refer to the docs in https://github.com/GoogleChrome/webstatus.dev/pull/2083**

Adds the core business logic for comparing feature states in the Event Producer worker. This commit implements the `Comparator` component, which detects granular changes between feature snapshots while safely handling schema evolution.

New File `pkg/differ/comparator.go`:
- **`calculateDiff`**: Iterates over previous and current feature maps to classify features as Added, Removed, or Modified.
- **`compareFeature`**: Performs field-level comparison (Name, Baseline Status, Browser Implementations).
- **Quiet Rollout Logic**: Uses the `OptionallySet.IsSet` flag to guard comparisons. If a field was missing in the previous snapshot (legacy schema), comparison is skipped to prevent false positive alerts during deployment.

Testing (`pkg/differ/comparator_test.go`):
- Added `TestCalculateDiff` covering basic lifecycle events (Add/Remove/Modify).
- Added `TestCompareFeature_Fields` to verify specific field change detection and schema evolution behavior.