### PR TITLE
chore: Fix copyright year from 202x to 2026 for files created in 2026

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-manage-subscriptions-dialog.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-manage-subscriptions-dialog.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/static/js/components/test/webstatus-subscribe-button.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-subscribe-button.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/static/js/components/webstatus-manage-subscriptions-dialog.ts
+++ b/frontend/src/static/js/components/webstatus-manage-subscriptions-dialog.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/static/js/components/webstatus-notification-panel.ts
+++ b/frontend/src/static/js/components/webstatus-notification-panel.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/frontend/src/static/js/components/webstatus-subscribe-button.ts
+++ b/frontend/src/static/js/components/webstatus-subscribe-button.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/pubsub/providers.tf
+++ b/infra/pubsub/providers.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/storage/spanner/migrations/000029.sql
+++ b/infra/storage/spanner/migrations/000029.sql
@@ -1,4 +1,4 @@
--- Copyright 2025 Google LLC
+-- Copyright 2026 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/infra/workers/email/providers.tf
+++ b/infra/workers/email/providers.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/workers/event_producer/providers.tf
+++ b/infra/workers/event_producer/providers.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/workers/providers.tf
+++ b/infra/workers/providers.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/infra/workers/push_delivery/providers.tf
+++ b/infra/workers/push_delivery/providers.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/email/chime/chimeadapters/email_worker.go
+++ b/lib/email/chime/chimeadapters/email_worker.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/email/chime/chimeadapters/email_worker_test.go
+++ b/lib/email/chime/chimeadapters/email_worker_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/email/chime/client.go
+++ b/lib/email/chime/client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/email/chime/client_test.go
+++ b/lib/email/chime/client_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/event/emailjob/v1/types.go
+++ b/lib/event/emailjob/v1/types.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcpgcs/gcpgcsadapters/event_producer.go
+++ b/lib/gcpgcs/gcpgcsadapters/event_producer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcpgcs/gcpgcsadapters/event_producer_test.go
+++ b/lib/gcpgcs/gcpgcsadapters/event_producer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcppubsub/gcppubsubadapters/backend_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/backend_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcppubsub/gcppubsubadapters/batch_event_producer.go
+++ b/lib/gcppubsub/gcppubsubadapters/batch_event_producer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcppubsub/gcppubsubadapters/batch_event_producer_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/batch_event_producer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcppubsub/gcppubsubadapters/email_worker.go
+++ b/lib/gcppubsub/gcppubsubadapters/email_worker.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcppubsub/gcppubsubadapters/email_worker_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/email_worker_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcppubsub/gcppubsubadapters/event_producer.go
+++ b/lib/gcppubsub/gcppubsubadapters/event_producer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcppubsub/gcppubsubadapters/event_producer_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/event_producer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcppubsub/gcppubsubadapters/push_delivery.go
+++ b/lib/gcppubsub/gcppubsubadapters/push_delivery.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcppubsub/gcppubsubadapters/push_delivery_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/push_delivery_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcppubsub/gcppubsubadapters/utils.go
+++ b/lib/gcppubsub/gcppubsubadapters/utils.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcppubsub/gcppubsubadapters/utils_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcpspanner/spanneradapters/email_worker.go
+++ b/lib/gcpspanner/spanneradapters/email_worker.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcpspanner/spanneradapters/email_worker_test.go
+++ b/lib/gcpspanner/spanneradapters/email_worker_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcpspanner/spanneradapters/event_producer.go
+++ b/lib/gcpspanner/spanneradapters/event_producer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcpspanner/spanneradapters/event_producer_test.go
+++ b/lib/gcpspanner/spanneradapters/event_producer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcpspanner/spanneradapters/push_delivery.go
+++ b/lib/gcpspanner/spanneradapters/push_delivery.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcpspanner/spanneradapters/push_delivery_test.go
+++ b/lib/gcpspanner/spanneradapters/push_delivery_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcpspanner/system_managed_saved_searches.go
+++ b/lib/gcpspanner/system_managed_saved_searches.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/gcpspanner/system_managed_saved_searches_test.go
+++ b/lib/gcpspanner/system_managed_saved_searches_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workers/email/pkg/digest/components.go
+++ b/workers/email/pkg/digest/components.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workers/email/pkg/digest/renderer.go
+++ b/workers/email/pkg/digest/renderer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workers/email/pkg/digest/renderer_test.go
+++ b/workers/email/pkg/digest/renderer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workers/email/pkg/digest/styles.go
+++ b/workers/email/pkg/digest/styles.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workers/email/pkg/digest/templates.go
+++ b/workers/email/pkg/digest/templates.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workers/email/pkg/sender/sender.go
+++ b/workers/email/pkg/sender/sender.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workers/email/pkg/sender/sender_test.go
+++ b/workers/email/pkg/sender/sender_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workers/event_producer/pkg/producer/batch_handler.go
+++ b/workers/event_producer/pkg/producer/batch_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workers/event_producer/pkg/producer/batch_handler_test.go
+++ b/workers/event_producer/pkg/producer/batch_handler_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workers/push_delivery/pkg/dispatcher/dispatcher.go
+++ b/workers/push_delivery/pkg/dispatcher/dispatcher.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
+++ b/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Follow up from this comment: https://github.com/GoogleChrome/webstatus.dev/pull/2210#discussion_r2748274701

Ran the following command:
```bash
git log --diff-filter=A --since="2026-01-01" --name-only --pretty=format:"" | \
sort -u | \
grep -vE '\.(svg|png)$' | \
while read f; do
  # Check if file exists and contains the wrong year
  if [ -f "$f" ] && grep -q "Copyright 202[0-57-9]" "$f"; then
     echo "Fixing: $f"
     # Perform the replacement
     sed -i 's/Copyright 202[0-57-9]/Copyright 2026/g' "$f"
  fi
done
```