### PR TITLE
infra: deploy notification system infrastructure and minor fixes

### DIFF
--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -40,6 +40,7 @@ frontend_docker_build_target = "static"
 
 backend_domains                      = ["api.webstatus.dev"]
 frontend_domains                     = ["webstatus.dev", "www.webstatus.dev"]
+frontend_base_url                    = "https://webstatus.dev"
 custom_ssl_certificates_for_frontend = []
 custom_ssl_certificates_for_backend  = []
 
@@ -97,3 +98,4 @@ auth_github_config_locations = {
 backend_min_instance_count  = 1
 frontend_min_instance_count = 1
 notification_channel_ids    = ["projects/web-compass-prod/notificationChannels/4991947607216940054"]
+email_service_account_email = "emailer-job-prod@webstatus-dev-internal-prod.iam.gserviceaccount.com"

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -38,8 +38,9 @@ google_analytics_id = "G-EPZE5TL134"
 
 frontend_docker_build_target = "static"
 
-backend_domains  = ["api-webstatus-dev.corp.goog"]
-frontend_domains = ["website-webstatus-dev.corp.goog"]
+backend_domains   = ["api-webstatus-dev.corp.goog"]
+frontend_domains  = ["website-webstatus-dev.corp.goog"]
+frontend_base_url = "https://website-webstatus-dev.corp.goog"
 
 # Temporary for UbP.
 custom_ssl_certificates_for_frontend = ["ub-self-sign"]
@@ -100,3 +101,4 @@ auth_github_config_locations = {
 backend_min_instance_count  = 0
 frontend_min_instance_count = 0
 notification_channel_ids    = ["projects/web-compass-staging/notificationChannels/7136127183667686021"]
+email_service_account_email = "emailer-job-staging@webstatus-dev-internal-staging.iam.gserviceaccount.com"

--- a/infra/pubsub/alerts.tf
+++ b/infra/pubsub/alerts.tf
@@ -1,0 +1,87 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ==========================================
+# 1. Critical: Dead Letter Queue Monitoring
+# ==========================================
+# Triggers if ANY message lands in a DLQ. This indicates a permanent failure
+# that requires manual investigation.
+
+resource "google_monitoring_alert_policy" "dlq_non_empty" {
+  display_name = "Pub/Sub DLQ Non-Empty (${var.env_id})"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Messages waiting in DLQ"
+    condition_threshold {
+      filter = join(" AND ", [
+        "resource.type=\"pubsub_subscription\"",
+        "metric.type=\"pubsub.googleapis.com/subscription/num_undelivered_messages\"",
+        "resource.label.subscription_id = one_of(\"${google_pubsub_subscription.ingestion_dlq_sub.name}\", \"${google_pubsub_subscription.notification_dlq_sub.name}\", \"${google_pubsub_subscription.delivery_dlq_sub.name}\")"
+      ])
+
+      duration        = "60s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_MAX"
+      }
+    }
+  }
+
+  notification_channels = var.notification_channel_ids
+
+  documentation {
+    content = "Messages have landed in a Dead Letter Queue. This means they failed processing 5 times. Check worker logs for panic/errors."
+  }
+}
+
+# ==========================================
+# 2. Warning: Worker Latency / Stuck Processing
+# ==========================================
+# Triggers if the oldest message in the main queues is older than 10 minutes.
+# This indicates workers are down, stuck, or overwhelmed.
+
+resource "google_monitoring_alert_policy" "queue_latency" {
+  display_name = "Pub/Sub High Latency (${var.env_id})"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Oldest Unacked Message > 10m"
+    condition_threshold {
+      filter = join(" AND ", [
+        "resource.type=\"pubsub_subscription\"",
+        "metric.type=\"pubsub.googleapis.com/subscription/oldest_unacked_message_age\"",
+        "resource.label.subscription_id = one_of(\"${google_pubsub_subscription.ingestion_jobs_sub.name}\", \"${google_pubsub_subscription.notification_events_sub.name}\", \"${google_pubsub_subscription.chime_delivery_sub.name}\")"
+      ])
+
+      duration        = "300s" # Condition must persist for 5 minutes
+      comparison      = "COMPARISON_GT"
+      threshold_value = 600 # 10 minutes (in seconds)
+
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_MAX"
+      }
+    }
+  }
+
+  notification_channels = var.notification_channel_ids
+
+  documentation {
+    content = "The oldest message in the queue is > 10 minutes old. Verify that the workers (EventProducer, PushDelivery, EmailWorker) are running and healthy."
+  }
+}

--- a/infra/pubsub/main.tf
+++ b/infra/pubsub/main.tf
@@ -1,0 +1,129 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ==========================================
+# 1. Ingestion Pipeline (Search Refresh)
+# ==========================================
+
+# DLQ for Ingestion
+resource "google_pubsub_topic" "ingestion_dlq" {
+  name    = "ingestion-jobs-dead-letter-${var.env_id}"
+  project = var.project_id
+}
+
+resource "google_pubsub_subscription" "ingestion_dlq_sub" {
+  name    = "ingestion-jobs-dead-letter-sub-${var.env_id}"
+  topic   = google_pubsub_topic.ingestion_dlq.name
+  project = var.project_id
+}
+
+# Main Topic: Batch Updates (Triggers Fan-Out)
+resource "google_pubsub_topic" "batch_updates" {
+  name    = "batch-updates-${var.env_id}"
+  project = var.project_id
+}
+
+resource "google_pubsub_subscription" "batch_updates_sub" {
+  name    = "batch-updates-sub-${var.env_id}"
+  topic   = google_pubsub_topic.batch_updates.name
+  project = var.project_id
+
+  dead_letter_policy {
+    dead_letter_topic     = google_pubsub_topic.ingestion_dlq.id
+    max_delivery_attempts = 5
+  }
+}
+
+# Main Topic: Ingestion Jobs (Single Search Refresh)
+resource "google_pubsub_topic" "ingestion_jobs" {
+  name    = "ingestion-jobs-${var.env_id}"
+  project = var.project_id
+}
+
+resource "google_pubsub_subscription" "ingestion_jobs_sub" {
+  name    = "ingestion-jobs-sub-${var.env_id}"
+  topic   = google_pubsub_topic.ingestion_jobs.name
+  project = var.project_id
+
+  dead_letter_policy {
+    dead_letter_topic     = google_pubsub_topic.ingestion_dlq.id
+    max_delivery_attempts = 5
+  }
+}
+
+# ==========================================
+# 2. Notification Pipeline (Event Processing)
+# ==========================================
+
+# DLQ for Notifications
+resource "google_pubsub_topic" "notification_dlq" {
+  name    = "notification-events-dead-letter-${var.env_id}"
+  project = var.project_id
+}
+
+resource "google_pubsub_subscription" "notification_dlq_sub" {
+  name    = "notification-events-dead-letter-sub-${var.env_id}"
+  topic   = google_pubsub_topic.notification_dlq.name
+  project = var.project_id
+}
+
+# Main Topic: Notification Events (Fan-Out to Dispatchers)
+resource "google_pubsub_topic" "notification_events" {
+  name    = "notification-events-${var.env_id}"
+  project = var.project_id
+}
+
+resource "google_pubsub_subscription" "notification_events_sub" {
+  name    = "notification-events-sub-${var.env_id}"
+  topic   = google_pubsub_topic.notification_events.name
+  project = var.project_id
+
+  dead_letter_policy {
+    dead_letter_topic     = google_pubsub_topic.notification_dlq.id
+    max_delivery_attempts = 5
+  }
+}
+
+# ==========================================
+# 3. Delivery Pipeline (Email Sending)
+# ==========================================
+
+# DLQ for Delivery
+resource "google_pubsub_topic" "delivery_dlq" {
+  name    = "delivery-dead-letter-${var.env_id}"
+  project = var.project_id
+}
+
+resource "google_pubsub_subscription" "delivery_dlq_sub" {
+  name    = "delivery-dead-letter-sub-${var.env_id}"
+  topic   = google_pubsub_topic.delivery_dlq.name
+  project = var.project_id
+}
+
+# Main Topic: Chime Delivery (Email)
+resource "google_pubsub_topic" "chime_delivery" {
+  name    = "chime-delivery-${var.env_id}"
+  project = var.project_id
+}
+
+resource "google_pubsub_subscription" "chime_delivery_sub" {
+  name    = "chime-delivery-sub-${var.env_id}"
+  topic   = google_pubsub_topic.chime_delivery.name
+  project = var.project_id
+
+  dead_letter_policy {
+    dead_letter_topic     = google_pubsub_topic.delivery_dlq.id
+    max_delivery_attempts = 5
+  }
+}

--- a/infra/pubsub/outputs.tf
+++ b/infra/pubsub/outputs.tf
@@ -1,0 +1,45 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "ingestion_topic_id" {
+  value = google_pubsub_topic.ingestion_jobs.id
+}
+
+output "ingestion_subscription_id" {
+  value = google_pubsub_subscription.ingestion_jobs_sub.id
+}
+
+output "batch_updates_topic_id" {
+  value = google_pubsub_topic.batch_updates.id
+}
+
+output "batch_updates_subscription_id" {
+  value = google_pubsub_subscription.batch_updates_sub.id
+}
+
+output "notification_topic_id" {
+  value = google_pubsub_topic.notification_events.id
+}
+
+output "notification_subscription_id" {
+  value = google_pubsub_subscription.notification_events_sub.id
+}
+
+output "email_delivery_topic_id" {
+  value = google_pubsub_topic.chime_delivery.id
+}
+
+output "email_delivery_subscription_id" {
+  value = google_pubsub_subscription.chime_delivery_sub.id
+}

--- a/infra/pubsub/providers.tf
+++ b/infra/pubsub/providers.tf
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      configuration_aliases = [
+        google.internal_project
+      ]
+    }
+  }
+}

--- a/infra/pubsub/variables.tf
+++ b/infra/pubsub/variables.tf
@@ -1,0 +1,26 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "The project ID to deploy to"
+  type        = string
+}
+
+variable "env_id" {
+  type = string
+}
+
+variable "notification_channel_ids" {
+  type = list(string)
+}

--- a/infra/storage/notification_state_bucket.tf
+++ b/infra/storage/notification_state_bucket.tf
@@ -1,0 +1,31 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_storage_bucket" "notification_state" {
+  provider                    = google.internal_project
+  project                     = var.projects.internal
+  name                        = "notification-state-${var.projects.internal}-${var.env_id}"
+  location                    = "US"
+  uniform_bucket_level_access = true
+  storage_class               = "MULTI_REGIONAL"
+
+  versioning {
+    enabled = true
+  }
+}
+
+# Export the name so it can be passed to the application
+output "notification_state_bucket_name" {
+  value = google_storage_bucket.notification_state.name
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -55,6 +55,7 @@ locals {
     var.spanner_region_override,
   "regional-${keys(var.region_information)[0]}")
   region_to_subnet_map = { for region, info in var.region_information : region => info.networks }
+  regions              = keys(var.region_information)
 }
 
 variable "secret_ids" {
@@ -202,4 +203,14 @@ variable "frontend_max_instance_count" {
 variable "notification_channel_ids" {
   description = "A list of notification channel ids to send alerts to."
   type        = list(string)
+}
+
+variable "email_service_account_email" {
+  description = "Pre-existing Service Account email for the Email Worker"
+  type        = string
+}
+
+variable "frontend_base_url" {
+  type        = string
+  description = "Frontend base URL. Useful for email notifications for assets."
 }

--- a/infra/workers/email/iam.tf
+++ b/infra/workers/email/iam.tf
@@ -1,0 +1,56 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_service_account" "worker_sa" {
+  account_id = var.service_account_email
+  project    = var.project_id
+  provider   = google.internal_project
+}
+
+# Grant permissions to the passed-in Service Account via the data source
+resource "google_spanner_database_iam_member" "db_user" {
+  instance = var.spanner_instance_id
+  database = var.spanner_database_id
+  role     = "roles/spanner.databaseUser"
+  member   = "serviceAccount:${data.google_service_account.worker_sa.email}"
+  provider = google.internal_project
+}
+
+resource "google_pubsub_subscription_iam_member" "email_sub" {
+  subscription = var.email_subscription_id
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${data.google_service_account.worker_sa.email}"
+  provider     = google.internal_project
+}
+
+resource "google_project_iam_member" "gcp_metric_permission" {
+  role     = "roles/monitoring.metricWriter"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${data.google_service_account.worker_sa.email}"
+}
+
+resource "google_project_iam_member" "gcp_log_permission" {
+  role     = "roles/logging.logWriter"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${data.google_service_account.worker_sa.email}"
+}
+
+resource "google_project_iam_member" "gcp_trace_permission" {
+  role     = "roles/cloudtrace.agent"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${data.google_service_account.worker_sa.email}"
+}

--- a/infra/workers/email/main.tf
+++ b/infra/workers/email/main.tf
@@ -1,0 +1,56 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_cloud_run_v2_worker_pool" "worker" {
+  for_each            = var.regions
+  name                = "email-worker-${var.env_id}-${each.key}"
+  provider            = google.internal_project
+  location            = each.key
+  project             = var.project_id
+  launch_stage        = "BETA"
+  deletion_protection = var.deletion_protection
+
+
+  scaling {
+    manual_instance_count = var.manual_instance_count
+  }
+  template {
+    service_account = data.google_service_account.worker_sa.email
+
+    containers {
+      image = var.image_url
+
+      env {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "SPANNER_INSTANCE"
+        value = var.spanner_instance_id
+      }
+      env {
+        name  = "SPANNER_DATABASE"
+        value = var.spanner_database_id
+      }
+      env {
+        name  = "EMAIL_SUBSCRIPTION_ID"
+        value = var.email_subscription_id
+      }
+      env {
+        name  = "FRONTEND_BASE_URL"
+        value = var.frontend_base_url
+      }
+    }
+  }
+}

--- a/infra/workers/email/providers.tf
+++ b/infra/workers/email/providers.tf
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      configuration_aliases = [
+        google.internal_project,
+      ]
+    }
+  }
+}

--- a/infra/workers/email/variables.tf
+++ b/infra/workers/email/variables.tf
@@ -1,0 +1,25 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" { type = string }
+variable "env_id" { type = string }
+variable "image_url" { type = string }
+variable "spanner_instance_id" { type = string }
+variable "spanner_database_id" { type = string }
+variable "email_subscription_id" { type = string }
+variable "manual_instance_count" { type = number }
+variable "service_account_email" { type = string }
+variable "regions" { type = set(string) }
+variable "deletion_protection" { type = bool }
+variable "frontend_base_url" { type = string }

--- a/infra/workers/event_producer/iam.tf
+++ b/infra/workers/event_producer/iam.tf
@@ -1,0 +1,81 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 1. Spanner Database User
+resource "google_spanner_database_iam_member" "db_user" {
+  instance = var.spanner_instance_id
+  database = var.spanner_database_id
+  role     = "roles/spanner.databaseUser"
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+  project  = var.project_id
+  provider = google.internal_project
+}
+
+# 2. GCS Object Admin
+resource "google_storage_bucket_iam_member" "bucket_admin" {
+  bucket   = var.state_bucket_name
+  role     = "roles/storage.objectAdmin"
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider = google.internal_project
+}
+
+# 3. Pub/Sub Subscriber (Ingestion + Batch)
+resource "google_pubsub_subscription_iam_member" "ingestion_sub" {
+  subscription = var.ingestion_subscription_id
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider     = google.internal_project
+}
+
+resource "google_pubsub_subscription_iam_member" "batch_sub" {
+  subscription = var.batch_subscription_id
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider     = google.internal_project
+}
+
+# 4. Pub/Sub Publisher (Notification)
+resource "google_pubsub_topic_iam_member" "notification_pub" {
+  topic    = var.notification_topic_id
+  role     = "roles/pubsub.publisher"
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider = google.internal_project
+}
+
+resource "google_pubsub_topic_iam_member" "ingestion_pub" {
+  topic  = var.ingestion_topic_id
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_project_iam_member" "gcp_metric_permission" {
+  role     = "roles/monitoring.metricWriter"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_project_iam_member" "gcp_log_permission" {
+  role     = "roles/logging.logWriter"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_project_iam_member" "gcp_trace_permission" {
+  role     = "roles/cloudtrace.agent"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+}

--- a/infra/workers/event_producer/main.tf
+++ b/infra/workers/event_producer/main.tf
@@ -1,0 +1,75 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_service_account" "worker_sa" {
+  account_id   = "event-producer-${var.env_id}"
+  display_name = "Event Producer Service Account (${var.env_id})"
+  project      = var.project_id
+  provider     = google.internal_project
+}
+
+resource "google_cloud_run_v2_worker_pool" "worker" {
+  for_each            = var.regions
+  name                = "event-producer-${var.env_id}-${each.key}"
+  location            = each.key
+  project             = var.project_id
+  provider            = google.internal_project
+  launch_stage        = "BETA"
+  deletion_protection = var.deletion_protection
+
+
+  scaling {
+    manual_instance_count = var.manual_instance_count
+  }
+  template {
+    service_account = google_service_account.worker_sa.email
+
+    containers {
+      image = var.image_url
+
+      env {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "SPANNER_INSTANCE"
+        value = var.spanner_instance_id
+      }
+      env {
+        name  = "SPANNER_DATABASE"
+        value = var.spanner_database_id
+      }
+      env {
+        name  = "STATE_BLOB_BUCKET"
+        value = var.state_bucket_name
+      }
+      env {
+        name  = "INGESTION_SUBSCRIPTION_ID"
+        value = var.ingestion_subscription_id
+      }
+      env {
+        name  = "INGESTION_TOPIC_ID"
+        value = var.ingestion_topic_id
+      }
+      env {
+        name  = "BATCH_UPDATE_SUBSCRIPTION_ID"
+        value = var.batch_subscription_id
+      }
+      env {
+        name  = "NOTIFICATION_TOPIC_ID"
+        value = var.notification_topic_id
+      }
+    }
+  }
+}

--- a/infra/workers/event_producer/providers.tf
+++ b/infra/workers/event_producer/providers.tf
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      configuration_aliases = [
+        google.internal_project,
+      ]
+    }
+  }
+}

--- a/infra/workers/event_producer/variables.tf
+++ b/infra/workers/event_producer/variables.tf
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" { type = string }
+variable "env_id" { type = string }
+variable "image_url" { type = string }
+variable "spanner_instance_id" { type = string }
+variable "spanner_database_id" { type = string }
+variable "state_bucket_name" { type = string }
+variable "ingestion_subscription_id" { type = string }
+variable "ingestion_topic_id" { type = string }
+variable "batch_subscription_id" { type = string }
+variable "notification_topic_id" { type = string }
+variable "manual_instance_count" { type = number }
+variable "regions" { type = set(string) }
+variable "deletion_protection" { type = bool }

--- a/infra/workers/main.tf
+++ b/infra/workers/main.tf
@@ -1,0 +1,120 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# --- 1. Event Producer ---
+
+# Build Image
+module "event_producer_image" {
+  source                = "../modules/go_image"
+  image_name            = "event_producer"
+  go_module_path        = "workers/event_producer"
+  binary_type           = "job"
+  docker_repository_url = var.docker_repository_details.url
+}
+
+# Deploy Service (Multi-Region)
+module "event_producer" {
+  source = "./event_producer"
+  providers = {
+    google.internal_project = google.internal_project
+  }
+
+  project_id = var.internal_project_id
+  env_id     = var.env_id
+  image_url  = module.event_producer_image.remote_image
+
+  spanner_instance_id = var.spanner_details.instance
+  spanner_database_id = var.spanner_details.database
+  state_bucket_name   = var.state_bucket_name
+
+  ingestion_subscription_id = var.pubsub_details.ingestion_subscription_id
+  ingestion_topic_id        = var.pubsub_details.ingestion_topic_id
+  batch_subscription_id     = var.pubsub_details.batch_subscription_id
+  notification_topic_id     = var.pubsub_details.notification_topic_id
+
+  manual_instance_count = var.worker_instance_count.event_producer_count
+  regions               = var.regions
+
+  deletion_protection = var.deletion_protection
+}
+
+# --- 2. Push Delivery ---
+
+# Build Image
+module "push_delivery_image" {
+  source                = "../modules/go_image"
+  image_name            = "push_delivery"
+  go_module_path        = "workers/push_delivery"
+  binary_type           = "job"
+  docker_repository_url = var.docker_repository_details.url
+}
+
+# Deploy Service (Multi-Region)
+module "push_delivery" {
+  source = "./push_delivery"
+  providers = {
+    google.internal_project = google.internal_project
+  }
+
+  project_id = var.internal_project_id
+  env_id     = var.env_id
+  image_url  = module.push_delivery_image.remote_image
+
+  spanner_instance_id = var.spanner_details.instance
+  spanner_database_id = var.spanner_details.database
+
+  notification_subscription_id = var.pubsub_details.notification_subscription_id
+  email_topic_id               = var.pubsub_details.email_topic_id
+
+  manual_instance_count = var.worker_instance_count.push_delivery_count
+  regions               = var.regions
+
+  deletion_protection = var.deletion_protection
+}
+
+# --- 3. Email Worker ---
+
+# Build Image
+module "email_image" {
+  source                = "../modules/go_image"
+  image_name            = "email"
+  go_module_path        = "workers/email"
+  binary_type           = "job"
+  docker_repository_url = var.docker_repository_details.url
+}
+
+# Deploy Service (Multi-Region)
+module "email" {
+  source = "./email"
+  providers = {
+    google.internal_project = google.internal_project
+  }
+
+  project_id = var.internal_project_id
+  env_id     = var.env_id
+  image_url  = module.email_image.remote_image
+
+  spanner_instance_id = var.spanner_details.instance
+  spanner_database_id = var.spanner_details.database
+
+  email_subscription_id = var.pubsub_details.email_subscription_id
+
+  manual_instance_count = var.worker_instance_count.email_count
+
+  service_account_email = var.email_service_account_email
+  regions               = var.regions
+
+  frontend_base_url   = var.frontend_base_url
+  deletion_protection = var.deletion_protection
+}

--- a/infra/workers/payloads/batch_immediate.json
+++ b/infra/workers/payloads/batch_immediate.json
@@ -1,0 +1,7 @@
+{
+  "apiVersion": "v1",
+  "kind": "BatchRefreshTrigger",
+  "data": {
+    "frequency": "IMMEDIATE"
+  }
+}

--- a/infra/workers/payloads/batch_monthly.json
+++ b/infra/workers/payloads/batch_monthly.json
@@ -1,0 +1,7 @@
+{
+  "apiVersion": "v1",
+  "kind": "BatchRefreshTrigger",
+  "data": {
+    "frequency": "MONTHLY"
+  }
+}

--- a/infra/workers/payloads/batch_weekly.json
+++ b/infra/workers/payloads/batch_weekly.json
@@ -1,0 +1,7 @@
+{
+  "apiVersion": "v1",
+  "kind": "BatchRefreshTrigger",
+  "data": {
+    "frequency": "WEEKLY"
+  }
+}

--- a/infra/workers/providers.tf
+++ b/infra/workers/providers.tf
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      configuration_aliases = [
+        google.internal_project,
+      ]
+    }
+  }
+}

--- a/infra/workers/push_delivery/iam.tf
+++ b/infra/workers/push_delivery/iam.tf
@@ -1,0 +1,56 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_spanner_database_iam_member" "db_user" {
+  instance = var.spanner_instance_id
+  database = var.spanner_database_id
+  role     = "roles/spanner.databaseUser"
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider = google.internal_project
+}
+
+resource "google_pubsub_subscription_iam_member" "sub" {
+  subscription = var.notification_subscription_id
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider     = google.internal_project
+}
+
+resource "google_pubsub_topic_iam_member" "pub" {
+  topic    = var.email_topic_id
+  role     = "roles/pubsub.publisher"
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider = google.internal_project
+}
+
+resource "google_project_iam_member" "gcp_metric_permission" {
+  role     = "roles/monitoring.metricWriter"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_project_iam_member" "gcp_log_permission" {
+  role     = "roles/logging.logWriter"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_project_iam_member" "gcp_trace_permission" {
+  role     = "roles/cloudtrace.agent"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+}

--- a/infra/workers/push_delivery/main.tf
+++ b/infra/workers/push_delivery/main.tf
@@ -1,0 +1,64 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_service_account" "worker_sa" {
+  account_id   = "push-delivery-${var.env_id}"
+  provider     = google.internal_project
+  display_name = "Push Delivery Service Account (${var.env_id})"
+  project      = var.project_id
+}
+
+resource "google_cloud_run_v2_worker_pool" "worker" {
+  for_each            = var.regions
+  name                = "push-delivery-${var.env_id}-${each.key}"
+  location            = each.key
+  project             = var.project_id
+  provider            = google.internal_project
+  launch_stage        = "BETA"
+  deletion_protection = var.deletion_protection
+
+  scaling {
+    manual_instance_count = var.manual_instance_count
+  }
+  template {
+    service_account = google_service_account.worker_sa.email
+
+
+
+    containers {
+      image = var.image_url
+
+      env {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "SPANNER_INSTANCE"
+        value = var.spanner_instance_id
+      }
+      env {
+        name  = "SPANNER_DATABASE"
+        value = var.spanner_database_id
+      }
+      env {
+        name  = "NOTIFICATION_SUBSCRIPTION_ID"
+        value = var.notification_subscription_id
+      }
+      env {
+        name  = "EMAIL_TOPIC_ID"
+        value = var.email_topic_id
+      }
+    }
+  }
+}

--- a/infra/workers/push_delivery/providers.tf
+++ b/infra/workers/push_delivery/providers.tf
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      configuration_aliases = [
+        google.internal_project,
+      ]
+    }
+  }
+}

--- a/infra/workers/push_delivery/variables.tf
+++ b/infra/workers/push_delivery/variables.tf
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" { type = string }
+variable "env_id" { type = string }
+variable "image_url" { type = string }
+variable "spanner_instance_id" { type = string }
+variable "spanner_database_id" { type = string }
+variable "notification_subscription_id" { type = string }
+variable "email_topic_id" { type = string }
+variable "manual_instance_count" { type = number }
+variable "regions" { type = set(string) }
+variable "deletion_protection" { type = bool }

--- a/infra/workers/scheduler.tf
+++ b/infra/workers/scheduler.tf
@@ -1,0 +1,65 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  primary_scheduler_region = tolist(var.regions)[0]
+}
+
+# 1. Weekly Job
+resource "google_cloud_scheduler_job" "batch_weekly" {
+  name        = "batch-refresh-weekly-${var.env_id}"
+  description = "Triggers the Weekly Saved Search Refresh Batch"
+  schedule    = "0 9 * * 1" # Every Monday at 9:00 AM
+  time_zone   = "Etc/UTC"
+  region      = local.primary_scheduler_region
+  project     = var.internal_project_id
+  provider    = google.internal_project
+
+  pubsub_target {
+    topic_name = var.pubsub_details.batch_topic_id
+    data       = base64encode(file("${path.module}/payloads/batch_weekly.json"))
+  }
+}
+
+# 2. Monthly Job
+resource "google_cloud_scheduler_job" "batch_monthly" {
+  name        = "batch-refresh-monthly-${var.env_id}"
+  description = "Triggers the Monthly Saved Search Refresh Batch"
+  schedule    = "0 9 1 * *" # 1st of every month at 9:00 AM
+  time_zone   = "Etc/UTC"
+  region      = local.primary_scheduler_region
+  project     = var.internal_project_id
+  provider    = google.internal_project
+
+  pubsub_target {
+    topic_name = var.pubsub_details.batch_topic_id
+    data       = base64encode(file("${path.module}/payloads/batch_monthly.json"))
+  }
+}
+
+# 3. Immediate Job (Every 15 minutes)
+resource "google_cloud_scheduler_job" "batch_immediate" {
+  name        = "batch-refresh-immediate-${var.env_id}"
+  description = "Triggers the Immediate Saved Search Refresh Batch (Every 15m)"
+  schedule    = "*/15 * * * *"
+  time_zone   = "Etc/UTC"
+  region      = local.primary_scheduler_region
+  project     = var.internal_project_id
+  provider    = google.internal_project
+
+  pubsub_target {
+    topic_name = var.pubsub_details.batch_topic_id
+    data       = base64encode(file("${path.module}/payloads/batch_immediate.json"))
+  }
+}

--- a/infra/workers/variables.tf
+++ b/infra/workers/variables.tf
@@ -1,0 +1,83 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "internal_project_id" {
+  description = "The internal project ID (where Spanner/PubSub live)"
+  type        = string
+}
+
+variable "env_id" {
+  description = "Environment ID"
+  type        = string
+}
+
+variable "regions" {
+  description = "List of region names to deploy workers into"
+  type        = set(string)
+}
+
+
+variable "docker_repository_details" {
+  description = "Docker repository details"
+  type = object({
+    url = string
+  })
+}
+
+variable "spanner_details" {
+  type = object({
+    instance = string
+    database = string
+  })
+}
+
+variable "state_bucket_name" {
+  type = string
+}
+
+variable "pubsub_details" {
+  type = object({
+    ingestion_subscription_id    = string
+    ingestion_topic_id           = string
+    batch_topic_id               = string
+    batch_subscription_id        = string
+    notification_topic_id        = string
+    notification_subscription_id = string
+    email_topic_id               = string
+    email_subscription_id        = string
+  })
+}
+
+variable "worker_instance_count" {
+  description = "Number of instances for manual scaling"
+  type = object({
+    event_producer_count = number
+    push_delivery_count  = number
+    email_count          = number
+  })
+}
+
+variable "email_service_account_email" {
+  description = "Pre-existing Service Account email for the Email Worker"
+  type        = string
+}
+
+variable "frontend_base_url" {
+  description = "Frontend base URL"
+  type        = string
+}
+
+variable "deletion_protection" {
+  type = bool
+}

--- a/lib/gcpgcs/gcpgcsadapters/event_producer.go
+++ b/lib/gcpgcs/gcpgcsadapters/event_producer.go
@@ -36,9 +36,7 @@ func NewEventProducer(client EventProducerBlobStorageClient, bucketName string) 
 }
 
 func (e *EventProducer) Store(ctx context.Context, dirs []string, key string, data []byte) (string, error) {
-	filepath := append([]string{e.bucketName}, dirs...)
-	// Add the key as the final element.
-	filepath = append(filepath, key)
+	filepath := append(dirs, key)
 	path := path.Join(filepath...)
 	if err := e.client.WriteBlob(ctx, path, data, blobtypes.WithContentType("application/json")); err != nil {
 		return "", err

--- a/lib/gcpgcs/gcpgcsadapters/event_producer_test.go
+++ b/lib/gcpgcs/gcpgcsadapters/event_producer_test.go
@@ -74,7 +74,7 @@ func TestStore(t *testing.T) {
 			dirs:         []string{},
 			key:          "file.json",
 			mockErr:      nil,
-			expectedPath: "test-bucket/file.json",
+			expectedPath: "file.json",
 			wantErr:      false,
 		},
 		{
@@ -82,7 +82,7 @@ func TestStore(t *testing.T) {
 			dirs:         []string{"folder1", "folder2"},
 			key:          "file.json",
 			mockErr:      nil,
-			expectedPath: "test-bucket/folder1/folder2/file.json",
+			expectedPath: "folder1/folder2/file.json",
 			wantErr:      false,
 		},
 		{
@@ -90,7 +90,7 @@ func TestStore(t *testing.T) {
 			dirs:         []string{"folder"},
 			key:          "file.json",
 			mockErr:      errors.New("gcs error"),
-			expectedPath: "test-bucket/folder/file.json",
+			expectedPath: "folder/file.json",
 			wantErr:      true,
 		},
 	}
@@ -143,7 +143,7 @@ func TestStore(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	bucketName := "test-bucket"
-	fullPath := "test-bucket/folder/file.json"
+	fullPath := "folder/file.json"
 	data := []byte("test-data")
 
 	tests := []struct {

--- a/lib/gcpspanner/spanneradapters/event_producer.go
+++ b/lib/gcpspanner/spanneradapters/event_producer.go
@@ -17,6 +17,7 @@ package spanneradapters
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -179,6 +180,10 @@ func (e *EventProducer) GetLatestEvent(ctx context.Context, frequency workertype
 
 	event, err := e.client.GetLatestSavedSearchNotificationEvent(ctx, searchID, snapshotType)
 	if err != nil {
+		if errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {
+			return nil, errors.Join(err, workertypes.ErrLatestEventNotFound)
+		}
+
 		return nil, err
 	}
 

--- a/lib/workertypes/types.go
+++ b/lib/workertypes/types.go
@@ -27,6 +27,7 @@ import (
 var (
 	ErrUnknownSummaryVersion    = errors.New("unknown summary version")
 	ErrFailedToSerializeSummary = errors.New("failed to serialize summary")
+	ErrLatestEventNotFound      = errors.New("latest event not found")
 )
 
 const (

--- a/workers/event_producer/pkg/producer/producer_test.go
+++ b/workers/event_producer/pkg/producer/producer_test.go
@@ -279,6 +279,7 @@ func TestProcessSearch_NoChanges(t *testing.T) {
 	pubMock := new(mockEventPublisher)
 
 	metaMock.getLatestEventReturns.info = nil
+	metaMock.getLatestEventReturns.err = workertypes.ErrLatestEventNotFound
 	differMock.runReturns.err = differ.ErrNoChangesDetected
 
 	producer := NewEventProducer(differMock, blobMock, metaMock, pubMock)


### PR DESCRIPTION
Deploys the complete infrastructure stack for the notification system (Pub/Sub, GCS, Cloud Run Workers, Scheduler).

Infrastructure Changes:
- **Pub/Sub (`infra/pubsub`)**: Defined global topics and subscriptions for the Ingestion, Notification, and Delivery pipelines. Configured Dead Letter Queues (DLQs) and monitoring alerts for queue latency and failures.
- **Workers (`infra/workers`)**: Added modules to deploy `event_producer`, `push_delivery`, and `email` as Cloud Run v2 Worker Pools. Supports multi-region deployment with manual scaling.
- **Storage**: Added the GCS bucket for storing notification state blobs.
- **Scheduler**: Configured singleton Cloud Scheduler jobs to trigger batch updates (Immediate, Weekly, Monthly).

Application Changes: (came about as I deployed to staging)
- **Event Producer**: Refactored `GetLatestEvent` to return a specific `ErrLatestEventNotFound` error, allowing `ProcessSearch` to gracefully handle cold starts (no prior history) without logging errors.