### PR TITLE
feat(api): update subscription triggers and frequencies

### DIFF
--- a/backend/pkg/httpserver/create_subscription.go
+++ b/backend/pkg/httpserver/create_subscription.go
@@ -29,9 +29,10 @@ import (
 // The exhaustive linter is configured to check that this map is complete.
 func getAllSubscriptionTriggersSet() map[backend.SubscriptionTriggerWritable]any {
 	return map[backend.SubscriptionTriggerWritable]any{
-		backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete: nil,
-		backend.SubscriptionTriggerFeatureBaselineLimitedToNewly:           nil,
-		backend.SubscriptionTriggerFeatureBaselineRegressionNewlyToLimited: nil,
+		backend.SubscriptionTriggerFeatureBaselineToNewly:                  nil,
+		backend.SubscriptionTriggerFeatureBaselineToWidely:                 nil,
+		backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete: nil,
+		backend.SubscriptionTriggerFeatureBaselineRegressionToLimited:      nil,
 	}
 }
 
@@ -76,7 +77,9 @@ func validateSubscriptionTrigger(trigger *[]backend.SubscriptionTriggerWritable,
 // The exhaustive linter is configured to check that this map is complete.
 func getAllSubscriptionFrequenciesSet() map[backend.SubscriptionFrequency]any {
 	return map[backend.SubscriptionFrequency]any{
-		backend.SubscriptionFrequencyDaily: nil,
+		backend.SubscriptionFrequencyImmediate: nil,
+		backend.SubscriptionFrequencyWeekly:    nil,
+		backend.SubscriptionFrequencyMonthly:   nil,
 	}
 }
 

--- a/backend/pkg/httpserver/create_subscription_test.go
+++ b/backend/pkg/httpserver/create_subscription_test.go
@@ -51,8 +51,8 @@ func TestCreateSubscription(t *testing.T) {
 					ChannelId:     "channel-id",
 					SavedSearchId: "search-id",
 					Triggers: []backend.SubscriptionTriggerWritable{
-						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
-					Frequency: "daily",
+						backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
+					Frequency: "immediate",
 				},
 				output: &backend.SubscriptionResponse{
 					Id:            "sub-id",
@@ -61,11 +61,11 @@ func TestCreateSubscription(t *testing.T) {
 					Triggers: []backend.SubscriptionTriggerResponseItem{
 						{
 							Value: backendtypes.AttemptToStoreSubscriptionTrigger(
-								backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
+								backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete),
 							RawValue: nil,
 						},
 					},
-					Frequency: "daily",
+					Frequency: "immediate",
 					CreatedAt: now,
 					UpdatedAt: now,
 				},
@@ -79,16 +79,16 @@ func TestCreateSubscription(t *testing.T) {
 				strings.NewReader(`{
 					"channel_id": "channel-id",
 					"saved_search_id": "search-id",
-					"triggers": ["feature_any_browser_implementation_complete"],
-					"frequency": "daily"
+					"triggers": ["feature_browser_implementation_any_complete"],
+					"frequency": "immediate"
 				}`),
 			),
 			expectedResponse: testJSONResponse(http.StatusCreated, `{
 				"id":"sub-id",
 				"channel_id":"channel-id",
 				"saved_search_id":"search-id",
-				"triggers": [{"value":"feature_any_browser_implementation_complete"}],
-				"frequency":"daily",
+				"triggers": [{"value":"feature_browser_implementation_any_complete"}],
+				"frequency":"immediate",
 				"created_at":"`+now.Format(time.RFC3339Nano)+`",
 				"updated_at":"`+now.Format(time.RFC3339Nano)+`"
 			}`),
@@ -103,8 +103,8 @@ func TestCreateSubscription(t *testing.T) {
 				"/v1/users/me/subscriptions",
 				strings.NewReader(`{
 					"saved_search_id": "search-id",
-					"triggers": ["feature_any_browser_implementation_complete"],
-					"frequency": "daily"
+					"triggers": ["feature_browser_implementation_any_complete"],
+					"frequency": "immediate"
 				}`),
 			),
 			expectedResponse: testJSONResponse(http.StatusBadRequest, `
@@ -124,8 +124,8 @@ func TestCreateSubscription(t *testing.T) {
 					ChannelId:     "channel-id",
 					SavedSearchId: "search-id",
 					Triggers: []backend.SubscriptionTriggerWritable{
-						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
-					Frequency: "daily",
+						backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
+					Frequency: "immediate",
 				},
 				output: nil,
 				err:    backendtypes.ErrUserNotAuthorizedForAction,
@@ -138,8 +138,8 @@ func TestCreateSubscription(t *testing.T) {
 				strings.NewReader(`{
 					"channel_id": "channel-id",
 					"saved_search_id": "search-id",
-					"triggers": ["feature_any_browser_implementation_complete"],
-					"frequency": "daily"
+					"triggers": ["feature_browser_implementation_any_complete"],
+					"frequency": "immediate"
 				}`)),
 			expectedResponse: testJSONResponse(http.StatusForbidden, `{
 				"code":403,
@@ -154,8 +154,8 @@ func TestCreateSubscription(t *testing.T) {
 					ChannelId:     "channel-id",
 					SavedSearchId: "search-id",
 					Triggers: []backend.SubscriptionTriggerWritable{
-						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
-					Frequency: "daily",
+						backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
+					Frequency: "immediate",
 				},
 				output: nil,
 				err:    fmt.Errorf("database error"),
@@ -168,8 +168,8 @@ func TestCreateSubscription(t *testing.T) {
 				strings.NewReader(`{
 					"channel_id": "channel-id",
 					"saved_search_id": "search-id",
-					"triggers": ["feature_any_browser_implementation_complete"],
-					"frequency": "daily"
+					"triggers": ["feature_browser_implementation_any_complete"],
+					"frequency": "immediate"
 				}`)),
 			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
 				"code":500,
@@ -214,8 +214,8 @@ func TestValidateSubscriptionCreation(t *testing.T) {
 				ChannelId:     "channel-id",
 				SavedSearchId: "search-id",
 				Triggers: []backend.SubscriptionTriggerWritable{
-					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
-				Frequency: backend.SubscriptionFrequencyDaily,
+					backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
+				Frequency: backend.SubscriptionFrequencyImmediate,
 			},
 			want: nil,
 		},
@@ -225,8 +225,8 @@ func TestValidateSubscriptionCreation(t *testing.T) {
 				ChannelId:     "",
 				SavedSearchId: "searchid",
 				Triggers: []backend.SubscriptionTriggerWritable{
-					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
-				Frequency: backend.SubscriptionFrequencyDaily,
+					backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
+				Frequency: backend.SubscriptionFrequencyImmediate,
 			},
 			want: &fieldValidationErrors{
 				fieldErrorMap: map[string]string{
@@ -240,8 +240,8 @@ func TestValidateSubscriptionCreation(t *testing.T) {
 				ChannelId:     "channelid",
 				SavedSearchId: "",
 				Triggers: []backend.SubscriptionTriggerWritable{
-					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
-				Frequency: backend.SubscriptionFrequencyDaily,
+					backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
+				Frequency: backend.SubscriptionFrequencyImmediate,
 			},
 			want: &fieldValidationErrors{
 				fieldErrorMap: map[string]string{
@@ -256,7 +256,7 @@ func TestValidateSubscriptionCreation(t *testing.T) {
 				SavedSearchId: "searchid",
 				Triggers: []backend.SubscriptionTriggerWritable{
 					"invalid_trigger"},
-				Frequency: backend.SubscriptionFrequencyDaily,
+				Frequency: backend.SubscriptionFrequencyImmediate,
 			},
 			want: &fieldValidationErrors{
 				fieldErrorMap: map[string]string{
@@ -270,7 +270,7 @@ func TestValidateSubscriptionCreation(t *testing.T) {
 				ChannelId:     "channelid",
 				SavedSearchId: "searchid",
 				Triggers: []backend.SubscriptionTriggerWritable{
-					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+					backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
 				Frequency: "invalid_frequency",
 			},
 			want: &fieldValidationErrors{

--- a/backend/pkg/httpserver/update_subscription_test.go
+++ b/backend/pkg/httpserver/update_subscription_test.go
@@ -50,7 +50,7 @@ func TestUpdateSubscription(t *testing.T) {
 				expectedSubscriptionID: "sub-id",
 				expectedUpdateRequest: backend.UpdateSubscriptionRequest{
 					Triggers: &[]backend.SubscriptionTriggerWritable{
-						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+						backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
 					UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
 						backend.UpdateSubscriptionRequestMaskTriggers},
 					Frequency: nil,
@@ -62,7 +62,7 @@ func TestUpdateSubscription(t *testing.T) {
 					Triggers: []backend.SubscriptionTriggerResponseItem{
 						{
 							Value: backendtypes.AttemptToStoreSubscriptionTrigger(
-								backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
+								backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete),
 							RawValue: nil,
 						},
 					},
@@ -79,7 +79,7 @@ func TestUpdateSubscription(t *testing.T) {
 				strings.NewReader(`
 					{
 						"triggers":
-							["feature_any_browser_implementation_complete"],
+							["feature_browser_implementation_any_complete"],
 						"update_mask": ["triggers"]
 					}`)),
 			expectedResponse: testJSONResponse(http.StatusOK,
@@ -87,7 +87,7 @@ func TestUpdateSubscription(t *testing.T) {
 					"id":"sub-id",
 					"channel_id":"channel-id",
 					"saved_search_id":"search-id",
-					"triggers": [{"value":"feature_any_browser_implementation_complete"}],
+					"triggers": [{"value":"feature_browser_implementation_any_complete"}],
 					"frequency":"daily",
 					"created_at":"`+now.Format(time.RFC3339Nano)+`",
 					"updated_at":"`+now.Format(time.RFC3339Nano)+`"
@@ -101,7 +101,7 @@ func TestUpdateSubscription(t *testing.T) {
 				expectedSubscriptionID: "sub-id",
 				expectedUpdateRequest: backend.UpdateSubscriptionRequest{
 					Triggers: &[]backend.SubscriptionTriggerWritable{
-						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete,
+						backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete,
 					},
 					Frequency: nil,
 					UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
@@ -116,7 +116,7 @@ func TestUpdateSubscription(t *testing.T) {
 				"/v1/users/me/subscriptions/sub-id",
 				strings.NewReader(`
 				{
-					"triggers": ["feature_any_browser_implementation_complete"],
+					"triggers": ["feature_browser_implementation_any_complete"],
 					"update_mask": ["triggers"]
 				}`)),
 			expectedResponse: testJSONResponse(http.StatusNotFound, `
@@ -134,7 +134,7 @@ func TestUpdateSubscription(t *testing.T) {
 				"/v1/users/me/subscriptions/sub-id",
 				strings.NewReader(`
 				{
-					"triggers": ["feature_any_browser_implementation_complete"],
+					"triggers": ["feature_browser_implementation_any_complete"],
 					"update_mask": ["invalid_field"]
 				}`)),
 			expectedResponse: testJSONResponse(http.StatusBadRequest, `
@@ -155,7 +155,7 @@ func TestUpdateSubscription(t *testing.T) {
 				expectedSubscriptionID: "sub-id",
 				expectedUpdateRequest: backend.UpdateSubscriptionRequest{
 					Triggers: &[]backend.SubscriptionTriggerWritable{
-						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+						backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
 					UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
 						backend.UpdateSubscriptionRequestMaskTriggers},
 					Frequency: nil,
@@ -169,7 +169,7 @@ func TestUpdateSubscription(t *testing.T) {
 				"/v1/users/me/subscriptions/sub-id",
 				strings.NewReader(`
 				{
-					"triggers": ["feature_any_browser_implementation_complete"],
+					"triggers": ["feature_browser_implementation_any_complete"],
 					"update_mask": ["triggers"]
 				}`)),
 			expectedResponse: testJSONResponse(http.StatusForbidden, `
@@ -186,7 +186,7 @@ func TestUpdateSubscription(t *testing.T) {
 				expectedSubscriptionID: "sub-id",
 				expectedUpdateRequest: backend.UpdateSubscriptionRequest{
 					Triggers: &[]backend.SubscriptionTriggerWritable{
-						backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+						backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
 					UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
 						backend.UpdateSubscriptionRequestMaskTriggers},
 					Frequency: nil,
@@ -200,7 +200,7 @@ func TestUpdateSubscription(t *testing.T) {
 				"/v1/users/me/subscriptions/sub-id",
 				strings.NewReader(`
 				{
-					"triggers": ["feature_any_browser_implementation_complete"],
+					"triggers": ["feature_browser_implementation_any_complete"],
 					"update_mask": ["triggers"]
 				}`)),
 			expectedResponse: testJSONResponse(http.StatusInternalServerError, `
@@ -250,7 +250,7 @@ func TestValidateSubscriptionUpdate(t *testing.T) {
 			name: "valid update",
 			input: &backend.UpdateSubscriptionRequest{
 				Triggers: &[]backend.SubscriptionTriggerWritable{
-					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+					backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
 				UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
 					backend.UpdateSubscriptionRequestMaskTriggers},
 				Frequency: nil,
@@ -261,7 +261,7 @@ func TestValidateSubscriptionUpdate(t *testing.T) {
 			name: "invalid update mask",
 			input: &backend.UpdateSubscriptionRequest{
 				Triggers: &[]backend.SubscriptionTriggerWritable{
-					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+					backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
 				UpdateMask: []backend.UpdateSubscriptionRequestUpdateMask{
 					"invalid_field"},
 				Frequency: nil,
@@ -290,7 +290,7 @@ func TestValidateSubscriptionUpdate(t *testing.T) {
 			name: "nil update mask",
 			input: &backend.UpdateSubscriptionRequest{
 				Triggers: &[]backend.SubscriptionTriggerWritable{
-					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
+					backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
 				UpdateMask: nil,
 				Frequency:  nil,
 			},

--- a/lib/event/batchrefreshtrigger/v1/types.go
+++ b/lib/event/batchrefreshtrigger/v1/types.go
@@ -22,7 +22,6 @@ type JobFrequency string
 const (
 	FrequencyUnknown   JobFrequency = "UNKNOWN"
 	FrequencyImmediate JobFrequency = "IMMEDIATE"
-	FrequencyDaily     JobFrequency = "DAILY"
 	FrequencyWeekly    JobFrequency = "WEEKLY"
 	FrequencyMonthly   JobFrequency = "MONTHLY"
 )
@@ -31,8 +30,6 @@ func (f JobFrequency) ToWorkerTypeJobFrequency() workertypes.JobFrequency {
 	switch f {
 	case FrequencyImmediate:
 		return workertypes.FrequencyImmediate
-	case FrequencyDaily:
-		return workertypes.FrequencyDaily
 	case FrequencyWeekly:
 		return workertypes.FrequencyWeekly
 	case FrequencyMonthly:

--- a/lib/event/featurediff/v1/types.go
+++ b/lib/event/featurediff/v1/types.go
@@ -25,7 +25,6 @@ type JobFrequency string
 const (
 	FrequencyUnknown   JobFrequency = "UNKNOWN"
 	FrequencyImmediate JobFrequency = "IMMEDIATE"
-	FrequencyDaily     JobFrequency = "DAILY"
 	FrequencyWeekly    JobFrequency = "WEEKLY"
 	FrequencyMonthly   JobFrequency = "MONTHLY"
 )
@@ -73,8 +72,6 @@ func (f JobFrequency) ToWorkertypes() workertypes.JobFrequency {
 	switch f {
 	case FrequencyImmediate:
 		return workertypes.FrequencyImmediate
-	case FrequencyDaily:
-		return workertypes.FrequencyDaily
 	case FrequencyWeekly:
 		return workertypes.FrequencyWeekly
 	case FrequencyMonthly:
@@ -90,8 +87,6 @@ func ToJobFrequency(freq workertypes.JobFrequency) JobFrequency {
 	switch freq {
 	case workertypes.FrequencyImmediate:
 		return FrequencyImmediate
-	case workertypes.FrequencyDaily:
-		return FrequencyDaily
 	case workertypes.FrequencyWeekly:
 		return FrequencyWeekly
 	case workertypes.FrequencyMonthly:

--- a/lib/event/refreshsearchcommand/v1/types.go
+++ b/lib/event/refreshsearchcommand/v1/types.go
@@ -26,7 +26,6 @@ type JobFrequency string
 const (
 	FrequencyUnknown   JobFrequency = "UNKNOWN"
 	FrequencyImmediate JobFrequency = "IMMEDIATE"
-	FrequencyDaily     JobFrequency = "DAILY"
 	FrequencyWeekly    JobFrequency = "WEEKLY"
 	FrequencyMonthly   JobFrequency = "MONTHLY"
 )
@@ -35,8 +34,6 @@ func (f JobFrequency) ToWorkerTypeJobFrequency() workertypes.JobFrequency {
 	switch f {
 	case FrequencyImmediate:
 		return workertypes.FrequencyImmediate
-	case FrequencyDaily:
-		return workertypes.FrequencyDaily
 	case FrequencyWeekly:
 		return workertypes.FrequencyWeekly
 	case FrequencyMonthly:

--- a/lib/event/searchconfigurationchanged/v1/types.go
+++ b/lib/event/searchconfigurationchanged/v1/types.go
@@ -26,7 +26,6 @@ type JobFrequency string
 const (
 	FrequencyUnknown   JobFrequency = "UNKNOWN"
 	FrequencyImmediate JobFrequency = "IMMEDIATE"
-	FrequencyDaily     JobFrequency = "DAILY"
 	FrequencyWeekly    JobFrequency = "WEEKLY"
 	FrequencyMonthly   JobFrequency = "MONTHLY"
 )
@@ -35,8 +34,6 @@ func (f JobFrequency) ToWorkerTypeJobFrequency() workertypes.JobFrequency {
 	switch f {
 	case FrequencyImmediate:
 		return workertypes.FrequencyImmediate
-	case FrequencyDaily:
-		return workertypes.FrequencyDaily
 	case FrequencyWeekly:
 		return workertypes.FrequencyWeekly
 	case FrequencyMonthly:

--- a/lib/gcppubsub/gcppubsubadapters/batch_event_producer_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/batch_event_producer_test.go
@@ -38,7 +38,7 @@ func TestBatchFanOutPublisherAdapter_PublishRefreshCommand(t *testing.T) {
 			cmd: workertypes.RefreshSearchCommand{
 				SearchID:  "search-123",
 				Query:     "query=abc",
-				Frequency: workertypes.FrequencyDaily,
+				Frequency: workertypes.FrequencyImmediate,
 				Timestamp: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			publishErr: nil,
@@ -49,7 +49,7 @@ func TestBatchFanOutPublisherAdapter_PublishRefreshCommand(t *testing.T) {
 				"data": {
 					"search_id": "search-123",
 					"query": "query=abc",
-					"frequency": "DAILY",
+					"frequency": "IMMEDIATE",
 					"timestamp": "2025-01-01T00:00:00Z"
 				}
 			}`,
@@ -59,7 +59,7 @@ func TestBatchFanOutPublisherAdapter_PublishRefreshCommand(t *testing.T) {
 			cmd: workertypes.RefreshSearchCommand{
 				SearchID:  "search-123",
 				Query:     "query=abc",
-				Frequency: workertypes.FrequencyDaily,
+				Frequency: workertypes.FrequencyImmediate,
 				Timestamp: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			publishErr:   errors.New("pubsub error"),

--- a/lib/gcppubsub/gcppubsubadapters/event_producer_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/event_producer_test.go
@@ -181,7 +181,7 @@ func TestSubscribe_RoutesRefreshSearchCommand(t *testing.T) {
 	refreshCmd := refreshv1.RefreshSearchCommand{
 		SearchID:  "s1",
 		Query:     "q1",
-		Frequency: "DAILY",
+		Frequency: "IMMEDIATE",
 		Timestamp: time.Time{},
 	}
 	ceWrapper := map[string]interface{}{
@@ -202,7 +202,7 @@ func TestSubscribe_RoutesRefreshSearchCommand(t *testing.T) {
 	expectedCall := searchCall{
 		SearchID:  "s1",
 		Query:     "q1",
-		Frequency: workertypes.FrequencyDaily,
+		Frequency: workertypes.FrequencyImmediate,
 		TriggerID: "msg-1",
 	}
 
@@ -293,7 +293,7 @@ func TestPublisher_Publish(t *testing.T) {
 		EventID:       "evt-1",
 		SearchID:      "search-1",
 		Query:         "query-1",
-		Frequency:     "DAILY",
+		Frequency:     workertypes.FrequencyImmediate,
 		Reasons:       []workertypes.Reason{workertypes.ReasonDataUpdated},
 		Summary:       []byte(`{"added": 1}`),
 		StateID:       "state-id-1",
@@ -332,7 +332,7 @@ func TestPublisher_Publish(t *testing.T) {
 			"diff_blob_path":  "gs://bucket/diff-blob",
 			"reasons":         []interface{}{"DATA_UPDATED"},
 			"generated_at":    now.Format(time.RFC3339),
-			"frequency":       "DAILY",
+			"frequency":       "IMMEDIATE",
 		},
 	}
 

--- a/lib/gcpspanner/saved_search_state.go
+++ b/lib/gcpspanner/saved_search_state.go
@@ -37,6 +37,7 @@ const (
 	SavedSearchSnapshotTypeImmediate SavedSearchSnapshotType = "IMMEDIATE"
 	SavedSearchSnapshotTypeWeekly    SavedSearchSnapshotType = "WEEKLY"
 	SavedSearchSnapshotTypeMonthly   SavedSearchSnapshotType = "MONTHLY"
+	SavedSearchSnapshotTypeUnknown   SavedSearchSnapshotType = "UNKNOWN"
 )
 
 type SavedSearchState struct {

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -3653,16 +3653,17 @@ func TestCreateSavedSearchSubscription(t *testing.T) {
 				ChannelId:     channelID,
 				SavedSearchId: savedSearchID,
 				Triggers: []backend.SubscriptionTriggerWritable{
-					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
-				Frequency: backend.SubscriptionFrequencyDaily,
+					backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
+				Frequency: backend.SubscriptionFrequencyImmediate,
 			},
 			createCfg: &mockCreateSavedSearchSubscriptionConfig{
 				expectedRequest: gcpspanner.CreateSavedSearchSubscriptionRequest{
 					UserID:        userID,
 					ChannelID:     channelID,
 					SavedSearchID: savedSearchID,
-					Triggers:      []string{"feature_any_browser_implementation_complete"},
-					Frequency:     string(backend.SubscriptionFrequencyDaily),
+					Triggers: []gcpspanner.SubscriptionTrigger{
+						gcpspanner.SubscriptionTriggerBrowserImplementationAnyComplete},
+					Frequency: gcpspanner.SavedSearchSnapshotTypeImmediate,
 				},
 				result:        valuePtr(subID),
 				returnedError: nil,
@@ -3674,8 +3675,8 @@ func TestCreateSavedSearchSubscription(t *testing.T) {
 					ID:            subID,
 					ChannelID:     channelID,
 					SavedSearchID: savedSearchID,
-					Triggers:      []string{"feature_any_browser_implementation_complete"},
-					Frequency:     string(backend.SubscriptionFrequencyDaily),
+					Triggers:      []gcpspanner.SubscriptionTrigger{gcpspanner.SubscriptionTriggerBrowserImplementationAnyComplete},
+					Frequency:     gcpspanner.SavedSearchSnapshotTypeImmediate,
 					CreatedAt:     now,
 					UpdatedAt:     now,
 				},
@@ -3688,11 +3689,11 @@ func TestCreateSavedSearchSubscription(t *testing.T) {
 				Triggers: []backend.SubscriptionTriggerResponseItem{
 					{
 						Value: backendtypes.AttemptToStoreSubscriptionTrigger(
-							backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
+							backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete),
 						RawValue: nil,
 					},
 				},
-				Frequency: backend.SubscriptionFrequencyDaily,
+				Frequency: backend.SubscriptionFrequencyImmediate,
 				CreatedAt: now,
 				UpdatedAt: now,
 			},
@@ -3704,16 +3705,16 @@ func TestCreateSavedSearchSubscription(t *testing.T) {
 				ChannelId:     channelID,
 				SavedSearchId: savedSearchID,
 				Triggers: []backend.SubscriptionTriggerWritable{
-					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
-				Frequency: backend.SubscriptionFrequencyDaily,
+					backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
+				Frequency: backend.SubscriptionFrequencyImmediate,
 			},
 			createCfg: &mockCreateSavedSearchSubscriptionConfig{
 				expectedRequest: gcpspanner.CreateSavedSearchSubscriptionRequest{
 					UserID:        userID,
 					ChannelID:     channelID,
 					SavedSearchID: savedSearchID,
-					Triggers:      []string{"feature_any_browser_implementation_complete"},
-					Frequency:     string(backend.SubscriptionFrequencyDaily),
+					Triggers:      []gcpspanner.SubscriptionTrigger{gcpspanner.SubscriptionTriggerBrowserImplementationAnyComplete},
+					Frequency:     gcpspanner.SavedSearchSnapshotTypeImmediate,
 				},
 				result:        nil,
 				returnedError: gcpspanner.ErrMissingRequiredRole,
@@ -3728,16 +3729,16 @@ func TestCreateSavedSearchSubscription(t *testing.T) {
 				ChannelId:     channelID,
 				SavedSearchId: savedSearchID,
 				Triggers: []backend.SubscriptionTriggerWritable{
-					backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete},
-				Frequency: backend.SubscriptionFrequencyDaily,
+					backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
+				Frequency: backend.SubscriptionFrequencyImmediate,
 			},
 			createCfg: &mockCreateSavedSearchSubscriptionConfig{
 				expectedRequest: gcpspanner.CreateSavedSearchSubscriptionRequest{
 					UserID:        userID,
 					ChannelID:     channelID,
 					SavedSearchID: savedSearchID,
-					Triggers:      []string{"feature_any_browser_implementation_complete"},
-					Frequency:     string(backend.SubscriptionFrequencyDaily),
+					Triggers:      []gcpspanner.SubscriptionTrigger{gcpspanner.SubscriptionTriggerBrowserImplementationAnyComplete},
+					Frequency:     gcpspanner.SavedSearchSnapshotTypeImmediate,
 				},
 				result:        nil,
 				returnedError: errTest,
@@ -3797,8 +3798,8 @@ func TestListSavedSearchSubscriptions(t *testing.T) {
 						ID:            "sub1",
 						ChannelID:     "chan1",
 						SavedSearchID: "search1",
-						Triggers:      []string{"feature_any_browser_implementation_complete"},
-						Frequency:     "daily",
+						Triggers:      []gcpspanner.SubscriptionTrigger{gcpspanner.SubscriptionTriggerBrowserImplementationAnyComplete},
+						Frequency:     gcpspanner.SavedSearchSnapshotTypeImmediate,
 						CreatedAt:     now,
 						UpdatedAt:     now,
 					},
@@ -3815,11 +3816,11 @@ func TestListSavedSearchSubscriptions(t *testing.T) {
 						Triggers: []backend.SubscriptionTriggerResponseItem{
 							{
 								Value: backendtypes.AttemptToStoreSubscriptionTrigger(
-									backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
+									backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete),
 								RawValue: nil,
 							},
 						},
-						Frequency: "daily",
+						Frequency: backend.SubscriptionFrequencyImmediate,
 						CreatedAt: now,
 						UpdatedAt: now,
 					},
@@ -3890,8 +3891,8 @@ func TestGetSavedSearchSubscription(t *testing.T) {
 					ID:            subID,
 					ChannelID:     "chan1",
 					SavedSearchID: "search1",
-					Triggers:      []string{"feature_any_browser_implementation_complete"},
-					Frequency:     "daily",
+					Triggers:      []gcpspanner.SubscriptionTrigger{gcpspanner.SubscriptionTriggerBrowserImplementationAnyComplete},
+					Frequency:     gcpspanner.SavedSearchSnapshotTypeImmediate,
 					CreatedAt:     now,
 					UpdatedAt:     now,
 				},
@@ -3904,11 +3905,11 @@ func TestGetSavedSearchSubscription(t *testing.T) {
 				Triggers: []backend.SubscriptionTriggerResponseItem{
 					{
 						Value: backendtypes.AttemptToStoreSubscriptionTrigger(
-							backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
+							backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete),
 						RawValue: nil,
 					},
 				},
-				Frequency: "daily",
+				Frequency: backend.SubscriptionFrequencyImmediate,
 				CreatedAt: now,
 				UpdatedAt: now,
 			},
@@ -3964,10 +3965,11 @@ func TestUpdateSavedSearchSubscription(t *testing.T) {
 	)
 	now := time.Now()
 	updatedTriggers := []backend.SubscriptionTriggerWritable{
-		backend.SubscriptionTriggerFeatureBaselineLimitedToNewly,
-		backend.SubscriptionTriggerFeatureBaselineRegressionNewlyToLimited,
+		backend.SubscriptionTriggerFeatureBaselineToNewly,
+		backend.SubscriptionTriggerFeatureBaselineRegressionToLimited,
 	}
-	updatedFrequency := backend.SubscriptionFrequencyDaily
+	updatedFrequency := backend.SubscriptionFrequencyImmediate
+	updatedSpannerFrequency := gcpspanner.SavedSearchSnapshotTypeImmediate
 
 	testCases := []struct {
 		name          string
@@ -3989,13 +3991,13 @@ func TestUpdateSavedSearchSubscription(t *testing.T) {
 				expectedRequest: gcpspanner.UpdateSavedSearchSubscriptionRequest{
 					ID:     subID,
 					UserID: userID,
-					Triggers: gcpspanner.OptionallySet[[]string]{
-						Value: []string{
-							"feature_baseline_limited_to_newly",
-							"feature_baseline_regression_newly_to_limited",
+					Triggers: gcpspanner.OptionallySet[[]gcpspanner.SubscriptionTrigger]{
+						Value: []gcpspanner.SubscriptionTrigger{
+							gcpspanner.SubscriptionTriggerFeatureBaselinePromoteToNewly,
+							gcpspanner.SubscriptionTriggerFeatureBaselineRegressionToLimited,
 						}, IsSet: true,
 					},
-					Frequency: gcpspanner.OptionallySet[string]{IsSet: false, Value: ""},
+					Frequency: gcpspanner.OptionallySet[gcpspanner.SavedSearchSnapshotType]{IsSet: false, Value: ""},
 				},
 				returnedError: nil,
 			},
@@ -4003,11 +4005,12 @@ func TestUpdateSavedSearchSubscription(t *testing.T) {
 				expectedSubscriptionID: subID,
 				expectedUserID:         userID,
 				result: &gcpspanner.SavedSearchSubscription{
-					ID:            subID,
-					Triggers:      []string{"feature_baseline_limited_to_newly"},
+					ID: subID,
+					Triggers: []gcpspanner.SubscriptionTrigger{
+						gcpspanner.SubscriptionTriggerFeatureBaselinePromoteToNewly},
 					ChannelID:     "channel",
 					SavedSearchID: "savedsearch",
-					Frequency:     "daily",
+					Frequency:     gcpspanner.SavedSearchSnapshotTypeImmediate,
 					CreatedAt:     now,
 					UpdatedAt:     now,
 				},
@@ -4018,13 +4021,13 @@ func TestUpdateSavedSearchSubscription(t *testing.T) {
 				Triggers: []backend.SubscriptionTriggerResponseItem{
 					{
 						Value: backendtypes.AttemptToStoreSubscriptionTrigger(
-							backend.SubscriptionTriggerFeatureBaselineLimitedToNewly),
+							backend.SubscriptionTriggerFeatureBaselineToNewly),
 						RawValue: nil,
 					},
 				},
 				ChannelId:     "channel",
 				SavedSearchId: "savedsearch",
-				Frequency:     "daily",
+				Frequency:     backend.SubscriptionFrequencyImmediate,
 				CreatedAt:     now,
 				UpdatedAt:     now,
 			},
@@ -4042,9 +4045,9 @@ func TestUpdateSavedSearchSubscription(t *testing.T) {
 				expectedRequest: gcpspanner.UpdateSavedSearchSubscriptionRequest{
 					ID:       subID,
 					UserID:   userID,
-					Triggers: gcpspanner.OptionallySet[[]string]{IsSet: false, Value: nil},
-					Frequency: gcpspanner.OptionallySet[string]{
-						Value: "daily", IsSet: true,
+					Triggers: gcpspanner.OptionallySet[[]gcpspanner.SubscriptionTrigger]{IsSet: false, Value: nil},
+					Frequency: gcpspanner.OptionallySet[gcpspanner.SavedSearchSnapshotType]{
+						Value: gcpspanner.SavedSearchSnapshotTypeImmediate, IsSet: true,
 					},
 				},
 				returnedError: nil,
@@ -4056,10 +4059,11 @@ func TestUpdateSavedSearchSubscription(t *testing.T) {
 					ID:            subID,
 					ChannelID:     "channel",
 					SavedSearchID: "savedsearchid",
-					Triggers:      []string{"feature_any_browser_implementation_complete"},
-					Frequency:     string(updatedFrequency),
-					CreatedAt:     now,
-					UpdatedAt:     now,
+					Triggers: []gcpspanner.SubscriptionTrigger{
+						gcpspanner.SubscriptionTriggerBrowserImplementationAnyComplete},
+					Frequency: updatedSpannerFrequency,
+					CreatedAt: now,
+					UpdatedAt: now,
 				},
 				returnedError: nil,
 			},
@@ -4070,7 +4074,7 @@ func TestUpdateSavedSearchSubscription(t *testing.T) {
 				Triggers: []backend.SubscriptionTriggerResponseItem{
 					{
 						Value: backendtypes.AttemptToStoreSubscriptionTrigger(
-							backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
+							backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete),
 						RawValue: nil,
 					},
 				},
@@ -4092,13 +4096,13 @@ func TestUpdateSavedSearchSubscription(t *testing.T) {
 				expectedRequest: gcpspanner.UpdateSavedSearchSubscriptionRequest{
 					ID:     subID,
 					UserID: userID,
-					Triggers: gcpspanner.OptionallySet[[]string]{
-						Value: []string{
-							"feature_baseline_limited_to_newly",
-							"feature_baseline_regression_newly_to_limited",
+					Triggers: gcpspanner.OptionallySet[[]gcpspanner.SubscriptionTrigger]{
+						Value: []gcpspanner.SubscriptionTrigger{
+							gcpspanner.SubscriptionTriggerFeatureBaselinePromoteToNewly,
+							gcpspanner.SubscriptionTriggerFeatureBaselineRegressionToLimited,
 						}, IsSet: true,
 					},
-					Frequency: gcpspanner.OptionallySet[string]{
+					Frequency: gcpspanner.OptionallySet[gcpspanner.SavedSearchSnapshotType]{
 						Value: "",
 						IsSet: false,
 					},
@@ -4223,7 +4227,7 @@ func assertUnknownTrigger(t *testing.T, itemIndex int,
 func TestSpannerTriggersToBackendTriggers(t *testing.T) {
 	testCases := []struct {
 		name          string
-		inputTriggers []string
+		inputTriggers []gcpspanner.SubscriptionTrigger
 		expectedItems []struct {
 			IsUnknown bool
 			Value     string
@@ -4232,9 +4236,9 @@ func TestSpannerTriggersToBackendTriggers(t *testing.T) {
 	}{
 		{
 			name: "All Valid Triggers",
-			inputTriggers: []string{
-				string(backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
-				string(backend.SubscriptionTriggerFeatureBaselineLimitedToNewly),
+			inputTriggers: []gcpspanner.SubscriptionTrigger{
+				gcpspanner.SubscriptionTriggerBrowserImplementationAnyComplete,
+				gcpspanner.SubscriptionTriggerFeatureBaselinePromoteToNewly,
 			},
 			expectedItems: []struct {
 				IsUnknown bool
@@ -4242,19 +4246,19 @@ func TestSpannerTriggersToBackendTriggers(t *testing.T) {
 				RawValue  *string
 			}{
 				{IsUnknown: false,
-					Value:    string(backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
+					Value:    string(backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete),
 					RawValue: nil},
 				{IsUnknown: false,
-					Value:    string(backend.SubscriptionTriggerFeatureBaselineLimitedToNewly),
+					Value:    string(backend.SubscriptionTriggerFeatureBaselineToNewly),
 					RawValue: nil},
 			},
 		},
 		{
 			name: "Mixed Valid and Unknown Triggers",
-			inputTriggers: []string{
-				string(backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
+			inputTriggers: []gcpspanner.SubscriptionTrigger{
+				gcpspanner.SubscriptionTriggerBrowserImplementationAnyComplete,
 				"deprecated_trigger",
-				string(backend.SubscriptionTriggerFeatureBaselineRegressionNewlyToLimited),
+				gcpspanner.SubscriptionTriggerFeatureBaselineRegressionToLimited,
 				"another_unknown",
 			},
 			expectedItems: []struct {
@@ -4263,13 +4267,13 @@ func TestSpannerTriggersToBackendTriggers(t *testing.T) {
 				RawValue  *string
 			}{
 				{IsUnknown: false,
-					Value:    string(backend.SubscriptionTriggerFeatureAnyBrowserImplementationComplete),
+					Value:    string(backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete),
 					RawValue: nil},
 				{IsUnknown: true,
 					Value:    string(backend.EnumUnknownValue),
 					RawValue: valuePtr("deprecated_trigger")},
 				{IsUnknown: false,
-					Value:    string(backend.SubscriptionTriggerFeatureBaselineRegressionNewlyToLimited),
+					Value:    string(backend.SubscriptionTriggerFeatureBaselineRegressionToLimited),
 					RawValue: nil},
 				{IsUnknown: true,
 					Value:    string(backend.EnumUnknownValue),
@@ -4278,7 +4282,7 @@ func TestSpannerTriggersToBackendTriggers(t *testing.T) {
 		},
 		{
 			name:          "All Unknown Triggers",
-			inputTriggers: []string{"unknown1", "unknown2"},
+			inputTriggers: []gcpspanner.SubscriptionTrigger{"unknown1", "unknown2"},
 			expectedItems: []struct {
 				IsUnknown bool
 				Value     string
@@ -4290,7 +4294,7 @@ func TestSpannerTriggersToBackendTriggers(t *testing.T) {
 		},
 		{
 			name:          "Empty Triggers",
-			inputTriggers: []string{},
+			inputTriggers: []gcpspanner.SubscriptionTrigger{},
 			expectedItems: []struct {
 				IsUnknown bool
 				Value     string

--- a/lib/gcpspanner/spanneradapters/event_producer.go
+++ b/lib/gcpspanner/spanneradapters/event_producer.go
@@ -134,16 +134,17 @@ func NewEventProducer(client EventProducerSpannerClient) *EventProducer {
 
 func convertFrequencyToSnapshotType(freq workertypes.JobFrequency) gcpspanner.SavedSearchSnapshotType {
 	switch freq {
-	// Eventually daily and unknown will be their own types.
-	case workertypes.FrequencyImmediate, workertypes.FrequencyDaily, workertypes.FrequencyUnknown:
+	case workertypes.FrequencyImmediate:
 		return gcpspanner.SavedSearchSnapshotTypeImmediate
 	case workertypes.FrequencyWeekly:
 		return gcpspanner.SavedSearchSnapshotTypeWeekly
 	case workertypes.FrequencyMonthly:
 		return gcpspanner.SavedSearchSnapshotTypeMonthly
+	case workertypes.FrequencyUnknown:
+		return gcpspanner.SavedSearchSnapshotTypeUnknown
 	}
 
-	return gcpspanner.SavedSearchSnapshotTypeImmediate
+	return gcpspanner.SavedSearchSnapshotTypeUnknown
 }
 
 func convertWorktypeReasonsToSpanner(reasons []workertypes.Reason) []string {

--- a/lib/gcpspanner/spanneradapters/event_producer_test.go
+++ b/lib/gcpspanner/spanneradapters/event_producer_test.go
@@ -200,8 +200,8 @@ func TestEventProducer_ReleaseLock(t *testing.T) {
 		wantErr          bool
 	}{
 		{
-			name:             "Daily maps to Immediate (as per implementation)",
-			freq:             workertypes.FrequencyDaily,
+			name:             "Regular release",
+			freq:             workertypes.FrequencyImmediate,
 			wantSnapshotType: gcpspanner.SavedSearchSnapshotTypeImmediate,
 			mockErr:          nil,
 			wantErr:          false,
@@ -432,7 +432,7 @@ func TestEventProducer_GetLatestEvent(t *testing.T) {
 		},
 		{
 			name:             "Spanner error",
-			freq:             workertypes.FrequencyDaily,
+			freq:             workertypes.FrequencyImmediate,
 			wantSnapshotType: gcpspanner.SavedSearchSnapshotTypeImmediate,
 			mockResp:         nil,
 			mockErr:          errors.New("db error"),

--- a/lib/workertypes/types.go
+++ b/lib/workertypes/types.go
@@ -572,7 +572,6 @@ type JobFrequency string
 const (
 	FrequencyUnknown   JobFrequency = "UNKNOWN"
 	FrequencyImmediate JobFrequency = "IMMEDIATE"
-	FrequencyDaily     JobFrequency = "DAILY"
 	FrequencyWeekly    JobFrequency = "WEEKLY"
 	FrequencyMonthly   JobFrequency = "MONTHLY"
 )

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -1813,22 +1813,28 @@ components:
         - EnumUnknownValue
     SubscriptionFrequency:
       type: string
-      description: The frequency for a subscription. Currently, only 'daily' is supported.
+      description: The frequency for a subscription.
       enum:
-        - daily
+        - immediate
+        - weekly
+        - monthly
       x-enumNames:
-        - SubscriptionFrequencyDaily
+        - SubscriptionFrequencyImmediate
+        - SubscriptionFrequencyWeekly
+        - SubscriptionFrequencyMonthly
     SubscriptionTriggerWritable:
       type: string
       description: The set of valid, user-selectable triggers for a subscription.
       enum:
-        - feature_baseline_limited_to_newly
-        - feature_any_browser_implementation_complete
-        - feature_baseline_regression_newly_to_limited
+        - feature_baseline_to_newly
+        - feature_baseline_to_widely
+        - feature_browser_implementation_any_complete
+        - feature_baseline_regression_to_limited
       x-enumNames:
-        - SubscriptionTriggerFeatureBaselineLimitedToNewly
-        - SubscriptionTriggerFeatureAnyBrowserImplementationComplete
-        - SubscriptionTriggerFeatureBaselineRegressionNewlyToLimited
+        - SubscriptionTriggerFeatureBaselineToNewly
+        - SubscriptionTriggerFeatureBaselineToWidely
+        - SubscriptionTriggerFeatureBrowserImplementationAnyComplete
+        - SubscriptionTriggerFeatureBaselineRegressionToLimited
     SubscriptionTriggerResponseValue:
       description: >
         Represents a subscription trigger value. Includes 'unknown' for handling deprecated triggers.

--- a/workers/event_producer/pkg/producer/batch_handler_test.go
+++ b/workers/event_producer/pkg/producer/batch_handler_test.go
@@ -100,7 +100,7 @@ func TestProcessBatchUpdate(t *testing.T) {
 			pub := &mockCommandPublisher{err: tc.pubErr, commands: nil}
 			handler := NewBatchUpdateHandler(lister, pub)
 
-			err := handler.ProcessBatchUpdate(context.Background(), "trigger-1", workertypes.FrequencyDaily)
+			err := handler.ProcessBatchUpdate(context.Background(), "trigger-1", workertypes.FrequencyImmediate)
 
 			if (err != nil) != tc.wantErr {
 				t.Errorf("ProcessBatchUpdate() error = %v, wantErr %v", err, tc.wantErr)
@@ -121,7 +121,7 @@ func TestProcessBatchUpdate(t *testing.T) {
 				if pub.commands[0].SearchID != "s1" {
 					t.Errorf("Command data mismatch")
 				}
-				if pub.commands[0].Frequency != workertypes.FrequencyDaily {
+				if pub.commands[0].Frequency != workertypes.FrequencyImmediate {
 					t.Errorf("Frequency mismatch")
 				}
 			}


### PR DESCRIPTION
tl;dr: This is to align with the triggers and frequencies in the mocks.

Updates the OpenAPI definition, internal storage types, and worker tests to align with the V1 notification capabilities, specifically removing `DAILY` frequency (as it's not in scope for user selection yet) and standardizing on `IMMEDIATE`, `WEEKLY`, and `MONTHLY`.

Changes:
- **API**:
  - Removed `DAILY` frequency.
  - Added `IMMEDIATE`, `WEEKLY`, and `MONTHLY` frequencies.
  - Renamed and expanded subscription triggers (e.g. `feature_baseline_to_widely`).
- **Storage**:
  - Updated `SavedSearchSubscription` struct to use typed `SubscriptionTrigger` and `JobFrequency` enums.
  - Updated Spanner adapters to convert between backend and storage types.
- **Workers**:
  - Updated `EventProducer` logic to map `IMMEDIATE` jobs correctly.
  - Updated `Dispatcher` tests to use `IMMEDIATE` frequency instead of `DAILY`.
- **Backend**:
  - Updated validation logic and tests to match the new enums.