### PR TITLE
feat(event_producer): propagate frequency and enhance blob path handling

### DIFF
--- a/lib/event/featurediff/v1/types.go
+++ b/lib/event/featurediff/v1/types.go
@@ -14,7 +14,28 @@
 
 package v1
 
-import "time"
+import (
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+type JobFrequency string
+
+const (
+	FrequencyUnknown   JobFrequency = "UNKNOWN"
+	FrequencyImmediate JobFrequency = "IMMEDIATE"
+	FrequencyDaily     JobFrequency = "DAILY"
+	FrequencyWeekly    JobFrequency = "WEEKLY"
+	FrequencyMonthly   JobFrequency = "MONTHLY"
+)
+
+type Reason string
+
+const (
+	ReasonQueryChanged Reason = "QUERY_CHANGED"
+	ReasonDataUpdated  Reason = "DATA_UPDATED"
+)
 
 // FeatureDiffEvent represents a change event for a saved search query.
 // It is the contract between the Event Producer and downstream workers (e.g. Push Delivery Worker).
@@ -28,16 +49,56 @@ type FeatureDiffEvent struct {
 	Query string `json:"query"`
 	// Reasons contains machine-readable tags explaining why this event was generated
 	// (e.g. ["DATA_UPDATED", "QUERY_EDITED"]).
-	Reasons []string `json:"reasons"`
+	Reasons []Reason `json:"reasons"`
 	// Summary is a JSON string summarizing the changes (e.g. '{"added": 1, "removed": 0}').
-	Summary string `json:"summary"`
+	Summary []byte `json:"summary"`
 	// StateID is the ID of the full snapshot blob in storage.
 	StateID string `json:"state_id"`
+	// StateBlobPath is the path to the full snapshot blob in storage.
+	StateBlobPath string `json:"state_blob_path"`
 	// DiffID is the ID of the diff blob in storage.
 	DiffID string `json:"diff_id"`
+	// DiffBlobPath is the path to the diff blob in storage.
+	DiffBlobPath string `json:"diff_blob_path"`
 	// GeneratedAt is the timestamp when the event was created.
 	GeneratedAt time.Time `json:"generated_at"`
+	// Frequency is the frequency that triggered the generation of this diff.
+	Frequency JobFrequency `json:"frequency"`
 }
 
 func (FeatureDiffEvent) Kind() string       { return "FeatureDiffEvent" }
 func (FeatureDiffEvent) APIVersion() string { return "v1" }
+
+func ToJobFrequency(freq workertypes.JobFrequency) JobFrequency {
+	switch freq {
+	case workertypes.FrequencyImmediate:
+		return FrequencyImmediate
+	case workertypes.FrequencyDaily:
+		return FrequencyDaily
+	case workertypes.FrequencyWeekly:
+		return FrequencyWeekly
+	case workertypes.FrequencyMonthly:
+		return FrequencyMonthly
+	case workertypes.FrequencyUnknown:
+		return FrequencyUnknown
+	}
+
+	return FrequencyUnknown
+}
+
+func ToReasons(reasons []workertypes.Reason) []Reason {
+	if len(reasons) == 0 {
+		return nil
+	}
+	result := make([]Reason, 0, len(reasons))
+	for _, r := range reasons {
+		switch r {
+		case workertypes.ReasonQueryChanged:
+			result = append(result, ReasonQueryChanged)
+		case workertypes.ReasonDataUpdated:
+			result = append(result, ReasonDataUpdated)
+		}
+	}
+
+	return result
+}

--- a/lib/workertypes/types.go
+++ b/lib/workertypes/types.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	v1 "github.com/GoogleChrome/webstatus.dev/lib/blobtypes/featurelistdiff/v1"
 )
@@ -184,15 +185,31 @@ const (
 )
 
 type PublishEventRequest struct {
-	EventID  string
-	StateID  string
-	DiffID   string
-	SearchID string
-	Summary  []byte
-	Reasons  []Reason
+	EventID       string
+	StateID       string
+	StateBlobPath string
+	DiffID        string
+	DiffBlobPath  string
+	SearchID      string
+	Query         string
+	Summary       []byte
+	Reasons       []Reason
+	Frequency     JobFrequency
+	GeneratedAt   time.Time
 }
 
 type LatestEventInfo struct {
-	EventID string
-	StateID string
+	EventID       string
+	StateBlobPath string
 }
+
+// JobFrequency defines how often a saved search should be checked.
+type JobFrequency string
+
+const (
+	FrequencyUnknown   JobFrequency = "UNKNOWN"
+	FrequencyImmediate JobFrequency = "IMMEDIATE"
+	FrequencyDaily     JobFrequency = "DAILY"
+	FrequencyWeekly    JobFrequency = "WEEKLY"
+	FrequencyMonthly   JobFrequency = "MONTHLY"
+)

--- a/workers/event_producer/pkg/differ/differ_test.go
+++ b/workers/event_producer/pkg/differ/differ_test.go
@@ -227,10 +227,11 @@ func TestRun(t *testing.T) {
 				workflow.summaryResult = []byte("summary")
 			},
 			wantResult: &DiffResult{
-				State:   BlobArtifact{ID: "state-id", Bytes: []byte("new-state")},
-				Diff:    BlobArtifact{ID: "event-456", Bytes: []byte("diff-output")},
-				Summary: []byte("summary"),
-				Reasons: nil,
+				State:       BlobArtifact{ID: "state-id", Bytes: []byte("new-state")},
+				Diff:        BlobArtifact{ID: "event-456", Bytes: []byte("diff-output")},
+				Summary:     []byte("summary"),
+				Reasons:     nil,
+				GeneratedAt: fixedTime,
 			},
 			wantErr: nil,
 			verifyMocks: func(t *testing.T, adapter *mockStateAdapter,
@@ -278,10 +279,11 @@ func TestRun(t *testing.T) {
 				workflow.summaryResult = []byte("summary-updated")
 			},
 			wantResult: &DiffResult{
-				State:   BlobArtifact{ID: "state-id", Bytes: []byte("new-state-updated")},
-				Diff:    BlobArtifact{ID: "event-456", Bytes: []byte("diff-updated")},
-				Summary: []byte("summary-updated"),
-				Reasons: []workertypes.Reason{workertypes.ReasonDataUpdated},
+				State:       BlobArtifact{ID: "state-id", Bytes: []byte("new-state-updated")},
+				Diff:        BlobArtifact{ID: "event-456", Bytes: []byte("diff-updated")},
+				Summary:     []byte("summary-updated"),
+				Reasons:     []workertypes.Reason{workertypes.ReasonDataUpdated},
+				GeneratedAt: fixedTime,
 			},
 			wantErr:     nil,
 			verifyMocks: noopVerifyMocks,
@@ -306,10 +308,11 @@ func TestRun(t *testing.T) {
 				workflow.summaryResult = []byte("summary-query-change")
 			},
 			wantResult: &DiffResult{
-				State:   BlobArtifact{ID: "state-id", Bytes: []byte("new-state-after-query-change")},
-				Diff:    BlobArtifact{ID: "event-456", Bytes: []byte("diff-after-query-change")},
-				Summary: []byte("summary-query-change"),
-				Reasons: []workertypes.Reason{workertypes.ReasonQueryChanged},
+				State:       BlobArtifact{ID: "state-id", Bytes: []byte("new-state-after-query-change")},
+				Diff:        BlobArtifact{ID: "event-456", Bytes: []byte("diff-after-query-change")},
+				Summary:     []byte("summary-query-change"),
+				Reasons:     []workertypes.Reason{workertypes.ReasonQueryChanged},
+				GeneratedAt: fixedTime,
 			},
 			wantErr: nil,
 			verifyMocks: func(t *testing.T, _ *mockStateAdapter,
@@ -341,10 +344,11 @@ func TestRun(t *testing.T) {
 				workflow.summaryResult = []byte("summary-flush-failed")
 			},
 			wantResult: &DiffResult{
-				State:   BlobArtifact{ID: "state-id", Bytes: []byte("new-state-flush-failed")},
-				Diff:    BlobArtifact{ID: "event-456", Bytes: []byte("diff-flush-failed")},
-				Summary: []byte("summary-flush-failed"),
-				Reasons: []workertypes.Reason{workertypes.ReasonQueryChanged},
+				State:       BlobArtifact{ID: "state-id", Bytes: []byte("new-state-flush-failed")},
+				Diff:        BlobArtifact{ID: "event-456", Bytes: []byte("diff-flush-failed")},
+				Summary:     []byte("summary-flush-failed"),
+				Reasons:     []workertypes.Reason{workertypes.ReasonQueryChanged},
+				GeneratedAt: fixedTime,
 			},
 			wantErr: nil,
 			verifyMocks: func(t *testing.T, _ *mockStateAdapter,

--- a/workers/event_producer/pkg/differ/types.go
+++ b/workers/event_producer/pkg/differ/types.go
@@ -122,4 +122,7 @@ type DiffResult struct {
 
 	// Reasons contains machine-readable tags explaining the event (e.g. "DATA_UPDATED", "QUERY_EDITED").
 	Reasons []workertypes.Reason
+
+	// Timestamp that the diff was generated
+	GeneratedAt time.Time
 }


### PR DESCRIPTION
Updates the event producer to support parallel timelines (e.g. IMMEDIDATE, WEEKLY, MONTHLY).

Key changes:
- Frequency Propagation: Thread JobFrequency through ProcessSearch to FeatureDiffEvent and PublishEventRequest. This allows downstream consumers to distinguish between schedules (e.g., Weekly vs Immediate) and ensures the producer loads the correct state cursor.
- Blob Storage Handling: Update BlobStorage interface to accept directory namespaces (state/, diff/) and return the full authoritative blob path. This decouples the producer from the underlying bucket structure.
- Artifact Naming: Append .json suffix to blob keys for better observability.
- Type Safety & Decoupling: Introduce distinct JobFrequency and Reason enums in featurediff/v1 (public contract) separate from workertypes (internal), with conversion functions to prevent breakage on internal refactors.
- Summary Payload: Change Summary field to []byte to handle pre-serialized JSON payloads correctly.
- Metadata: Update LatestEventInfo, PublishEventRequest, and FeatureDiffEvent to carry full blob paths (StateBlobPath, DiffBlobPath).
- Timestamps: Explicitly pass GeneratedAt from the differ result to ensure consistency across artifacts and events.