### PR TITLE
feat(backend): implement search configuration publisher adapter

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -23,6 +23,7 @@ require (
 	cloud.google.com/go/logging v1.13.1 // indirect
 	cloud.google.com/go/longrunning v0.7.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
+	cloud.google.com/go/pubsub/v2 v2.0.0 // indirect
 	cloud.google.com/go/secretmanager v1.16.0 // indirect
 	cloud.google.com/go/spanner v1.86.1 // indirect
 	cloud.google.com/go/storage v1.57.2 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -445,6 +445,8 @@ cloud.google.com/go/pubsub v1.26.0/go.mod h1:QgBH3U/jdJy/ftjPhTkyXNj543Tin1pRYcd
 cloud.google.com/go/pubsub v1.27.1/go.mod h1:hQN39ymbV9geqBnfQq6Xf63yNhUAhv9CZhzp5O6qsW0=
 cloud.google.com/go/pubsub v1.28.0/go.mod h1:vuXFpwaVoIPQMGXqRyUQigu/AX1S3IWugR9xznmcXX8=
 cloud.google.com/go/pubsub v1.30.0/go.mod h1:qWi1OPS0B+b5L+Sg6Gmc9zD1Y+HaM0MdUr7LsupY1P4=
+cloud.google.com/go/pubsub/v2 v2.0.0 h1:0qS6mRJ41gD1lNmM/vdm6bR7DQu6coQcVwD+VPf0Bz0=
+cloud.google.com/go/pubsub/v2 v2.0.0/go.mod h1:0aztFxNzVQIRSZ8vUr79uH2bS3jwLebwK6q1sgEub+E=
 cloud.google.com/go/pubsublite v1.5.0/go.mod h1:xapqNQ1CuLfGi23Yda/9l4bBCKz/wC3KIJ5gKcxveZg=
 cloud.google.com/go/pubsublite v1.6.0/go.mod h1:1eFCS0U11xlOuMFV/0iBqw3zP12kddMeCbj/F3FSj9k=
 cloud.google.com/go/pubsublite v1.7.0/go.mod h1:8hVMwRXfDfvGm3fahVbtDbiLePT3gpoiJYJY+vxWxVM=
@@ -1105,6 +1107,8 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
+go.einride.tech/aip v0.68.1 h1:16/AfSxcQISGN5z9C5lM+0mLYXihrHbQ1onvYTr93aQ=
+go.einride.tech/aip v0.68.1/go.mod h1:XaFtaj4HuA3Zwk9xoBtTWgNubZ0ZZXv9BZJCkuKuWbg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/backend/manifests/pod.yaml
+++ b/backend/manifests/pod.yaml
@@ -59,6 +59,12 @@ spec:
           value: auth:9099
         - name: GITHUB_API_BASE_URL
           value: http://api-github-mock.default.svc.cluster.local:8080/
+        - name: PUBSUB_PROJECT_ID
+          value: local
+        - name: PUBSUB_EMULATOR_HOST
+          value: pubsub:8060
+        - name: INGESTION_TOPIC_ID
+          value: 'ingestion-jobs-topic-id'
       resources:
         limits:
           cpu: 250m

--- a/backend/pkg/httpserver/create_saved_search.go
+++ b/backend/pkg/httpserver/create_saved_search.go
@@ -176,5 +176,11 @@ func (s *Server) CreateSavedSearch(ctx context.Context, request backend.CreateSa
 		}, nil
 	}
 
+	err = s.eventPublisher.PublishSearchConfigurationChanged(ctx, output, user.ID, true)
+	if err != nil {
+		// We should not mark this as a failure. Only log it.
+		slog.WarnContext(ctx, "unable to publish search configuration changed event during create", "error", err)
+	}
+
 	return backend.CreateSavedSearch201JSONResponse(*output), nil
 }

--- a/backend/pkg/httpserver/create_subscription_test.go
+++ b/backend/pkg/httpserver/create_subscription_test.go
@@ -190,6 +190,7 @@ func TestCreateSubscription(t *testing.T) {
 				metadataStorer:          nil,
 				userGitHubClientFactory: nil,
 				operationResponseCaches: nil,
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t),
 			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)

--- a/backend/pkg/httpserver/delete_notification_channel_test.go
+++ b/backend/pkg/httpserver/delete_notification_channel_test.go
@@ -95,6 +95,7 @@ func TestDeleteNotificationChannel(t *testing.T) {
 				metadataStorer:          nil,
 				operationResponseCaches: nil,
 				userGitHubClientFactory: nil,
+				eventPublisher:          nil,
 			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)

--- a/backend/pkg/httpserver/delete_subscription_test.go
+++ b/backend/pkg/httpserver/delete_subscription_test.go
@@ -117,6 +117,7 @@ func TestDeleteSubscription(t *testing.T) {
 				metadataStorer:          nil,
 				userGitHubClientFactory: nil,
 				operationResponseCaches: nil,
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t),
 			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)

--- a/backend/pkg/httpserver/get_feature_metadata_test.go
+++ b/backend/pkg/httpserver/get_feature_metadata_test.go
@@ -114,7 +114,9 @@ func TestGetFeatureMetadata(t *testing.T) {
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: mockMetadataStorer, userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
-				baseURL:                 getTestBaseURL(t)}
+				baseURL:                 getTestBaseURL(t),
+				eventPublisher:          nil,
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			mockCacher.AssertExpectations()
 			// TODO: Start tracking call count and assert call count.

--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -413,6 +413,7 @@ func TestGetFeature(t *testing.T) {
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountGetFeature,

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -537,6 +537,7 @@ func TestListFeatures(t *testing.T) {
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountFeaturesSearch,

--- a/backend/pkg/httpserver/get_notification_channel_test.go
+++ b/backend/pkg/httpserver/get_notification_channel_test.go
@@ -118,6 +118,7 @@ func TestGetNotificationChannel(t *testing.T) {
 				metadataStorer:          nil,
 				operationResponseCaches: nil,
 				userGitHubClientFactory: nil,
+				eventPublisher:          nil,
 			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)

--- a/backend/pkg/httpserver/get_saved_search_test.go
+++ b/backend/pkg/httpserver/get_saved_search_test.go
@@ -73,6 +73,7 @@ func TestGetSavedSearch(t *testing.T) {
 				t:                 t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
+				eventPublisher:          nil,
 				operationResponseCaches: nil, baseURL: getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)

--- a/backend/pkg/httpserver/get_subscription_test.go
+++ b/backend/pkg/httpserver/get_subscription_test.go
@@ -144,6 +144,7 @@ func TestGetSubscription(t *testing.T) {
 				metadataStorer:          nil,
 				userGitHubClientFactory: nil,
 				operationResponseCaches: nil,
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t),
 			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)

--- a/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
+++ b/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
@@ -298,6 +298,7 @@ func TestListAggregatedBaselineStatusCounts(t *testing.T) {
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListBaselineStatusCounts,

--- a/backend/pkg/httpserver/list_aggregated_feature_support_test.go
+++ b/backend/pkg/httpserver/list_aggregated_feature_support_test.go
@@ -315,6 +315,7 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListBrowserFeatureCountMetric,

--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
@@ -301,6 +301,7 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMetricsOverTimeWithAggregatedTotals,

--- a/backend/pkg/httpserver/list_chromium_usage_test.go
+++ b/backend/pkg/httpserver/list_chromium_usage_test.go
@@ -155,6 +155,7 @@ func TestListChromeDailyUsageStats(t *testing.T) {
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListChromeDailyUsageStats,

--- a/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
@@ -297,6 +297,7 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMetricsForFeatureIDBrowserAndChannel,

--- a/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
@@ -346,6 +346,7 @@ func TestListMissingOneImplementationCounts(t *testing.T) {
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMissingOneImplCounts,

--- a/backend/pkg/httpserver/list_missing_one_implementation_features_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_features_test.go
@@ -199,6 +199,7 @@ func TestListMissingOneImplementationFeatures(t *testing.T) {
 			mockCacher := NewMockRawBytesDataCacher(t, nil, nil)
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMissingOneImplFeatures,

--- a/backend/pkg/httpserver/list_notification_channels_test.go
+++ b/backend/pkg/httpserver/list_notification_channels_test.go
@@ -138,6 +138,7 @@ func TestListNotificationChannels(t *testing.T) {
 				metadataStorer:          nil,
 				operationResponseCaches: nil,
 				userGitHubClientFactory: nil,
+				eventPublisher:          nil,
 			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)

--- a/backend/pkg/httpserver/list_subscriptions_test.go
+++ b/backend/pkg/httpserver/list_subscriptions_test.go
@@ -180,6 +180,7 @@ func TestListSubscriptions(t *testing.T) {
 				metadataStorer:          nil,
 				userGitHubClientFactory: nil,
 				operationResponseCaches: nil,
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t),
 			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)

--- a/backend/pkg/httpserver/list_user_saved_searches_test.go
+++ b/backend/pkg/httpserver/list_user_saved_searches_test.go
@@ -180,7 +180,8 @@ func TestListUserSavedSearches(t *testing.T) {
 				t:                        t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
-				operationResponseCaches: nil, baseURL: getTestBaseURL(t)}
+				operationResponseCaches: nil, baseURL: getTestBaseURL(t),
+				eventPublisher: nil}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListUserSavedSearches,

--- a/backend/pkg/httpserver/ping_user_test.go
+++ b/backend/pkg/httpserver/ping_user_test.go
@@ -267,6 +267,7 @@ func TestPingUser(t *testing.T) {
 				),
 				operationResponseCaches: nil,
 				baseURL:                 getTestBaseURL(t),
+				eventPublisher:          nil,
 			}
 
 			req := httptest.NewRequest(http.MethodPost, "/v1/users/me/ping", tc.body)

--- a/backend/pkg/httpserver/put_user_saved_search_bookmark_test.go
+++ b/backend/pkg/httpserver/put_user_saved_search_bookmark_test.go
@@ -107,6 +107,7 @@ func TestPutUserSavedSearchBookmark(t *testing.T) {
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
 				operationResponseCaches: nil,
+				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t)}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{authMiddlewareOption}...)

--- a/backend/pkg/httpserver/remove_saved_search_test.go
+++ b/backend/pkg/httpserver/remove_saved_search_test.go
@@ -106,7 +106,7 @@ func TestRemoveSavedSearch(t *testing.T) {
 				t:                        t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
-				operationResponseCaches: nil, baseURL: getTestBaseURL(t)}
+				operationResponseCaches: nil, baseURL: getTestBaseURL(t), eventPublisher: nil}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{authMiddlewareOption}...)
 			assertMocksExpectations(t, 1, mockStorer.callCountDeleteUserSavedSearch,

--- a/backend/pkg/httpserver/remove_user_saved_search_bookmark_test.go
+++ b/backend/pkg/httpserver/remove_user_saved_search_bookmark_test.go
@@ -106,7 +106,7 @@ func TestRemoveUserSavedSearchBookmark(t *testing.T) {
 				t:                                t,
 			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
-				operationResponseCaches: nil, baseURL: getTestBaseURL(t)}
+				operationResponseCaches: nil, baseURL: getTestBaseURL(t), eventPublisher: nil}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{authMiddlewareOption}...)
 			assertMocksExpectations(t, 1, mockStorer.callCountRemoveUserSavedSearchBookmark,

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -170,6 +170,7 @@ type Server struct {
 	operationResponseCaches *operationResponseCaches
 	baseURL                 *url.URL
 	userGitHubClientFactory UserGitHubClientFactory
+	eventPublisher          EventPublisher
 }
 
 type GitHubUserClient interface {
@@ -221,11 +222,17 @@ type RouteCacheOptions struct {
 	AggregatedFeatureStatsOptions []cachetypes.CacheOption
 }
 
+type EventPublisher interface {
+	PublishSearchConfigurationChanged(ctx context.Context, resp *backend.SavedSearchResponse,
+		userID string, isCreation bool) error
+}
+
 func NewHTTPServer(
 	port string,
 	baseURL *url.URL,
 	metadataStorer WebFeatureMetadataStorer,
 	wptMetricsStorer WPTMetricsStorer,
+	eventPublisher EventPublisher,
 	rawBytesDataCacher RawBytesDataCacher,
 	routeCacheOptions RouteCacheOptions,
 	userGitHubClientFactory UserGitHubClientFactory,
@@ -235,6 +242,7 @@ func NewHTTPServer(
 	srv := &Server{
 		metadataStorer:          metadataStorer,
 		wptMetricsStorer:        wptMetricsStorer,
+		eventPublisher:          eventPublisher,
 		operationResponseCaches: initOperationResponseCaches(rawBytesDataCacher, routeCacheOptions),
 		baseURL:                 baseURL,
 		userGitHubClientFactory: userGitHubClientFactory,

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -855,6 +855,38 @@ func (m *MockWPTMetricsStorer) DeleteNotificationChannel(
 	return m.deleteNotificationChannelCfg.err
 }
 
+type MockPublishSearchConfigurationChangedConfig struct {
+	expectedResp       *backend.SavedSearchResponse
+	expectedUserID     string
+	expectedIsCreation bool
+	err                error
+}
+
+type MockEventPublisher struct {
+	t                                          *testing.T
+	callCountPublishSearchConfigurationChanged int
+	publishSearchConfigurationChangedCfg       *MockPublishSearchConfigurationChangedConfig
+}
+
+func (m *MockEventPublisher) PublishSearchConfigurationChanged(
+	_ context.Context,
+	resp *backend.SavedSearchResponse,
+	userID string,
+	isCreation bool) error {
+	m.callCountPublishSearchConfigurationChanged++
+	if !reflect.DeepEqual(resp, m.publishSearchConfigurationChangedCfg.expectedResp) {
+		m.t.Errorf("unexpected response %+v", resp)
+	}
+	if userID != m.publishSearchConfigurationChangedCfg.expectedUserID {
+		m.t.Errorf("unexpected user id %s", userID)
+	}
+	if isCreation != m.publishSearchConfigurationChangedCfg.expectedIsCreation {
+		m.t.Errorf("unexpected is creation %t", isCreation)
+	}
+
+	return m.publishSearchConfigurationChangedCfg.err
+}
+
 func TestGetPageSizeOrDefault(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/backend/pkg/httpserver/update_saved_search.go
+++ b/backend/pkg/httpserver/update_saved_search.go
@@ -128,5 +128,11 @@ func (s *Server) UpdateSavedSearch(
 		}, nil
 	}
 
+	err = s.eventPublisher.PublishSearchConfigurationChanged(ctx, output, user.ID, false)
+	if err != nil {
+		// We should not mark this as a failure. Only log it.
+		slog.ErrorContext(ctx, "unable to publish search configuration changed event during update", "error", err)
+	}
+
 	return backend.UpdateSavedSearch200JSONResponse(*output), nil
 }

--- a/backend/pkg/httpserver/update_saved_search_test.go
+++ b/backend/pkg/httpserver/update_saved_search_test.go
@@ -61,6 +61,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		cfg                  *MockUpdateUserSavedSearchConfig
+		publishCfg           *MockPublishSearchConfigurationChangedConfig
 		authMiddlewareOption testServerOption
 		request              *http.Request
 		expectedResponse     *http.Response
@@ -68,6 +69,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 		{
 			name:                 "missing body update error",
 			cfg:                  nil,
+			publishCfg:           nil,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequest(
 				http.MethodPatch,
@@ -81,6 +83,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 		{
 			name:                 "empty update mask error",
 			cfg:                  nil,
+			publishCfg:           nil,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequest(
 				http.MethodPatch,
@@ -94,6 +97,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 		{
 			name:                 "update with invalid masks error",
 			cfg:                  nil,
+			publishCfg:           nil,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequest(
 				http.MethodPatch,
@@ -110,6 +114,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 		{
 			name:                 "missing fields, all update masks set, update error",
 			cfg:                  nil,
+			publishCfg:           nil,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequest(
 				http.MethodPatch,
@@ -138,6 +143,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 				output:                nil,
 				err:                   backendtypes.ErrUserNotAuthorizedForAction,
 			},
+			publishCfg:           nil,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 
 			request: httptest.NewRequest(
@@ -161,6 +167,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 				output:                nil,
 				err:                   backendtypes.ErrEntityDoesNotExist,
 			},
+			publishCfg:           nil,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 
 			request: httptest.NewRequest(
@@ -184,6 +191,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 				output:                nil,
 				err:                   errTest,
 			},
+			publishCfg:           nil,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 
 			request: httptest.NewRequest(
@@ -220,6 +228,25 @@ func TestUpdateSavedSearch(t *testing.T) {
 				},
 				err: nil,
 			},
+			publishCfg: &MockPublishSearchConfigurationChangedConfig{
+				expectedResp: &backend.SavedSearchResponse{
+					Id:          "saved-search-id",
+					Name:        "test name",
+					Query:       `name:"test"`,
+					Description: valuePtr("test description"),
+					Permissions: &backend.UserSavedSearchPermissions{
+						Role: valuePtr(backend.SavedSearchOwner),
+					},
+					BookmarkStatus: &backend.UserSavedSearchBookmark{
+						Status: backend.BookmarkActive,
+					},
+					CreatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+				expectedIsCreation: false,
+				expectedUserID:     "testID1",
+				err:                nil,
+			},
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 
 			request: httptest.NewRequest(
@@ -245,7 +272,7 @@ func TestUpdateSavedSearch(t *testing.T) {
 			),
 		},
 		{
-			name: "success, all fields, clear description with explicit null",
+			name: "success, all fields, clear description with explicit null, failed publish",
 			cfg: &MockUpdateUserSavedSearchConfig{
 				expectedSavedSearchID: "saved-search-id",
 				expectedUserID:        "testID1",
@@ -265,6 +292,25 @@ func TestUpdateSavedSearch(t *testing.T) {
 					UpdatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
 				},
 				err: nil,
+			},
+			publishCfg: &MockPublishSearchConfigurationChangedConfig{
+				expectedResp: &backend.SavedSearchResponse{
+					Id:          "saved-search-id",
+					Name:        "test name",
+					Query:       `name:"test"`,
+					Description: nil,
+					Permissions: &backend.UserSavedSearchPermissions{
+						Role: valuePtr(backend.SavedSearchOwner),
+					},
+					BookmarkStatus: &backend.UserSavedSearchBookmark{
+						Status: backend.BookmarkActive,
+					},
+					CreatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+				expectedIsCreation: false,
+				expectedUserID:     "testID1",
+				err:                errTest,
 			},
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 
@@ -318,6 +364,25 @@ func TestUpdateSavedSearch(t *testing.T) {
 				},
 				err: nil,
 			},
+			publishCfg: &MockPublishSearchConfigurationChangedConfig{
+				expectedResp: &backend.SavedSearchResponse{
+					Id:          "saved-search-id",
+					Name:        "test name",
+					Query:       `name:"test"`,
+					Description: nil,
+					Permissions: &backend.UserSavedSearchPermissions{
+						Role: valuePtr(backend.SavedSearchOwner),
+					},
+					BookmarkStatus: &backend.UserSavedSearchBookmark{
+						Status: backend.BookmarkActive,
+					},
+					CreatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt: time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+				expectedUserID:     "testID1",
+				expectedIsCreation: false,
+				err:                nil,
+			},
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 
 			request: httptest.NewRequest(
@@ -355,8 +420,13 @@ func TestUpdateSavedSearch(t *testing.T) {
 				updateUserSavedSearchCfg: tc.cfg,
 				t:                        t,
 			}
+			mockPublisher := &MockEventPublisher{
+				t: t,
+				callCountPublishSearchConfigurationChanged: 0,
+				publishSearchConfigurationChangedCfg:       tc.publishCfg,
+			}
 			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
-				operationResponseCaches: nil, baseURL: getTestBaseURL(t)}
+				operationResponseCaches: nil, baseURL: getTestBaseURL(t), eventPublisher: mockPublisher}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 		})

--- a/backend/pkg/httpserver/update_subscription_test.go
+++ b/backend/pkg/httpserver/update_subscription_test.go
@@ -227,6 +227,7 @@ func TestUpdateSubscription(t *testing.T) {
 				metadataStorer:          nil,
 				operationResponseCaches: nil,
 				userGitHubClientFactory: nil,
+				eventPublisher:          nil,
 			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
 			assertMocksExpectations(t,

--- a/backend/skaffold.yaml
+++ b/backend/skaffold.yaml
@@ -22,6 +22,7 @@ requires:
   - path: ../.dev/valkey
   - path: ../.dev/spanner
   - path: ../.dev/wiremock
+  - path: ../.dev/pubsub
 profiles:
   - name: local
     build:

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -139,6 +139,14 @@ resource "google_cloud_run_v2_service" "service" {
         name  = "BASE_URL"
         value = var.backend_api_url
       }
+      env {
+        name  = "INGESTION_TOPIC_ID"
+        value = var.ingestion_topic_id
+      }
+      env {
+        name  = "PUBSUB_PROJECT_ID"
+        value = var.pubsub_project_id
+      }
     }
     containers {
       name  = "otel"
@@ -212,6 +220,13 @@ resource "google_cloud_run_service_iam_member" "public" {
   service  = each.value.name
   role     = "roles/run.invoker"
   member   = "allUsers"
+}
+
+resource "google_pubsub_topic_iam_member" "pub" {
+  topic    = var.ingestion_topic_id
+  role     = "roles/pubsub.publisher"
+  member   = "serviceAccount:${google_service_account.backend.email}"
+  provider = google.internal_project
 }
 
 resource "google_compute_region_network_endpoint_group" "neg" {

--- a/infra/backend/variables.tf
+++ b/infra/backend/variables.tf
@@ -108,3 +108,5 @@ variable "backend_api_url" {
   type = string
 }
 
+variable "pubsub_project_id" { type = string }
+variable "ingestion_topic_id" { type = string }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -124,6 +124,8 @@ module "backend" {
   firebase_settings = {
     tenant_id = module.auth.tenant_id
   }
+  pubsub_project_id  = var.projects.internal
+  ingestion_topic_id = module.pubsub.ingestion_topic_id
 }
 
 module "frontend" {

--- a/lib/gcppubsub/gcppubsubadapters/backend.go
+++ b/lib/gcppubsub/gcppubsubadapters/backend.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcppubsubadapters
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/event"
+	searchconfigv1 "github.com/GoogleChrome/webstatus.dev/lib/event/searchconfigurationchanged/v1"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+type BackendAdapter struct {
+	client  EventPublisher
+	topicID string
+}
+
+func NewBackendAdapter(client EventPublisher, topicID string) *BackendAdapter {
+	return &BackendAdapter{client: client, topicID: topicID}
+}
+
+func (p *BackendAdapter) PublishSearchConfigurationChanged(
+	ctx context.Context,
+	resp *backend.SavedSearchResponse,
+	userID string,
+	isCreation bool) error {
+
+	evt := searchconfigv1.SearchConfigurationChangedEvent{
+		SearchID:   resp.Id,
+		Query:      resp.Query,
+		UserID:     userID,
+		Timestamp:  resp.UpdatedAt,
+		IsCreation: isCreation,
+		Frequency:  searchconfigv1.FrequencyImmediate,
+	}
+
+	msg, err := event.New(evt)
+	if err != nil {
+		return fmt.Errorf("failed to create event: %w", err)
+	}
+
+	id, err := p.client.Publish(ctx, p.topicID, msg)
+	if err != nil {
+		return fmt.Errorf("failed to publish message: %w", err)
+	}
+
+	slog.InfoContext(ctx, "published search configuration changed event",
+		"msgID", id,
+		"searchID", evt.SearchID,
+		"isCreation", evt.IsCreation)
+
+	return nil
+}

--- a/lib/gcppubsub/gcppubsubadapters/backend_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/backend_test.go
@@ -1,0 +1,136 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcppubsubadapters
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/google/go-cmp/cmp"
+)
+
+func testSavedSearchResponse(id string, query string, updatedAt time.Time) *backend.SavedSearchResponse {
+	var resp backend.SavedSearchResponse
+	resp.Id = id
+	resp.Query = query
+	resp.UpdatedAt = updatedAt
+
+	return &resp
+}
+func TestSearchConfigurationPublisherAdapter_Publish(t *testing.T) {
+	fixedTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		resp         *backend.SavedSearchResponse
+		userID       string
+		isCreation   bool
+		publishErr   error
+		wantErr      bool
+		expectedJSON string
+	}{
+		{
+			name:       "success creation",
+			resp:       testSavedSearchResponse("search-123", "group:css", fixedTime),
+			userID:     "user-1",
+			isCreation: true,
+			publishErr: nil,
+			wantErr:    false,
+			expectedJSON: `{
+				"apiVersion": "v1",
+				"kind": "SearchConfigurationChangedEvent",
+				"data": {
+					"search_id": "search-123",
+					"query": "group:css",
+					"user_id": "user-1",
+					"timestamp": "2025-01-01T00:00:00Z",
+					"is_creation": true,
+					"frequency": "IMMEDIATE"
+				}
+			}`,
+		},
+		{
+			name:       "success update",
+			resp:       testSavedSearchResponse("search-456", "group:html", fixedTime.Add(24*time.Hour)),
+			userID:     "user-1",
+			isCreation: false,
+			publishErr: nil,
+			wantErr:    false,
+			expectedJSON: `{
+				"apiVersion": "v1",
+				"kind": "SearchConfigurationChangedEvent",
+				"data": {
+					"search_id": "search-456",
+					"query": "group:html",
+					"user_id": "user-1",
+					"timestamp": "2025-01-02T00:00:00Z",
+					"is_creation": false,
+					"frequency": "IMMEDIATE"
+				}
+			}`,
+		},
+		{
+			name:         "publish error",
+			resp:         testSavedSearchResponse("search-err", "group:html", fixedTime),
+			userID:       "user-1",
+			isCreation:   false,
+			publishErr:   errors.New("pubsub error"),
+			wantErr:      true,
+			expectedJSON: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			publisher := new(mockPublisher)
+			publisher.err = tc.publishErr
+			adapter := NewBackendAdapter(publisher, "test-topic")
+
+			err := adapter.PublishSearchConfigurationChanged(context.Background(), tc.resp, tc.userID, tc.isCreation)
+
+			if (err != nil) != tc.wantErr {
+				t.Errorf("PublishSearchConfigurationChanged() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			if tc.wantErr {
+				return
+			}
+
+			if publisher.publishedTopic != "test-topic" {
+				t.Errorf("Topic mismatch: got %s, want test-topic", publisher.publishedTopic)
+			}
+
+			// Unmarshal actual data
+			var actual interface{}
+			if err := json.Unmarshal(publisher.publishedData, &actual); err != nil {
+				t.Fatalf("failed to unmarshal published data: %v", err)
+			}
+
+			// Unmarshal expected data
+			var expected interface{}
+			if err := json.Unmarshal([]byte(tc.expectedJSON), &expected); err != nil {
+				t.Fatalf("failed to unmarshal expected data: %v", err)
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("Payload mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduces the `BackendAdapter` in `gcppubsubadapters` to handle publishing `SearchConfigurationChangedEvent` messages from the API layer.

This adapter encapsulates the logic for mapping the API's `SavedSearchResponse` model to the internal event struct. This simplifies the handler code by allowing it to pass the response object directly along with context like `userID` and `isCreation`.

This infrastructure is required to trigger the "Cold Start" (initial state generation) or "Query Update" workflows in the Event Producer whenever a user creates or modifies a saved search.

Changes:
- **Adapter**: Added `BackendAdapter` with `PublishSearchConfigurationChanged`.
- **Wiring**: Integrated the publisher into the Backend Server and its handlers (`CreateSavedSearch`, `UpdateSavedSearch`).
- Added terraform so that the backend is configured to use the pubsub topic.

Depends on #2176 