### PR TITLE
refactor(workers): unify event types and enable explicit spanner IDs

### DIFF
--- a/lib/gcpspanner/saved_search_notification_events.go
+++ b/lib/gcpspanner/saved_search_notification_events.go
@@ -86,7 +86,7 @@ func (m savedSearchNotificationEventMapper) NewEntity(id string, req SavedSearch
 // This saves the event and updates the state pointer, but explicitly KEEPS the lock.
 // The worker is expected to call ReleaseLock via defer.
 func (c *Client) PublishSavedSearchNotificationEvent(ctx context.Context,
-	event SavedSearchNotificationCreateRequest, newStatePath, workerID string) (*string, error) {
+	event SavedSearchNotificationCreateRequest, newStatePath, workerID string, opts ...CreateOption) (*string, error) {
 	var id *string
 	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 		// Check Lock & Update State (Using ReadInspectMutateWithTransaction)
@@ -121,7 +121,8 @@ func (c *Client) PublishSavedSearchNotificationEvent(ctx context.Context,
 		}
 
 		// Insert Event
-		newID, err := newEntityCreator[savedSearchNotificationEventMapper](c).createWithTransaction(ctx, txn, event)
+		newID, err := newEntityCreator[savedSearchNotificationEventMapper](c).createWithTransaction(ctx, txn, event,
+			opts...)
 		if err != nil {
 			return err
 		}

--- a/lib/workertypes/events.go
+++ b/lib/workertypes/events.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workertypes
+
+// The structs in this file implement the event.Event interface from github.com/GoogleChrome/webstatus.dev/lib/event
+// New fields must be added in a non-breaking way or in a new struct.
+
+// NotificationEventCreatedV1 lets consumers know that a particular notification has been created.
+type NotificationEventCreatedV1 struct {
+	ID string `json:"id"`
+}
+
+func (e NotificationEventCreatedV1) Kind() string { return "NotificationEventCreated" }
+
+func (e NotificationEventCreatedV1) APIVersion() string { return "v1" }

--- a/lib/workertypes/types.go
+++ b/lib/workertypes/types.go
@@ -1,0 +1,106 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workertypes
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	// VersionEventSummaryV1 defines the schema version for v1 of the EventSummary.
+	VersionEventSummaryV1 = "v1"
+)
+
+type SavedSearchState struct {
+	StateBlobPath *string
+}
+
+type SavedSearchStateUpdateRequest struct {
+	StateBlobPath *string
+
+	UpdateMask []SavedSearchStateUpdateRequestUpdateMask
+}
+
+type SavedSearchStateUpdateRequestUpdateMask string
+
+const (
+	SavedSearchStateUpdateRequestStateBlobPath SavedSearchStateUpdateRequestUpdateMask = "state_blob_path"
+)
+
+// NotificationEventRequest encapsulates the data needed to insert a row into the Events table.
+type NotificationEventRequest struct {
+	EventID      string
+	SearchID     string
+	SnapshotType string
+	Reasons      []string
+	DiffBlobPath string
+	Summary      EventSummary
+	NewStatePath string
+	WorkerID     string
+}
+
+// SummaryCategories defines the specific counts for different change types.
+type SummaryCategories struct {
+	QueryChanged    int `json:"query_changed,omitzero"`
+	Added           int `json:"added,omitzero"`
+	Removed         int `json:"removed,omitzero"`
+	Moved           int `json:"moved,omitzero"`
+	Split           int `json:"split,omitzero"`
+	Updated         int `json:"updated,omitzero"`
+	UpdatedImpl     int `json:"updated_impl,omitzero"`
+	UpdatedRename   int `json:"updated_rename,omitzero"`
+	UpdatedBaseline int `json:"updated_baseline,omitzero"`
+}
+
+// EventSummary matches the JSON structure stored in the database 'Summary' column.
+type EventSummary struct {
+	SchemaVersion string            `json:"schemaVersion"`
+	Text          string            `json:"text"`
+	Categories    SummaryCategories `json:"categories,omitzero"`
+}
+
+// SummaryVisitor defines the contract for consuming immutable Event Summaries.
+// Unlike state blobs which are migrated to the latest schema, summaries are
+// historical records that should be rendered as-is. The Visitor pattern forces
+// consumers to explicitly handle each schema version (e.g. V1, V2) independently.
+type SummaryVisitor interface {
+	VisitV1(s EventSummary) error
+}
+
+// ParseEventSummary handles the version detection and dispatching logic.
+// Consumers (like the Delivery Worker) should use this instead of raw json.Unmarshal.
+func ParseEventSummary(data []byte, v SummaryVisitor) error {
+	// 1. Peek at version
+	var header struct {
+		SchemaVersion string `json:"schemaVersion"`
+	}
+	if err := json.Unmarshal(data, &header); err != nil {
+		return fmt.Errorf("invalid summary json: %w", err)
+	}
+
+	// 2. Dispatch
+	switch header.SchemaVersion {
+	case VersionEventSummaryV1:
+		var s EventSummary
+		if err := json.Unmarshal(data, &s); err != nil {
+			return fmt.Errorf("failed to parse v1 summary: %w", err)
+		}
+
+		return v.VisitV1(s)
+	default:
+		return fmt.Errorf("unknown summary version: %q", header.SchemaVersion)
+	}
+}

--- a/lib/workertypes/types_test.go
+++ b/lib/workertypes/types_test.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workertypes
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// assertingVisitor used for TestParseEventSummary to verify visitor calls.
+type assertingVisitor struct {
+	t           *testing.T
+	wantSummary EventSummary
+	visitedV1   bool
+}
+
+func (v *assertingVisitor) VisitV1(got EventSummary) error {
+	v.visitedV1 = true
+	if diff := cmp.Diff(v.wantSummary, got); diff != "" {
+		v.t.Errorf("VisitV1 argument mismatch (-want +got):\n%s", diff)
+	}
+
+	return nil
+}
+
+func TestParseEventSummary(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantVisit   bool
+		wantSummary *EventSummary
+		wantErr     bool
+	}{
+		{
+			name:      "Explicit V1",
+			input:     `{"schemaVersion": "v1", "text": "Hello"}`,
+			wantVisit: true,
+			wantSummary: &EventSummary{
+				SchemaVersion: "v1",
+				Text:          "Hello",
+				Categories: SummaryCategories{
+					QueryChanged:    0,
+					Added:           0,
+					Removed:         0,
+					Moved:           0,
+					Split:           0,
+					Updated:         0,
+					UpdatedImpl:     0,
+					UpdatedRename:   0,
+					UpdatedBaseline: 0,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "Unknown Version",
+			input:       `{"schemaVersion": "v99", "text": "Future"}`,
+			wantSummary: nil,
+			wantVisit:   false,
+			wantErr:     true,
+		},
+		{
+			name:        "Invalid JSON",
+			input:       `{broken`,
+			wantSummary: nil,
+			wantVisit:   false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var summary EventSummary
+			if tc.wantSummary != nil {
+				summary = *tc.wantSummary
+			}
+			v := &assertingVisitor{
+				t:           t,
+				visitedV1:   false,
+				wantSummary: summary,
+			}
+			err := ParseEventSummary([]byte(tc.input), v)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Error("Expected error, got nil")
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if v.visitedV1 != tc.wantVisit {
+				t.Errorf("VisistedV1 = %v, want %v", v.visitedV1, tc.wantVisit)
+			}
+		})
+	}
+}

--- a/workers/event_producer/go.mod
+++ b/workers/event_producer/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/GoogleChrome/webstatus.dev/lib v0.0.0-00010101000000-000000000000
 	github.com/GoogleChrome/webstatus.dev/lib/gen v0.0.0-20251119220853-b545639c35ae
 	github.com/google/go-cmp v0.7.0
+	github.com/google/uuid v1.6.0
 	github.com/oapi-codegen/runtime v1.1.2
 )
 
@@ -43,7 +44,6 @@ require (
 	github.com/go-openapi/swag/jsonname v0.25.3 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.7 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/workers/event_producer/pkg/differ/types.go
+++ b/workers/event_producer/pkg/differ/types.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/blobtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
 )
 
 const (
@@ -256,27 +257,9 @@ type FeatureModified struct {
 	BrowserChanges map[backend.SupportedBrowsers]*Change[string] `json:"browserChanges,omitzero"`
 }
 
-// SummaryCategories defines the specific counts for different change types.
-type SummaryCategories struct {
-	QueryChanged    int `json:"query_changed,omitzero"`
-	Added           int `json:"added,omitzero"`
-	Removed         int `json:"removed,omitzero"`
-	Moved           int `json:"moved,omitzero"`
-	Split           int `json:"split,omitzero"`
-	Updated         int `json:"updated,omitzero"`
-	UpdatedImpl     int `json:"updated_impl,omitzero"`
-	UpdatedRename   int `json:"updated_rename,omitzero"`
-	UpdatedBaseline int `json:"updated_baseline,omitzero"`
-}
-
-// EventSummary matches the JSON structure stored in the database 'Summary' column.
-type EventSummary struct {
-	Text       string            `json:"text"`
-	Categories SummaryCategories `json:"categories,omitzero"`
-}
-
-func (d FeatureDiff) Summarize() EventSummary {
-	var s EventSummary
+func (d FeatureDiff) Summarize() workertypes.EventSummary {
+	var s workertypes.EventSummary
+	s.SchemaVersion = workertypes.VersionEventSummaryV1
 	var parts []string
 
 	if d.QueryChanged {

--- a/workers/event_producer/pkg/differ/types_test.go
+++ b/workers/event_producer/pkg/differ/types_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
 )
 
 func TestOptionallySet_Marshaling(t *testing.T) {
@@ -218,7 +219,7 @@ func TestSummarize(t *testing.T) {
 		name         string
 		diff         FeatureDiff
 		expectedText string
-		expectedCats SummaryCategories
+		expectedCats workertypes.SummaryCategories
 	}{
 		{
 			name: "Empty",
@@ -231,7 +232,7 @@ func TestSummarize(t *testing.T) {
 				Splits:       nil,
 			},
 			expectedText: "No changes detected",
-			expectedCats: SummaryCategories{
+			expectedCats: workertypes.SummaryCategories{
 				QueryChanged:    0,
 				Added:           0,
 				Removed:         0,
@@ -297,7 +298,7 @@ func TestSummarize(t *testing.T) {
 			// 1 features split, 3 features updated"
 			expectedText: "Search criteria updated, 2 features added, 1 features removed, 1 features moved/renamed, " +
 				"1 features split, 3 features updated",
-			expectedCats: SummaryCategories{
+			expectedCats: workertypes.SummaryCategories{
 				QueryChanged:    1,
 				Added:           2,
 				Removed:         1,


### PR DESCRIPTION
Refactors the event data structures into a shared library to support consumption by multiple workers and updates the Spanner client to allow deterministic ID generation.

New Package `lib/workertypes`:
- Centralizes `EventSummary`, `SummaryCategories`, and `NotificationEventRequest` types.
- Provides `ParseEventSummary` with a Visitor pattern, allowing downstream consumers (like the Delivery worker) to handle schema versions (e.g. V1) safely and immutably.

Library (`lib/gcpspanner`):
- Update `PublishSavedSearchNotificationEvent` to accept `...CreateOption`.
- This enables the caller to pass `WithID(uuid)`, ensuring the Database Primary Key matches the pre-generated GCS Blob path (`events/{uuid}.json`).

Event Producer (`workers/event_producer`):
- Update internal `differ` package to return `workertypes.EventSummary`.
- Remove local definitions of summary structs in favor of the shared library.