### PR TITLE
implement state retrieval and locking infrastructure

### DIFF
--- a/backend/pkg/httpserver/get_feature.go
+++ b/backend/pkg/httpserver/get_feature.go
@@ -82,7 +82,7 @@ func (s *Server) GetFeature(
 	}
 	result, err := s.wptMetricsStorer.GetFeature(ctx, request.FeatureId,
 		getWPTMetricViewOrDefault(request.Params.WptMetricView),
-		defaultBrowsers(),
+		backendtypes.DefaultBrowsers(),
 	)
 	if err != nil {
 		if errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {

--- a/backend/pkg/httpserver/get_features.go
+++ b/backend/pkg/httpserver/get_features.go
@@ -69,7 +69,7 @@ func (s *Server) ListFeatures(
 		node,
 		req.Params.Sort,
 		getWPTMetricViewOrDefault(req.Params.WptMetricView),
-		defaultBrowsers(),
+		backendtypes.DefaultBrowsers(),
 	)
 
 	if err != nil {

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -183,18 +183,6 @@ type UserGitHubClient struct {
 
 type UserGitHubClientFactory func(token string) *UserGitHubClient
 
-func defaultBrowsers() []backend.BrowserPathParam {
-	return []backend.BrowserPathParam{
-		backend.Chrome,
-		backend.Edge,
-		backend.Firefox,
-		backend.Safari,
-		backend.ChromeAndroid,
-		backend.FirefoxAndroid,
-		backend.SafariIos,
-	}
-}
-
 func getPageSizeOrDefault(pageSize *int) int {
 	// maxPageSize comes from the <repo_root>/openapi/backend/openapi.yaml
 	maxPageSize := 100

--- a/infra/storage/spanner/migrations/000029.sql
+++ b/infra/storage/spanner/migrations/000029.sql
@@ -1,0 +1,17 @@
+-- Copyright 2025 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- This index helps get the latest events for a search for the event producer worker.
+CREATE INDEX IF NOT EXISTS SavedSearchNotificationEvents_BySearchAndSnapshotType
+ON SavedSearchNotificationEvents (SavedSearchId, SnapshotType, Timestamp DESC);

--- a/lib/backendtypes/types.go
+++ b/lib/backendtypes/types.go
@@ -86,3 +86,15 @@ func AttemptToStoreSubscriptionTriggerUnknown() backend.SubscriptionTriggerRespo
 
 	return ret
 }
+
+func DefaultBrowsers() []backend.BrowserPathParam {
+	return []backend.BrowserPathParam{
+		backend.Chrome,
+		backend.Edge,
+		backend.Firefox,
+		backend.Safari,
+		backend.ChromeAndroid,
+		backend.FirefoxAndroid,
+		backend.SafariIos,
+	}
+}

--- a/workers/event_producer/pkg/producer/producer_test.go
+++ b/workers/event_producer/pkg/producer/producer_test.go
@@ -94,6 +94,17 @@ type mockEventMetadataStore struct {
 		info *workertypes.LatestEventInfo
 		err  error
 	}
+	acquireLockReturns error
+	releaseLockReturns error
+}
+
+func (m *mockEventMetadataStore) AcquireLock(_ context.Context, _ string, _ workertypes.JobFrequency, _ string,
+	_ time.Duration) error {
+	return m.acquireLockReturns
+}
+
+func (m *mockEventMetadataStore) ReleaseLock(_ context.Context, _ string, _ workertypes.JobFrequency, _ string) error {
+	return m.releaseLockReturns
 }
 
 func (m *mockEventMetadataStore) PublishEvent(_ context.Context, req workertypes.PublishEventRequest) error {


### PR DESCRIPTION
Enables the Event Producer to fetch the previous state and coordinate execution via distributed locking.

Changes:
- **Spanner**: Added `GetLatestSavedSearchNotificationEvent` to fetch the last known state for a search/frequency pair.
- **Schema**: Added index `SavedSearchNotificationEvents_BySearchAndSnapshotType` to optimize state lookups.
- **Producer**: Updated `ProcessSearch` to acquire/release locks (currently using triggerID) and fetch the previous state before diffing.
- **Refactor**: Exported `DefaultBrowsers` in `backendtypes` for shared use between the API server and worker adapters