### PR TITLE
feat(email_worker): add pub/sub subscriber and spanner adapter

### DIFF
--- a/lib/event/emailjob/v1/types.go
+++ b/lib/event/emailjob/v1/types.go
@@ -59,6 +59,21 @@ const (
 	FrequencyMonthly   JobFrequency = "MONTHLY"
 )
 
+func (f JobFrequency) ToWorkerTypeJobFrequency() workertypes.JobFrequency {
+	switch f {
+	case FrequencyImmediate:
+		return workertypes.FrequencyImmediate
+	case FrequencyWeekly:
+		return workertypes.FrequencyWeekly
+	case FrequencyMonthly:
+		return workertypes.FrequencyMonthly
+	case FrequencyUnknown:
+		return workertypes.FrequencyUnknown
+	}
+
+	return workertypes.FrequencyUnknown
+}
+
 func ToJobFrequency(freq workertypes.JobFrequency) JobFrequency {
 	switch freq {
 	case workertypes.FrequencyImmediate:

--- a/lib/gcppubsub/gcppubsubadapters/email_worker.go
+++ b/lib/gcppubsub/gcppubsubadapters/email_worker.go
@@ -1,0 +1,84 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcppubsubadapters
+
+import (
+	"context"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/event"
+	v1 "github.com/GoogleChrome/webstatus.dev/lib/event/emailjob/v1"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+// EmailWorkerMessageHandler defines the interface for the Sender logic.
+type EmailWorkerMessageHandler interface {
+	ProcessMessage(ctx context.Context, job workertypes.IncomingEmailDeliveryJob) error
+}
+
+type EmailWorkerSubscriberAdapter struct {
+	sender          EmailWorkerMessageHandler
+	eventSubscriber EventSubscriber
+	subscriptionID  string
+	router          *event.Router
+}
+
+func NewEmailWorkerSubscriberAdapter(
+	sender EmailWorkerMessageHandler,
+	eventSubscriber EventSubscriber,
+	subscriptionID string,
+) *EmailWorkerSubscriberAdapter {
+	router := event.NewRouter()
+
+	ret := &EmailWorkerSubscriberAdapter{
+		sender:          sender,
+		eventSubscriber: eventSubscriber,
+		subscriptionID:  subscriptionID,
+		router:          router,
+	}
+
+	event.Register(router, ret.handleEmailJobEvent)
+
+	return ret
+}
+
+func (a *EmailWorkerSubscriberAdapter) Subscribe(ctx context.Context) error {
+	return a.eventSubscriber.Subscribe(ctx, a.subscriptionID, func(ctx context.Context,
+		msgID string, data []byte) error {
+		return a.router.HandleMessage(ctx, msgID, data)
+	})
+}
+
+func (a *EmailWorkerSubscriberAdapter) handleEmailJobEvent(
+	ctx context.Context, msgID string, event v1.EmailJobEvent) error {
+
+	incomingJob := workertypes.IncomingEmailDeliveryJob{
+		EmailDeliveryJob: workertypes.EmailDeliveryJob{
+			SubscriptionID: event.SubscriptionID,
+			RecipientEmail: event.RecipientEmail,
+			ChannelID:      event.ChannelID,
+			SummaryRaw:     event.SummaryRaw,
+			Metadata: workertypes.DeliveryMetadata{
+				EventID:     event.Metadata.EventID,
+				SearchID:    event.Metadata.SearchID,
+				Query:       event.Metadata.Query,
+				Frequency:   event.Metadata.Frequency.ToWorkerTypeJobFrequency(),
+				GeneratedAt: event.Metadata.GeneratedAt,
+			},
+		},
+		EmailEventID: msgID,
+	}
+
+	return a.sender.ProcessMessage(ctx, incomingJob)
+}

--- a/lib/gcppubsub/gcppubsubadapters/email_worker_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/email_worker_test.go
@@ -1,0 +1,172 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcppubsubadapters
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	v1 "github.com/GoogleChrome/webstatus.dev/lib/event/emailjob/v1"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+	"github.com/google/go-cmp/cmp"
+)
+
+// --- Mocks ---
+
+type mockEmailWorkerMessageHandler struct {
+	calls []workertypes.IncomingEmailDeliveryJob
+	mu    sync.Mutex
+	err   error
+}
+
+func (m *mockEmailWorkerMessageHandler) ProcessMessage(
+	_ context.Context, job workertypes.IncomingEmailDeliveryJob) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, job)
+
+	return m.err
+}
+
+// --- Tests ---
+
+type emailTestEnv struct {
+	sender   *mockEmailWorkerMessageHandler
+	adapter  *EmailWorkerSubscriberAdapter
+	handleFn func(context.Context, string, []byte) error
+	stop     func()
+}
+
+func setupEmailTestAdapter(t *testing.T) *emailTestEnv {
+	t.Helper()
+	sender := new(mockEmailWorkerMessageHandler)
+	subscriber := &mockSubscriber{block: make(chan struct{}), mu: sync.Mutex{}, handlers: nil}
+	subscriptionID := "email-sub"
+
+	adapter := NewEmailWorkerSubscriberAdapter(sender, subscriber, subscriptionID)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errChan := make(chan error)
+	go func() {
+		errChan <- adapter.Subscribe(ctx)
+	}()
+
+	// Wait briefly for Subscribe to start and register the handler
+	time.Sleep(50 * time.Millisecond)
+
+	subscriber.mu.Lock()
+	handleFn := subscriber.handlers[subscriptionID]
+	subscriber.mu.Unlock()
+
+	if handleFn == nil {
+		cancel()
+		t.Fatalf("Subscribe did not register a handler for subscription %s", subscriptionID)
+	}
+
+	return &emailTestEnv{
+		sender:  sender,
+		adapter: adapter,
+		handleFn: func(ctx context.Context, msgID string, data []byte) error {
+			return handleFn(ctx, msgID, data)
+		},
+		stop: func() {
+			close(subscriber.block)
+			cancel()
+			<-errChan
+		},
+	}
+}
+
+func TestEmailWorkerSubscriberAdapter_RoutesEmailJobEvent(t *testing.T) {
+	env := setupEmailTestAdapter(t)
+	defer env.stop()
+
+	now := time.Now()
+	emailJobEvent := v1.EmailJobEvent{
+		SubscriptionID: "sub-123",
+		RecipientEmail: "test@example.com",
+		ChannelID:      "chan-456",
+		SummaryRaw:     []byte(`{"key":"value"}`),
+		Metadata: v1.EmailJobEventMetadata{
+			EventID:     "event-789",
+			SearchID:    "search-abc",
+			Query:       "is:open",
+			Frequency:   v1.FrequencyMonthly,
+			GeneratedAt: now,
+		},
+	}
+
+	ceWrapper := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "EmailJobEvent",
+		"data":       emailJobEvent,
+	}
+	ceBytes, err := json.Marshal(ceWrapper)
+	if err != nil {
+		t.Fatalf("Failed to marshal event: %v", err)
+	}
+
+	msgID := "msg-xyz"
+	if err := env.handleFn(context.Background(), msgID, ceBytes); err != nil {
+		t.Errorf("handleFn failed: %v", err)
+	}
+
+	if len(env.sender.calls) != 1 {
+		t.Fatalf("Expected 1 call to ProcessMessage, got %d", len(env.sender.calls))
+	}
+
+	expectedJob := workertypes.IncomingEmailDeliveryJob{
+		EmailDeliveryJob: workertypes.EmailDeliveryJob{
+			SubscriptionID: "sub-123",
+			RecipientEmail: "test@example.com",
+			ChannelID:      "chan-456",
+			SummaryRaw:     []byte(`{"key":"value"}`),
+			Metadata: workertypes.DeliveryMetadata{
+				EventID:     "event-789",
+				SearchID:    "search-abc",
+				Query:       "is:open",
+				Frequency:   workertypes.FrequencyMonthly,
+				GeneratedAt: now,
+			},
+		},
+		EmailEventID: msgID,
+	}
+
+	if diff := cmp.Diff(expectedJob, env.sender.calls[0]); diff != "" {
+		t.Errorf("ProcessMessage call mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestEmailWorkerSubscriberAdapter_ReturnsErrorOnUnknownEvent(t *testing.T) {
+	env := setupEmailTestAdapter(t)
+	defer env.stop()
+
+	ceWrapper := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "UnknownEvent",
+		"data":       map[string]string{"foo": "bar"},
+	}
+	ceBytes, _ := json.Marshal(ceWrapper)
+
+	err := env.handleFn(context.Background(), "msg-1", ceBytes)
+	if err == nil {
+		t.Error("Expected an error for an unknown event, but got nil")
+	}
+}

--- a/lib/gcppubsub/gcppubsubadapters/event_producer.go
+++ b/lib/gcppubsub/gcppubsubadapters/event_producer.go
@@ -159,5 +159,11 @@ func (a *EventProducerPublisherAdapter) Publish(ctx context.Context,
 		return "", err
 	}
 
-	return a.eventPublisher.Publish(ctx, a.topicID, b)
+	id, err := a.eventPublisher.Publish(ctx, a.topicID, b)
+	if err != nil {
+		return "", err
+	}
+	slog.InfoContext(ctx, "published feature diff event", "id", id, "eventID", req.EventID)
+
+	return id, nil
 }

--- a/lib/gcpspanner/spanneradapters/email_worker.go
+++ b/lib/gcpspanner/spanneradapters/email_worker.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"time"
+)
+
+type EmailWorkerSpannerClient interface {
+	RecordNotificationChannelSuccess(ctx context.Context, channelID string, timestamp time.Time, eventID string) error
+	RecordNotificationChannelFailure(ctx context.Context, channelID string, errorMsg string, timestamp time.Time,
+		isPermanent bool, eventID string) error
+}
+
+type EmailWorkerChannelStateManager struct {
+	client EmailWorkerSpannerClient
+}
+
+func NewEmailWorkerChannelStateManager(client EmailWorkerSpannerClient) *EmailWorkerChannelStateManager {
+	return &EmailWorkerChannelStateManager{client: client}
+}
+
+func (s *EmailWorkerChannelStateManager) RecordSuccess(ctx context.Context, channelID string,
+	timestamp time.Time, eventID string) error {
+	return s.client.RecordNotificationChannelSuccess(ctx, channelID, timestamp, eventID)
+}
+
+func (s *EmailWorkerChannelStateManager) RecordFailure(ctx context.Context, channelID string, err error,
+	timestamp time.Time, permanentUserFailure bool, emailEventID string) error {
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+
+	return s.client.RecordNotificationChannelFailure(ctx, channelID, msg, timestamp, permanentUserFailure, emailEventID)
+}

--- a/lib/gcpspanner/spanneradapters/email_worker_test.go
+++ b/lib/gcpspanner/spanneradapters/email_worker_test.go
@@ -1,0 +1,133 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type mockEmailWorkerSpannerClient struct {
+	successCalled bool
+	successReq    struct {
+		ChannelID string
+		Timestamp time.Time
+		EventID   string
+	}
+	successErr error
+
+	failureCalled bool
+	failureReq    struct {
+		ChannelID   string
+		Msg         string
+		Timestamp   time.Time
+		IsPermanent bool
+		EventID     string
+	}
+	failureErr error
+}
+
+func (m *mockEmailWorkerSpannerClient) RecordNotificationChannelSuccess(
+	_ context.Context, channelID string, timestamp time.Time, eventID string) error {
+	m.successCalled = true
+	m.successReq.ChannelID = channelID
+	m.successReq.Timestamp = timestamp
+	m.successReq.EventID = eventID
+
+	return m.successErr
+}
+
+func (m *mockEmailWorkerSpannerClient) RecordNotificationChannelFailure(
+	_ context.Context, channelID, errorMsg string, timestamp time.Time, isPermanent bool, eventID string) error {
+	m.failureCalled = true
+	m.failureReq.ChannelID = channelID
+	m.failureReq.Msg = errorMsg
+	m.failureReq.Timestamp = timestamp
+	m.failureReq.IsPermanent = isPermanent
+	m.failureReq.EventID = eventID
+
+	return m.failureErr
+}
+
+func TestRecordSuccess(t *testing.T) {
+	mock := new(mockEmailWorkerSpannerClient)
+	adapter := NewEmailWorkerChannelStateManager(mock)
+
+	ts := time.Now()
+	eventID := "evt-1"
+	err := adapter.RecordSuccess(context.Background(), "chan-1", ts, eventID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mock.successCalled {
+		t.Error("RecordNotificationChannelSuccess not called")
+	}
+
+	expectedReq := struct {
+		ChannelID string
+		Timestamp time.Time
+		EventID   string
+	}{
+		ChannelID: "chan-1",
+		Timestamp: ts,
+		EventID:   eventID,
+	}
+
+	if diff := cmp.Diff(expectedReq, mock.successReq); diff != "" {
+		t.Errorf("RecordNotificationChannelSuccess request mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestRecordFailure(t *testing.T) {
+	mock := new(mockEmailWorkerSpannerClient)
+	adapter := NewEmailWorkerChannelStateManager(mock)
+
+	testErr := errors.New("smtp error")
+	ts := time.Now()
+	eventID := "evt-2"
+	isPermanent := true
+
+	err := adapter.RecordFailure(context.Background(), "chan-1", testErr, ts, isPermanent, eventID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mock.failureCalled {
+		t.Error("RecordNotificationChannelFailure not called")
+	}
+
+	expectedReq := struct {
+		ChannelID   string
+		Msg         string
+		Timestamp   time.Time
+		IsPermanent bool
+		EventID     string
+	}{
+		ChannelID:   "chan-1",
+		Msg:         testErr.Error(),
+		Timestamp:   ts,
+		IsPermanent: isPermanent,
+		EventID:     eventID,
+	}
+
+	if diff := cmp.Diff(expectedReq, mock.failureReq); diff != "" {
+		t.Errorf("RecordNotificationChannelFailure request mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Implements the Pub/Sub subscriber adapter for the email worker and the Spanner adapter for managing notification channel state.

Changes:
- **Pub/Sub Adapter**: Created `EmailWorkerSubscriberAdapter` to receive `EmailJobEvent` messages from Pub/Sub and route them to the email worker's message handler. Includes unit tests.
- **Spanner Adapter**: Added `EmailWorkerChannelStateManager` to record notification channel success and failure events. Includes unit tests.
- **Event Types**: Added a `ToWorkerTypeJobFrequency` method to the `JobFrequency` type in `lib/event/emailjob/v1` to convert between the event type and the worker type.