### PR TITLE
feat(email): Refactor documentation handling in email templates

### DIFF
--- a/lib/workertypes/types.go
+++ b/lib/workertypes/types.go
@@ -113,6 +113,10 @@ type DocLink struct {
 	Slug  *string `json:"slug,omitempty"`
 }
 
+type Docs struct {
+	MDNDocs []DocLink `json:"mdn_docs,omitempty"`
+}
+
 type BaselineStatus string
 
 const (
@@ -174,7 +178,7 @@ type SummaryHighlight struct {
 	Type        SummaryHighlightType `json:"type"`
 	FeatureID   string               `json:"feature_id"`
 	FeatureName string               `json:"feature_name"`
-	DocLinks    []DocLink            `json:"doc_links,omitempty"`
+	Docs        *Docs                `json:"docs,omitempty"`
 
 	// Strongly typed change fields to support i18n and avoid interface{}
 	NameChange     *Change[string]                       `json:"name_change,omitempty"`
@@ -331,7 +335,7 @@ func (g FeatureDiffV1SummaryGenerator) processModified(highlights []SummaryHighl
 			Type:           SummaryHighlightTypeChanged,
 			FeatureID:      m.ID,
 			FeatureName:    m.Name,
-			DocLinks:       toDocLinks(m.Docs),
+			Docs:           toDocLinks(m.Docs),
 			NameChange:     nil,
 			BaselineChange: nil,
 			BrowserChanges: nil,
@@ -400,7 +404,7 @@ func (g FeatureDiffV1SummaryGenerator) processAdded(highlights []SummaryHighligh
 			Type:           SummaryHighlightTypeAdded,
 			FeatureID:      a.ID,
 			FeatureName:    a.Name,
-			DocLinks:       toDocLinks(a.Docs),
+			Docs:           toDocLinks(a.Docs),
 			NameChange:     nil,
 			BaselineChange: nil,
 			BrowserChanges: nil,
@@ -422,7 +426,7 @@ func (g FeatureDiffV1SummaryGenerator) processRemoved(highlights []SummaryHighli
 			Type:           SummaryHighlightTypeRemoved,
 			FeatureID:      r.ID,
 			FeatureName:    r.Name,
-			DocLinks:       nil,
+			Docs:           nil,
 			Moved:          nil,
 			Split:          nil,
 			BaselineChange: nil,
@@ -444,7 +448,7 @@ func (g FeatureDiffV1SummaryGenerator) processDeleted(highlights []SummaryHighli
 			Type:           SummaryHighlightTypeDeleted,
 			FeatureID:      r.ID,
 			FeatureName:    r.Name,
-			DocLinks:       nil,
+			Docs:           nil,
 			Moved:          nil,
 			Split:          nil,
 			BaselineChange: nil,
@@ -473,7 +477,7 @@ func (g FeatureDiffV1SummaryGenerator) processMoves(highlights []SummaryHighligh
 			BrowserChanges: nil,
 			BaselineChange: nil,
 			NameChange:     nil,
-			DocLinks:       nil,
+			Docs:           nil,
 			Split:          nil,
 		})
 	}
@@ -503,27 +507,29 @@ func (g FeatureDiffV1SummaryGenerator) processSplits(highlights []SummaryHighlig
 			BrowserChanges: nil,
 			BaselineChange: nil,
 			NameChange:     nil,
-			DocLinks:       nil,
+			Docs:           nil,
 		})
 	}
 
 	return highlights, false
 }
 
-func toDocLinks(docs *v1.Docs) []DocLink {
+func toDocLinks(docs *v1.Docs) *Docs {
 	if docs == nil {
 		return nil
 	}
-	links := make([]DocLink, 0, len(docs.MdnDocs))
+	ret := new(Docs)
+	mdnDocs := make([]DocLink, 0, len(docs.MdnDocs))
 	for _, d := range docs.MdnDocs {
-		links = append(links, DocLink{
+		mdnDocs = append(mdnDocs, DocLink{
 			URL:   d.URL,
 			Title: d.Title,
 			Slug:  d.Slug,
 		})
 	}
+	ret.MDNDocs = mdnDocs
 
-	return links
+	return ret
 }
 
 func toBaselineValue(s v1.BaselineState) BaselineValue {

--- a/lib/workertypes/types_test.go
+++ b/lib/workertypes/types_test.go
@@ -290,13 +290,15 @@ func TestGenerateJSONSummaryFeatureDiffV1(t *testing.T) {
             "type": "Added",
             "feature_id": "2",
             "feature_name": "B",
-            "doc_links": [
-                {
-                    "url": "https://mdn.io/B",
-                    "title": "B",
-                    "slug": "slug-b"
-                }
-            ]
+            "docs": {
+                "mdn_docs": [
+					{
+						"url": "https://mdn.io/B",
+						"title": "B",
+						"slug": "slug-b"
+					}
+            	]
+			}
         },
         {
             "type": "Removed",

--- a/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
+++ b/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
@@ -170,7 +170,7 @@ func TestProcessEvent_Success(t *testing.T) {
 			Type:        workertypes.SummaryHighlightTypeChanged,
 			FeatureID:   "test-feature-id",
 			FeatureName: "Test Feature",
-			DocLinks:    nil,
+			Docs:        nil,
 			NameChange:  nil,
 			BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
 				From: newBaselineValue(workertypes.BaselineStatusLimited),
@@ -445,7 +445,7 @@ func withBaselineHighlight(
 		Type:        workertypes.SummaryHighlightTypeChanged,
 		FeatureID:   "test-feature-id",
 		FeatureName: "Test Feature",
-		DocLinks:    nil,
+		Docs:        nil,
 		BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
 			From: newBaselineValue(from),
 			To:   newBaselineValue(to),
@@ -467,7 +467,7 @@ func withBrowserChangeHighlight(
 		Type:           workertypes.SummaryHighlightTypeChanged,
 		FeatureID:      "test-feature-id",
 		FeatureName:    "Test Feature",
-		DocLinks:       nil,
+		Docs:           nil,
 		BaselineChange: nil,
 		BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
 			workertypes.BrowserChrome: {


### PR DESCRIPTION
This commit introduces a more structured approach to handling documentation links within the email templates.

Previously, documentation links were represented by a `DocLinks []DocLink` slice, implicitly assuming all links were MDN. This limited the extensibility for future documentation sources.

This change refactors the `DocLinks` field in `SummaryHighlight` to `Docs *Docs`, where `Docs` is a new struct containing `MDNDocs []DocLink`. This allows for explicit categorization of documentation types in the next PR.

The `toDocLinks` function has been updated to construct and return the new `*Docs` struct.