### PR TITLE
feat(event_producer): implement v1 diff producer and workflow

### DIFF
--- a/workers/event_producer/pkg/producer/diff.go
+++ b/workers/event_producer/pkg/producer/diff.go
@@ -1,0 +1,385 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package producer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/blobtypes"
+	featurelistv1 "github.com/GoogleChrome/webstatus.dev/lib/blobtypes/featurelist/v1"
+	featurelistdiffv1 "github.com/GoogleChrome/webstatus.dev/lib/blobtypes/featurelistdiff/v1"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/generic"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes/comparables"
+	"github.com/GoogleChrome/webstatus.dev/workers/event_producer/pkg/differ"
+)
+
+var ErrInvalidFormat = errors.New("invalid format")
+
+// FeatureFetcher abstracts the external API.
+type FeatureFetcher interface {
+	FetchFeatures(ctx context.Context, query string) ([]backend.Feature, error)
+	GetFeature(ctx context.Context, featureID string) (*backendtypes.GetFeatureResult, error)
+}
+
+type migratorFunc func(bytes []byte) ([]byte, error)
+
+// stateConverter is a generic function type that defines how to convert a
+// versioned state snapshot of type S into the canonical diffing format.
+type stateConverter[S any] func(state *S) (map[string]comparables.Feature, string)
+
+// stateSerializerFunc defines how to create a versioned state snapshot `S`
+// from the canonical feature map and serialize it into raw bytes.
+type stateSerializerFunc[S any] func(id, searchID, eventID, query string,
+	snapshot map[string]comparables.Feature, timestamp time.Time) ([]byte, error)
+
+// v1StateSerializerFunc implements StateSerializerFunc for v1.FeatureListSnapshot.
+func v1StateSerializerFunc(id, searchID, eventID, query string,
+	snapshot map[string]comparables.Feature, timestamp time.Time) ([]byte, error) {
+	// Convert the canonical comparables.Feature map back to v1.Feature map
+	// This is the inverse of convertV1SnapshotToComparable logic.
+	v1Features := make(map[string]featurelistv1.Feature, len(snapshot))
+	for id, comparableFeature := range snapshot {
+		v1Features[id] = convertComparableToV1Feature(comparableFeature)
+	}
+
+	payload := featurelistv1.FeatureListSnapshot{
+		Metadata: featurelistv1.StateMetadata{
+			GeneratedAt:    timestamp,
+			SearchID:       searchID,
+			QuerySignature: query,
+			ID:             id,
+			EventID:        eventID,
+		},
+		Data: featurelistv1.FeatureListData{
+			Features: v1Features,
+		},
+	}
+
+	return blobtypes.NewBlob(payload)
+}
+
+// genericStateAdapter is a single, reusable implementation of the differ.StateAdapter interface.
+// It is generic over the state snapshot type S.
+type genericStateAdapter[S snapshot] struct {
+	migrator   migratorFunc
+	converter  stateConverter[S]
+	serializer stateSerializerFunc[S]
+}
+
+// newGenericStateAdapter creates the adapter, injecting the specific converter it should use.
+func newGenericStateAdapter[S snapshot](
+	migrator migratorFunc,
+	converter stateConverter[S],
+	serializer stateSerializerFunc[S],
+) *genericStateAdapter[S] {
+	return &genericStateAdapter[S]{
+		migrator:   migrator,
+		converter:  converter,
+		serializer: serializer,
+	}
+}
+
+type snapshot interface {
+	ID() string
+}
+
+// Load implements the differ.StateAdapter interface.
+func (a *genericStateAdapter[S]) Load(bytes []byte) (
+	map[string]comparables.Feature, string, string, bool, error,
+) {
+	if len(bytes) == 0 {
+		return nil, "", "", true, nil
+	}
+	migratedBytes, err := a.migrator(bytes)
+	if err != nil {
+		return nil, "", "", false, err
+	}
+
+	// 1. Unmarshal into the generic type S.
+	// We declare a variable of type S, and Go's generics ensure it's the correct concrete struct.
+	var snapshot S
+	if err := json.Unmarshal(migratedBytes, &snapshot); err != nil {
+		return nil, "", "", false, errors.Join(err, ErrInvalidFormat)
+	}
+
+	// 2. Use the injected converter function to perform the translation.
+	compMap, signature := a.converter(&snapshot)
+
+	// 3. Return the canonical data.
+	return compMap, snapshot.ID(), signature, false, nil
+}
+
+func (a *genericStateAdapter[S]) Serialize(id, searchID, eventID, query string,
+	timestamp time.Time, snapshot map[string]comparables.Feature) ([]byte, error) {
+	return a.serializer(id, searchID, eventID, query, snapshot, timestamp)
+}
+
+// V1DiffSerializer is a concrete implementation for serializing V1 diffs.
+type V1DiffSerializer struct{}
+
+// NewV1DiffSerializer creates a new serializer for V1 diffs.
+func NewV1DiffSerializer() *V1DiffSerializer {
+	return &V1DiffSerializer{}
+}
+
+// Serialize implements the differ.DiffSerializer interface.
+// It takes the pure V1 diff data and wraps it in the versioned blob envelope.
+func (s *V1DiffSerializer) Serialize(
+	id, searchID, eventID, newStateID, previousStateID string, diff *featurelistdiffv1.FeatureDiff, timestamp time.Time,
+) ([]byte, error) {
+
+	payload := featurelistdiffv1.FeatureListDiffSnapshot{
+		Metadata: featurelistdiffv1.DiffMetadata{
+			ID:              id,
+			EventID:         eventID,
+			SearchID:        searchID,
+			NewStateID:      newStateID,
+			PreviousStateID: previousStateID,
+			GeneratedAt:     timestamp,
+		},
+		Data: *diff,
+	}
+
+	return blobtypes.NewBlob(payload)
+}
+
+// convertV1SnapshotToComparable matches the StateConverter[featurelistv1.FeatureListSnapshot] signature.
+func convertV1SnapshotToComparable(state *featurelistv1.FeatureListSnapshot) (map[string]comparables.Feature, string) {
+	comparableMap := make(map[string]comparables.Feature, len(state.Data.Features))
+	for id, v1Feature := range state.Data.Features {
+		comparableMap[id] = convertV1FeatureToComparable(v1Feature)
+	}
+
+	return comparableMap, state.Metadata.QuerySignature
+}
+
+func NewDiffer(client FeatureFetcher) *differ.FeatureDiffer[featurelistdiffv1.FeatureDiff] {
+	m := blobtypes.NewMigrator()
+	// In the future, do the registration for migration here
+	v1MigrationFunc := func(bytes []byte) ([]byte, error) {
+		return blobtypes.Apply[featurelistv1.FeatureListSnapshot](m, bytes)
+	}
+
+	stateAdapter := newGenericStateAdapter(v1MigrationFunc, convertV1SnapshotToComparable, v1StateSerializerFunc)
+
+	diffSerializer := NewV1DiffSerializer()
+	workflow := featurelistdiffv1.NewFeatureDiffWorkflow(client, &workertypes.FeatureDiffV1SummaryGenerator{})
+
+	return differ.NewFeatureDiffer[featurelistdiffv1.FeatureDiff](client, workflow, stateAdapter, diffSerializer)
+}
+
+// convertV1FeatureToComparable maps a V1 feature struct to the canonical comparables.Feature.
+func convertV1FeatureToComparable(v1f featurelistv1.Feature) comparables.Feature {
+	// 1. Convert name and ID
+	name := generic.OptionallySet[string]{Value: v1f.Name.Value, IsSet: true}
+	id := v1f.ID
+
+	// 2. Convert BaselineStatus
+	baselineStatus := generic.UnsetOpt[comparables.BaselineState]()
+	if v1f.BaselineStatus.IsSet {
+		baselineStatus.IsSet = true
+		baselineInfoStatus := generic.UnsetOpt[backend.BaselineInfoStatus]()
+		if v1f.BaselineStatus.Value.Status.IsSet {
+			baselineInfoStatus.IsSet = true
+			var status backend.BaselineInfoStatus
+			switch v1f.BaselineStatus.Value.Status.Value {
+			case featurelistv1.Limited:
+				status = backend.Limited
+			case featurelistv1.Newly:
+				status = backend.Newly
+			case featurelistv1.Widely:
+				status = backend.Widely
+			}
+			baselineInfoStatus.Value = status
+			baselineStatus.Value.Status = baselineInfoStatus
+		}
+		baselineStatus.Value.LowDate = v1f.BaselineStatus.Value.LowDate
+		baselineStatus.Value.HighDate = v1f.BaselineStatus.Value.HighDate
+
+	}
+
+	// 3. Convert BrowserImplementations
+	browserImpls := generic.UnsetOpt[comparables.BrowserImplementations]()
+	if v1f.BrowserImpls.IsSet {
+		browserImpls.IsSet = true
+		browserImpls.Value = comparables.BrowserImplementations{
+			Chrome:         convertV1BrowserStatusToComparableState(v1f.BrowserImpls.Value.Chrome),
+			ChromeAndroid:  convertV1BrowserStatusToComparableState(v1f.BrowserImpls.Value.ChromeAndroid),
+			Edge:           convertV1BrowserStatusToComparableState(v1f.BrowserImpls.Value.Edge),
+			Firefox:        convertV1BrowserStatusToComparableState(v1f.BrowserImpls.Value.Firefox),
+			FirefoxAndroid: convertV1BrowserStatusToComparableState(v1f.BrowserImpls.Value.FirefoxAndroid),
+			Safari:         convertV1BrowserStatusToComparableState(v1f.BrowserImpls.Value.Safari),
+			SafariIos:      convertV1BrowserStatusToComparableState(v1f.BrowserImpls.Value.SafariIos),
+		}
+	}
+
+	// 4. Convert Docs
+	docs := generic.UnsetOpt[comparables.Docs]()
+	if v1f.Docs.IsSet {
+		docs.IsSet = true
+		mdnDocs := generic.UnsetOpt[[]comparables.MdnDoc]()
+		if v1f.Docs.Value.MdnDocs.IsSet {
+			mdnDocs.IsSet = true
+			for _, v1Doc := range v1f.Docs.Value.MdnDocs.Value {
+				mdnDocs.Value = append(mdnDocs.Value, comparables.MdnDoc{
+					URL:   v1Doc.URL,
+					Title: v1Doc.Title,
+					Slug:  v1Doc.Slug,
+				})
+			}
+		}
+		docs.Value.MdnDocs = mdnDocs
+	}
+
+	return comparables.Feature{
+		ID:             id,
+		Name:           name,
+		BaselineStatus: baselineStatus,
+		BrowserImpls:   browserImpls,
+		Docs:           docs,
+	}
+}
+
+// convertV1BrowserStatusToComparableState converts a simple string status from V1
+// into the more detailed comparables.BrowserState.
+func convertV1BrowserStatusToComparableState(
+	state generic.OptionallySet[featurelistv1.BrowserState]) generic.OptionallySet[comparables.BrowserState] {
+	browserState := generic.UnsetOpt[comparables.BrowserState]()
+	if !state.IsSet {
+		return browserState
+	}
+	browserState.IsSet = true
+	browserImplStatus := generic.UnsetOpt[backend.BrowserImplementationStatus]()
+	var status backend.BrowserImplementationStatus
+	if state.Value.Status.IsSet {
+		switch state.Value.Status.Value {
+		case featurelistv1.Available:
+			status = backend.Available
+		case featurelistv1.Unavailable:
+			status = backend.Unavailable
+		}
+		browserImplStatus.IsSet = true
+		browserImplStatus.Value = status
+		browserState.Value.Status = browserImplStatus
+	}
+	browserState.Value.Version = state.Value.Version
+	browserState.Value.Date = state.Value.Date
+
+	return browserState
+}
+
+// convertComparableToV1Feature maps a canonical comparables.Feature to a V1 feature struct.
+func convertComparableToV1Feature(cf comparables.Feature) featurelistv1.Feature {
+	// 1. Convert name and ID
+	name := generic.OptionallySet[string]{Value: cf.Name.Value, IsSet: cf.Name.IsSet}
+	id := cf.ID
+
+	// 2. Convert BaselineStatus
+	baselineStatus := generic.UnsetOpt[featurelistv1.BaselineState]()
+	if cf.BaselineStatus.IsSet {
+		baselineStatus.IsSet = true
+		baselineInfoStatus := generic.UnsetOpt[featurelistv1.BaselineInfoStatus]()
+		if cf.BaselineStatus.Value.Status.IsSet {
+			baselineInfoStatus.IsSet = true
+			var status featurelistv1.BaselineInfoStatus
+			switch cf.BaselineStatus.Value.Status.Value {
+			case backend.Limited:
+				status = featurelistv1.Limited
+			case backend.Newly:
+				status = featurelistv1.Newly
+			case backend.Widely:
+				status = featurelistv1.Widely
+			}
+			baselineInfoStatus.Value = status
+			baselineStatus.Value.Status = baselineInfoStatus
+		}
+		baselineStatus.Value.LowDate = cf.BaselineStatus.Value.LowDate
+		baselineStatus.Value.HighDate = cf.BaselineStatus.Value.HighDate
+	}
+
+	// 3. Convert BrowserImplementations
+	browserImpls := generic.UnsetOpt[featurelistv1.BrowserImplementations]()
+	if cf.BrowserImpls.IsSet {
+		browserImpls.IsSet = true
+		browserImpls.Value = featurelistv1.BrowserImplementations{
+			Chrome:         convertComparableBrowserStateToV1(cf.BrowserImpls.Value.Chrome),
+			ChromeAndroid:  convertComparableBrowserStateToV1(cf.BrowserImpls.Value.ChromeAndroid),
+			Edge:           convertComparableBrowserStateToV1(cf.BrowserImpls.Value.Edge),
+			Firefox:        convertComparableBrowserStateToV1(cf.BrowserImpls.Value.Firefox),
+			FirefoxAndroid: convertComparableBrowserStateToV1(cf.BrowserImpls.Value.FirefoxAndroid),
+			Safari:         convertComparableBrowserStateToV1(cf.BrowserImpls.Value.Safari),
+			SafariIos:      convertComparableBrowserStateToV1(cf.BrowserImpls.Value.SafariIos),
+		}
+	}
+
+	// 4. Convert Docs
+	docs := generic.UnsetOpt[featurelistv1.Docs]()
+	if cf.Docs.IsSet {
+		docs.IsSet = true
+		mdnDocs := generic.UnsetOpt[[]featurelistv1.MdnDoc]()
+		if cf.Docs.Value.MdnDocs.IsSet {
+			mdnDocs.IsSet = true
+			for _, compDoc := range cf.Docs.Value.MdnDocs.Value {
+				mdnDocs.Value = append(mdnDocs.Value, featurelistv1.MdnDoc{
+					URL:   compDoc.URL,
+					Title: compDoc.Title,
+					Slug:  compDoc.Slug,
+				})
+			}
+		}
+		docs.Value.MdnDocs = mdnDocs
+	}
+
+	return featurelistv1.Feature{
+		ID:             id,
+		Name:           name,
+		BaselineStatus: baselineStatus,
+		BrowserImpls:   browserImpls,
+		Docs:           docs,
+	}
+}
+
+// convertComparableBrowserStateToV1 converts a comparables.BrowserState to a V1 featurelistv1.BrowserState.
+func convertComparableBrowserStateToV1(
+	state generic.OptionallySet[comparables.BrowserState]) generic.OptionallySet[featurelistv1.BrowserState] {
+	v1BrowserState := generic.UnsetOpt[featurelistv1.BrowserState]()
+	if !state.IsSet {
+		return v1BrowserState
+	}
+	v1BrowserState.IsSet = true
+	v1BrowserImplStatus := generic.UnsetOpt[featurelistv1.BrowserImplementationStatus]()
+	var status featurelistv1.BrowserImplementationStatus
+	if state.Value.Status.IsSet {
+		switch state.Value.Status.Value {
+		case backend.Available:
+			status = featurelistv1.Available
+		case backend.Unavailable:
+			status = featurelistv1.Unavailable
+		}
+		v1BrowserImplStatus.IsSet = true
+		v1BrowserImplStatus.Value = status
+		v1BrowserState.Value.Status = v1BrowserImplStatus
+	}
+	v1BrowserState.Value.Version = state.Value.Version
+	v1BrowserState.Value.Date = state.Value.Date
+
+	return v1BrowserState
+}

--- a/workers/event_producer/pkg/producer/diff_test.go
+++ b/workers/event_producer/pkg/producer/diff_test.go
@@ -1,0 +1,286 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package producer
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	featurelistv1 "github.com/GoogleChrome/webstatus.dev/lib/blobtypes/featurelist/v1"
+	featurelistdiffv1 "github.com/GoogleChrome/webstatus.dev/lib/blobtypes/featurelistdiff/v1"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/generic"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes/comparables"
+	"github.com/GoogleChrome/webstatus.dev/workers/event_producer/pkg/differ"
+	"github.com/google/go-cmp/cmp"
+)
+
+// A concrete type for the generic parameter S in our tests.
+type testSnapshot struct {
+	Data   string `json:"data"`
+	IDVal  string `json:"idVal"`
+	idFunc func() string
+}
+
+// mock ID method for snapshot interface.
+func (s testSnapshot) ID() string {
+	if s.idFunc != nil {
+		return s.idFunc()
+	}
+
+	return s.IDVal
+}
+
+// TestGenericStateAdapter_Load tests the loading logic of the generic adapter.
+func TestGenericStateAdapter_Load(t *testing.T) {
+	testErr := errors.New("test error")
+	testSnapshotMap := map[string]comparables.Feature{"feat-a": {
+		ID:             "feat-a",
+		Name:           generic.UnsetOpt[string](),
+		BaselineStatus: generic.UnsetOpt[comparables.BaselineState](),
+		BrowserImpls:   generic.UnsetOpt[comparables.BrowserImplementations](),
+		Docs:           generic.UnsetOpt[comparables.Docs](),
+	}}
+
+	tests := []struct {
+		name          string
+		inputBytes    []byte
+		mockMigrator  migratorFunc
+		mockConverter stateConverter[testSnapshot]
+		wantSnapshot  map[string]comparables.Feature
+		wantID        string
+		wantSignature string
+		wantIsEmpty   bool
+		wantErr       error
+	}{
+		{
+			name:         "Empty input bytes",
+			inputBytes:   nil,
+			mockMigrator: func(b []byte) ([]byte, error) { return b, nil },
+			mockConverter: func(_ *testSnapshot) (map[string]comparables.Feature, string) {
+				return nil, ""
+			},
+			wantSnapshot:  nil,
+			wantID:        "",
+			wantSignature: "",
+			wantIsEmpty:   true,
+			wantErr:       nil,
+		},
+		{
+			name:         "Successful load",
+			inputBytes:   []byte(`{"data":"some-data", "idVal": "state-123"}`),
+			mockMigrator: func(b []byte) ([]byte, error) { return b, nil },
+			mockConverter: func(s *testSnapshot) (map[string]comparables.Feature, string) {
+				if s.Data != "some-data" {
+					t.Errorf("converter received unexpected data: %s", s.Data)
+				}
+
+				return testSnapshotMap, "sig-123"
+			},
+			wantSnapshot:  testSnapshotMap,
+			wantID:        "state-123",
+			wantSignature: "sig-123",
+			wantIsEmpty:   false,
+			wantErr:       nil,
+		},
+		{
+			name:         "Migrator fails",
+			inputBytes:   []byte("data"),
+			mockMigrator: func(_ []byte) ([]byte, error) { return nil, testErr },
+			mockConverter: func(_ *testSnapshot) (map[string]comparables.Feature, string) {
+				t.Error("converter should not be called when migrator fails")
+
+				return nil, ""
+			},
+			wantSnapshot:  nil,
+			wantID:        "",
+			wantSignature: "",
+			wantIsEmpty:   false,
+			wantErr:       testErr,
+		},
+		{
+			name:         "Unmarshal fails",
+			inputBytes:   []byte("invalid-json"),
+			mockMigrator: func(b []byte) ([]byte, error) { return b, nil },
+			mockConverter: func(_ *testSnapshot) (map[string]comparables.Feature, string) {
+				t.Error("converter should not be called when unmarshal fails")
+
+				return nil, ""
+			},
+			wantSnapshot:  nil,
+			wantID:        "",
+			wantSignature: "",
+			wantIsEmpty:   false,
+			wantErr:       ErrInvalidFormat,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter := newGenericStateAdapter(tc.mockMigrator, tc.mockConverter, nil)
+
+			gotSnapshot, gotID, gotSignature, gotIsEmpty, err := adapter.Load(tc.inputBytes)
+
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Load() error = %v, want type/is %v", err, tc.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(tc.wantSnapshot, gotSnapshot); diff != "" {
+				t.Errorf("Load() snapshot mismatch (-want +got):\n%s", diff)
+			}
+			if gotID != tc.wantID {
+				t.Errorf("Load() id mismatch: got %q, want %q", gotID, tc.wantID)
+			}
+			if gotSignature != tc.wantSignature {
+				t.Errorf("Load() signature mismatch: got %q, want %q", gotSignature, tc.wantSignature)
+			}
+			if gotIsEmpty != tc.wantIsEmpty {
+				t.Errorf("Load() isEmpty mismatch: got %v, want %v", gotIsEmpty, tc.wantIsEmpty)
+			}
+		})
+	}
+}
+
+// TestV1DiffSerializer_Serialize tests the V1 diff serializer.
+func TestV1DiffSerializer_Serialize(t *testing.T) {
+	serializer := NewV1DiffSerializer()
+	diff := &featurelistdiffv1.FeatureDiff{
+		QueryChanged: false,
+		Added:        []featurelistdiffv1.FeatureAdded{{ID: "feat-a", Name: "Feature A", Reason: "", Docs: nil}},
+		Removed:      nil,
+		Modified:     nil,
+		Moves:        nil,
+		Splits:       nil,
+	}
+	metadata := differ.DiffMetadata{
+		ID:              "diff-id1",
+		EventID:         "event-1",
+		SearchID:        "search-1",
+		NewStateID:      "state-2",
+		PreviousStateID: "state-1",
+	}
+	now := time.Now()
+
+	bytes, err := serializer.Serialize(metadata.ID, metadata.SearchID,
+		metadata.EventID, metadata.NewStateID, metadata.PreviousStateID, diff, now)
+	if err != nil {
+		t.Fatalf("Serialize() failed: %v", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(bytes, &raw); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	if kind, _ := raw["kind"].(string); kind != featurelistdiffv1.KindFeatureListDiff {
+		t.Errorf("envelope.Kind mismatch: got %q, want %q", kind, featurelistdiffv1.KindFeatureListDiff)
+	}
+	if version, _ := raw["apiVersion"].(string); version != featurelistdiffv1.V1FeatureListDiff {
+		t.Errorf("envelope.Version mismatch: got %q, want %q", version, featurelistdiffv1.V1FeatureListDiff)
+	}
+
+	// Remarshal the inner part to test the payload
+	payloadBytes, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var snapshot featurelistdiffv1.FeatureListDiffSnapshot
+	if err := json.Unmarshal(payloadBytes, &snapshot); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	if snapshot.Metadata.EventID != metadata.EventID {
+		t.Errorf("metadata.EventID mismatch")
+	}
+	if len(snapshot.Data.Added) != 1 {
+		t.Errorf("snapshot.Data was not serialized correctly")
+	}
+}
+
+// TestConversionFunctions tests the round trip of V1 <-> Comparable conversions.
+func TestConversionFunctions(t *testing.T) {
+	now := time.Now()
+	versionStr := "1.0"
+
+	// Define a fully populated canonical feature
+	canonicalFeature := comparables.Feature{
+		ID:   "feat-1",
+		Name: generic.OptionallySet[string]{Value: "Feature One", IsSet: true},
+		BaselineStatus: generic.OptionallySet[comparables.BaselineState]{
+			IsSet: true,
+			Value: comparables.BaselineState{
+				Status:   generic.OptionallySet[backend.BaselineInfoStatus]{Value: backend.Widely, IsSet: true},
+				LowDate:  generic.OptionallySet[*time.Time]{Value: &now, IsSet: true},
+				HighDate: generic.UnsetOpt[*time.Time](),
+			},
+		},
+		BrowserImpls: generic.OptionallySet[comparables.BrowserImplementations]{
+			IsSet: true,
+			Value: comparables.BrowserImplementations{
+				Chrome: generic.OptionallySet[comparables.BrowserState]{
+					IsSet: true,
+					Value: comparables.BrowserState{
+						Status:  generic.OptionallySet[backend.BrowserImplementationStatus]{Value: backend.Available, IsSet: true},
+						Version: generic.OptionallySet[*string]{Value: &versionStr, IsSet: true},
+						Date:    generic.OptionallySet[*time.Time]{Value: &now, IsSet: true},
+					},
+				},
+				ChromeAndroid: generic.UnsetOpt[comparables.BrowserState](),
+				Edge:          generic.UnsetOpt[comparables.BrowserState](),
+				Firefox: generic.OptionallySet[comparables.BrowserState]{
+					IsSet: true,
+					Value: comparables.BrowserState{
+						Status:  generic.OptionallySet[backend.BrowserImplementationStatus]{Value: backend.Unavailable, IsSet: true},
+						Version: generic.UnsetOpt[*string](),
+						Date:    generic.UnsetOpt[*time.Time](),
+					},
+				},
+				FirefoxAndroid: generic.UnsetOpt[comparables.BrowserState](),
+				Safari:         generic.UnsetOpt[comparables.BrowserState](), // Unset browser
+				SafariIos:      generic.UnsetOpt[comparables.BrowserState](),
+			},
+		},
+		Docs: generic.UnsetOpt[comparables.Docs](),
+	}
+
+	// 1. Convert Canonical -> V1
+	v1Feature := convertComparableToV1Feature(canonicalFeature)
+
+	// Assert V1 structure is correct
+	if !v1Feature.BrowserImpls.Value.Chrome.IsSet ||
+		!v1Feature.BrowserImpls.Value.Chrome.Value.Status.IsSet ||
+		v1Feature.BrowserImpls.Value.Chrome.Value.Status.Value != featurelistv1.Available {
+		t.Error("failed to convert browser status to V1")
+	}
+	if v1Feature.BrowserImpls.Value.Safari.IsSet {
+		t.Error("expected unset Safari to remain unset in V1")
+	}
+	if !v1Feature.BaselineStatus.IsSet ||
+		v1Feature.BaselineStatus.Value.Status.Value != featurelistv1.Widely {
+		t.Error("failed to convert baseline status to V1")
+	}
+
+	// 2. Convert V1 -> Canonical (Round trip)
+	roundTrippedFeature := convertV1FeatureToComparable(v1Feature)
+
+	// 3. Compare original with round-tripped
+	if diff := cmp.Diff(canonicalFeature, roundTrippedFeature); diff != "" {
+		t.Errorf("round trip conversion mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/workers/event_producer/pkg/producer/producer.go
+++ b/workers/event_producer/pkg/producer/producer.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package producer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+	"github.com/GoogleChrome/webstatus.dev/workers/event_producer/pkg/differ"
+)
+
+// FeatureDiffer encapsulates the core logic for comparing the live state.
+type FeatureDiffer interface {
+	Run(ctx context.Context, searchID, query, eventID string, previousStateBytes []byte) (*differ.DiffResult, error)
+}
+
+// BlobStorage handles the persistence of opaque data blobs (State Snapshots and Diff Reports).
+type BlobStorage interface {
+	Store(ctx context.Context, key string, data []byte) error
+	Get(ctx context.Context, key string) ([]byte, error)
+}
+
+// EventMetadataStore handles the publishing and retrieval of event metadata.
+type EventMetadataStore interface {
+	PublishEvent(ctx context.Context, req workertypes.PublishEventRequest) error
+	// GetLatestEvent retrieves the last known event for a search to establish continuity.
+	GetLatestEvent(ctx context.Context, searchID string) (*workertypes.LatestEventInfo, error)
+}
+
+// EventPublisher handles broadcasting the event to the rest of the system (e.g. via Pub/Sub).
+type EventPublisher interface {
+	Publish(ctx context.Context, req workertypes.PublishEventRequest) error
+}
+
+// EventProducer orchestrates the diffing and publishing pipeline.
+type EventProducer struct {
+	differ    FeatureDiffer
+	blobStore BlobStorage
+	metaStore EventMetadataStore
+	publisher EventPublisher
+}
+
+func NewEventProducer(d FeatureDiffer, b BlobStorage, m EventMetadataStore, p EventPublisher) *EventProducer {
+	return &EventProducer{
+		differ:    d,
+		blobStore: b,
+		metaStore: m,
+		publisher: p,
+	}
+}
+
+// ProcessSearch is the main entry point triggered when a search query needs to be checked.
+// triggerID is the unique ID for this execution (e.g., from a Pub/Sub message).
+func (p *EventProducer) ProcessSearch(ctx context.Context, searchID string, query string, triggerID string) error {
+	// 1. Fetch Previous State
+	// We need the last known state to compute the diff.
+	lastEvent, err := p.metaStore.GetLatestEvent(ctx, searchID)
+	if err != nil {
+		return fmt.Errorf("failed to get latest event info: %w", err)
+	}
+
+	var previousStateBytes []byte
+	if lastEvent != nil && lastEvent.StateID != "" {
+		// If we have history, fetch the actual bytes from "Cold Storage"
+		previousStateBytes, err = p.blobStore.Get(ctx, lastEvent.StateID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch previous state blob: %w", err)
+		}
+	}
+
+	// 2. Run the Differ
+	// This performs the logic: Fetch Live -> Compare(Old, New) -> Generate Artifacts
+	result, err := p.differ.Run(ctx, searchID, query, triggerID, previousStateBytes)
+	if err != nil {
+		if errors.Is(err, differ.ErrNoChangesDetected) {
+			slog.InfoContext(ctx, "no changes detected", "search_id", searchID)
+
+			return nil
+		}
+
+		return fmt.Errorf("differ execution failed: %w", err)
+	}
+
+	// 3. Store Artifacts (Blob Storage)
+	// We have to save both the Full State and the Diff.
+	// Note: We are trusting the Differ to have generated valid IDs in the result.
+	if err := p.blobStore.Store(ctx, result.State.ID, result.State.Bytes); err != nil {
+		return fmt.Errorf("failed to store state blob: %w", err)
+	}
+
+	if len(result.Diff.Bytes) > 0 {
+		if err := p.blobStore.Store(ctx, result.Diff.ID, result.Diff.Bytes); err != nil {
+			return fmt.Errorf("failed to store diff blob: %w", err)
+		}
+	}
+
+	// 4. Publish Metadata (Hot Storage)
+	req := workertypes.PublishEventRequest{
+		EventID:  triggerID,
+		SearchID: searchID,
+		StateID:  result.State.ID,
+		DiffID:   result.Diff.ID,
+		Summary:  result.Summary,
+		Reasons:  result.Reasons,
+	}
+
+	if err := p.metaStore.PublishEvent(ctx, req); err != nil {
+		return fmt.Errorf("failed to publish event metadata: %w", err)
+	}
+
+	// 6. Publish Notification (Topic)
+	// Notify downstream workers that a new event is available.
+	if err := p.publisher.Publish(ctx, req); err != nil {
+		return fmt.Errorf("failed to publish event notification: %w", err)
+	}
+
+	slog.InfoContext(ctx, "event published successfully", "event_id", triggerID, "reasons", result.Reasons)
+
+	return nil
+}

--- a/workers/event_producer/pkg/producer/producer_test.go
+++ b/workers/event_producer/pkg/producer/producer_test.go
@@ -1,0 +1,387 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package producer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+	"github.com/GoogleChrome/webstatus.dev/workers/event_producer/pkg/differ"
+	"github.com/google/go-cmp/cmp"
+)
+
+//
+// Mocks for testing the EventProducer
+//
+
+type mockFeatureDiffer struct {
+	runCalledWith struct {
+		searchID           string
+		query              string
+		eventID            string
+		previousStateBytes []byte
+	}
+	runReturns struct {
+		result *differ.DiffResult
+		err    error
+	}
+}
+
+func (m *mockFeatureDiffer) Run(_ context.Context, searchID, query, eventID string,
+	previousStateBytes []byte) (*differ.DiffResult, error) {
+	m.runCalledWith.searchID = searchID
+	m.runCalledWith.query = query
+	m.runCalledWith.eventID = eventID
+	m.runCalledWith.previousStateBytes = previousStateBytes
+
+	return m.runReturns.result, m.runReturns.err
+}
+
+type mockBlobStorage struct {
+	storeCalls  map[string][]byte
+	storeErrors map[string]error
+	getResults  map[string][]byte
+	getErrors   map[string]error
+}
+
+func (m *mockBlobStorage) Store(_ context.Context, key string, data []byte) error {
+	if err, ok := m.storeErrors[key]; ok {
+		return err
+	}
+	if m.storeCalls == nil {
+		m.storeCalls = make(map[string][]byte)
+	}
+	m.storeCalls[key] = data
+
+	return nil
+}
+
+func (m *mockBlobStorage) Get(_ context.Context, key string) ([]byte, error) {
+	if err, ok := m.getErrors[key]; ok {
+		return nil, err
+	}
+
+	return m.getResults[key], nil
+}
+
+type mockEventMetadataStore struct {
+	publishEventCalledWith workertypes.PublishEventRequest
+	publishEventReturns    error
+	getLatestEventReturns  struct {
+		info *workertypes.LatestEventInfo
+		err  error
+	}
+}
+
+func (m *mockEventMetadataStore) PublishEvent(_ context.Context, req workertypes.PublishEventRequest) error {
+	m.publishEventCalledWith = req
+
+	return m.publishEventReturns
+}
+
+func (m *mockEventMetadataStore) GetLatestEvent(_ context.Context, _ string) (*workertypes.LatestEventInfo, error) {
+	return m.getLatestEventReturns.info, m.getLatestEventReturns.err
+}
+
+type mockEventPublisher struct {
+	publishCalledWith workertypes.PublishEventRequest
+	publishReturns    error
+}
+
+func (m *mockEventPublisher) Publish(_ context.Context, req workertypes.PublishEventRequest) error {
+	m.publishCalledWith = req
+
+	return m.publishReturns
+}
+
+func TestProcessSearch_Success(t *testing.T) {
+	ctx := context.Background()
+	searchID := "search-abc"
+	triggerID := "trigger-123"
+	query := "q=test"
+
+	// 1. Define a helper struct for mocks to fix lll and function signature complexity
+	type testMocks struct {
+		differ *mockFeatureDiffer
+		blob   *mockBlobStorage
+		meta   *mockEventMetadataStore
+		pub    *mockEventPublisher
+	}
+
+	type testCase struct {
+		name        string
+		setup       func(*testMocks)
+		verify      func(*testing.T, *testMocks)
+		expectedReq workertypes.PublishEventRequest
+	}
+
+	tests := []testCase{
+		{
+			name: "First run (cold start)",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = nil
+				m.differ.runReturns.result = &differ.DiffResult{
+					State:   differ.BlobArtifact{ID: "state-1", Bytes: []byte("state-data")},
+					Diff:    differ.BlobArtifact{ID: "diff-1", Bytes: []byte("diff-data")},
+					Summary: []byte("summary"),
+					Reasons: []workertypes.Reason{workertypes.ReasonDataUpdated},
+				}
+			},
+			expectedReq: workertypes.PublishEventRequest{
+				EventID:  triggerID,
+				SearchID: searchID,
+				StateID:  "state-1",
+				DiffID:   "diff-1",
+				Summary:  []byte("summary"),
+				Reasons:  []workertypes.Reason{workertypes.ReasonDataUpdated},
+			},
+			verify: func(t *testing.T, m *testMocks) {
+				if m.differ.runCalledWith.previousStateBytes != nil {
+					t.Error("expected previousStateBytes to be nil on first run")
+				}
+				if _, ok := m.blob.storeCalls["state-1"]; !ok {
+					t.Error("expected state blob to be stored")
+				}
+				if _, ok := m.blob.storeCalls["diff-1"]; !ok {
+					t.Error("expected diff blob to be stored")
+				}
+			},
+		},
+		{
+			name: "Subsequent run with changes",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = &workertypes.LatestEventInfo{
+					EventID: "",
+					StateID: "prev-state-0",
+				}
+				m.blob.getResults = map[string][]byte{
+					"prev-state-0": []byte("old-state-data"),
+				}
+				m.differ.runReturns.result = &differ.DiffResult{
+					State:   differ.BlobArtifact{ID: "state-2", Bytes: []byte("new-state-data")},
+					Diff:    differ.BlobArtifact{ID: "diff-2", Bytes: []byte("new-diff-data")},
+					Summary: []byte("new-summary"),
+					Reasons: []workertypes.Reason{workertypes.ReasonQueryChanged},
+				}
+			},
+			// To satisfy exhaustruct, we define zero values explicitly if needed,
+			// or just the fields we verify.
+			expectedReq: workertypes.PublishEventRequest{
+				EventID:  triggerID,
+				SearchID: searchID,
+				StateID:  "state-2",
+				DiffID:   "diff-2",
+				Summary:  []byte("new-summary"),
+				Reasons:  []workertypes.Reason{workertypes.ReasonQueryChanged},
+			},
+			verify: func(t *testing.T, m *testMocks) {
+				if string(m.differ.runCalledWith.previousStateBytes) != "old-state-data" {
+					t.Errorf("got prev state %s", m.differ.runCalledWith.previousStateBytes)
+				}
+				if _, ok := m.blob.storeCalls["state-2"]; !ok {
+					t.Error("expected new state blob to be stored")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			mocks := &testMocks{
+				differ: new(mockFeatureDiffer),
+				blob:   new(mockBlobStorage),
+				meta:   new(mockEventMetadataStore),
+				pub:    new(mockEventPublisher),
+			}
+			tc.setup(mocks)
+
+			// Execute
+			producer := NewEventProducer(mocks.differ, mocks.blob, mocks.meta, mocks.pub)
+			err := producer.ProcessSearch(ctx, searchID, query, triggerID)
+
+			// Verify
+			if err != nil {
+				t.Fatalf("ProcessSearch() unexpected error: %v", err)
+			}
+
+			// Common verification for success cases
+			if diff := cmp.Diff(tc.expectedReq, mocks.meta.publishEventCalledWith); diff != "" {
+				t.Errorf("PublishEvent metadata mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.expectedReq, mocks.pub.publishCalledWith); diff != "" {
+				t.Errorf("Publish notification mismatch (-want +got):\n%s", diff)
+			}
+
+			// Custom verification
+			if tc.verify != nil {
+				tc.verify(t, mocks)
+			}
+		})
+	}
+}
+
+func TestProcessSearch_NoChanges(t *testing.T) {
+	// Separated because the assertions are completely different
+	// (checking that things did NOT happen).
+	ctx := context.Background()
+	differMock := new(mockFeatureDiffer)
+	blobMock := new(mockBlobStorage)
+	metaMock := new(mockEventMetadataStore)
+	pubMock := new(mockEventPublisher)
+
+	metaMock.getLatestEventReturns.info = nil
+	differMock.runReturns.err = differ.ErrNoChangesDetected
+
+	producer := NewEventProducer(differMock, blobMock, metaMock, pubMock)
+	err := producer.ProcessSearch(ctx, "search-id", "q=test", "trigger-id")
+
+	if err != nil {
+		t.Fatalf("expected nil error for no changes, got %v", err)
+	}
+	if len(blobMock.storeCalls) > 0 {
+		t.Error("expected no blobs to be stored")
+	}
+	if metaMock.publishEventCalledWith.EventID != "" {
+		t.Error("expected no metadata published")
+	}
+	if pubMock.publishCalledWith.EventID != "" {
+		t.Error("expected no notification published")
+	}
+}
+
+func TestProcessSearch_Failures(t *testing.T) {
+	ctx := context.Background()
+	type testMocks struct {
+		differ *mockFeatureDiffer
+		blob   *mockBlobStorage
+		meta   *mockEventMetadataStore
+		pub    *mockEventPublisher
+	}
+
+	type testCase struct {
+		name   string
+		setup  func(*testMocks)
+		verify func(*testing.T, *testMocks)
+	}
+
+	tests := []testCase{
+		{
+			name: "GetLatestEvent fails",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.err = errors.New("db error")
+			},
+			verify: nil, // No extra verification needed
+		},
+		{
+			name: "Get blob fails",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = &workertypes.LatestEventInfo{
+					EventID: "",
+					StateID: "prev-state-x",
+				}
+				m.blob.getErrors = map[string]error{"prev-state-x": errors.New("gcs error")}
+			},
+			verify: nil,
+		},
+		{
+			name: "Differ Run fails",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = nil
+				m.differ.runReturns.err = errors.New("differ fatal error")
+			},
+			verify: nil,
+		},
+		{
+			name: "Store state blob fails",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = nil
+				m.differ.runReturns.result = &differ.DiffResult{
+					State:   differ.BlobArtifact{ID: "state-fail", Bytes: []byte("state")},
+					Diff:    differ.BlobArtifact{ID: "diff-fail", Bytes: []byte("diff")},
+					Summary: nil,
+					Reasons: nil,
+				}
+				m.blob.storeErrors = map[string]error{
+					"state-fail": errors.New("storage error"),
+				}
+			},
+			verify: func(t *testing.T, m *testMocks) {
+				if _, ok := m.blob.storeCalls["diff-fail"]; ok {
+					t.Error("should not have tried to store diff blob when state blob failed")
+				}
+				if m.meta.publishEventCalledWith.EventID != "" {
+					t.Error("should not have published metadata")
+				}
+			},
+		},
+		{
+			name: "Publish event metadata fails",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = nil
+				m.differ.runReturns.result = &differ.DiffResult{
+					State:   differ.BlobArtifact{ID: "state-1", Bytes: []byte("state-data")},
+					Diff:    differ.BlobArtifact{ID: "diff-1", Bytes: []byte("diff-data")},
+					Summary: nil,
+					Reasons: nil,
+				}
+				m.meta.publishEventReturns = errors.New("metadata store error")
+			},
+			verify: func(t *testing.T, m *testMocks) {
+				if _, ok := m.blob.storeCalls["state-1"]; !ok {
+					t.Error("expected state blob to be stored even if metadata publish fails")
+				}
+			},
+		},
+		{
+			name: "Publish event notification fails",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = nil
+				m.differ.runReturns.result = &differ.DiffResult{
+					State:   differ.BlobArtifact{ID: "state-1", Bytes: []byte("state-data")},
+					Diff:    differ.BlobArtifact{ID: "diff-1", Bytes: []byte("diff-data")},
+					Summary: nil,
+					Reasons: nil,
+				}
+				m.pub.publishReturns = errors.New("pubsub error")
+			},
+			verify: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mocks := &testMocks{
+				differ: new(mockFeatureDiffer),
+				blob:   new(mockBlobStorage),
+				meta:   new(mockEventMetadataStore),
+				pub:    new(mockEventPublisher),
+			}
+			tc.setup(mocks)
+
+			producer := NewEventProducer(mocks.differ, mocks.blob, mocks.meta, mocks.pub)
+			err := producer.ProcessSearch(ctx, "search-abc", "q=test", "trigger-123")
+
+			if err == nil {
+				t.Error("ProcessSearch() expected error, got nil")
+			}
+			if tc.verify != nil {
+				tc.verify(t, mocks)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Wires together the new generic `FeatureDiffer` with the concrete V1 implementations. This shows that all the used blob version configurations are updated in one place.

- Creates the V1 `StateAdapter` and `DiffSerializer`.
- Implements the `producer.EventProducer` which orchestrates fetching data, running the differ, and publishing results.

Part of #2107

Split up of #2106