### PR TITLE
feat(push_delivery): implement spanner adapter and strongly-typed subscribers

### DIFF
--- a/lib/gcpspanner/spanneradapters/push_delivery.go
+++ b/lib/gcpspanner/spanneradapters/push_delivery.go
@@ -1,0 +1,99 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+type PushDeliverySpannerClient interface {
+	FindAllActivePushSubscriptions(
+		ctx context.Context,
+		savedSearchID string,
+		frequency gcpspanner.SavedSearchSnapshotType,
+	) ([]gcpspanner.SubscriberDestination, error)
+}
+
+type PushDeliverySubscriberFinder struct {
+	client PushDeliverySpannerClient
+}
+
+func NewPushDeliverySubscriberFinder(client PushDeliverySpannerClient) *PushDeliverySubscriberFinder {
+	return &PushDeliverySubscriberFinder{client: client}
+}
+
+func (f *PushDeliverySubscriberFinder) FindSubscribers(ctx context.Context, searchID string,
+	frequency workertypes.JobFrequency) (*workertypes.SubscriberSet, error) {
+	spannerFrequency := convertFrequencyToSnapshotType(frequency)
+
+	dests, err := f.client.FindAllActivePushSubscriptions(ctx, searchID, spannerFrequency)
+	if err != nil {
+		return nil, err
+	}
+
+	set := &workertypes.SubscriberSet{
+		Emails: make([]workertypes.EmailSubscriber, 0),
+	}
+
+	for _, dest := range dests {
+		// If EmailConfig is set, it's an email subscriber.
+		if dest.EmailConfig != nil {
+			set.Emails = append(set.Emails, workertypes.EmailSubscriber{
+				SubscriptionID: dest.SubscriptionID,
+				UserID:         dest.UserID,
+				Triggers:       convertSpannerTriggersToJobTriggers(dest.Triggers),
+				EmailAddress:   dest.EmailConfig.Address,
+			})
+		}
+	}
+
+	return set, nil
+}
+
+func convertSpannerTriggersToJobTriggers(triggers []gcpspanner.SubscriptionTrigger) []workertypes.JobTrigger {
+	if triggers == nil {
+		return nil
+	}
+	jobTriggers := make([]workertypes.JobTrigger, 0, len(triggers))
+	for _, t := range triggers {
+		jobTriggers = append(jobTriggers, convertSpannerTriggerToJobTrigger(t))
+	}
+
+	return jobTriggers
+}
+
+func convertSpannerTriggerToJobTrigger(trigger gcpspanner.SubscriptionTrigger) workertypes.JobTrigger {
+	switch trigger {
+	case gcpspanner.SubscriptionTriggerFeatureBaselinePromoteToNewly:
+		return workertypes.FeaturePromotedToNewly
+	case gcpspanner.SubscriptionTriggerFeatureBaselinePromoteToWidely:
+		return workertypes.FeaturePromotedToWidely
+	case gcpspanner.SubscriptionTriggerFeatureBaselineRegressionToLimited:
+		return workertypes.FeatureRegressedToLimited
+	case gcpspanner.SubscriptionTriggerBrowserImplementationAnyComplete:
+		return workertypes.BrowserImplementationAnyComplete
+	case gcpspanner.SubscriptionTriggerUnknown:
+		break
+	}
+	// Should not reach here.
+	slog.WarnContext(context.TODO(), "unknown subscription trigger encountered in push deliveryspanner adapter",
+		"trigger", trigger)
+
+	return ""
+}

--- a/lib/gcpspanner/spanneradapters/push_delivery_test.go
+++ b/lib/gcpspanner/spanneradapters/push_delivery_test.go
@@ -1,0 +1,242 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+	"github.com/google/go-cmp/cmp"
+)
+
+type mockPushDeliverySpannerClient struct {
+	findAllCalledWith *findAllCalledWith
+	findAllReturns    findAllReturns
+}
+
+type findAllCalledWith struct {
+	SearchID  string
+	Frequency gcpspanner.SavedSearchSnapshotType
+}
+
+type findAllReturns struct {
+	dests []gcpspanner.SubscriberDestination
+	err   error
+}
+
+func (m *mockPushDeliverySpannerClient) FindAllActivePushSubscriptions(
+	_ context.Context,
+	savedSearchID string,
+	frequency gcpspanner.SavedSearchSnapshotType,
+) ([]gcpspanner.SubscriberDestination, error) {
+	m.findAllCalledWith = &findAllCalledWith{
+		SearchID:  savedSearchID,
+		Frequency: frequency,
+	}
+
+	return m.findAllReturns.dests, m.findAllReturns.err
+}
+
+func TestFindSubscribers(t *testing.T) {
+	tests := []struct {
+		name          string
+		dests         []gcpspanner.SubscriberDestination
+		clientErr     error
+		expectedCall  *findAllCalledWith
+		expectedSet   *workertypes.SubscriberSet
+		expectedError error
+	}{
+		{
+			name: "Success with Email and Triggers",
+			expectedCall: &findAllCalledWith{
+				SearchID:  "search-1",
+				Frequency: gcpspanner.SavedSearchSnapshotTypeImmediate,
+			},
+			dests: []gcpspanner.SubscriberDestination{
+				{
+					SubscriptionID: "sub-1",
+					UserID:         "user-1",
+					Type:           "EMAIL",
+					ChannelID:      "chan-1",
+					EmailConfig: &gcpspanner.EmailConfig{
+						Address:           "test@example.com",
+						IsVerified:        true,
+						VerificationToken: nil,
+					},
+					Triggers: []gcpspanner.SubscriptionTrigger{
+						gcpspanner.SubscriptionTriggerFeatureBaselinePromoteToNewly,
+						gcpspanner.SubscriptionTriggerFeatureBaselinePromoteToWidely,
+					},
+				},
+			},
+			expectedSet: &workertypes.SubscriberSet{
+				Emails: []workertypes.EmailSubscriber{
+					{
+						SubscriptionID: "sub-1",
+						UserID:         "user-1",
+						EmailAddress:   "test@example.com",
+						Triggers: []workertypes.JobTrigger{
+							workertypes.FeaturePromotedToNewly,
+							workertypes.FeaturePromotedToWidely,
+						},
+					},
+				},
+			},
+			clientErr:     nil,
+			expectedError: nil,
+		},
+		{
+			name: "Mixed types (Webhook ignored)",
+			expectedCall: &findAllCalledWith{
+				SearchID:  "search-1",
+				Frequency: gcpspanner.SavedSearchSnapshotTypeImmediate,
+			},
+			clientErr: nil,
+			dests: []gcpspanner.SubscriberDestination{
+				{
+					UserID:         "user-1",
+					SubscriptionID: "sub-1",
+					Type:           "EMAIL",
+					ChannelID:      "chan-1",
+					EmailConfig: &gcpspanner.EmailConfig{
+						Address:           "test@example.com",
+						IsVerified:        true,
+						VerificationToken: nil,
+					},
+					Triggers: []gcpspanner.SubscriptionTrigger{
+						gcpspanner.SubscriptionTriggerBrowserImplementationAnyComplete,
+					},
+				},
+				{
+					SubscriptionID: "sub-2",
+					Type:           "WEBHOOK",
+					ChannelID:      "chan-2",
+					EmailConfig:    nil, // Webhooks don't have EmailConfig
+					Triggers:       nil,
+					UserID:         "user-3",
+				},
+			},
+			expectedSet: &workertypes.SubscriberSet{
+				Emails: []workertypes.EmailSubscriber{
+					{
+						SubscriptionID: "sub-1",
+						UserID:         "user-1",
+						EmailAddress:   "test@example.com",
+						Triggers: []workertypes.JobTrigger{
+							workertypes.BrowserImplementationAnyComplete,
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Client Error",
+			expectedCall: &findAllCalledWith{
+				SearchID:  "search-1",
+				Frequency: gcpspanner.SavedSearchSnapshotTypeImmediate,
+			},
+			expectedSet:   nil,
+			dests:         nil,
+			clientErr:     errTest,
+			expectedError: errTest,
+		},
+		{
+			name: "Nil Email Config (Should Skip)",
+			expectedCall: &findAllCalledWith{
+				SearchID:  "search-1",
+				Frequency: gcpspanner.SavedSearchSnapshotTypeImmediate,
+			},
+			dests: []gcpspanner.SubscriberDestination{
+				{
+					UserID:         "user-1",
+					SubscriptionID: "sub-1",
+					Type:           "EMAIL",
+					ChannelID:      "chan-1",
+					Triggers:       nil,
+					EmailConfig:    nil, // Missing config should be skipped
+				},
+			},
+			clientErr: nil,
+			expectedSet: &workertypes.SubscriberSet{
+				Emails: []workertypes.EmailSubscriber{},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Unknown Trigger (Should be logged/ignored/empty string)",
+			expectedCall: &findAllCalledWith{
+				SearchID:  "search-1",
+				Frequency: gcpspanner.SavedSearchSnapshotTypeImmediate,
+			},
+			dests: []gcpspanner.SubscriberDestination{
+				{
+					UserID:         "user-1",
+					SubscriptionID: "sub-1",
+					Type:           "EMAIL",
+					ChannelID:      "chan-1",
+					EmailConfig: &gcpspanner.EmailConfig{
+						Address:           "test@example.com",
+						IsVerified:        true,
+						VerificationToken: nil,
+					},
+					Triggers: []gcpspanner.SubscriptionTrigger{
+						"some_unknown_trigger",
+					},
+				},
+			},
+			clientErr: nil,
+			expectedSet: &workertypes.SubscriberSet{
+				Emails: []workertypes.EmailSubscriber{
+					{
+						UserID:         "user-1",
+						SubscriptionID: "sub-1",
+						EmailAddress:   "test@example.com",
+						Triggers: []workertypes.JobTrigger{
+							"", // Unknown triggers map to empty string/zero value in current implementation
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := new(mockPushDeliverySpannerClient)
+			mock.findAllReturns.dests = tc.dests
+			mock.findAllReturns.err = tc.clientErr
+
+			finder := NewPushDeliverySubscriberFinder(mock)
+			set, err := finder.FindSubscribers(context.Background(), "search-1", workertypes.FrequencyImmediate)
+
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("FindSubscribers error = %v, wantErr %v", err, tc.expectedError)
+			}
+
+			if diff := cmp.Diff(tc.expectedSet, set); diff != "" {
+				t.Errorf("SubscriberSet mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.expectedCall, mock.findAllCalledWith); diff != "" {
+				t.Errorf("findAllCalledWith mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/lib/workertypes/types.go
+++ b/lib/workertypes/types.go
@@ -588,11 +588,20 @@ type SearchJob struct {
 	Query string
 }
 
+type JobTrigger string
+
+const (
+	FeaturePromotedToNewly           JobTrigger = "FEATURE_PROMOTED_TO_NEWLY"
+	FeaturePromotedToWidely          JobTrigger = "FEATURE_PROMOTED_TO_WIDELY"
+	FeatureRegressedToLimited        JobTrigger = "FEATURE_REGRESSED_TO_LIMITED"
+	BrowserImplementationAnyComplete JobTrigger = "BROWSER_IMPLEMENTATION_ANY_COMPLETE"
+)
+
 // EmailSubscriber represents a subscriber using an Email channel.
 type EmailSubscriber struct {
 	SubscriptionID string
 	UserID         string
-	Triggers       []string
+	Triggers       []JobTrigger
 	EmailAddress   string
 }
 

--- a/workers/push_delivery/pkg/dispatcher/dispatcher.go
+++ b/workers/push_delivery/pkg/dispatcher/dispatcher.go
@@ -170,7 +170,7 @@ func (g *deliveryJobGenerator) JobCount() int {
 }
 
 // shouldNotifyV1 determines if the V1 event summary matches any of the user's triggers.
-func shouldNotifyV1(triggers []string, summary workertypes.EventSummary) bool {
+func shouldNotifyV1(triggers []workertypes.JobTrigger, summary workertypes.EventSummary) bool {
 	hasChanges := summary.Categories.Added > 0 ||
 		summary.Categories.Removed > 0 ||
 		summary.Categories.Updated > 0 ||

--- a/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
+++ b/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
@@ -135,13 +135,13 @@ func TestProcessEvent_Success(t *testing.T) {
 			{
 				SubscriptionID: "sub-1",
 				UserID:         "user-1",
-				Triggers:       []string{"any_change"}, // Matches logic in shouldNotifyV1
+				Triggers:       []workertypes.JobTrigger{"any_change"}, // Matches logic in shouldNotifyV1
 				EmailAddress:   "user1@example.com",
 			},
 			{
 				SubscriptionID: "sub-2",
 				UserID:         "user-2",
-				Triggers:       []string{}, // Empty triggers = no notify
+				Triggers:       []workertypes.JobTrigger{}, // Empty triggers = no notify
 				EmailAddress:   "user2@example.com",
 			},
 		},
@@ -220,7 +220,7 @@ func TestProcessEvent_NoChanges_FiltersAll(t *testing.T) {
 			{
 				SubscriptionID: "sub-1",
 				UserID:         "user-1",
-				Triggers:       []string{"any_change"},
+				Triggers:       []workertypes.JobTrigger{"any_change"},
 				EmailAddress:   "user1@example.com",
 			},
 		},
@@ -303,8 +303,8 @@ func TestProcessEvent_PublisherPartialFailure(t *testing.T) {
 	// Two subscribers
 	subSet := &workertypes.SubscriberSet{
 		Emails: []workertypes.EmailSubscriber{
-			{SubscriptionID: "sub-1", Triggers: []string{"change"}, UserID: "u1", EmailAddress: "e1"},
-			{SubscriptionID: "sub-2", Triggers: []string{"change"}, UserID: "u2", EmailAddress: "e2"},
+			{SubscriptionID: "sub-1", Triggers: []workertypes.JobTrigger{"change"}, UserID: "u1", EmailAddress: "e1"},
+			{SubscriptionID: "sub-2", Triggers: []workertypes.JobTrigger{"change"}, UserID: "u2", EmailAddress: "e2"},
 		},
 	}
 
@@ -355,7 +355,7 @@ func TestProcessEvent_JobCount(t *testing.T) {
 	// Verify that if no jobs are generated (e.g. no matching triggers), ProcessEvent returns early/cleanly.
 	subSet := &workertypes.SubscriberSet{
 		Emails: []workertypes.EmailSubscriber{
-			{SubscriptionID: "sub-1", Triggers: []string{}, EmailAddress: "e1", UserID: "u1"}, // No match
+			{SubscriptionID: "sub-1", Triggers: []workertypes.JobTrigger{}, EmailAddress: "e1", UserID: "u1"}, // No match
 		},
 	}
 	finder := &mockSubscriptionFinder{


### PR DESCRIPTION
Introduces the `PushDeliverySubscriberFinder` adapter in `spanneradapters`. This component is responsible for retrieving subscribers from Spanner and mapping them into the domain-layer `SubscriberSet`.

Key changes:
- **Spanner Adapter (`spanneradapters/push_delivery.go`)**: Implemented `FindSubscribers` which calls `FindAllActivePushSubscriptions` and maps the results.
- **Spanner Client (`gcpspanner`)**:
  - Updated `SubscriberDestination` to hold a strongly-typed `EmailConfig` instead of raw `spanner.NullJSON`.
  - Moved JSON unmarshalling logic into the Spanner client layer (`toPublic` and `loadSubscriptionConfigs`), ensuring raw bytes don't leak into the adapter.
  - Added `Triggers` (typed as `[]SubscriptionTrigger`) to the destination struct.