### PR TITLE
feat(event_producer): implement generic event producer logic

### DIFF
--- a/workers/event_producer/pkg/producer/producer.go
+++ b/workers/event_producer/pkg/producer/producer.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package producer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+	"github.com/GoogleChrome/webstatus.dev/workers/event_producer/pkg/differ"
+)
+
+// FeatureDiffer encapsulates the core logic for comparing the live state.
+type FeatureDiffer interface {
+	Run(ctx context.Context, searchID, query, eventID string, previousStateBytes []byte) (*differ.DiffResult, error)
+}
+
+// BlobStorage handles the persistence of opaque data blobs (State Snapshots and Diff Reports).
+type BlobStorage interface {
+	Store(ctx context.Context, key string, data []byte) error
+	Get(ctx context.Context, key string) ([]byte, error)
+}
+
+// EventMetadataStore handles the publishing and retrieval of event metadata.
+type EventMetadataStore interface {
+	PublishEvent(ctx context.Context, req workertypes.PublishEventRequest) error
+	// GetLatestEvent retrieves the last known event for a search to establish continuity.
+	GetLatestEvent(ctx context.Context, searchID string) (*workertypes.LatestEventInfo, error)
+}
+
+// EventPublisher handles broadcasting the event to the rest of the system (e.g. via Pub/Sub).
+type EventPublisher interface {
+	Publish(ctx context.Context, req workertypes.PublishEventRequest) error
+}
+
+// EventProducer orchestrates the diffing and publishing pipeline.
+type EventProducer struct {
+	differ    FeatureDiffer
+	blobStore BlobStorage
+	metaStore EventMetadataStore
+	publisher EventPublisher
+}
+
+func NewEventProducer(d FeatureDiffer, b BlobStorage, m EventMetadataStore, p EventPublisher) *EventProducer {
+	return &EventProducer{
+		differ:    d,
+		blobStore: b,
+		metaStore: m,
+		publisher: p,
+	}
+}
+
+// ProcessSearch is the main entry point triggered when a search query needs to be checked.
+// triggerID is the unique ID for this execution (e.g., from a Pub/Sub message).
+func (p *EventProducer) ProcessSearch(ctx context.Context, searchID string, query string, triggerID string) error {
+	// 1. Fetch Previous State
+	// We need the last known state to compute the diff.
+	lastEvent, err := p.metaStore.GetLatestEvent(ctx, searchID)
+	if err != nil {
+		return fmt.Errorf("failed to get latest event info: %w", err)
+	}
+
+	var previousStateBytes []byte
+	if lastEvent != nil && lastEvent.StateID != "" {
+		// If we have history, fetch the actual bytes from "Cold Storage"
+		previousStateBytes, err = p.blobStore.Get(ctx, lastEvent.StateID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch previous state blob: %w", err)
+		}
+	}
+
+	// 2. Run the Differ
+	// This performs the logic: Fetch Live -> Compare(Old, New) -> Generate Artifacts
+	result, err := p.differ.Run(ctx, searchID, query, triggerID, previousStateBytes)
+	if err != nil {
+		if errors.Is(err, differ.ErrNoChangesDetected) {
+			slog.InfoContext(ctx, "no changes detected", "search_id", searchID)
+
+			return nil
+		}
+
+		return fmt.Errorf("differ execution failed: %w", err)
+	}
+
+	// 3. Store Artifacts (Blob Storage)
+	// We have to save both the Full State and the Diff.
+	// Note: We are trusting the Differ to have generated valid IDs in the result.
+	if err := p.blobStore.Store(ctx, result.State.ID, result.State.Bytes); err != nil {
+		return fmt.Errorf("failed to store state blob: %w", err)
+	}
+
+	if len(result.Diff.Bytes) > 0 {
+		if err := p.blobStore.Store(ctx, result.Diff.ID, result.Diff.Bytes); err != nil {
+			return fmt.Errorf("failed to store diff blob: %w", err)
+		}
+	}
+
+	// 4. Publish Metadata (Hot Storage)
+	req := workertypes.PublishEventRequest{
+		EventID:  triggerID,
+		SearchID: searchID,
+		StateID:  result.State.ID,
+		DiffID:   result.Diff.ID,
+		Summary:  result.Summary,
+		Reasons:  result.Reasons,
+	}
+
+	if err := p.metaStore.PublishEvent(ctx, req); err != nil {
+		return fmt.Errorf("failed to publish event metadata: %w", err)
+	}
+
+	// 6. Publish Notification (Topic)
+	// Notify downstream workers that a new event is available.
+	if err := p.publisher.Publish(ctx, req); err != nil {
+		return fmt.Errorf("failed to publish event notification: %w", err)
+	}
+
+	slog.InfoContext(ctx, "event published successfully", "event_id", triggerID, "reasons", result.Reasons)
+
+	return nil
+}

--- a/workers/event_producer/pkg/producer/producer_test.go
+++ b/workers/event_producer/pkg/producer/producer_test.go
@@ -1,0 +1,387 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package producer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+	"github.com/GoogleChrome/webstatus.dev/workers/event_producer/pkg/differ"
+	"github.com/google/go-cmp/cmp"
+)
+
+//
+// Mocks for testing the EventProducer
+//
+
+type mockFeatureDiffer struct {
+	runCalledWith struct {
+		searchID           string
+		query              string
+		eventID            string
+		previousStateBytes []byte
+	}
+	runReturns struct {
+		result *differ.DiffResult
+		err    error
+	}
+}
+
+func (m *mockFeatureDiffer) Run(_ context.Context, searchID, query, eventID string,
+	previousStateBytes []byte) (*differ.DiffResult, error) {
+	m.runCalledWith.searchID = searchID
+	m.runCalledWith.query = query
+	m.runCalledWith.eventID = eventID
+	m.runCalledWith.previousStateBytes = previousStateBytes
+
+	return m.runReturns.result, m.runReturns.err
+}
+
+type mockBlobStorage struct {
+	storeCalls  map[string][]byte
+	storeErrors map[string]error
+	getResults  map[string][]byte
+	getErrors   map[string]error
+}
+
+func (m *mockBlobStorage) Store(_ context.Context, key string, data []byte) error {
+	if err, ok := m.storeErrors[key]; ok {
+		return err
+	}
+	if m.storeCalls == nil {
+		m.storeCalls = make(map[string][]byte)
+	}
+	m.storeCalls[key] = data
+
+	return nil
+}
+
+func (m *mockBlobStorage) Get(_ context.Context, key string) ([]byte, error) {
+	if err, ok := m.getErrors[key]; ok {
+		return nil, err
+	}
+
+	return m.getResults[key], nil
+}
+
+type mockEventMetadataStore struct {
+	publishEventCalledWith workertypes.PublishEventRequest
+	publishEventReturns    error
+	getLatestEventReturns  struct {
+		info *workertypes.LatestEventInfo
+		err  error
+	}
+}
+
+func (m *mockEventMetadataStore) PublishEvent(_ context.Context, req workertypes.PublishEventRequest) error {
+	m.publishEventCalledWith = req
+
+	return m.publishEventReturns
+}
+
+func (m *mockEventMetadataStore) GetLatestEvent(_ context.Context, _ string) (*workertypes.LatestEventInfo, error) {
+	return m.getLatestEventReturns.info, m.getLatestEventReturns.err
+}
+
+type mockEventPublisher struct {
+	publishCalledWith workertypes.PublishEventRequest
+	publishReturns    error
+}
+
+func (m *mockEventPublisher) Publish(_ context.Context, req workertypes.PublishEventRequest) error {
+	m.publishCalledWith = req
+
+	return m.publishReturns
+}
+
+func TestProcessSearch_Success(t *testing.T) {
+	ctx := context.Background()
+	searchID := "search-abc"
+	triggerID := "trigger-123"
+	query := "q=test"
+
+	// 1. Define a helper struct for mocks to fix lll and function signature complexity
+	type testMocks struct {
+		differ *mockFeatureDiffer
+		blob   *mockBlobStorage
+		meta   *mockEventMetadataStore
+		pub    *mockEventPublisher
+	}
+
+	type testCase struct {
+		name        string
+		setup       func(*testMocks)
+		verify      func(*testing.T, *testMocks)
+		expectedReq workertypes.PublishEventRequest
+	}
+
+	tests := []testCase{
+		{
+			name: "First run (cold start)",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = nil
+				m.differ.runReturns.result = &differ.DiffResult{
+					State:   differ.BlobArtifact{ID: "state-1", Bytes: []byte("state-data")},
+					Diff:    differ.BlobArtifact{ID: "diff-1", Bytes: []byte("diff-data")},
+					Summary: []byte("summary"),
+					Reasons: []workertypes.Reason{workertypes.ReasonDataUpdated},
+				}
+			},
+			expectedReq: workertypes.PublishEventRequest{
+				EventID:  triggerID,
+				SearchID: searchID,
+				StateID:  "state-1",
+				DiffID:   "diff-1",
+				Summary:  []byte("summary"),
+				Reasons:  []workertypes.Reason{workertypes.ReasonDataUpdated},
+			},
+			verify: func(t *testing.T, m *testMocks) {
+				if m.differ.runCalledWith.previousStateBytes != nil {
+					t.Error("expected previousStateBytes to be nil on first run")
+				}
+				if _, ok := m.blob.storeCalls["state-1"]; !ok {
+					t.Error("expected state blob to be stored")
+				}
+				if _, ok := m.blob.storeCalls["diff-1"]; !ok {
+					t.Error("expected diff blob to be stored")
+				}
+			},
+		},
+		{
+			name: "Subsequent run with changes",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = &workertypes.LatestEventInfo{
+					EventID: "",
+					StateID: "prev-state-0",
+				}
+				m.blob.getResults = map[string][]byte{
+					"prev-state-0": []byte("old-state-data"),
+				}
+				m.differ.runReturns.result = &differ.DiffResult{
+					State:   differ.BlobArtifact{ID: "state-2", Bytes: []byte("new-state-data")},
+					Diff:    differ.BlobArtifact{ID: "diff-2", Bytes: []byte("new-diff-data")},
+					Summary: []byte("new-summary"),
+					Reasons: []workertypes.Reason{workertypes.ReasonQueryChanged},
+				}
+			},
+			// To satisfy exhaustruct, we define zero values explicitly if needed,
+			// or just the fields we verify.
+			expectedReq: workertypes.PublishEventRequest{
+				EventID:  triggerID,
+				SearchID: searchID,
+				StateID:  "state-2",
+				DiffID:   "diff-2",
+				Summary:  []byte("new-summary"),
+				Reasons:  []workertypes.Reason{workertypes.ReasonQueryChanged},
+			},
+			verify: func(t *testing.T, m *testMocks) {
+				if string(m.differ.runCalledWith.previousStateBytes) != "old-state-data" {
+					t.Errorf("got prev state %s", m.differ.runCalledWith.previousStateBytes)
+				}
+				if _, ok := m.blob.storeCalls["state-2"]; !ok {
+					t.Error("expected new state blob to be stored")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			mocks := &testMocks{
+				differ: new(mockFeatureDiffer),
+				blob:   new(mockBlobStorage),
+				meta:   new(mockEventMetadataStore),
+				pub:    new(mockEventPublisher),
+			}
+			tc.setup(mocks)
+
+			// Execute
+			producer := NewEventProducer(mocks.differ, mocks.blob, mocks.meta, mocks.pub)
+			err := producer.ProcessSearch(ctx, searchID, query, triggerID)
+
+			// Verify
+			if err != nil {
+				t.Fatalf("ProcessSearch() unexpected error: %v", err)
+			}
+
+			// Common verification for success cases
+			if diff := cmp.Diff(tc.expectedReq, mocks.meta.publishEventCalledWith); diff != "" {
+				t.Errorf("PublishEvent metadata mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.expectedReq, mocks.pub.publishCalledWith); diff != "" {
+				t.Errorf("Publish notification mismatch (-want +got):\n%s", diff)
+			}
+
+			// Custom verification
+			if tc.verify != nil {
+				tc.verify(t, mocks)
+			}
+		})
+	}
+}
+
+func TestProcessSearch_NoChanges(t *testing.T) {
+	// Separated because the assertions are completely different
+	// (checking that things did NOT happen).
+	ctx := context.Background()
+	differMock := new(mockFeatureDiffer)
+	blobMock := new(mockBlobStorage)
+	metaMock := new(mockEventMetadataStore)
+	pubMock := new(mockEventPublisher)
+
+	metaMock.getLatestEventReturns.info = nil
+	differMock.runReturns.err = differ.ErrNoChangesDetected
+
+	producer := NewEventProducer(differMock, blobMock, metaMock, pubMock)
+	err := producer.ProcessSearch(ctx, "search-id", "q=test", "trigger-id")
+
+	if err != nil {
+		t.Fatalf("expected nil error for no changes, got %v", err)
+	}
+	if len(blobMock.storeCalls) > 0 {
+		t.Error("expected no blobs to be stored")
+	}
+	if metaMock.publishEventCalledWith.EventID != "" {
+		t.Error("expected no metadata published")
+	}
+	if pubMock.publishCalledWith.EventID != "" {
+		t.Error("expected no notification published")
+	}
+}
+
+func TestProcessSearch_Failures(t *testing.T) {
+	ctx := context.Background()
+	type testMocks struct {
+		differ *mockFeatureDiffer
+		blob   *mockBlobStorage
+		meta   *mockEventMetadataStore
+		pub    *mockEventPublisher
+	}
+
+	type testCase struct {
+		name   string
+		setup  func(*testMocks)
+		verify func(*testing.T, *testMocks)
+	}
+
+	tests := []testCase{
+		{
+			name: "GetLatestEvent fails",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.err = errors.New("db error")
+			},
+			verify: nil, // No extra verification needed
+		},
+		{
+			name: "Get blob fails",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = &workertypes.LatestEventInfo{
+					EventID: "",
+					StateID: "prev-state-x",
+				}
+				m.blob.getErrors = map[string]error{"prev-state-x": errors.New("gcs error")}
+			},
+			verify: nil,
+		},
+		{
+			name: "Differ Run fails",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = nil
+				m.differ.runReturns.err = errors.New("differ fatal error")
+			},
+			verify: nil,
+		},
+		{
+			name: "Store state blob fails",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = nil
+				m.differ.runReturns.result = &differ.DiffResult{
+					State:   differ.BlobArtifact{ID: "state-fail", Bytes: []byte("state")},
+					Diff:    differ.BlobArtifact{ID: "diff-fail", Bytes: []byte("diff")},
+					Summary: nil,
+					Reasons: nil,
+				}
+				m.blob.storeErrors = map[string]error{
+					"state-fail": errors.New("storage error"),
+				}
+			},
+			verify: func(t *testing.T, m *testMocks) {
+				if _, ok := m.blob.storeCalls["diff-fail"]; ok {
+					t.Error("should not have tried to store diff blob when state blob failed")
+				}
+				if m.meta.publishEventCalledWith.EventID != "" {
+					t.Error("should not have published metadata")
+				}
+			},
+		},
+		{
+			name: "Publish event metadata fails",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = nil
+				m.differ.runReturns.result = &differ.DiffResult{
+					State:   differ.BlobArtifact{ID: "state-1", Bytes: []byte("state-data")},
+					Diff:    differ.BlobArtifact{ID: "diff-1", Bytes: []byte("diff-data")},
+					Summary: nil,
+					Reasons: nil,
+				}
+				m.meta.publishEventReturns = errors.New("metadata store error")
+			},
+			verify: func(t *testing.T, m *testMocks) {
+				if _, ok := m.blob.storeCalls["state-1"]; !ok {
+					t.Error("expected state blob to be stored even if metadata publish fails")
+				}
+			},
+		},
+		{
+			name: "Publish event notification fails",
+			setup: func(m *testMocks) {
+				m.meta.getLatestEventReturns.info = nil
+				m.differ.runReturns.result = &differ.DiffResult{
+					State:   differ.BlobArtifact{ID: "state-1", Bytes: []byte("state-data")},
+					Diff:    differ.BlobArtifact{ID: "diff-1", Bytes: []byte("diff-data")},
+					Summary: nil,
+					Reasons: nil,
+				}
+				m.pub.publishReturns = errors.New("pubsub error")
+			},
+			verify: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mocks := &testMocks{
+				differ: new(mockFeatureDiffer),
+				blob:   new(mockBlobStorage),
+				meta:   new(mockEventMetadataStore),
+				pub:    new(mockEventPublisher),
+			}
+			tc.setup(mocks)
+
+			producer := NewEventProducer(mocks.differ, mocks.blob, mocks.meta, mocks.pub)
+			err := producer.ProcessSearch(ctx, "search-abc", "q=test", "trigger-123")
+
+			if err == nil {
+				t.Error("ProcessSearch() expected error, got nil")
+			}
+			if tc.verify != nil {
+				tc.verify(t, mocks)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds the `EventProducer` struct and its core `ProcessSearch` method. This component is the high-level orchestrator that:

1. Fetches the previous state from blob storage (using the metadata store).
2. Executes the generic `Differ` to calculate changes.
3. Persists new artifacts (state snapshots and diffs) to blob storage.
4. Publishes metadata to the database and notifications to Pub/Sub.
