### PR TITLE
feat(lib): implement diff reconciler for feature moves and splits

### DIFF
--- a/lib/blobtypes/featurelistdiff/v1/reconciler.go
+++ b/lib/blobtypes/featurelistdiff/v1/reconciler.go
@@ -1,0 +1,207 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"context"
+	"errors"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+)
+
+// ReconcileHistory analyzes the "Removed" list to detect if features were actually Moved or Split
+// rather than deleted.
+//
+// It performs a "Detective" pass:
+// 1. For every removed feature, ask the DB: "What is your current status?"
+// 2. If the DB says "I moved to ID 'B'", we check if 'B' is in our "Added" list.
+// 3. If yes, we link them together into a "Move" event and remove them from the raw Added/Removed lists.
+//
+// This transforms a confusing [Removed: "Grid", Added: "CSS Grid"] diff into a clear
+// [Moved: "Grid" -> "CSS Grid"] diff.
+func (w *FeatureDiffWorkflow) ReconcileHistory(ctx context.Context) error {
+	renames := make(map[string]string)
+	splits := make(map[string][]string)
+	visitor := &reconciliationVisitor{renames: renames, splits: splits, currentID: ""}
+
+	// Phase 1: Investigation
+	// Iterate through all removed features to build a map of their historical outcomes.
+	for i := range w.diff.Removed {
+		r := &w.diff.Removed[i]
+
+		// Check the current status of the removed feature ID in the database.
+		result, err := w.fetcher.GetFeature(ctx, r.ID)
+		if err != nil {
+			// If the entity is completely gone from the DB, it's a true deletion.
+			// We update the reason to allow for specific UI messaging (e.g. "Deleted from platform").
+			if errors.Is(err, backendtypes.ErrEntityDoesNotExist) {
+				r.Reason = ReasonDeleted
+
+				continue
+			}
+
+			return err
+		}
+
+		// Update the visitor context so it knows which OldID owns the result we are about to visit.
+		visitor.currentID = r.ID
+
+		// Dispatch based on whether the feature is Regular (exists), Moved, or Split.
+		if err := result.Visit(ctx, visitor); err != nil {
+			return err
+		}
+	}
+
+	// Phase 2: Correlation
+	// If we found any history records, try to match them with the 'Added' list.
+	if len(renames) > 0 {
+		reconcileMoves(w.diff, renames)
+	}
+	if len(splits) > 0 {
+		reconcileSplits(w.diff, splits)
+	}
+
+	return nil
+}
+
+// reconciliationVisitor implements the Visitor pattern to populate the renames/splits maps
+// based on the polymorphic result returned by GetFeature.
+type reconciliationVisitor struct {
+	currentID string
+	renames   map[string]string
+	splits    map[string][]string
+}
+
+func (v *reconciliationVisitor) VisitRegularFeature(_ context.Context, _ backendtypes.RegularFeatureResult) error {
+	// No-op: The feature exists in the DB (is Regular) but was removed from our snapshot.
+	// This implies it simply fell out of scope of the user's query (e.g. tags changed).
+	// We leave it as a standard "Removed" item with ReasonUnmatched.
+	return nil
+}
+
+func (v *reconciliationVisitor) VisitMovedFeature(_ context.Context, result backendtypes.MovedFeatureResult) error {
+	v.renames[v.currentID] = result.NewFeatureID()
+
+	return nil
+}
+
+func (v *reconciliationVisitor) VisitSplitFeature(_ context.Context, result backendtypes.SplitFeatureResult) error {
+	splitFeatures := result.SplitFeature()
+	targetIDs := make([]string, 0, len(splitFeatures.Features))
+	for _, f := range splitFeatures.Features {
+		targetIDs = append(targetIDs, f.Id)
+	}
+	v.splits[v.currentID] = targetIDs
+
+	return nil
+}
+
+// reconcileMoves modifies the diff in-place. It pairs Removed items with Added items
+// based on the provided renames map (OldID -> NewID).
+func reconcileMoves(diff *FeatureDiff, renames map[string]string) {
+	// Index the Added list for O(1) lookups
+	addedMap := make(map[string]FeatureAdded)
+	for _, a := range diff.Added {
+		addedMap[a.ID] = a
+	}
+
+	var newRemoved []FeatureRemoved
+	newMoves := diff.Moves
+
+	for _, r := range diff.Removed {
+		newID, isRenamed := renames[r.ID]
+		target, isAdded := addedMap[newID]
+
+		// A Move is only valid for *this* diff if the target ID is actually present in the 'Added' list.
+		// If the target ID is missing (e.g. filtered out by the user's query), we treat the original
+		// item as simply Removed.
+		if isRenamed && isAdded {
+			newMoves = append(newMoves, FeatureMoved{
+				FromID:   r.ID,
+				ToID:     newID,
+				FromName: r.Name,
+				ToName:   target.Name,
+			})
+			// Consume the added item so it doesn't appear as a standalone "Added" event later.
+			delete(addedMap, newID)
+		} else {
+			newRemoved = append(newRemoved, r)
+		}
+	}
+
+	// Reconstruct the Added list with only the remaining (unclaimed) items.
+	var newAdded []FeatureAdded
+	for _, a := range diff.Added {
+		if _, exists := addedMap[a.ID]; exists {
+			newAdded = append(newAdded, a)
+		}
+	}
+
+	diff.Removed = newRemoved
+	diff.Added = newAdded
+	diff.Moves = newMoves
+}
+
+// reconcileSplits modifies the diff in-place. It pairs Removed items with one or more Added items
+// based on the provided splits map (OldID -> [NewID...]).
+func reconcileSplits(diff *FeatureDiff, splits map[string][]string) {
+	addedMap := make(map[string]FeatureAdded)
+	for _, a := range diff.Added {
+		addedMap[a.ID] = a
+	}
+
+	var newRemoved []FeatureRemoved
+	newSplits := diff.Splits
+
+	for _, r := range diff.Removed {
+		targetIDs, isSplit := splits[r.ID]
+		var foundTargets []FeatureAdded
+		foundAny := false
+
+		if isSplit {
+			for _, targetID := range targetIDs {
+				// Check if any of the split targets are in our Added list.
+				// Even if only 1 of 5 targets matches the user's query, we still report it as a Split.
+				if target, isAdded := addedMap[targetID]; isAdded {
+					foundTargets = append(foundTargets, target)
+					foundAny = true
+					// Consume the added item
+					delete(addedMap, targetID)
+				}
+			}
+		}
+
+		if foundAny {
+			newSplits = append(newSplits, FeatureSplit{
+				FromID:   r.ID,
+				FromName: r.Name,
+				To:       foundTargets,
+			})
+		} else {
+			newRemoved = append(newRemoved, r)
+		}
+	}
+
+	var newAdded []FeatureAdded
+	for _, a := range diff.Added {
+		if _, exists := addedMap[a.ID]; exists {
+			newAdded = append(newAdded, a)
+		}
+	}
+
+	diff.Removed = newRemoved
+	diff.Added = newAdded
+	diff.Splits = newSplits
+}

--- a/lib/blobtypes/featurelistdiff/v1/reconciler_test.go
+++ b/lib/blobtypes/featurelistdiff/v1/reconciler_test.go
@@ -1,0 +1,390 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/google/go-cmp/cmp"
+)
+
+// mockReconcileClient mocks the FeatureFetcher interface for reconciliation tests.
+type mockReconcileClient struct {
+	// Map featureID -> Result to return
+	results map[string]*backendtypes.GetFeatureResult
+	// Map featureID -> Error to return
+	errors map[string]error
+}
+
+func (m *mockReconcileClient) FetchFeatures(_ context.Context, _ string) ([]backend.Feature, error) {
+	return nil, nil // Not used in reconciler tests
+}
+
+func (m *mockReconcileClient) GetFeature(
+	_ context.Context,
+	featureID string,
+) (*backendtypes.GetFeatureResult, error) {
+	if err, ok := m.errors[featureID]; ok {
+		return nil, err
+	}
+	if res, ok := m.results[featureID]; ok {
+		return res, nil
+	}
+	// Default to not found if not mocked
+	return nil, backendtypes.ErrEntityDoesNotExist
+}
+
+func TestReconcileHistory(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialDiff  *FeatureDiff
+		mockResults  map[string]*backendtypes.GetFeatureResult
+		mockErrors   map[string]error
+		expectedDiff *FeatureDiff
+		wantErr      bool
+	}{
+		{
+			name: "Scenario 1: Feature Moved (Rename)",
+			initialDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "old-id", Name: "Old Name", Reason: ReasonUnmatched}},
+				Added:        []FeatureAdded{{ID: "new-id", Name: "New Name", Reason: ReasonNewMatch, Docs: nil}},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"old-id": backendtypes.NewGetFeatureResult(
+					backendtypes.NewMovedFeatureResult("new-id"),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				Removed: nil, // Should be cleared
+				Added:   nil, // Should be cleared
+				Moves: []FeatureMoved{
+					{FromID: "old-id", FromName: "Old Name", ToID: "new-id", ToName: "New Name"},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Splits:       nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 2: Feature Split (Full)",
+			initialDiff: &FeatureDiff{
+				Removed: []FeatureRemoved{{ID: "monolith", Name: "Monolith Feature", Reason: ReasonUnmatched}},
+				Added: []FeatureAdded{
+					{ID: "part-1", Name: "Part 1", Reason: ReasonNewMatch, Docs: nil},
+					{ID: "part-2", Name: "Part 2", Reason: ReasonNewMatch, Docs: nil},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"monolith": backendtypes.NewGetFeatureResult(
+					backendtypes.NewSplitFeatureResult(backend.FeatureEvolutionSplit{
+						Features: []backend.FeatureSplitInfo{
+							{Id: "part-1"},
+							{Id: "part-2"},
+						},
+					}),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				Removed: nil,
+				Added:   nil,
+				Splits: []FeatureSplit{
+					{
+						FromID:   "monolith",
+						FromName: "Monolith Feature",
+						To: []FeatureAdded{
+							{ID: "part-1", Name: "Part 1", Reason: ReasonNewMatch, Docs: nil},
+							{ID: "part-2", Name: "Part 2", Reason: ReasonNewMatch, Docs: nil},
+						},
+					},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 3: Feature Split (Partial / Out of Scope)",
+			// 'part-2' matches the split definition but isn't in the Added list (maybe filtered out by query)
+			initialDiff: &FeatureDiff{
+				Removed: []FeatureRemoved{{ID: "monolith", Name: "Monolith Feature", Reason: ReasonUnmatched}},
+				Added: []FeatureAdded{
+					{ID: "part-1", Name: "Part 1", Reason: ReasonNewMatch, Docs: nil},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"monolith": backendtypes.NewGetFeatureResult(
+					backendtypes.NewSplitFeatureResult(backend.FeatureEvolutionSplit{
+						Features: []backend.FeatureSplitInfo{
+							{Id: "part-1"},
+							{Id: "part-2"},
+						},
+					}),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				Removed: nil,
+				Added:   nil,
+				Splits: []FeatureSplit{
+					{
+						FromID:   "monolith",
+						FromName: "Monolith Feature",
+						// Only part-1 is included because part-2 wasn't in the 'Added' list
+						To: []FeatureAdded{
+							{ID: "part-1", Name: "Part 1", Reason: ReasonNewMatch, Docs: nil},
+						},
+					},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 4: Regular Removal (No Move/Split)",
+			initialDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "removed-id", Name: "Removed Feature", Reason: ReasonUnmatched}},
+				Added:        nil,
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"removed-id": backendtypes.NewGetFeatureResult(
+					backendtypes.NewRegularFeatureResult(&backend.Feature{
+						FeatureId:              "removed-id",
+						Name:                   "",
+						Spec:                   nil,
+						Baseline:               nil,
+						BrowserImplementations: nil,
+						Discouraged:            nil,
+						Usage:                  nil,
+						Wpt:                    nil,
+						VendorPositions:        nil,
+						DeveloperSignals:       nil,
+					}),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				// Remains in Removed list
+				Removed:      []FeatureRemoved{{ID: "removed-id", Name: "Removed Feature", Reason: ReasonUnmatched}},
+				Added:        nil,
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 5: Hard Delete (EntityDoesNotExist)",
+			initialDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "deleted-id", Name: "Deleted Feature", Reason: ReasonUnmatched}},
+				Added:        nil,
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: nil,
+			mockErrors: map[string]error{
+				"deleted-id": backendtypes.ErrEntityDoesNotExist,
+			},
+			expectedDiff: &FeatureDiff{
+				// Remains in Removed list, but Reason updated to Deleted
+				Removed:      []FeatureRemoved{{ID: "deleted-id", Name: "Deleted Feature", Reason: ReasonDeleted}},
+				Added:        nil,
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 6: Move Target Missing from Added List",
+			// History says A moved to B, but B is NOT in the Added list.
+			// Should act as a regular removal.
+			initialDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "old-id", Name: "Old Name", Reason: ReasonUnmatched}},
+				Added:        []FeatureAdded{{ID: "unrelated-id", Name: "Unrelated", Reason: ReasonNewMatch, Docs: nil}},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"old-id": backendtypes.NewGetFeatureResult(
+					backendtypes.NewMovedFeatureResult("missing-new-id"),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "old-id", Name: "Old Name", Reason: ReasonUnmatched}},
+				Added:        []FeatureAdded{{ID: "unrelated-id", Name: "Unrelated", Reason: ReasonNewMatch, Docs: nil}},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 7: DB Error",
+			initialDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "error-id", Name: "Error Feature", Reason: ReasonUnmatched}},
+				Added:        nil,
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: nil,
+			mockErrors: map[string]error{
+				"error-id": errors.New("db connection failed"),
+			},
+			expectedDiff: nil,
+			wantErr:      true,
+		},
+		{
+			name: "Scenario 8: Split Targets Completely Missing",
+			// History says A split into B, but B is NOT in the Added list.
+			// Should act as a regular removal (hitting the 'else' block).
+			initialDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "monolith", Name: "Monolith Feature", Reason: ReasonUnmatched}},
+				Added:        []FeatureAdded{{ID: "unrelated", Name: "Unrelated", Reason: ReasonNewMatch, Docs: nil}},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"monolith": backendtypes.NewGetFeatureResult(
+					backendtypes.NewSplitFeatureResult(backend.FeatureEvolutionSplit{
+						Features: []backend.FeatureSplitInfo{
+							{Id: "missing-part"},
+						},
+					}),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				Removed:      []FeatureRemoved{{ID: "monolith", Name: "Monolith Feature", Reason: ReasonUnmatched}},
+				Added:        []FeatureAdded{{ID: "unrelated", Name: "Unrelated", Reason: ReasonNewMatch, Docs: nil}},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Scenario 9: Unrelated Additions Preserved",
+			// A moved to B. C is just a new feature.
+			// Result should be Move(A->B) + Added(C). B should NOT be in Added list.
+			initialDiff: &FeatureDiff{
+				Removed: []FeatureRemoved{{ID: "old-id", Name: "Old Name", Reason: ReasonUnmatched}},
+				Added: []FeatureAdded{
+					{ID: "new-id", Name: "New Name", Reason: ReasonNewMatch, Docs: nil},
+					{ID: "extra-id", Name: "Extra Feature", Reason: ReasonNewMatch, Docs: nil},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+			},
+			mockResults: map[string]*backendtypes.GetFeatureResult{
+				"old-id": backendtypes.NewGetFeatureResult(
+					backendtypes.NewMovedFeatureResult("new-id"),
+				),
+			},
+			mockErrors: nil,
+			expectedDiff: &FeatureDiff{
+				Removed: nil,
+				Added:   []FeatureAdded{{ID: "extra-id", Name: "Extra Feature", Reason: ReasonNewMatch, Docs: nil}},
+				Moves: []FeatureMoved{
+					{FromID: "old-id", FromName: "Old Name", ToID: "new-id", ToName: "New Name"},
+				},
+				QueryChanged: false,
+				Modified:     nil,
+				Splits:       nil,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &mockReconcileClient{
+				results: tc.mockResults,
+				errors:  tc.mockErrors,
+			}
+			w := NewFeatureDiffWorkflow(client, nil)
+
+			// We manually sort inputs here to ensure the test case inputs match
+			// what a real system might produce before reconciliation.
+			// (Though in reality, the Comparator output is usually unsorted until Run() finishes).
+			if tc.initialDiff != nil {
+				tc.initialDiff.Sort()
+			}
+
+			w.diff = tc.initialDiff
+
+			err := w.ReconcileHistory(context.Background())
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("reconcileHistory() expected error, got nil")
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("reconcileHistory() unexpected error: %v", err)
+			}
+
+			if tc.expectedDiff != nil {
+				tc.expectedDiff.Sort()
+			}
+
+			if diff := cmp.Diff(tc.expectedDiff, w.diff); diff != "" {
+				t.Errorf("reconcileHistory() mismatch. (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Moves the reconciliation logic from the old `event_producer` into the new `lib/blobtypes/featurelistdiff/v1` package.

The `ReconcileHistory` function enriches a simple diff by detecting when a "removed" feature was actually moved or split into other features. It does this by querying the database for the history of the removed feature ID. This makes the final diff notifications much more semantic and user-friendly.

This logic already exists in https://github.com/GoogleChrome/webstatus.dev/blob/29de49913acfeefef7ce28ae95d3801ccb605253/workers/event_producer/pkg/differ/reconciler.go. But to prevent too many changes at once, it will be removed in the future. (And if we do a simple move, things would not compile)

Part of #2107

Split up of #2106