### PR TITLE
feat(event_producer): implement batch event producer pubsub and spanner adapters

### DIFF
--- a/lib/gcppubsub/gcppubsubadapters/batch_event_producer.go
+++ b/lib/gcppubsub/gcppubsubadapters/batch_event_producer.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcppubsubadapters
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/event"
+	refreshv1 "github.com/GoogleChrome/webstatus.dev/lib/event/refreshsearchcommand/v1"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+type BatchFanOutPublisherAdapter struct {
+	client  EventPublisher
+	topicID string
+}
+
+func NewBatchFanOutPublisherAdapter(client EventPublisher, topicID string) *BatchFanOutPublisherAdapter {
+	return &BatchFanOutPublisherAdapter{client: client, topicID: topicID}
+}
+
+func (a *BatchFanOutPublisherAdapter) PublishRefreshCommand(ctx context.Context,
+	cmd workertypes.RefreshSearchCommand) error {
+	evt := refreshv1.RefreshSearchCommand{
+		SearchID:  cmd.SearchID,
+		Query:     cmd.Query,
+		Frequency: refreshv1.JobFrequency(cmd.Frequency),
+		Timestamp: cmd.Timestamp,
+	}
+
+	msg, err := event.New(evt)
+	if err != nil {
+		return fmt.Errorf("failed to create event: %w", err)
+	}
+
+	if _, err := a.client.Publish(ctx, a.topicID, msg); err != nil {
+		return fmt.Errorf("failed to publish message: %w", err)
+	}
+
+	return nil
+}

--- a/lib/gcppubsub/gcppubsubadapters/batch_event_producer_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/batch_event_producer_test.go
@@ -1,0 +1,106 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcppubsubadapters
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestBatchFanOutPublisherAdapter_PublishRefreshCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		cmd          workertypes.RefreshSearchCommand
+		publishErr   error
+		wantErr      bool
+		expectedJSON string
+	}{
+		{
+			name: "success",
+			cmd: workertypes.RefreshSearchCommand{
+				SearchID:  "search-123",
+				Query:     "query=abc",
+				Frequency: workertypes.FrequencyDaily,
+				Timestamp: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			publishErr: nil,
+			wantErr:    false,
+			expectedJSON: `{
+				"apiVersion": "v1",
+				"kind": "RefreshSearchCommand",
+				"data": {
+					"search_id": "search-123",
+					"query": "query=abc",
+					"frequency": "DAILY",
+					"timestamp": "2025-01-01T00:00:00Z"
+				}
+			}`,
+		},
+		{
+			name: "publish error",
+			cmd: workertypes.RefreshSearchCommand{
+				SearchID:  "search-123",
+				Query:     "query=abc",
+				Frequency: workertypes.FrequencyDaily,
+				Timestamp: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			publishErr:   errors.New("pubsub error"),
+			wantErr:      true,
+			expectedJSON: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			publisher := new(mockPublisher)
+			publisher.err = tc.publishErr
+			adapter := NewBatchFanOutPublisherAdapter(publisher, "test-topic")
+
+			err := adapter.PublishRefreshCommand(context.Background(), tc.cmd)
+
+			if (err != nil) != tc.wantErr {
+				t.Errorf("PublishRefreshCommand() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			if !tc.wantErr {
+				verifyJSONPayload(t, publisher.publishedData, tc.expectedJSON)
+			}
+		})
+	}
+}
+
+func verifyJSONPayload(t *testing.T, actualBytes []byte, expectedJSON string) {
+	t.Helper()
+
+	var actual interface{}
+	if err := json.Unmarshal(actualBytes, &actual); err != nil {
+		t.Fatalf("failed to unmarshal actual data: %v", err)
+	}
+
+	var expected interface{}
+	if err := json.Unmarshal([]byte(expectedJSON), &expected); err != nil {
+		t.Fatalf("failed to unmarshal expected data: %v", err)
+	}
+
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("Payload mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/lib/gcpspanner/list_user_saved_searches.go
+++ b/lib/gcpspanner/list_user_saved_searches.go
@@ -168,29 +168,20 @@ func (c *Client) ListUserSavedSearches(
 	}, nil
 }
 
-type savedSearchIDContainer struct {
-	ID string `spanner:"ID"`
+type SavedSearchBriefDetails struct {
+	ID    string `spanner:"ID"`
+	Query string `spanner:"Query"`
 }
 
 func (m userSavedSearchListerMapper) SelectAll() spanner.Statement {
 	return spanner.Statement{
-		SQL:    "SELECT ID FROM SavedSearches",
+		SQL:    "SELECT ID, Query FROM SavedSearches",
 		Params: nil,
 	}
 }
 
 // Used by the Cloud Scheduler batch job to find all entities to process.
-func (c *Client) ListAllSavedSearchIDs(
-	ctx context.Context) ([]string, error) {
-	ret, err := newAllEntityReader[userSavedSearchListerMapper, savedSearchIDContainer](c).readAll(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	ids := make([]string, 0, len(ret))
-	for _, r := range ret {
-		ids = append(ids, r.ID)
-	}
-
-	return ids, nil
+func (c *Client) ListAllSavedSearches(
+	ctx context.Context) ([]SavedSearchBriefDetails, error) {
+	return newAllEntityReader[userSavedSearchListerMapper, SavedSearchBriefDetails](c).readAll(ctx)
 }

--- a/lib/gcpspanner/spanneradapters/event_producer.go
+++ b/lib/gcpspanner/spanneradapters/event_producer.go
@@ -224,3 +224,30 @@ func (e *EventProducer) PublishEvent(ctx context.Context, req workertypes.Publis
 
 	return nil
 }
+
+type BatchEventProducerSpannerClient interface {
+	ListAllSavedSearches(
+		ctx context.Context) ([]gcpspanner.SavedSearchBriefDetails, error)
+}
+
+type BatchEventProducer struct {
+	client BatchEventProducerSpannerClient
+}
+
+func NewBatchEventProducer(client BatchEventProducerSpannerClient) *BatchEventProducer {
+	return &BatchEventProducer{client: client}
+}
+
+func (b *BatchEventProducer) ListAllSavedSearches(ctx context.Context) ([]workertypes.SearchJob, error) {
+	details, err := b.client.ListAllSavedSearches(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	jobs := make([]workertypes.SearchJob, 0, len(details))
+	for _, detail := range details {
+		jobs = append(jobs, workertypes.SearchJob{ID: detail.ID, Query: detail.Query})
+	}
+
+	return jobs, nil
+}

--- a/lib/workertypes/types.go
+++ b/lib/workertypes/types.go
@@ -213,3 +213,15 @@ const (
 	FrequencyWeekly    JobFrequency = "WEEKLY"
 	FrequencyMonthly   JobFrequency = "MONTHLY"
 )
+
+type RefreshSearchCommand struct {
+	SearchID  string
+	Query     string
+	Frequency JobFrequency
+	Timestamp time.Time
+}
+
+type SearchJob struct {
+	ID    string
+	Query string
+}

--- a/workers/event_producer/pkg/producer/batch_handler.go
+++ b/workers/event_producer/pkg/producer/batch_handler.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package producer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/event"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+type SearchLister interface {
+	ListAllSavedSearches(ctx context.Context) ([]workertypes.SearchJob, error)
+}
+
+type CommandPublisher interface {
+	PublishRefreshCommand(ctx context.Context, cmd workertypes.RefreshSearchCommand) error
+}
+
+type BatchUpdateHandler struct {
+	lister    SearchLister
+	publisher CommandPublisher
+	now       func() time.Time
+}
+
+func NewBatchUpdateHandler(lister SearchLister, publisher CommandPublisher) *BatchUpdateHandler {
+	return &BatchUpdateHandler{
+		lister:    lister,
+		publisher: publisher,
+		now:       time.Now,
+	}
+}
+
+func (h *BatchUpdateHandler) ProcessBatchUpdate(ctx context.Context, triggerID string,
+	frequency workertypes.JobFrequency) error {
+	slog.InfoContext(ctx, "starting batch update fan-out", "trigger_id", triggerID, "frequency", frequency)
+
+	// 1. List all Saved Searches
+	searches, err := h.lister.ListAllSavedSearches(ctx)
+	if err != nil {
+		// Transient db error should be retried
+		return fmt.Errorf("%w: failed to list saved searches: %w", event.ErrTransientFailure, err)
+	}
+
+	slog.InfoContext(ctx, "found saved searches to refresh", "count", len(searches))
+
+	// 2. Fan-out
+	for _, search := range searches {
+		cmd := workertypes.RefreshSearchCommand{
+			SearchID:  search.ID,
+			Query:     search.Query,
+			Frequency: frequency,
+			Timestamp: h.now(),
+		}
+
+		if err := h.publisher.PublishRefreshCommand(ctx, cmd); err != nil {
+			// If we fail to publish one, we should probably fail the whole batch so it retries.
+			// But we don't want to re-publish successfully published ones if possible.
+			// Pub/Sub doesn't support transactional batch publishes across messages easily.
+			// Ideally, we just return error and let the handler retry.
+			// Idempotency in ProcessSearch handles the duplicates.
+			slog.ErrorContext(ctx, "failed to publish refresh command", "search_id", search.ID, "error", err,
+				"trigger_id", triggerID, "frequency", frequency)
+
+			return fmt.Errorf("%w: failed to publish refresh command for search %s: %w",
+				event.ErrTransientFailure, search.ID, err)
+		}
+	}
+
+	slog.InfoContext(ctx, "batch update fan-out complete", "trigger_id", triggerID)
+
+	return nil
+}

--- a/workers/event_producer/pkg/producer/batch_handler_test.go
+++ b/workers/event_producer/pkg/producer/batch_handler_test.go
@@ -1,0 +1,130 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package producer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/event"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+type mockSearchLister struct {
+	searches []workertypes.SearchJob
+	err      error
+}
+
+func (m *mockSearchLister) ListAllSavedSearches(_ context.Context) ([]workertypes.SearchJob, error) {
+	return m.searches, m.err
+}
+
+type mockCommandPublisher struct {
+	commands []workertypes.RefreshSearchCommand
+	err      error
+}
+
+func (m *mockCommandPublisher) PublishRefreshCommand(_ context.Context, cmd workertypes.RefreshSearchCommand) error {
+	m.commands = append(m.commands, cmd)
+
+	return m.err
+}
+
+func TestProcessBatchUpdate(t *testing.T) {
+	tests := []struct {
+		name           string
+		searches       []workertypes.SearchJob
+		listerErr      error
+		pubErr         error
+		expectPubCalls int
+		wantErr        bool
+		transient      bool
+	}{
+		{
+			name: "success with searches",
+			searches: []workertypes.SearchJob{
+				{ID: "s1", Query: "q=1"},
+				{ID: "s2", Query: "q=2"},
+			},
+			listerErr:      nil,
+			pubErr:         nil,
+			expectPubCalls: 2,
+			wantErr:        false,
+			transient:      false,
+		},
+		{
+			name:           "success empty list",
+			searches:       []workertypes.SearchJob{},
+			expectPubCalls: 0,
+			listerErr:      nil,
+			pubErr:         nil,
+			wantErr:        false,
+			transient:      false,
+		},
+		{
+			name:           "lister error",
+			listerErr:      errors.New("db error"),
+			wantErr:        true,
+			transient:      true,
+			searches:       nil,
+			pubErr:         nil,
+			expectPubCalls: 0,
+		},
+		{
+			name:           "publisher error",
+			listerErr:      nil,
+			searches:       []workertypes.SearchJob{{ID: "s1", Query: "q=1"}},
+			pubErr:         errors.New("pub error"),
+			wantErr:        true,
+			transient:      true,
+			expectPubCalls: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lister := &mockSearchLister{searches: tc.searches, err: tc.listerErr}
+			pub := &mockCommandPublisher{err: tc.pubErr, commands: nil}
+			handler := NewBatchUpdateHandler(lister, pub)
+
+			err := handler.ProcessBatchUpdate(context.Background(), "trigger-1", workertypes.FrequencyDaily)
+
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ProcessBatchUpdate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			if tc.wantErr && tc.transient {
+				if !errors.Is(err, event.ErrTransientFailure) {
+					t.Errorf("Expected error to be transient")
+				}
+			}
+
+			if len(pub.commands) != tc.expectPubCalls {
+				t.Errorf("Expected %d publish calls, got %d", tc.expectPubCalls, len(pub.commands))
+			}
+
+			// Verify command content for success case
+			if !tc.wantErr && len(tc.searches) > 0 {
+				if pub.commands[0].SearchID != "s1" {
+					t.Errorf("Command data mismatch")
+				}
+				if pub.commands[0].Frequency != workertypes.FrequencyDaily {
+					t.Errorf("Frequency mismatch")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduces the necessary adapters to support the batch fan-out process for scheduled refreshes.

This includes:
- **Pub/Sub Adapter (`gcppubsubadapters`)**: Added `BatchFanOutPublisherAdapter` which converts `workertypes.RefreshSearchCommand` into a `refreshsearchcommand/v1` CloudEvent and publishes it to the ingestion topic.
- **Spanner Adapter (`spanneradapters`)**: Added `BatchEventProducer` and its `ListAllSavedSearches` method to fetch all saved searches for processing.
- **Spanner Library (`gcpspanner`)**: Updated `ListAllSavedSearches` to return `SavedSearchBriefDetails` (ID and Query) instead of just IDs, allowing the batch handler to populate the command fully without downstream lookups.
- **Worker Types**: Added `RefreshSearchCommand` and `SearchJob` struct definitions.