### PR TITLE
feat(workers): implement feature history reconciliation logic [3/4]

### DIFF
--- a/workers/event_producer/go.mod
+++ b/workers/event_producer/go.mod
@@ -9,6 +9,7 @@ replace github.com/GoogleChrome/webstatus.dev/lib/gen => ../../lib/gen
 require (
 	github.com/GoogleChrome/webstatus.dev/lib v0.0.0-00010101000000-000000000000
 	github.com/GoogleChrome/webstatus.dev/lib/gen v0.0.0-20251119220853-b545639c35ae
+	github.com/google/go-cmp v0.7.0
 )
 
 require (

--- a/workers/event_producer/pkg/differ/reconciler.go
+++ b/workers/event_producer/pkg/differ/reconciler.go
@@ -1,0 +1,207 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package differ
+
+import (
+	"context"
+	"errors"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+)
+
+// reconcileHistory analyzes the "Removed" list to detect if features were actually Moved or Split
+// rather than deleted.
+//
+// It performs a "Detective" pass:
+// 1. For every removed feature, ask the DB: "What is your current status?"
+// 2. If the DB says "I moved to ID 'B'", we check if 'B' is in our "Added" list.
+// 3. If yes, we link them together into a "Move" event and remove them from the raw Added/Removed lists.
+//
+// This transforms a confusing [Removed: "Grid", Added: "CSS Grid"] diff into a clear
+// [Moved: "Grid" -> "CSS Grid"] diff.
+func (d *FeatureDiffer) reconcileHistory(ctx context.Context, diff *FeatureDiff) (*FeatureDiff, error) {
+	renames := make(map[string]string)
+	splits := make(map[string][]string)
+	visitor := &reconciliationVisitor{renames: renames, splits: splits, currentID: ""}
+
+	// Phase 1: Investigation
+	// Iterate through all removed features to build a map of their historical outcomes.
+	for i := range diff.Removed {
+		r := &diff.Removed[i]
+
+		// Check the current status of the removed feature ID in the database.
+		result, err := d.client.GetFeature(ctx, r.ID)
+		if err != nil {
+			// If the entity is completely gone from the DB, it's a true deletion.
+			// We update the reason to allow for specific UI messaging (e.g. "Deleted from platform").
+			if errors.Is(err, backendtypes.ErrEntityDoesNotExist) {
+				r.Reason = ReasonDeleted
+
+				continue
+			}
+
+			return nil, err
+		}
+
+		// Update the visitor context so it knows which OldID owns the result we are about to visit.
+		visitor.currentID = r.ID
+
+		// Dispatch based on whether the feature is Regular (exists), Moved, or Split.
+		if err := result.Visit(ctx, visitor); err != nil {
+			return nil, err
+		}
+	}
+
+	// Phase 2: Correlation
+	// If we found any history records, try to match them with the 'Added' list.
+	if len(renames) > 0 {
+		reconcileMoves(diff, renames)
+	}
+	if len(splits) > 0 {
+		reconcileSplits(diff, splits)
+	}
+
+	return diff, nil
+}
+
+// reconciliationVisitor implements the Visitor pattern to populate the renames/splits maps
+// based on the polymorphic result returned by GetFeature.
+type reconciliationVisitor struct {
+	currentID string
+	renames   map[string]string
+	splits    map[string][]string
+}
+
+func (v *reconciliationVisitor) VisitRegularFeature(_ context.Context, _ backendtypes.RegularFeatureResult) error {
+	// No-op: The feature exists in the DB (is Regular) but was removed from our snapshot.
+	// This implies it simply fell out of scope of the user's query (e.g. tags changed).
+	// We leave it as a standard "Removed" item with ReasonUnmatched.
+	return nil
+}
+
+func (v *reconciliationVisitor) VisitMovedFeature(_ context.Context, result backendtypes.MovedFeatureResult) error {
+	v.renames[v.currentID] = result.NewFeatureID()
+
+	return nil
+}
+
+func (v *reconciliationVisitor) VisitSplitFeature(_ context.Context, result backendtypes.SplitFeatureResult) error {
+	splitFeatures := result.SplitFeature()
+	targetIDs := make([]string, 0, len(splitFeatures.Features))
+	for _, f := range splitFeatures.Features {
+		targetIDs = append(targetIDs, f.Id)
+	}
+	v.splits[v.currentID] = targetIDs
+
+	return nil
+}
+
+// reconcileMoves modifies the diff in-place. It pairs Removed items with Added items
+// based on the provided renames map (OldID -> NewID).
+func reconcileMoves(diff *FeatureDiff, renames map[string]string) {
+	// Index the Added list for O(1) lookups
+	addedMap := make(map[string]FeatureAdded)
+	for _, a := range diff.Added {
+		addedMap[a.ID] = a
+	}
+
+	var newRemoved []FeatureRemoved
+	newMoves := diff.Moves
+
+	for _, r := range diff.Removed {
+		newID, isRenamed := renames[r.ID]
+		target, isAdded := addedMap[newID]
+
+		// A Move is only valid for *this* diff if the target ID is actually present in the 'Added' list.
+		// If the target ID is missing (e.g. filtered out by the user's query), we treat the original
+		// item as simply Removed.
+		if isRenamed && isAdded {
+			newMoves = append(newMoves, FeatureMoved{
+				FromID:   r.ID,
+				ToID:     newID,
+				FromName: r.Name,
+				ToName:   target.Name,
+			})
+			// Consume the added item so it doesn't appear as a standalone "Added" event later.
+			delete(addedMap, newID)
+		} else {
+			newRemoved = append(newRemoved, r)
+		}
+	}
+
+	// Reconstruct the Added list with only the remaining (unclaimed) items.
+	var newAdded []FeatureAdded
+	for _, a := range diff.Added {
+		if _, exists := addedMap[a.ID]; exists {
+			newAdded = append(newAdded, a)
+		}
+	}
+
+	diff.Removed = newRemoved
+	diff.Added = newAdded
+	diff.Moves = newMoves
+}
+
+// reconcileSplits modifies the diff in-place. It pairs Removed items with one or more Added items
+// based on the provided splits map (OldID -> [NewID...]).
+func reconcileSplits(diff *FeatureDiff, splits map[string][]string) {
+	addedMap := make(map[string]FeatureAdded)
+	for _, a := range diff.Added {
+		addedMap[a.ID] = a
+	}
+
+	var newRemoved []FeatureRemoved
+	newSplits := diff.Splits
+
+	for _, r := range diff.Removed {
+		targetIDs, isSplit := splits[r.ID]
+		var foundTargets []FeatureAdded
+		foundAny := false
+
+		if isSplit {
+			for _, targetID := range targetIDs {
+				// Check if any of the split targets are in our Added list.
+				// Even if only 1 of 5 targets matches the user's query, we still report it as a Split.
+				if target, isAdded := addedMap[targetID]; isAdded {
+					foundTargets = append(foundTargets, target)
+					foundAny = true
+					// Consume the added item
+					delete(addedMap, targetID)
+				}
+			}
+		}
+
+		if foundAny {
+			newSplits = append(newSplits, FeatureSplit{
+				FromID:   r.ID,
+				FromName: r.Name,
+				To:       foundTargets,
+			})
+		} else {
+			newRemoved = append(newRemoved, r)
+		}
+	}
+
+	var newAdded []FeatureAdded
+	for _, a := range diff.Added {
+		if _, exists := addedMap[a.ID]; exists {
+			newAdded = append(newAdded, a)
+		}
+	}
+
+	diff.Removed = newRemoved
+	diff.Added = newAdded
+	diff.Splits = newSplits
+}

--- a/workers/event_producer/pkg/differ/reconciler_test.go
+++ b/workers/event_producer/pkg/differ/reconciler_test.go
@@ -1,0 +1,391 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package differ
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/google/go-cmp/cmp"
+)
+
+// mockReconcileClient mocks the FeatureFetcher interface for reconciliation tests.
+type mockReconcileClient struct {
+	// Map featureID -> Result to return
+	results map[string]*backendtypes.GetFeatureResult
+	// Map featureID -> Error to return
+	errors map[string]error
+}
+
+func (m *mockReconcileClient) FetchFeatures(_ context.Context, _ string) ([]backend.Feature, error) {
+	return nil, nil // Not used in reconciler tests
+}
+
+func (m *mockReconcileClient) GetFeature(
+	_ context.Context,
+	featureID string,
+) (*backendtypes.GetFeatureResult, error) {
+	if err, ok := m.errors[featureID]; ok {
+		return nil, err
+	}
+	if res, ok := m.results[featureID]; ok {
+		return res, nil
+	}
+	// Default to not found if not mocked
+	return nil, backendtypes.ErrEntityDoesNotExist
+}
+
+func TestReconcileHistory(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialDiff  *FeatureDiff
+		mockResults  map[string]*backendtypes.GetFeatureResult
+		mockErrors   map[string]error
+		expectedDiff *FeatureDiff
+		wantErr      bool
+	}{
+		{
+			name: "Scenario 1: Feature Moved (Rename)",
+			initialDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "old-id", Name: "Old Name", Reason: ReasonUnmatched}},
+				Added:        []FeatureAdded{{ID: "new-id", Name: "New Name", Reason: ReasonNewMatch}},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"old-id": backendtypes.NewGetFeatureResult(
+					backendtypes.NewMovedFeatureResult("new-id"),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				Removed: nil, // Should be cleared
+				Added:   nil, // Should be cleared
+				Moves: []FeatureMoved{
+					{FromID: "old-id", FromName: "Old Name", ToID: "new-id", ToName: "New Name"},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Splits:       nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 2: Feature Split (Full)",
+			initialDiff: &FeatureDiff{
+				Removed: []FeatureRemoved{{ID: "monolith", Name: "Monolith Feature", Reason: ReasonUnmatched}},
+				Added: []FeatureAdded{
+					{ID: "part-1", Name: "Part 1", Reason: ReasonNewMatch},
+					{ID: "part-2", Name: "Part 2", Reason: ReasonNewMatch},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"monolith": backendtypes.NewGetFeatureResult(
+					backendtypes.NewSplitFeatureResult(backend.FeatureEvolutionSplit{
+						Features: []backend.FeatureSplitInfo{
+							{Id: "part-1"},
+							{Id: "part-2"},
+						},
+					}),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				Removed: nil,
+				Added:   nil,
+				Splits: []FeatureSplit{
+					{
+						FromID:   "monolith",
+						FromName: "Monolith Feature",
+						To: []FeatureAdded{
+							{ID: "part-1", Name: "Part 1", Reason: ReasonNewMatch},
+							{ID: "part-2", Name: "Part 2", Reason: ReasonNewMatch},
+						},
+					},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 3: Feature Split (Partial / Out of Scope)",
+			// 'part-2' matches the split definition but isn't in the Added list (maybe filtered out by query)
+			initialDiff: &FeatureDiff{
+				Removed: []FeatureRemoved{{ID: "monolith", Name: "Monolith Feature", Reason: ReasonUnmatched}},
+				Added: []FeatureAdded{
+					{ID: "part-1", Name: "Part 1", Reason: ReasonNewMatch},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"monolith": backendtypes.NewGetFeatureResult(
+					backendtypes.NewSplitFeatureResult(backend.FeatureEvolutionSplit{
+						Features: []backend.FeatureSplitInfo{
+							{Id: "part-1"},
+							{Id: "part-2"},
+						},
+					}),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				Removed: nil,
+				Added:   nil,
+				Splits: []FeatureSplit{
+					{
+						FromID:   "monolith",
+						FromName: "Monolith Feature",
+						// Only part-1 is included because part-2 wasn't in the 'Added' list
+						To: []FeatureAdded{
+							{ID: "part-1", Name: "Part 1", Reason: ReasonNewMatch},
+						},
+					},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 4: Regular Removal (No Move/Split)",
+			initialDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "removed-id", Name: "Removed Feature", Reason: ReasonUnmatched}},
+				Added:        nil,
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"removed-id": backendtypes.NewGetFeatureResult(
+					backendtypes.NewRegularFeatureResult(&backend.Feature{
+						FeatureId:              "removed-id",
+						Name:                   "",
+						Spec:                   nil,
+						Baseline:               nil,
+						BrowserImplementations: nil,
+						Discouraged:            nil,
+						Usage:                  nil,
+						Wpt:                    nil,
+						VendorPositions:        nil,
+						DeveloperSignals:       nil,
+					}),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				// Remains in Removed list
+				Removed:      []FeatureRemoved{{ID: "removed-id", Name: "Removed Feature", Reason: ReasonUnmatched}},
+				Added:        nil,
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 5: Hard Delete (EntityDoesNotExist)",
+			initialDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "deleted-id", Name: "Deleted Feature", Reason: ReasonUnmatched}},
+				Added:        nil,
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: nil,
+			mockErrors: map[string]error{
+				"deleted-id": backendtypes.ErrEntityDoesNotExist,
+			},
+			expectedDiff: &FeatureDiff{
+				// Remains in Removed list, but Reason updated to Deleted
+				Removed:      []FeatureRemoved{{ID: "deleted-id", Name: "Deleted Feature", Reason: ReasonDeleted}},
+				Added:        nil,
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 6: Move Target Missing from Added List",
+			// History says A moved to B, but B is NOT in the Added list.
+			// Should act as a regular removal.
+			initialDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "old-id", Name: "Old Name", Reason: ReasonUnmatched}},
+				Added:        []FeatureAdded{{ID: "unrelated-id", Name: "Unrelated", Reason: ReasonNewMatch}},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"old-id": backendtypes.NewGetFeatureResult(
+					backendtypes.NewMovedFeatureResult("missing-new-id"),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "old-id", Name: "Old Name", Reason: ReasonUnmatched}},
+				Added:        []FeatureAdded{{ID: "unrelated-id", Name: "Unrelated", Reason: ReasonNewMatch}},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 7: DB Error",
+			initialDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "error-id", Name: "Error Feature", Reason: ReasonUnmatched}},
+				Added:        nil,
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: nil,
+			mockErrors: map[string]error{
+				"error-id": errors.New("db connection failed"),
+			},
+			expectedDiff: nil,
+			wantErr:      true,
+		},
+		{
+			name: "Scenario 8: Split Targets Completely Missing",
+			// History says A split into B, but B is NOT in the Added list.
+			// Should act as a regular removal (hitting the 'else' block).
+			initialDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "monolith", Name: "Monolith Feature", Reason: ReasonUnmatched}},
+				Added:        []FeatureAdded{{ID: "unrelated", Name: "Unrelated", Reason: ReasonNewMatch}},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"monolith": backendtypes.NewGetFeatureResult(
+					backendtypes.NewSplitFeatureResult(backend.FeatureEvolutionSplit{
+						Features: []backend.FeatureSplitInfo{
+							{Id: "missing-part"},
+						},
+					}),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "monolith", Name: "Monolith Feature", Reason: ReasonUnmatched}},
+				Added:        []FeatureAdded{{ID: "unrelated", Name: "Unrelated", Reason: ReasonNewMatch}},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 9: Unrelated Additions Preserved",
+			// A moved to B. C is just a new feature.
+			// Result should be Move(A->B) + Added(C). B should NOT be in Added list.
+			initialDiff: &FeatureDiff{
+				Removed: []FeatureRemoved{{ID: "old-id", Name: "Old Name", Reason: ReasonUnmatched}},
+				Added: []FeatureAdded{
+					{ID: "new-id", Name: "New Name", Reason: ReasonNewMatch},
+					{ID: "extra-id", Name: "Extra Feature", Reason: ReasonNewMatch},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"old-id": backendtypes.NewGetFeatureResult(
+					backendtypes.NewMovedFeatureResult("new-id"),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				Removed: nil,
+				Added:   []FeatureAdded{{ID: "extra-id", Name: "Extra Feature", Reason: ReasonNewMatch}},
+				Moves: []FeatureMoved{
+					{FromID: "old-id", FromName: "Old Name", ToID: "new-id", ToName: "New Name"},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Splits:       nil,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &mockReconcileClient{
+				results: tc.mockResults,
+				errors:  tc.mockErrors,
+			}
+			differ := NewFeatureDiffer(client)
+
+			// We manually sort inputs here to ensure the test case inputs match
+			// what a real system might produce before reconciliation.
+			// (Though in reality, the Comparator output is usually unsorted until Run() finishes).
+			if tc.initialDiff != nil {
+				tc.initialDiff.Sort()
+			}
+
+			gotDiff, err := differ.reconcileHistory(context.Background(), tc.initialDiff)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("reconcileHistory() expected error, got nil")
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("reconcileHistory() unexpected error: %v", err)
+			}
+
+			if gotDiff != nil {
+				gotDiff.Sort()
+			}
+			if tc.expectedDiff != nil {
+				tc.expectedDiff.Sort()
+			}
+
+			if diff := cmp.Diff(tc.expectedDiff, gotDiff); diff != "" {
+				t.Errorf("reconcileHistory() mismatch. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/workers/event_producer/pkg/differ/types.go
+++ b/workers/event_producer/pkg/differ/types.go
@@ -15,6 +15,7 @@
 package differ
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/blobtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
@@ -52,6 +55,26 @@ const (
 	ReasonUnmatched ChangeReason = "unmatched"
 	ReasonDeleted   ChangeReason = "deleted"
 )
+
+// FeatureFetcher abstracts the external API.
+type FeatureFetcher interface {
+	FetchFeatures(ctx context.Context, query string) ([]backend.Feature, error)
+	GetFeature(ctx context.Context, featureID string) (*backendtypes.GetFeatureResult, error)
+}
+
+type FeatureDiffer struct {
+	client   FeatureFetcher
+	migrator *blobtypes.Migrator
+}
+
+func NewFeatureDiffer(client FeatureFetcher) *FeatureDiffer {
+	m := blobtypes.NewMigrator()
+
+	return &FeatureDiffer{
+		client:   client,
+		migrator: m,
+	}
+}
 
 // --- Generics ---
 


### PR DESCRIPTION
**For more information about the differ, refer to the docs in https://github.com/GoogleChrome/webstatus.dev/pull/2083**

Adds the reconciliation layer to the Event Producer. This logic runs after the raw diff calculation to correlate "Removed" features with "Added" features by checking the historical record (Moves/Splits). This ensures users receive continuity alerts (e.g., "Grid Renamed to CSS Grid") instead of confusing "Removed/Added" noise.

New File `pkg/differ/reconciler.go`:
- Implements `reconcileHistory`: Iterates through removed features and queries the backend to determine their current status.
- Implements `reconcileMoves`: Detects 1:1 renames by matching a Moved feature's new ID with an entry in the Added list.
- Implements `reconcileSplits`: Detects 1:N splits by checking if any target IDs from a Split record exist in the Added list.

New File `pkg/differ/reconciler_test.go`:
- Adds comprehensive test scenarios for Moves, Full Splits, Partial/Out-of-Scope Splits, Hard Deletes, and Database Errors.

Updated `pkg/differ/types.go`:
- Defines the `FeatureDiffer` struct and `FeatureFetcher` interface to support the new reconciliation dependencies.

Dependencies:
- Adds `google/go-cmp` for deterministic struct comparison in tests.