### PR TITLE
feat(lib): implement v1 feature list comparator

### DIFF
--- a/lib/blobtypes/featurelistdiff/v1/comparator.go
+++ b/lib/blobtypes/featurelistdiff/v1/comparator.go
@@ -1,0 +1,330 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"cmp"
+	"slices"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/generic"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes/comparables"
+)
+
+func (w *FeatureDiffWorkflow) CalculateDiff(oldMap, newMap map[string]comparables.Feature) {
+	for id, newF := range newMap {
+		oldF, exists := oldMap[id]
+		if !exists {
+			var docs *Docs
+			if newF.Docs.IsSet {
+				v1Docs := toV1Docs(newF.Docs.Value)
+				docs = &v1Docs
+			}
+			w.diff.Added = append(w.diff.Added, FeatureAdded{
+				ID:     id,
+				Name:   newF.Name.Value,
+				Reason: ReasonNewMatch,
+				Docs:   docs,
+			})
+
+			continue
+		}
+
+		if mod, changed := compareFeature(oldF, newF); changed {
+			w.diff.Modified = append(w.diff.Modified, mod)
+		}
+	}
+
+	for id, oldF := range oldMap {
+		if _, exists := newMap[id]; !exists {
+			w.diff.Removed = append(w.diff.Removed, FeatureRemoved{
+				ID: id, Name: oldF.Name.Value, Reason: ReasonUnmatched,
+			})
+		}
+	}
+}
+
+func compareFeature(oldF, newF comparables.Feature) (FeatureModified, bool) {
+	var docs *Docs
+	if newF.Docs.IsSet {
+		v1Docs := toV1Docs(newF.Docs.Value)
+		docs = &v1Docs
+	}
+	mod := FeatureModified{
+		ID:             newF.ID,
+		Name:           newF.Name.Value,
+		Docs:           docs,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+		DocsChange:     nil,
+	}
+	hasMods := false
+
+	// 1. Name Change
+	if oldF.Name.IsSet && oldF.Name.Value != newF.Name.Value {
+		mod.NameChange = &Change[string]{From: oldF.Name.Value, To: newF.Name.Value}
+		hasMods = true
+	}
+
+	// 2. Baseline Status
+	baselineChange, baselineHasChanged := compareBaseline(oldF.BaselineStatus, newF.BaselineStatus)
+	if baselineHasChanged {
+		mod.BaselineChange = baselineChange
+		hasMods = true
+	}
+
+	// 3. Browser Implementations
+	browserChanges, browserHasChanged := compareBrowserImpls(oldF.BrowserImpls, newF.BrowserImpls)
+	if browserHasChanged {
+		mod.BrowserChanges = browserChanges
+		hasMods = true
+	}
+
+	docsChange, docsHaveChanged := compareDocs(oldF.Docs, newF.Docs)
+	if docsHaveChanged {
+		mod.DocsChange = docsChange
+		// Docs do not trigger a feature change
+	}
+
+	return mod, hasMods
+}
+
+// compareBaseline checks for a baseline status change.
+func compareBaseline(
+	oldStatus, newStatus generic.OptionallySet[comparables.BaselineState],
+) (*Change[BaselineState], bool) {
+	if oldStatus.IsSet {
+		oldBase := oldStatus.Value
+		newBase := newStatus.Value
+		if oldBase.Status.IsSet && oldBase.Status.Value != newBase.Status.Value {
+			return &Change[BaselineState]{
+				From: toV1BaselineState(oldBase),
+				To:   toV1BaselineState(newBase),
+			}, true
+		}
+	}
+
+	return nil, false
+}
+
+func toV1BaselineState(bs comparables.BaselineState) BaselineState {
+	return BaselineState{
+		Status:   toV1BaselineInfoStatus(bs.Status),
+		LowDate:  bs.LowDate,
+		HighDate: bs.HighDate,
+	}
+}
+
+func toV1BaselineInfoStatus(
+	status generic.OptionallySet[backend.BaselineInfoStatus],
+) generic.OptionallySet[BaselineInfoStatus] {
+	if !status.IsSet {
+		return generic.UnsetOpt[BaselineInfoStatus]()
+	}
+
+	return generic.OptionallySet[BaselineInfoStatus]{
+		IsSet: true,
+		Value: toV1BaselineInfoStatusValue(status.Value),
+	}
+}
+
+func toV1BaselineInfoStatusValue(status backend.BaselineInfoStatus) BaselineInfoStatus {
+	switch status {
+	case backend.Limited:
+		return Limited
+	case backend.Newly:
+		return Newly
+	case backend.Widely:
+		return Widely
+	}
+
+	return Limited
+}
+
+// compareBrowserImpls checks for changes in browser implementations.
+func compareBrowserImpls(
+	oldImpls, newImpls generic.OptionallySet[comparables.BrowserImplementations],
+) (map[SupportedBrowsers]*Change[BrowserState], bool) {
+	changes := make(map[SupportedBrowsers]*Change[BrowserState])
+	hasChanged := false
+
+	if !oldImpls.IsSet {
+		return changes, false
+	}
+
+	oldB := oldImpls.Value
+	newB := newImpls.Value
+
+	browserMap := map[SupportedBrowsers]struct {
+		Old generic.OptionallySet[comparables.BrowserState]
+		New generic.OptionallySet[comparables.BrowserState]
+	}{
+		Chrome:         {Old: oldB.Chrome, New: newB.Chrome},
+		ChromeAndroid:  {Old: oldB.ChromeAndroid, New: newB.ChromeAndroid},
+		Edge:           {Old: oldB.Edge, New: newB.Edge},
+		Firefox:        {Old: oldB.Firefox, New: newB.Firefox},
+		FirefoxAndroid: {Old: oldB.FirefoxAndroid, New: newB.FirefoxAndroid},
+		Safari:         {Old: oldB.Safari, New: newB.Safari},
+		SafariIos:      {Old: oldB.SafariIos, New: newB.SafariIos},
+	}
+
+	for key, data := range browserMap {
+		if change, changed := compareBrowserState(data.Old, data.New); changed {
+			changes[key] = toV1BrowserChange(change)
+			hasChanged = true
+		}
+	}
+
+	return changes, hasChanged
+}
+
+// compareDocs checks for changes in the documentation links.
+func compareDocs(oldDocs, newDocs generic.OptionallySet[comparables.Docs]) (*Change[Docs], bool) {
+	if !oldDocs.IsSet || !oldDocs.Value.MdnDocs.IsSet {
+
+		return nil, false
+	}
+
+	oldMdnDocs := oldDocs.Value.MdnDocs.Value
+	newMdnDocs := newDocs.Value.MdnDocs.Value
+	sortMDNDocs := func(a, b comparables.MdnDoc) int {
+		return cmp.Compare(a.URL.Value, b.URL.Value)
+	}
+	slices.SortFunc(oldMdnDocs, sortMDNDocs)
+	slices.SortFunc(newMdnDocs, sortMDNDocs)
+
+	mdnDocsEqual := func(a, b comparables.MdnDoc) bool {
+		return a.URL.Value == b.URL.Value
+	}
+	if !slices.EqualFunc(oldMdnDocs, newMdnDocs, mdnDocsEqual) {
+		return &Change[Docs]{
+			From: toV1Docs(oldDocs.Value),
+			To:   toV1Docs(newDocs.Value),
+		}, true
+	}
+
+	return nil, false
+}
+
+func toV1Docs(d comparables.Docs) Docs {
+	var mdnDocs []MdnDoc
+	if d.MdnDocs.IsSet {
+		for _, doc := range d.MdnDocs.Value {
+			mdnDocs = append(mdnDocs, MdnDoc{
+				URL:   doc.URL.Value,
+				Title: doc.Title.Value,
+				Slug:  doc.Slug.Value,
+			})
+		}
+	}
+
+	return Docs{MdnDocs: mdnDocs}
+}
+
+func toV1BrowserImplementationStatus(status generic.OptionallySet[backend.BrowserImplementationStatus]) generic.
+	OptionallySet[BrowserImplementationStatus] {
+	if !status.IsSet {
+		return generic.UnsetOpt[BrowserImplementationStatus]()
+	}
+
+	return generic.OptionallySet[BrowserImplementationStatus]{
+		IsSet: true,
+		Value: toV1BrowserImplementationStatusValue(status.Value),
+	}
+}
+
+func toV1BrowserImplementationStatusValue(status backend.BrowserImplementationStatus) BrowserImplementationStatus {
+	switch status {
+	case backend.Available:
+		return Available
+	case backend.Unavailable:
+		return Unavailable
+	}
+
+	return Unavailable
+}
+
+func toV1BrowserChange(change *Change[comparables.BrowserState]) *Change[BrowserState] {
+	if change == nil {
+		return nil
+	}
+
+	return &Change[BrowserState]{
+		From: BrowserState{
+			Status:  toV1BrowserImplementationStatus(change.From.Status),
+			Version: change.From.Version,
+			Date:    change.From.Date,
+		},
+		To: BrowserState{
+			Status:  toV1BrowserImplementationStatus(change.To.Status),
+			Version: change.To.Version,
+			Date:    change.To.Date,
+		},
+	}
+}
+
+// compareBrowserState checks for changes in a single browser's state.
+func compareBrowserState(
+	oldB, newB generic.OptionallySet[comparables.BrowserState],
+) (*Change[comparables.BrowserState], bool) {
+	if !oldB.IsSet {
+		return nil, false
+	}
+	// Check Status
+	isChanged := oldB.Value.Status.IsSet && oldB.Value.Status.Value != newB.Value.Status.Value
+	// Check Version
+	if !isChanged && oldB.Value.Version.IsSet && !pointersEqual(oldB.Value.Version.Value, newB.Value.Version.Value) {
+		isChanged = true
+	}
+	// Check Date
+	if !isChanged && oldB.Value.Date.IsSet && !pointersEqualFn(oldB.Value.Date.Value, newB.Value.Date.Value, timeEqual) {
+		isChanged = true
+	}
+
+	if isChanged {
+		return &Change[comparables.BrowserState]{
+			From: oldB.Value,
+			To:   newB.Value,
+		}, true
+	}
+
+	return nil, false
+}
+
+func pointersEqual[T comparable](a, b *T) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+
+	return *a == *b
+}
+
+func pointersEqualFn[T any](a, b *T, isEqual func(a, b T) bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+
+	return isEqual(*a, *b)
+}
+
+func timeEqual(a, b time.Time) bool { return a.Equal(b) }

--- a/lib/blobtypes/featurelistdiff/v1/comparator_test.go
+++ b/lib/blobtypes/featurelistdiff/v1/comparator_test.go
@@ -1,0 +1,318 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/generic"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes/comparables"
+)
+
+func newBaseFeature(id, name string, status backend.BaselineInfoStatus) comparables.Feature {
+	return comparables.Feature{
+		ID:   id,
+		Name: generic.OptionallySet[string]{Value: name, IsSet: true},
+		BaselineStatus: generic.OptionallySet[comparables.BaselineState]{
+			Value: comparables.BaselineState{
+				Status: generic.OptionallySet[backend.BaselineInfoStatus]{
+					Value: status, IsSet: true},
+				LowDate:  generic.OptionallySet[*time.Time]{IsSet: false, Value: nil},
+				HighDate: generic.OptionallySet[*time.Time]{IsSet: false, Value: nil},
+			},
+			IsSet: true,
+		},
+		BrowserImpls: generic.OptionallySet[comparables.BrowserImplementations]{
+			IsSet: true,
+			Value: comparables.BrowserImplementations{
+				Chrome:         unsetBrowserState(),
+				ChromeAndroid:  unsetBrowserState(),
+				Edge:           unsetBrowserState(),
+				Firefox:        unsetBrowserState(),
+				FirefoxAndroid: unsetBrowserState(),
+				Safari:         unsetBrowserState(),
+				SafariIos:      unsetBrowserState(),
+			},
+		},
+		Docs: generic.UnsetOpt[comparables.Docs](),
+	}
+}
+
+func unsetBrowserState() generic.OptionallySet[comparables.BrowserState] {
+	return generic.OptionallySet[comparables.BrowserState]{
+		IsSet: false,
+		Value: comparables.BrowserState{
+			Status:  generic.UnsetOpt[backend.BrowserImplementationStatus](),
+			Date:    generic.UnsetOpt[*time.Time](),
+			Version: generic.UnsetOpt[*string](),
+		},
+	}
+}
+
+func TestCalculateDiff(t *testing.T) {
+	tests := []struct {
+		name         string
+		oldMap       map[string]comparables.Feature
+		newMap       map[string]comparables.Feature
+		wantAdded    int
+		wantRemoved  int
+		wantModified int
+	}{
+		{
+			name:         "No Changes",
+			oldMap:       map[string]comparables.Feature{"1": newBaseFeature("1", "A", "limited")},
+			newMap:       map[string]comparables.Feature{"1": newBaseFeature("1", "A", "limited")},
+			wantAdded:    0,
+			wantRemoved:  0,
+			wantModified: 0,
+		},
+		{
+			name:         "Addition",
+			oldMap:       map[string]comparables.Feature{},
+			newMap:       map[string]comparables.Feature{"2": newBaseFeature("2", "A", "limited")},
+			wantAdded:    1,
+			wantRemoved:  0,
+			wantModified: 0,
+		},
+		{
+			name:         "Removal",
+			oldMap:       map[string]comparables.Feature{"1": newBaseFeature("1", "A", "limited")},
+			newMap:       map[string]comparables.Feature{},
+			wantAdded:    0,
+			wantRemoved:  1,
+			wantModified: 0,
+		},
+		{
+			name: "Modification",
+			oldMap: map[string]comparables.Feature{
+				"1": newBaseFeature("1", "A", "limited"),
+			},
+			newMap: map[string]comparables.Feature{
+				"1": newBaseFeature("1", "A", "widely"),
+			},
+			wantAdded:    0,
+			wantRemoved:  0,
+			wantModified: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := NewFeatureDiffWorkflow(nil, nil)
+			w.CalculateDiff(tc.oldMap, tc.newMap)
+			diff := w.diff
+			if len(diff.Added) != tc.wantAdded {
+				t.Errorf("Added count: got %d, want %d", len(diff.Added), tc.wantAdded)
+			}
+			if len(diff.Removed) != tc.wantRemoved {
+				t.Errorf("Removed count: got %d, want %d", len(diff.Removed), tc.wantRemoved)
+			}
+			if len(diff.Modified) != tc.wantModified {
+				t.Errorf("Modified count: got %d, want %d", len(diff.Modified), tc.wantModified)
+			}
+		})
+	}
+}
+
+func TestCompareFeature_NameChange(t *testing.T) {
+	oldF := newBaseFeature("1", "Old Name", "limited")
+	newF := newBaseFeature("1", "New Name", "limited")
+
+	mod, changed := compareFeature(oldF, newF)
+
+	if !changed {
+		t.Fatal("expected a change, but none was reported")
+	}
+	if mod.NameChange == nil {
+		t.Fatal("NameChange is nil")
+	}
+	if mod.NameChange.From != "Old Name" || mod.NameChange.To != "New Name" {
+		t.Errorf("NameChange mismatch: got %+v", mod.NameChange)
+	}
+	if mod.BaselineChange != nil || mod.BrowserChanges != nil || mod.DocsChange != nil {
+		t.Error("unexpected changes reported for other fields")
+	}
+}
+
+func TestCompareFeature_BaselineChange(t *testing.T) {
+	oldF := newBaseFeature("1", "A", "limited")
+	newF := newBaseFeature("1", "A", "widely")
+
+	mod, changed := compareFeature(oldF, newF)
+
+	if !changed {
+		t.Fatal("expected a change, but none was reported")
+	}
+	if mod.BaselineChange == nil {
+		t.Fatal("BaselineChange is nil")
+	}
+	if mod.BaselineChange.From.Status.Value != Limited || mod.BaselineChange.To.Status.Value != Widely {
+		t.Errorf("BaselineChange mismatch: got %+v", mod.BaselineChange)
+	}
+	if mod.NameChange != nil || mod.BrowserChanges != nil || mod.DocsChange != nil {
+		t.Error("unexpected changes reported for other fields")
+	}
+}
+
+func TestCompareFeature_BrowserStatusChange(t *testing.T) {
+	oldF := newBaseFeature("1", "A", "limited")
+	oldF.BrowserImpls.Value.Chrome = newBrowserState(backend.Unavailable, nil, nil)
+
+	newF := newBaseFeature("1", "A", "limited")
+	newF.BrowserImpls.Value.Chrome = newBrowserState(backend.Available, nil, nil)
+
+	mod, changed := compareFeature(oldF, newF)
+
+	if !changed {
+		t.Fatal("expected a change, but none was reported")
+	}
+	if len(mod.BrowserChanges) == 0 {
+		t.Fatal("BrowserChanges is empty")
+	}
+	chg, ok := mod.BrowserChanges[Chrome]
+	if !ok {
+		t.Fatal("Chrome change not detected")
+	}
+	if chg.To.Status.Value != Available {
+		t.Errorf("Chrome status change mismatch: got %v", chg.To.Status.Value)
+	}
+}
+
+func TestCompareFeature_BrowserVersionChange(t *testing.T) {
+	oldF := newBaseFeature("1", "A", "limited")
+	oldF.BrowserImpls.Value.Chrome = newBrowserState(backend.Available, generic.ValuePtr("120"), nil)
+
+	newF := newBaseFeature("1", "A", "limited")
+	newF.BrowserImpls.Value.Chrome = newBrowserState(backend.Available, generic.ValuePtr("121"), nil)
+
+	mod, changed := compareFeature(oldF, newF)
+
+	if !changed {
+		t.Fatal("expected a change")
+	}
+	chg := mod.BrowserChanges[Chrome]
+	if chg.To.Version.Value == nil || *chg.To.Version.Value != "121" {
+		t.Errorf("Chrome version change mismatch: got %v", chg.To.Version.Value)
+	}
+}
+
+func TestCompareFeature_BrowserDateChange(t *testing.T) {
+	oldDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	newDate := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	oldF := newBaseFeature("1", "A", "limited")
+	oldF.BrowserImpls.Value.Chrome = newBrowserState(backend.Available, nil, &oldDate)
+
+	newF := newBaseFeature("1", "A", "limited")
+	newF.BrowserImpls.Value.Chrome = newBrowserState(backend.Available, nil, &newDate)
+
+	mod, changed := compareFeature(oldF, newF)
+
+	if !changed {
+		t.Fatal("expected a change")
+	}
+	chg := mod.BrowserChanges[Chrome]
+	if chg.To.Date.Value == nil || !chg.To.Date.Value.Equal(newDate) {
+		t.Errorf("Chrome date change mismatch: got %v", chg.To.Date.Value)
+	}
+}
+
+func TestCompareFeature_DocsChange_DoesNotTriggerModification(t *testing.T) {
+	oldF := newBaseFeature("1", "A", "limited")
+	oldF.Docs = newDocs("https://example-old.com")
+
+	newF := newBaseFeature("1", "A", "limited")
+	newF.Docs = newDocs("https://example-new.com")
+
+	mod, changed := compareFeature(oldF, newF)
+
+	if changed {
+		t.Error("docs-only change should not trigger a modification")
+	}
+	if mod.DocsChange == nil {
+		t.Fatal("DocsChange was not populated")
+	}
+	if mod.DocsChange.To.MdnDocs[0].URL != "https://example-new.com" {
+		t.Errorf("DocsChange.To has wrong URL: %s", mod.DocsChange.To.MdnDocs[0].URL)
+	}
+}
+
+func TestCompareFeature_QuietRollout_NewBrowser(t *testing.T) {
+	// Old feature is missing any data for Chrome
+	oldF := newBaseFeature("1", "A", "limited")
+
+	// New feature now has data for Chrome
+	newF := newBaseFeature("1", "A", "limited")
+	newF.BrowserImpls.Value.Chrome = newBrowserState(backend.Available, nil, nil)
+
+	_, changed := compareFeature(oldF, newF)
+
+	if changed {
+		t.Error("quiet rollout of a new browser should not trigger a change")
+	}
+}
+
+func TestCompareFeature_QuietRollout_NewTopLevelField(t *testing.T) {
+	// Old feature is missing the entire BrowserImpls struct
+	oldF := newBaseFeature("1", "A", "limited")
+	oldF.BrowserImpls = generic.UnsetOpt[comparables.BrowserImplementations]()
+
+	// New feature now has the struct and data for a browser
+	newF := newBaseFeature("1", "A", "limited")
+	newF.BrowserImpls.Value.Chrome = newBrowserState(backend.Available, nil, nil)
+
+	_, changed := compareFeature(oldF, newF)
+
+	if changed {
+		t.Error("quiet rollout of a new top-level field should not trigger a change")
+	}
+}
+
+// --- Test Helpers ---
+
+func newBrowserState(
+	status backend.BrowserImplementationStatus,
+	version *string,
+	date *time.Time,
+) generic.OptionallySet[comparables.BrowserState] {
+	return generic.OptionallySet[comparables.BrowserState]{
+		Value: comparables.BrowserState{
+			Status:  generic.OptionallySet[backend.BrowserImplementationStatus]{Value: status, IsSet: true},
+			Version: generic.OptionallySet[*string]{Value: version, IsSet: version != nil},
+			Date:    generic.OptionallySet[*time.Time]{Value: date, IsSet: date != nil},
+		},
+		IsSet: true,
+	}
+}
+
+func newDocs(url string) generic.OptionallySet[comparables.Docs] {
+	return generic.OptionallySet[comparables.Docs]{
+		IsSet: true,
+		Value: comparables.Docs{
+			MdnDocs: generic.OptionallySet[[]comparables.MdnDoc]{
+				IsSet: true,
+				Value: []comparables.MdnDoc{
+					{
+						URL:   generic.OptionallySet[string]{Value: url, IsSet: true},
+						Title: generic.OptionallySet[*string]{Value: generic.ValuePtr("Example"), IsSet: true},
+						Slug:  generic.OptionallySet[*string]{Value: generic.ValuePtr("example"), IsSet: true},
+					},
+				},
+			},
+		},
+	}
+}

--- a/lib/blobtypes/featurelistdiff/v1/workflow.go
+++ b/lib/blobtypes/featurelistdiff/v1/workflow.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"context"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+)
+
+// Implements StateCompareWorkflow interface.
+type FeatureDiffWorkflow struct {
+	diff       *FeatureDiff
+	fetcher    FeatureFetcher
+	summaryGen SummaryGenerator
+}
+
+// FeatureFetcher abstracts the external API.
+type FeatureFetcher interface {
+	GetFeature(ctx context.Context, featureID string) (*backendtypes.GetFeatureResult, error)
+}
+
+type SummaryGenerator interface {
+	GenerateJSONSummary(diff FeatureDiff) ([]byte, error)
+}
+
+func NewFeatureDiffWorkflow(fetcher FeatureFetcher, summaryGen SummaryGenerator) *FeatureDiffWorkflow {
+	return &FeatureDiffWorkflow{
+		diff:       new(FeatureDiff),
+		fetcher:    fetcher,
+		summaryGen: summaryGen,
+	}
+}
+
+func (w *FeatureDiffWorkflow) HasRemovedFeatures() bool {
+	return len(w.diff.Removed) > 0
+}
+
+func (w *FeatureDiffWorkflow) HasChanges() bool {
+	return w.diff.HasChanges()
+}
+
+func (w *FeatureDiffWorkflow) HasDataChanges() bool {
+	return w.diff.HasDataChanges()
+}
+
+func (w *FeatureDiffWorkflow) SetQueryChanged(changed bool) {
+	w.diff.QueryChanged = changed
+}
+
+func (w *FeatureDiffWorkflow) GenerateJSONSummary() ([]byte, error) {
+	return w.summaryGen.GenerateJSONSummary(*w.diff)
+}
+
+func (w *FeatureDiffWorkflow) GetDiff() *FeatureDiff {
+	return w.diff
+}


### PR DESCRIPTION
Adds the core diffing logic in `comparator.go`. This includes the main `CalculateDiff` function and the `compareFeature` function, which can identify changes to a feature's name, baseline status, and browser implementations.

The comparison logic correctly handles `OptionallySet` fields to prevent false positives during "quiet rollouts" of new fields.

**NOTE**: This logic already exists in https://github.com/GoogleChrome/webstatus.dev/blob/dcabed3a68ca642b5d9e3ebecc69416bf11772d3/workers/event_producer/pkg/differ/comparator.go. But to prevent too many changes at once, it will be removed in the future. (And if we do a simple move, things would not compile)

Now, the comparison can happen in the version specific struct files. That way, each version can easily keep their comparison logic separate.

`workflow.go`: Defines the `FeatureDiffWorkflow` struct, which acts as the state container for the diffing process. It manages the internal `FeatureDiff` struct and allows for distinct phases (Calculation, Reconciliation, Summary).

Part of #2107

Split up of #2106