### PR TITLE
refactor(featurelistdiff): Differentiate between removed and deleted features

### DIFF
--- a/lib/blobtypes/featurelistdiff/v1/types.go
+++ b/lib/blobtypes/featurelistdiff/v1/types.go
@@ -94,6 +94,7 @@ type FeatureDiff struct {
 	QueryChanged bool              `json:"queryChanged,omitempty"`
 	Added        []FeatureAdded    `json:"added,omitempty"`
 	Removed      []FeatureRemoved  `json:"removed,omitempty"`
+	Deleted      []FeatureDeleted  `json:"deleted,omitempty"`
 	Modified     []FeatureModified `json:"modified,omitempty"`
 	Moves        []FeatureMoved    `json:"moves,omitempty"`
 	Splits       []FeatureSplit    `json:"splits,omitempty"`
@@ -124,6 +125,13 @@ func (d *FeatureDiff) Sort() {
 		}
 
 		return d.Removed[i].ID < d.Removed[j].ID
+	})
+	sort.Slice(d.Deleted, func(i, j int) bool {
+		if d.Deleted[i].Name != d.Deleted[j].Name {
+			return d.Deleted[i].Name < d.Deleted[j].Name
+		}
+
+		return d.Deleted[i].ID < d.Deleted[j].ID
 	})
 	sort.Slice(d.Modified, func(i, j int) bool {
 		if d.Modified[i].Name != d.Modified[j].Name {
@@ -182,6 +190,12 @@ type FeatureRemoved struct {
 	Reason ChangeReason `json:"reason"`
 }
 
+type FeatureDeleted struct {
+	ID     string       `json:"id"`
+	Name   string       `json:"name"`
+	Reason ChangeReason `json:"reason"`
+}
+
 type FeatureMoved struct {
 	FromID   string `json:"fromId"`
 	ToID     string `json:"toId"`
@@ -223,7 +237,7 @@ func (d FeatureDiff) HasChanges() bool {
 }
 
 func (d FeatureDiff) HasDataChanges() bool {
-	return len(d.Added) > 0 || len(d.Removed) > 0 ||
+	return len(d.Added) > 0 || len(d.Removed) > 0 || len(d.Deleted) > 0 ||
 		len(d.Modified) > 0 || len(d.Moves) > 0 || len(d.Splits) > 0
 }
 

--- a/lib/blobtypes/featurelistdiff/v1/types_test.go
+++ b/lib/blobtypes/featurelistdiff/v1/types_test.go
@@ -36,6 +36,7 @@ func TestHasChanges(t *testing.T) {
 				Modified:     nil,
 				Moves:        nil,
 				Splits:       nil,
+				Deleted:      nil,
 			},
 			expected: false,
 		},
@@ -48,6 +49,7 @@ func TestHasChanges(t *testing.T) {
 				Modified:     nil,
 				Moves:        nil,
 				Splits:       nil,
+				Deleted:      nil,
 			},
 			expected: true,
 		},
@@ -60,6 +62,7 @@ func TestHasChanges(t *testing.T) {
 				Modified:     nil,
 				Moves:        nil,
 				Splits:       nil,
+				Deleted:      nil,
 			},
 			expected: true,
 		},
@@ -72,6 +75,22 @@ func TestHasChanges(t *testing.T) {
 				Modified:     nil,
 				Moves:        nil,
 				Splits:       nil,
+				Deleted:      nil,
+			},
+			expected: true,
+		},
+		{
+			name: "Deleted",
+			diff: FeatureDiff{
+				QueryChanged: false,
+				Added:        nil,
+				Removed:      nil,
+				Modified:     nil,
+				Moves:        nil,
+				Splits:       nil,
+				Deleted: []FeatureDeleted{
+					{ID: "1", Name: "A", Reason: ReasonDeleted},
+				},
 			},
 			expected: true,
 		},
@@ -101,8 +120,9 @@ func TestHasChanges(t *testing.T) {
 					BrowserChanges: nil,
 					DocsChange:     nil,
 				}},
-				Moves:  nil,
-				Splits: nil,
+				Moves:   nil,
+				Splits:  nil,
+				Deleted: nil,
 			},
 			expected: true,
 		},
@@ -115,6 +135,7 @@ func TestHasChanges(t *testing.T) {
 				Modified:     nil,
 				Moves:        []FeatureMoved{{FromID: "A", ToID: "B", FromName: "A", ToName: "B"}},
 				Splits:       nil,
+				Deleted:      nil,
 			},
 			expected: true,
 		},
@@ -127,6 +148,7 @@ func TestHasChanges(t *testing.T) {
 				Modified:     nil,
 				Moves:        nil,
 				Splits:       []FeatureSplit{{FromID: "A", FromName: "A", To: nil}},
+				Deleted:      nil,
 			},
 			expected: true,
 		},
@@ -176,6 +198,10 @@ func TestFeatureDiff_Sort(t *testing.T) {
 				To:       nil,
 			},
 		},
+		Deleted: []FeatureDeleted{
+			{ID: "2", Name: "B", Reason: ReasonDeleted},
+			{ID: "1", Name: "A", Reason: ReasonDeleted},
+		},
 	}
 
 	diff.Sort()
@@ -188,6 +214,11 @@ func TestFeatureDiff_Sort(t *testing.T) {
 	// Removed: A(1), B(2)
 	if diff.Removed[0].ID != "1" || diff.Removed[1].ID != "2" {
 		t.Errorf("Removed sort failed: %+v", diff.Removed)
+	}
+
+	// Deleted: A(1), B(2)
+	if diff.Deleted[0].ID != "1" || diff.Deleted[1].ID != "2" {
+		t.Errorf("Deleted sort failed: %+v", diff.Deleted)
 	}
 
 	// Modified: A(1), B(2)

--- a/lib/workertypes/types_test.go
+++ b/lib/workertypes/types_test.go
@@ -60,6 +60,7 @@ func TestParseEventSummary(t *testing.T) {
 					QueryChanged:    0,
 					Added:           0,
 					Removed:         0,
+					Deleted:         0,
 					Moved:           0,
 					Split:           0,
 					Updated:         0,
@@ -121,6 +122,7 @@ func TestParseEventSummary(t *testing.T) {
 
 func TestGenerateJSONSummaryFeatureDiffV1(t *testing.T) {
 	newlyDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	browserImplDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	tests := []struct {
 		name          string
 		diff          v1.FeatureDiff
@@ -136,6 +138,7 @@ func TestGenerateJSONSummaryFeatureDiffV1(t *testing.T) {
 				Modified:     nil,
 				Moves:        nil,
 				Splits:       nil,
+				Deleted:      nil,
 			},
 			expected:      `{"schemaVersion":"v1","text":"No changes detected","truncated":false,"highlights":null}`,
 			expectedError: nil,
@@ -152,6 +155,9 @@ func TestGenerateJSONSummaryFeatureDiffV1(t *testing.T) {
 				},
 				Removed: []v1.FeatureRemoved{
 					{ID: "3", Name: "C", Reason: v1.ReasonUnmatched},
+				},
+				Deleted: []v1.FeatureDeleted{
+					{ID: "4", Name: "D", Reason: v1.ReasonDeleted},
 				},
 				Moves: []v1.FeatureMoved{
 					{FromID: "4", ToID: "5", FromName: "D", ToName: "E"},
@@ -192,7 +198,7 @@ func TestGenerateJSONSummaryFeatureDiffV1(t *testing.T) {
 								Version: generic.UnsetOpt[*string](),
 							}, To: v1.BrowserState{
 								Status:  generic.SetOpt(v1.Available),
-								Date:    generic.UnsetOpt[*time.Time](),
+								Date:    generic.SetOpt(&browserImplDate),
 								Version: generic.SetOpt(generic.ValuePtr("123")),
 							}},
 							v1.ChromeAndroid:  nil,
@@ -220,11 +226,12 @@ func TestGenerateJSONSummaryFeatureDiffV1(t *testing.T) {
 			expected: `{
     "schemaVersion": "v1",
     "text": "Search criteria updated, 2 features added, 1 features removed, ` +
-				`1 features moved/renamed, 1 features split, 3 features updated",
+				`1 features deleted, 1 features moved/renamed, 1 features split, 3 features updated",
     "categories": {
         "query_changed": 1,
         "added": 2,
         "removed": 1,
+		"deleted": 1,
         "moved": 1,
         "split": 1,
         "updated": 3,
@@ -258,6 +265,7 @@ func TestGenerateJSONSummaryFeatureDiffV1(t *testing.T) {
                         "status": "unavailable"
                     },
                     "to": {
+						"date": "2024-01-01T00:00:00Z",
                         "status": "available",
                         "version": "123"
                     }
@@ -294,6 +302,11 @@ func TestGenerateJSONSummaryFeatureDiffV1(t *testing.T) {
             "type": "Removed",
             "feature_id": "3",
             "feature_name": "C"
+        },
+		{
+            "type": "Deleted",
+            "feature_id": "4",
+            "feature_name": "D"
         },
         {
             "type": "Moved",

--- a/workers/event_producer/pkg/producer/diff_test.go
+++ b/workers/event_producer/pkg/producer/diff_test.go
@@ -163,6 +163,7 @@ func TestV1DiffSerializer_Serialize(t *testing.T) {
 	diff := &featurelistdiffv1.FeatureDiff{
 		QueryChanged: false,
 		Added:        []featurelistdiffv1.FeatureAdded{{ID: "feat-a", Name: "Feature A", Reason: "", Docs: nil}},
+		Deleted:      nil,
 		Removed:      nil,
 		Modified:     nil,
 		Moves:        nil,

--- a/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
+++ b/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
@@ -71,6 +71,7 @@ func createTestSummary(hasChanges bool) workertypes.EventSummary {
 	categories := workertypes.SummaryCategories{
 		QueryChanged:    0,
 		Added:           0,
+		Deleted:         0,
 		Removed:         0,
 		Moved:           0,
 		Split:           0,
@@ -429,10 +430,12 @@ func newBaselineValue(status workertypes.BaselineStatus) workertypes.BaselineVal
 
 func newBrowserValue(status workertypes.BrowserStatus) workertypes.BrowserValue {
 	version := "100"
+	testDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	return workertypes.BrowserValue{
 		Status:  status,
 		Version: &version,
+		Date:    &testDate,
 	}
 }
 


### PR DESCRIPTION
Introduces a clear distinction between features that are truly deleted from the database versus those that are simply no longer present in a given search result (which could be due to a move, split, or rename).

Previously, the reconciler would mark a feature as "Removed" and set its reason to "Deleted" if it no longer existed. This approach was ambiguous because the feature remained in the `Removed` list, which is primarily intended for features that might have been moved or split.

This change introduces a new `Deleted` slice to the `FeatureDiff` struct. The reconciler logic is updated to check for a feature's existence when it's reported as removed. If it returns an `ErrEntityDoesNotExist`, the feature is moved from the `Removed` list to the new `Deleted` list.

This ensures the `Removed` list now accurately contains only features that need to be further analyzed for potential moves or splits, making the diffing process more robust and the resulting data structure clearer.