### PR TITLE
feat(workers): implement feature differ orchestration logic [4/4]

### DIFF
--- a/workers/event_producer/go.mod
+++ b/workers/event_producer/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/GoogleChrome/webstatus.dev/lib v0.0.0-00010101000000-000000000000
 	github.com/GoogleChrome/webstatus.dev/lib/gen v0.0.0-20251119220853-b545639c35ae
 	github.com/google/go-cmp v0.7.0
+	github.com/oapi-codegen/runtime v1.1.2
 )
 
 require (
@@ -48,7 +49,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/oapi-codegen/runtime v1.1.2 // indirect
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect

--- a/workers/event_producer/pkg/differ/differ.go
+++ b/workers/event_producer/pkg/differ/differ.go
@@ -1,0 +1,262 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package differ
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/blobtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// Run executes the core diffing pipeline.
+func (d *FeatureDiffer) Run(ctx context.Context, searchID string, query string,
+	previousStateBytes []byte) ([]byte, *FeatureDiff, bool, error) {
+	// 1. Load Context
+	prevCtx, err := d.loadPreviousContext(previousStateBytes)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("%w: failed to load previous state: %w", ErrFatal, err)
+	}
+
+	// 2. Plan
+	plan := d.determinePlan(query, prevCtx)
+
+	// 3. Execute Fetch
+	data, err := d.executePlan(ctx, plan)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("%w: failed to fetch data: %w", ErrTransient, err)
+	}
+	data.OldSnapshot = prevCtx.Snapshot
+
+	// 4. Compute Pure Diff
+	var diff *FeatureDiff
+	// We check data.TargetSnapshot != nil because if the Flush Strategy failed (in executePlan),
+	// it returns nil to signal "Skip Diffing".
+	// toSnapshot() guarantees a non-nil map (empty map) for valid empty results,
+	// so nil strictly means "Data Not Available".
+	if !plan.IsColdStart && data.TargetSnapshot != nil {
+		diff = calculateDiff(data.OldSnapshot, data.TargetSnapshot)
+	} else {
+		diff = new(FeatureDiff)
+	}
+
+	// 5. Reconcile History
+	if len(diff.Removed) > 0 && !plan.IsColdStart {
+		diff, err = d.reconcileHistory(ctx, diff)
+		if err != nil {
+			return nil, nil, false, fmt.Errorf("%w: failed to reconcile history: %w", ErrTransient, err)
+		}
+	}
+
+	if plan.QueryChanged {
+		diff.QueryChanged = true
+	}
+
+	// 6. Finalize (Sort & Decide)
+	if diff != nil {
+		diff.Sort()
+	}
+
+	// 7. Output Decision
+	shouldWrite := diff.HasChanges() || plan.IsColdStart || plan.QueryChanged
+	if !shouldWrite {
+		return nil, nil, false, nil
+	}
+
+	newStateBytes, err := d.serializeState(searchID, query, data.NewSnapshot)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("%w: failed to serialize new state: %w", ErrFatal, err)
+	}
+
+	return newStateBytes, diff, true, nil
+}
+
+func (d *FeatureDiffer) serializeState(searchID, query string, snapshot map[string]ComparableFeature) ([]byte, error) {
+	payload := FeatureListSnapshot{
+		Metadata: StateMetadata{
+			GeneratedAt:    time.Now(),
+			SearchID:       searchID,
+			QuerySignature: query,
+		},
+		Data: FeatureListData{
+			Features: snapshot,
+		},
+	}
+
+	return blobtypes.NewBlob(payload)
+}
+
+// --- Internal Helper: Context Loading ---
+
+type previousContext struct {
+	Signature string
+	Snapshot  map[string]ComparableFeature
+	IsEmpty   bool
+}
+
+func (d *FeatureDiffer) loadPreviousContext(bytes []byte) (previousContext, error) {
+	if len(bytes) == 0 {
+		return previousContext{IsEmpty: true, Signature: "", Snapshot: nil}, nil
+	}
+
+	migratedBytes, err := blobtypes.Apply[FeatureListSnapshot](d.migrator, bytes)
+	if err != nil {
+		return previousContext{}, err
+	}
+
+	var snapshot FeatureListSnapshot
+	if err := json.Unmarshal(migratedBytes, &snapshot); err != nil {
+		return previousContext{}, fmt.Errorf("failed to unmarshal snapshot: %w", err)
+	}
+
+	return previousContext{
+		Signature: snapshot.Metadata.QuerySignature,
+		Snapshot:  snapshot.Data.Features,
+		IsEmpty:   false,
+	}, nil
+}
+
+// --- Internal Helper: Planning ---
+
+type executionPlan struct {
+	IsColdStart   bool
+	QueryChanged  bool
+	CurrentQuery  string
+	PreviousQuery string
+}
+
+func (d *FeatureDiffer) determinePlan(currentQuery string, prev previousContext) executionPlan {
+	plan := executionPlan{
+		CurrentQuery:  currentQuery,
+		PreviousQuery: "",
+		IsColdStart:   false,
+		QueryChanged:  false,
+	}
+
+	if prev.IsEmpty {
+		plan.IsColdStart = true
+
+		return plan
+	}
+
+	if prev.Signature != currentQuery {
+		plan.QueryChanged = true
+		plan.PreviousQuery = prev.Signature
+	}
+
+	return plan
+}
+
+// --- Internal Helper: Execution ---
+
+type executionData struct {
+	OldSnapshot    map[string]ComparableFeature
+	TargetSnapshot map[string]ComparableFeature
+	NewSnapshot    map[string]ComparableFeature
+}
+
+func (d *FeatureDiffer) executePlan(ctx context.Context, plan executionPlan) (executionData, error) {
+	data := executionData{
+		OldSnapshot:    nil,
+		TargetSnapshot: nil,
+		NewSnapshot:    nil,
+	}
+
+	newLive, err := d.client.FetchFeatures(ctx, plan.CurrentQuery)
+	if err != nil {
+		return data, err
+	}
+	data.NewSnapshot = toSnapshot(newLive)
+
+	if plan.IsColdStart {
+		return data, nil
+	}
+
+	if plan.QueryChanged {
+		oldLive, err := d.client.FetchFeatures(ctx, plan.PreviousQuery)
+		if err == nil {
+			data.TargetSnapshot = toSnapshot(oldLive)
+		} else {
+			// Fallback: If old query fails, we return nil TargetSnapshot.
+			// Run() detects this and skips diffing, treating it as a silent reset.
+			return executionData{
+				NewSnapshot:    data.NewSnapshot,
+				TargetSnapshot: nil,
+				OldSnapshot:    nil}, nil
+		}
+	} else {
+		data.TargetSnapshot = data.NewSnapshot
+	}
+
+	return data, nil
+}
+
+func toSnapshot(features []backend.Feature) map[string]ComparableFeature {
+	m := make(map[string]ComparableFeature)
+	for _, f := range features {
+		m[f.FeatureId] = toComparable(f)
+	}
+
+	return m
+}
+
+func toComparable(f backend.Feature) ComparableFeature {
+	status := backend.Limited
+	if f.Baseline != nil && f.Baseline.Status != nil {
+		status = *f.Baseline.Status
+	}
+	cf := ComparableFeature{
+		ID:             f.FeatureId,
+		Name:           OptionallySet[string]{Value: f.Name, IsSet: true},
+		BaselineStatus: OptionallySet[backend.BaselineInfoStatus]{Value: status, IsSet: true},
+		BrowserImpls: BrowserImplementations{
+			Chrome:         OptionallySet[string]{Value: "", IsSet: false},
+			ChromeAndroid:  OptionallySet[string]{Value: "", IsSet: false},
+			Edge:           OptionallySet[string]{Value: "", IsSet: false},
+			Firefox:        OptionallySet[string]{Value: "", IsSet: false},
+			FirefoxAndroid: OptionallySet[string]{Value: "", IsSet: false},
+			Safari:         OptionallySet[string]{Value: "", IsSet: false},
+			SafariIos:      OptionallySet[string]{Value: "", IsSet: false},
+		},
+	}
+
+	// Manually map known browsers from the map to the struct.
+	// This hardcoding is intentional: it ensures we only track what we have defined in the struct,
+	// allowing us to control schema evolution via struct updates.
+	if f.BrowserImplementations != nil {
+		raw := *f.BrowserImplementations
+		getStatus := func(key string) OptionallySet[string] {
+			if impl, ok := raw[key]; ok && impl.Status != nil {
+				return OptionallySet[string]{Value: string(*impl.Status), IsSet: true}
+			}
+
+			return OptionallySet[string]{Value: "", IsSet: false}
+		}
+
+		// Map to struct fields using backend constants or strings
+		cf.BrowserImpls.Chrome = getStatus(string(backend.Chrome))
+		cf.BrowserImpls.ChromeAndroid = getStatus(string(backend.ChromeAndroid))
+		cf.BrowserImpls.Edge = getStatus(string(backend.Edge))
+		cf.BrowserImpls.Firefox = getStatus(string(backend.Firefox))
+		cf.BrowserImpls.FirefoxAndroid = getStatus(string(backend.FirefoxAndroid))
+		cf.BrowserImpls.Safari = getStatus(string(backend.Safari))
+		cf.BrowserImpls.SafariIos = getStatus(string(backend.SafariIos))
+	}
+
+	return cf
+}

--- a/workers/event_producer/pkg/differ/differ_test.go
+++ b/workers/event_producer/pkg/differ/differ_test.go
@@ -1,0 +1,490 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package differ
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/blobtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/oapi-codegen/runtime/types"
+)
+
+// mockFetcher implements FeatureFetcher for testing.
+type mockFetcher struct {
+	// query -> features
+	queryResults map[string][]backend.Feature
+	// featureID -> result
+	featureDetails map[string]*backendtypes.GetFeatureResult
+	// featureID -> error (for GetFeature)
+	featureErrors map[string]error
+	// specific error for FetchFeatures
+	fetchError error
+}
+
+func (m *mockFetcher) FetchFeatures(_ context.Context, query string) ([]backend.Feature, error) {
+	if m.fetchError != nil {
+		return nil, m.fetchError
+	}
+	// If query key is missing in the map, simulate an error if needed,
+	// or return empty slice.
+	// For testing "Flush Failed", we want to simulate an error for a specific query.
+	// We can use a convention: if query starts with "error:", return error.
+	if query == "error:old" {
+		return nil, errors.New("simulated fetch error")
+	}
+
+	return m.queryResults[query], nil
+}
+
+func (m *mockFetcher) GetFeature(_ context.Context, id string) (*backendtypes.GetFeatureResult, error) {
+	if err := m.featureErrors[id]; err != nil {
+		return nil, err
+	}
+	if res, ok := m.featureDetails[id]; ok {
+		return res, nil
+	}
+	// Default to exists (Regular) if not specified, to prevent accidental "Deleted" detection in integration tests
+	return backendtypes.NewGetFeatureResult(
+		backendtypes.NewRegularFeatureResult(&backend.Feature{
+			FeatureId:              id,
+			Name:                   "",
+			Spec:                   nil,
+			Baseline:               nil,
+			BrowserImplementations: nil,
+			Discouraged:            nil,
+			Usage:                  nil,
+			Wpt:                    nil,
+			VendorPositions:        nil,
+			DeveloperSignals:       nil,
+		}),
+	), nil
+}
+
+// Helper to construct a backend.Feature with minimal fields.
+func makeFeature(id, name, status string) backend.Feature {
+	s := backend.BaselineInfoStatus(status)
+
+	return backend.Feature{
+		FeatureId:              id,
+		Name:                   name,
+		Spec:                   nil,
+		Discouraged:            nil,
+		Usage:                  nil,
+		Wpt:                    nil,
+		VendorPositions:        nil,
+		DeveloperSignals:       nil,
+		BrowserImplementations: nil,
+		Baseline: &backend.BaselineInfo{
+			Status:   &s,
+			LowDate:  nil,
+			HighDate: nil,
+		},
+	}
+}
+
+// Helper to create a previous state blob using the real serialization logic.
+func makeStateBlob(t *testing.T, searchID, query string, features []backend.Feature) []byte {
+	snapshot := toSnapshot(features)
+	payload := FeatureListSnapshot{
+		Metadata: StateMetadata{
+			GeneratedAt:    time.Now(),
+			SearchID:       searchID,
+			QuerySignature: query,
+		},
+		Data: FeatureListData{
+			Features: snapshot,
+		},
+	}
+	b, err := blobtypes.NewBlob(payload)
+	if err != nil {
+		t.Fatalf("failed to create state blob: %v", err)
+	}
+
+	return b
+}
+
+func TestRun(t *testing.T) {
+	ctx := context.Background()
+	searchID := "search-123"
+
+	tests := []struct {
+		name         string
+		query        string
+		oldStateBlob []byte
+		mock         *mockFetcher
+		wantDiff     *FeatureDiff
+		wantWrite    bool
+		wantErr      bool
+	}{
+		{
+			name:         "Cold Start",
+			query:        "group:css",
+			oldStateBlob: nil,
+			mock: &mockFetcher{
+				queryResults: map[string][]backend.Feature{
+					"group:css": {makeFeature("1", "Grid", "limited")},
+				},
+				featureDetails: nil,
+				featureErrors:  nil,
+				fetchError:     nil,
+			},
+			wantDiff: &FeatureDiff{
+				QueryChanged: false,
+				Added:        nil,
+				Removed:      nil,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			wantWrite: true,
+			wantErr:   false,
+		}, {
+			name:  "No Changes",
+			query: "group:css",
+			oldStateBlob: makeStateBlob(t, searchID, "group:css", []backend.Feature{
+				makeFeature("1", "Grid", "limited"),
+			}),
+			mock: &mockFetcher{
+				queryResults: map[string][]backend.Feature{
+					"group:css": {makeFeature("1", "Grid", "limited")},
+				},
+				featureDetails: nil,
+				featureErrors:  nil,
+				fetchError:     nil,
+			},
+			wantDiff:  nil,
+			wantWrite: false,
+			wantErr:   false,
+		},
+		{
+			name:  "Data Update",
+			query: "group:css",
+			oldStateBlob: makeStateBlob(t, searchID, "group:css", []backend.Feature{
+				makeFeature("1", "Grid", "limited"),
+			}),
+			mock: &mockFetcher{
+				queryResults: map[string][]backend.Feature{
+					"group:css": {makeFeature("1", "Grid", "widely")},
+				},
+				featureDetails: nil,
+				featureErrors:  nil,
+				fetchError:     nil,
+			},
+			wantDiff: &FeatureDiff{
+				QueryChanged: false,
+				Added:        nil,
+				Removed:      nil,
+				Modified: []FeatureModified{
+					{
+						ID:   "1",
+						Name: "Grid",
+						BaselineChange: &Change[backend.BaselineInfoStatus]{
+							From: backend.Limited,
+							To:   backend.Widely,
+						},
+						NameChange:     nil,
+						BrowserChanges: nil,
+					},
+				},
+				Moves:  nil,
+				Splits: nil,
+			},
+			wantWrite: true,
+			wantErr:   false,
+		},
+		{
+			name:  "Query Change (Flush Success)",
+			query: "group:new",
+			oldStateBlob: makeStateBlob(t, searchID, "group:old", []backend.Feature{
+				makeFeature("1", "OldFeature", "limited"),
+			}),
+			mock: &mockFetcher{
+				queryResults: map[string][]backend.Feature{
+					"group:new": {},
+					// Old query shows update happened before switch
+					"group:old": {makeFeature("1", "OldFeature", "widely")},
+				},
+				featureDetails: nil,
+				featureErrors:  nil,
+				fetchError:     nil,
+			},
+			wantDiff: &FeatureDiff{
+				QueryChanged: true,
+				Added:        nil,
+				Removed:      nil,
+				Modified: []FeatureModified{
+					{
+						ID:   "1",
+						Name: "OldFeature",
+						BaselineChange: &Change[backend.BaselineInfoStatus]{
+							From: backend.Limited,
+							To:   backend.Widely,
+						},
+						NameChange:     nil,
+						BrowserChanges: nil,
+					},
+				},
+				Moves:  nil,
+				Splits: nil,
+			},
+			wantWrite: true,
+			wantErr:   false,
+		},
+		{
+			name:  "Query Change (Flush Failed)",
+			query: "group:new",
+			// Old state has a query "error:old" which will trigger mock error
+			oldStateBlob: makeStateBlob(t, searchID, "error:old", []backend.Feature{
+				makeFeature("1", "OldFeature", "limited"),
+			}),
+			mock: &mockFetcher{
+				queryResults: map[string][]backend.Feature{
+					"group:new": {makeFeature("2", "NewFeature", "limited")},
+				},
+				featureDetails: nil,
+				featureErrors:  nil,
+				fetchError:     nil,
+			},
+			// Expectation: Fallback logic kicks in. We skip diffing the data.
+			// Result is just QueryChanged=true, with NO removals/adds reported.
+			wantDiff: &FeatureDiff{
+				QueryChanged: true,
+				Added:        nil,
+				Removed:      nil,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			wantWrite: true,
+			wantErr:   false,
+		},
+		{
+			name:  "Reconciliation (Move)",
+			query: "group:css",
+			oldStateBlob: makeStateBlob(t, searchID, "group:css", []backend.Feature{
+				makeFeature("old-id", "Old Name", "limited"),
+			}),
+			mock: &mockFetcher{
+				queryResults: map[string][]backend.Feature{
+					"group:css": {makeFeature("new-id", "New Name", "limited")},
+				},
+				featureDetails: map[string]*backendtypes.GetFeatureResult{
+					"old-id": backendtypes.NewGetFeatureResult(
+						backendtypes.NewMovedFeatureResult("new-id"),
+					),
+				},
+				featureErrors: nil,
+				fetchError:    nil,
+			},
+			wantDiff: &FeatureDiff{
+				QueryChanged: false,
+				Added:        nil,
+				Removed:      nil,
+				Modified:     nil,
+				Moves: []FeatureMoved{
+					{FromID: "old-id", ToID: "new-id", FromName: "Old Name", ToName: "New Name"},
+				},
+				Splits: nil,
+			},
+			wantWrite: true,
+			wantErr:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := NewFeatureDiffer(tc.mock)
+
+			newState, diff, shouldWrite, err := d.Run(ctx, searchID, tc.query, tc.oldStateBlob)
+
+			// Helper 1: Verify Error state
+			if checkRunError(t, tc.wantErr, err) {
+				return
+			}
+
+			// Helper 2: Verify Diff output
+			checkRunDiff(t, tc.wantDiff, diff)
+
+			// Verify Write logic
+			if shouldWrite != tc.wantWrite {
+				t.Errorf("shouldWrite = %v, want %v", shouldWrite, tc.wantWrite)
+			}
+			if tc.wantWrite && len(newState) == 0 {
+				t.Error("Expected newState bytes, got empty")
+			}
+		})
+	}
+}
+
+// checkRunError handles verifying if an error occurred vs if one was expected.
+// Returns true if the test should stop (error mismatch found or error was expected and received).
+func checkRunError(t *testing.T, wantErr bool, err error) bool {
+	t.Helper()
+	if wantErr {
+		if err == nil {
+			t.Fatal("Run() expected error, got nil")
+		}
+
+		return true
+	}
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	return false
+}
+
+// checkRunDiff handles comparing the expected diff with the actual diff.
+func checkRunDiff(t *testing.T, wantDiff, gotDiff *FeatureDiff) {
+	t.Helper()
+	if wantDiff != nil {
+		if gotDiff == nil {
+			t.Fatal("Expected diff, got nil")
+		}
+		// Sort for deterministic comparison
+		gotDiff.Sort()
+		wantDiff.Sort()
+
+		if d := cmp.Diff(wantDiff, gotDiff, cmpopts.EquateEmpty()); d != "" {
+			t.Errorf("Diff mismatch (-want +got):\n%s", d)
+		}
+	} else {
+		if gotDiff != nil {
+			t.Errorf("Expected nil diff, got: %+v", gotDiff)
+		}
+	}
+}
+
+func TestToComparable(t *testing.T) {
+	avail := backend.Available
+	unavail := backend.Unavailable
+	status := backend.Widely
+	date := types.Date{Time: time.Now()}
+
+	tests := []struct {
+		name string
+		in   backend.Feature
+		want ComparableFeature
+	}{
+		{
+			name: "Fully Populated",
+			in: backend.Feature{
+				FeatureId:   "feat-1",
+				Name:        "Feature One",
+				Spec:        nil,
+				Discouraged: nil,
+				Usage:       nil,
+				Wpt:         nil,
+				Baseline: &backend.BaselineInfo{
+					Status:   &status,
+					LowDate:  nil,
+					HighDate: nil,
+				},
+				BrowserImplementations: &map[string]backend.BrowserImplementation{
+					"chrome":  {Status: &avail, Date: &date, Version: nil},
+					"firefox": {Status: &unavail, Date: nil, Version: nil},
+					"safari":  {Status: &avail, Date: nil, Version: nil},
+					"unknown": {Status: &avail, Date: nil, Version: nil}, // Should be ignored
+				},
+				VendorPositions:  nil,
+				DeveloperSignals: nil,
+			},
+			want: createExpectedFeature("feat-1", "Feature One", backend.Widely, map[backend.SupportedBrowsers]string{
+				backend.Chrome:         "available",
+				backend.ChromeAndroid:  "",
+				backend.Firefox:        "unavailable",
+				backend.FirefoxAndroid: "",
+				backend.Safari:         "available",
+				backend.SafariIos:      "",
+				backend.Edge:           "",
+			}),
+		},
+		{
+			name: "Minimal (Nil Maps)",
+			in: backend.Feature{
+				FeatureId:              "feat-2",
+				Name:                   "Minimal Feature",
+				Baseline:               nil,
+				Spec:                   nil,
+				BrowserImplementations: nil,
+				Discouraged:            nil,
+				Usage:                  nil,
+				Wpt:                    nil,
+				VendorPositions:        nil,
+				DeveloperSignals:       nil,
+			},
+			want: createExpectedFeature("feat-2", "Minimal Feature", backend.Limited, nil),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := toComparable(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("toComparable mismatch.\nGot:  %+v\nWant: %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// createExpectedFeature constructs a ComparableFeature with all OptionallySet fields initialized.
+// This is required to pass the exhaustruct linter in tests.
+func createExpectedFeature(id, name string, baseline backend.BaselineInfoStatus,
+	browsers map[backend.SupportedBrowsers]string) ComparableFeature {
+	cf := ComparableFeature{
+		ID:             id,
+		Name:           OptionallySet[string]{Value: name, IsSet: true},
+		BaselineStatus: OptionallySet[backend.BaselineInfoStatus]{Value: baseline, IsSet: true},
+		BrowserImpls: BrowserImplementations{
+			// Initialize all to IsSet=false by default
+			Chrome:         OptionallySet[string]{IsSet: false, Value: ""},
+			ChromeAndroid:  OptionallySet[string]{IsSet: false, Value: ""},
+			Edge:           OptionallySet[string]{IsSet: false, Value: ""},
+			Firefox:        OptionallySet[string]{IsSet: false, Value: ""},
+			FirefoxAndroid: OptionallySet[string]{IsSet: false, Value: ""},
+			Safari:         OptionallySet[string]{IsSet: false, Value: ""},
+			SafariIos:      OptionallySet[string]{IsSet: false, Value: ""},
+		},
+	}
+
+	// Override specific browsers if provided
+	if browsers != nil {
+		setIfPresent(browsers, "chrome", &cf.BrowserImpls.Chrome)
+		setIfPresent(browsers, "chrome_android", &cf.BrowserImpls.ChromeAndroid)
+		setIfPresent(browsers, "edge", &cf.BrowserImpls.Edge)
+		setIfPresent(browsers, "firefox", &cf.BrowserImpls.Firefox)
+		setIfPresent(browsers, "firefox_android", &cf.BrowserImpls.FirefoxAndroid)
+		setIfPresent(browsers, "safari", &cf.BrowserImpls.Safari)
+		setIfPresent(browsers, "safari_ios", &cf.BrowserImpls.SafariIos)
+	}
+
+	return cf
+}
+
+func setIfPresent[K comparable, V any](m map[K]V, key K, target *OptionallySet[V]) {
+	var zero V
+	if val, ok := m[key]; ok && !reflect.DeepEqual(zero, val) {
+		target.IsSet = true
+		target.Value = val
+	}
+}


### PR DESCRIPTION
**For more information about the differ, refer to the docs in https://github.com/GoogleChrome/webstatus.dev/pull/2083**

Finalizes the Event Producer worker by wiring up the orchestration logic (`differ.go`). This component manages the end-to-end lifecycle of a change detection job: loading previous state, determining the fetch strategy (Standard vs. Flush), executing the diff, reconciling history, and serializing the new state.

New File `pkg/differ/differ.go`:
- **`Run`**: The main entry point. Orchestrates the pipeline: Context Loading -> Planning -> Execution -> Diffing -> Reconciliation -> Output Decision.
- **`loadPreviousContext`**: Reads the previous state blob from GCS and uses `lib/blobtypes` to migrate it to the current schema version.
- **`executePlan`**: Implements the "Flush Strategy". If the user changed their query, it first fetches data using the *old* query to catch any pending updates before switching to the *new* query.
- **`serializeState`**: Wraps the new feature list in a standardized `BlobEnvelope` for storage.

Testing (`pkg/differ/differ_test.go`):
- Added comprehensive integration tests using a `mockFetcher`.
- Verifies all execution paths: Cold Start, No Changes, Data Updates, Query Changes (Flush Success/Failure), and Moves.
- Uses `checkRunDiff` helpers to ensure deterministic test assertions.

Dependencies:
- Adds `oapi-codegen/runtime` to `go.mod` to support generated backend types in tests.