### PR TITLE
feat(email): Pass job triggers to email delivery jobs

### DIFF
--- a/lib/gcppubsub/gcppubsubadapters/email_worker.go
+++ b/lib/gcppubsub/gcppubsubadapters/email_worker.go
@@ -76,6 +76,7 @@ func (a *EmailWorkerSubscriberAdapter) handleEmailJobEvent(
 				Frequency:   event.Metadata.Frequency.ToWorkerTypeJobFrequency(),
 				GeneratedAt: event.Metadata.GeneratedAt,
 			},
+			Triggers: event.ToWorkerTypeJobTriggers(),
 		},
 		EmailEventID: msgID,
 	}

--- a/lib/gcppubsub/gcppubsubadapters/email_worker_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/email_worker_test.go
@@ -111,6 +111,9 @@ func TestEmailWorkerSubscriberAdapter_RoutesEmailJobEvent(t *testing.T) {
 			Frequency:   v1.FrequencyMonthly,
 			GeneratedAt: now,
 		},
+		Triggers: []v1.JobTrigger{
+			v1.BrowserImplementationAnyComplete,
+		},
 	}
 
 	ceWrapper := map[string]interface{}{
@@ -144,6 +147,9 @@ func TestEmailWorkerSubscriberAdapter_RoutesEmailJobEvent(t *testing.T) {
 				Query:       "is:open",
 				Frequency:   workertypes.FrequencyMonthly,
 				GeneratedAt: now,
+			},
+			Triggers: []workertypes.JobTrigger{
+				workertypes.BrowserImplementationAnyComplete,
 			},
 		},
 		EmailEventID: msgID,

--- a/lib/gcppubsub/gcppubsubadapters/push_delivery.go
+++ b/lib/gcppubsub/gcppubsubadapters/push_delivery.go
@@ -49,6 +49,7 @@ func (p *PushDeliveryPublisher) PublishEmailJob(ctx context.Context, job workert
 			Frequency:   v1.ToJobFrequency(job.Metadata.Frequency),
 			GeneratedAt: job.Metadata.GeneratedAt,
 		},
+		Triggers:  v1.ToJobTriggers(job.Triggers),
 		ChannelID: job.ChannelID,
 	})
 	if err != nil {

--- a/lib/gcppubsub/gcppubsubadapters/push_delivery_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/push_delivery_test.go
@@ -112,6 +112,10 @@ func TestPushDeliveryPublisher_PublishEmailJob(t *testing.T) {
 			GeneratedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
 		},
 		ChannelID: "chan-1",
+		Triggers: []workertypes.JobTrigger{
+			workertypes.FeaturePromotedToNewly,
+			workertypes.FeaturePromotedToWidely,
+		},
 	}
 
 	err := publisher.PublishEmailJob(context.Background(), job)
@@ -135,6 +139,7 @@ func TestPushDeliveryPublisher_PublishEmailJob(t *testing.T) {
 			"subscription_id": "sub-1",
 			"recipient_email": "test@example.com",
 			"summary_raw":     base64.StdEncoding.EncodeToString([]byte(`{"text": "Test Body"}`)),
+			"triggers":        []any{"FEATURE_PROMOTED_TO_NEWLY", "FEATURE_PROMOTED_TO_WIDELY"},
 			"metadata": map[string]interface{}{
 				"event_id":     "event-1",
 				"search_id":    "search-1",

--- a/workers/email/pkg/sender/sender_test.go
+++ b/workers/email/pkg/sender/sender_test.go
@@ -123,6 +123,9 @@ func TestProcessMessage_Success(t *testing.T) {
 			RecipientEmail: "user@example.com",
 			SummaryRaw:     []byte("{}"),
 			ChannelID:      "chan-1",
+			Triggers: []workertypes.JobTrigger{
+				workertypes.BrowserImplementationAnyComplete,
+			},
 		},
 		EmailEventID: "job-id",
 	}
@@ -178,6 +181,7 @@ func TestProcessMessage_RenderError(t *testing.T) {
 			RecipientEmail: "user@example.com",
 			SummaryRaw:     []byte("{}"),
 			ChannelID:      "chan-1",
+			Triggers:       nil,
 		},
 		EmailEventID: "job-id",
 	}
@@ -220,6 +224,7 @@ func TestProcessMessage_SendError(t *testing.T) {
 			RecipientEmail: "user@example.com",
 			SummaryRaw:     []byte("{}"),
 			ChannelID:      "chan-1",
+			Triggers:       nil,
 		},
 		EmailEventID: "job-id",
 	}

--- a/workers/push_delivery/pkg/dispatcher/dispatcher.go
+++ b/workers/push_delivery/pkg/dispatcher/dispatcher.go
@@ -154,6 +154,7 @@ func (g *deliveryJobGenerator) VisitV1(s workertypes.EventSummary) error {
 			SummaryRaw:     g.rawSummary,
 			Metadata:       deliveryMetadata,
 			ChannelID:      sub.ChannelID,
+			Triggers:       sub.Triggers,
 		})
 	}
 
@@ -196,29 +197,8 @@ func shouldNotifyV1(triggers []workertypes.JobTrigger, summary workertypes.Event
 
 func matchesTrigger(t workertypes.JobTrigger, summary workertypes.EventSummary) bool {
 	for _, h := range summary.Highlights {
-		switch t {
-		case workertypes.FeaturePromotedToNewly:
-			if h.BaselineChange != nil && h.BaselineChange.To.Status == workertypes.BaselineStatusNewly {
-				return true
-			}
-		case workertypes.FeaturePromotedToWidely:
-			if h.BaselineChange != nil && h.BaselineChange.To.Status == workertypes.BaselineStatusWidely {
-				return true
-			}
-		case workertypes.FeatureRegressedToLimited:
-			if h.BaselineChange != nil && h.BaselineChange.To.Status == workertypes.BaselineStatusLimited {
-				return true
-			}
-		case workertypes.BrowserImplementationAnyComplete:
-			// BrowserChanges is a map, so we iterate values
-			for _, change := range h.BrowserChanges {
-				if change == nil {
-					continue
-				}
-				if change.To.Status == workertypes.BrowserStatusAvailable {
-					return true
-				}
-			}
+		if h.MatchesTrigger(t) {
+			return true
 		}
 	}
 

--- a/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
+++ b/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
@@ -206,6 +206,7 @@ func TestProcessEvent_Success(t *testing.T) {
 		SubscriptionID: "sub-1",
 		RecipientEmail: "user1@example.com",
 		SummaryRaw:     summaryBytes,
+		Triggers:       []workertypes.JobTrigger{workertypes.FeaturePromotedToNewly},
 		Metadata: workertypes.DeliveryMetadata{
 			EventID:     eventID,
 			SearchID:    searchID,


### PR DESCRIPTION
This commit enhances the email delivery job by including the associated job triggers.

Previously, the `EmailDeliveryJob` struct did not contain trigger information, which limited the ability to customize email content based on why a notification was sent.

This change introduces a `Triggers []JobTrigger` field to `lib/workertypes/EmailDeliveryJob` and `lib/event/emailjob/v1/EmailJobEvent`. Helper functions are added to `lib/event/emailjob/v1/types.go` for converting between internal `workertypes.JobTrigger` and `emailjob/v1.JobTrigger` types.

Additionally, the `SummaryHighlight` struct in `lib/workertypes/types.go` now includes a `MatchesTrigger` method, encapsulating the logic for checking if a highlight satisfies a given trigger. This method is then utilized in `workers/push_delivery/pkg/dispatcher/dispatcher.go` within the `matchesTrigger` function, centralizing the trigger matching logic.

The `EmailWorkerSubscriberAdapter` in `lib/gcppubsub/gcppubsubadapters/email_worker.go` and `PushDeliveryPublisher` in `lib/gcppubsub/gcppubsubadapters/push_delivery.go` are updated to correctly pass and receive these triggers. Corresponding tests have also been updated to reflect these changes.

This refactoring allows the email worker to eventually render more dynamic and personalized email content based on the specific triggers that caused the notification.