### PR TITLE
Fix styles for email digest and improve subject line handling

### DIFF
--- a/workers/email/pkg/digest/components.go
+++ b/workers/email/pkg/digest/components.go
@@ -15,26 +15,6 @@
 // nolint:lll  // WONTFIX - for readability
 package digest
 
-const componentStyles = `{{- define "style_badge_wrapper" -}}align-self: stretch; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; justify-content: flex-start; align-items: center; display: flex;{{- end -}}
-{{- define "style_badge_inner_wrapper" -}}flex: 1 1 0; flex-direction: column; justify-content: center; align-items: flex-start; display: inline-flex;{{- end -}}
-{{- define "style_change_detail_wrapper" -}}align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: inline-flex; width: 100%;{{- end -}}
-{{- define "style_change_detail_inner" -}}flex: 1 1 0;{{- end -}}
-{{- define "style_banner_wrapper" -}}align-self: stretch; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; justify-content: flex-start; align-items: center; gap: 8px; display: flex;{{- end -}}
-{{- define "style_banner_icon_wrapper_28" -}}height: 28px; position: relative; overflow: hidden; display: flex; align-items: center;{{- end -}}
-{{- define "style_banner_icon_wrapper_20" -}}height: 20px; position: relative; margin-right: 4px;{{- end -}}
-{{- define "style_img_responsive" -}}display: block; width: auto;{{- end -}}
-{{- define "style_banner_text_wrapper" -}}flex: 1 1 0;{{- end -}}
-{{- define "style_banner_browser_logos_wrapper" -}}justify-content: flex-start; align-items: center; display: flex; margin-right: 8px;{{- end -}}
-{{- define "style_browser_item_row" -}}align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;{{- end -}}
-{{- define "style_browser_item_logo_wrapper" -}}justify-content: flex-start; align-items: center; display: flex;{{- end -}}
-{{- define "style_browser_item_feature_link_wrapper" -}}align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: inline-flex; margin-top: 8px;{{- end -}}
-{{- define "style_button_wrapper" -}}margin: 20px 0; text-align: center;{{- end -}}
-{{- define "style_footer_wrapper" -}}align-self: stretch; padding-top: 16px; flex-direction: column; justify-content: flex-start; align-items: flex-start; gap: 12px; display: flex; {{- template "font_family_main" -}};{{- end -}}
-{{- define "style_footer_hr" -}}align-self: stretch; height: 1px; background: #E4E4E7;{{- end -}}
-{{- define "style_footer_text_wrapper" -}}align-self: stretch;{{- end -}}
-{{- define "style_feature_title_row_wrapper" -}}align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;{{- end -}}
-{{- define "style_feature_title_row_inner" -}}flex: 1 1 0;{{- end -}}`
-
 const badgeComponent = `{{- define "badge" -}}
 <div style='{{- template "style_badge_wrapper" -}}; background: {{- badgeBackgroundColor .Title -}};'>
     <div style='{{- template "style_badge_inner_wrapper" -}}'>
@@ -47,10 +27,10 @@ const badgeComponent = `{{- define "badge" -}}
 {{- end -}}`
 
 const introTextComponent = `{{- define "intro_text" -}}
-<div style='{{- template "style_section_wrapper" -}}'>
-    <h2 style='{{- template "style_subject_header" -}}'>{{.Subject}}</h2>
+<div style='{{- template "style_intro_wrapper" -}}'>
+    <h2 style='{{- template "style_subject_header" -}}'>{{.FullSubject}}</h2>
     <div style='{{- template "style_query_text" -}}'>
-        Here is your update for the saved search <strong style='font-weight: bold;'>'{{.Query}}'</strong>. 
+        Here is your update for the saved search <strong style='font-weight: bold;'>'{{.Query}}'</strong>.
         {{.SummaryText}}.
     </div>
 </div>
@@ -68,13 +48,17 @@ const changeDetailComponent = `{{- define "change_detail" -}}
 const baselineChangeItemComponent = `{{- define "baseline_change_item" -}}
 <div style='{{- template "style_section_wrapper" -}}'>
     <div style='{{- template "style_banner_wrapper" -}}; {{- template "color_bg_success" -}}'>
-        <div style='{{- template "style_banner_icon_wrapper_28" -}}'>
-            <img src="{{.ToURL}}" height="28" alt="{{.To}}" style='{{- template "style_img_responsive" -}}' />
-        </div>
-        <div style='{{- template "style_banner_text_wrapper" -}}'>
-            <span style='{{- template "style_text_banner_bold" -}}'>Baseline</span>
-            <span style='{{- template "style_text_banner_normal" -}}'> {{.To}} </span>
-        </div>
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+            <tr>
+                <td width="36" align="left" valign="middle">
+                    <img src="{{.ToURL}}" height="28" alt="{{.To}}" style='{{- template "style_img_responsive" -}}' />
+                </td>
+                <td align="left" valign="middle">
+                    <span style='{{- template "style_text_banner_bold" -}}'>Baseline</span>
+                    <span style='{{- template "style_text_banner_normal" -}}'> {{.To}} </span>
+                </td>
+            </tr>
+        </table>
     </div>
     <div style='{{- template "style_card_body" -}}'>
         <div style='{{- template "style_browser_item_row" -}}'>
@@ -89,12 +73,18 @@ const baselineChangeItemComponent = `{{- define "baseline_change_item" -}}
 
 const browserItemComponent = `{{- define "browser_change_row" -}}
     <div style='{{- template "style_browser_item_row" -}}'>
-        <div style='{{- template "style_browser_item_logo_wrapper" -}}'>
-            <img src="{{.LogoURL}}" height="20" alt="{{.Name}}" style='{{- template "style_img_responsive" -}}' />
-        </div>
-        <div style='{{- template "style_text_browser_item" -}}'>
-            {{.Name}}: {{ template "browser_status_detail" .From }} &rarr; {{ template "browser_status_detail" .To -}}
-        </div>
+        <table border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+            <tr>
+                <td align="left" valign="middle" style="padding-right: 10px;">
+                    <img src="{{.LogoURL}}" height="20" alt="{{.Name}}" style='{{- template "style_img_responsive" -}}' />
+                </td>
+                <td align="left" valign="middle">
+                    <div style='{{- template "style_text_browser_item" -}}'>
+                        {{.Name}}: {{ template "browser_status_detail" .From }} &rarr; {{ template "browser_status_detail" .To -}}
+                    </div>
+                </td>
+            </tr>
+        </table>
     </div>
 {{- end -}}
 
@@ -136,55 +126,70 @@ const footerComponent = `{{- define "footer" -}}
 
 const bannerComponents = `{{- define "banner_baseline_widely" -}}
 <div style='{{- template "style_banner_wrapper" -}}{{- template "color_bg_success" -}}'>
-    <div style='{{- template "style_banner_icon_wrapper_28" -}}'>
-        <img src="{{.LogoURL}}" height="28" alt="Widely Available" style='{{- template "style_img_responsive" -}}' />
-    </div>
-    <div style='{{- template "style_banner_text_wrapper" -}}'>
-        <span style='{{- template "style_text_banner_bold" -}}'>Baseline</span>
-        <span style='{{- template "style_text_banner_normal" -}}'> Widely available </span>
-    </div>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <tr>
+            <td width="36" align="left" valign="middle">
+                <img src="{{.LogoURL}}" height="28" alt="Widely Available" style='{{- template "style_img_responsive" -}}' />
+            </td>
+            <td align="left" valign="middle">
+                <span style='{{- template "style_text_banner_bold" -}}'>Baseline</span>
+                <span style='{{- template "style_text_banner_normal" -}}'> Widely available </span>
+            </td>
+        </tr>
+    </table>
 </div>
 {{- end -}}
 {{- define "banner_baseline_newly" -}}
 <div style='{{- template "style_banner_wrapper" -}}{{- template "color_bg_info" -}}'>
-    <div style='{{- template "style_banner_icon_wrapper_28" -}}'>
-        <img src="{{.LogoURL}}" height="28" alt="Newly Available" style='{{- template "style_img_responsive" -}}' />
-    </div>
-    <div style='{{- template "style_banner_text_wrapper" -}}'>
-        <span style='{{- template "style_text_banner_bold" -}}'>Baseline</span>
-        <span style='{{- template "style_text_banner_normal" -}}'> Newly available </span>
-    </div>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <tr>
+            <td width="36" align="left" valign="middle">
+                <img src="{{.LogoURL}}" height="28" alt="Newly Available" style='{{- template "style_img_responsive" -}}' />
+            </td>
+            <td align="left" valign="middle">
+                <span style='{{- template "style_text_banner_bold" -}}'>Baseline</span>
+                <span style='{{- template "style_text_banner_normal" -}}'> Newly available </span>
+            </td>
+        </tr>
+    </table>
 </div>
 {{- end -}}
 {{- define "banner_baseline_regression" -}}
 <div style='{{- template "style_banner_wrapper" -}}{{- template "color_bg_neutral" -}}'>
-    <div style='{{- template "style_banner_icon_wrapper_28" -}}'>
-        <img src="{{.LogoURL}}" height="28" alt="Regressed" style='{{- template "style_img_responsive" -}}' />
-    </div>
-    <div style='{{- template "style_banner_text_wrapper" -}}'>
-        <span style='{{- template "style_text_banner_bold" -}}'>Regressed</span>
-        <span style='{{- template "style_text_banner_normal" -}}'> to limited availability</span>
-    </div>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <tr>
+            <td width="36" align="left" valign="middle">
+                <img src="{{.LogoURL}}" height="28" alt="Regressed" style='{{- template "style_img_responsive" -}}' />
+            </td>
+            <td align="left" valign="middle">
+                <span style='{{- template "style_text_banner_bold" -}}'>Regressed</span>
+                <span style='{{- template "style_text_banner_normal" -}}'> to limited availability</span>
+            </td>
+        </tr>
+    </table>
 </div>
 {{- end -}}
 {{- define "banner_browser_implementation" -}}
 <div style='{{- template "style_banner_wrapper" -}}{{- template "color_bg_neutral" -}}'>
-    <div style='{{- template "style_banner_browser_logos_wrapper" -}}'>
-        {{- /* Always display the 4 main browser logos as requested */ -}}
-        <div style='{{- template "style_banner_icon_wrapper_20" -}}'>
-            <img src="{{browserLogoURL "chrome"}}" height="20" style='{{- template "style_img_responsive" -}}' />
-        </div>
-        <div style='{{- template "style_banner_icon_wrapper_20" -}}'>
-            <img src="{{browserLogoURL "edge"}}" height="20" style='{{- template "style_img_responsive" -}}' />
-        </div>
-        <div style='{{- template "style_banner_icon_wrapper_20" -}}'>
-            <img src="{{browserLogoURL "firefox"}}" height="20" style='{{- template "style_img_responsive" -}}' />
-        </div>
-        <div style='{{- template "style_banner_icon_wrapper_20" -}}'>
-            <img src="{{browserLogoURL "safari"}}" height="20" style='{{- template "style_img_responsive" -}}' />
-        </div>
-    </div>
-    <div style='{{- template "style_banner_text_wrapper" -}}; {{- template "style_text_banner_normal" -}}'>Browser support changed</div>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <tr>
+            <td width="28" align="left" valign="middle">
+                 <img src="{{browserLogoURL "chrome"}}" height="20" style='{{- template "style_img_responsive" -}}' />
+            </td>
+            <td width="28" align="left" valign="middle">
+                 <img src="{{browserLogoURL "edge"}}" height="20" style='{{- template "style_img_responsive" -}}' />
+            </td>
+            <td width="28" align="left" valign="middle">
+                 <img src="{{browserLogoURL "firefox"}}" height="20" style='{{- template "style_img_responsive" -}}' />
+            </td>
+            <td width="28" align="left" valign="middle">
+                 <img src="{{browserLogoURL "safari"}}" height="20" style='{{- template "style_img_responsive" -}}' />
+            </td>
+            <td align="left" valign="middle" style="padding-left: 8px;">
+                 <span style='{{- template "style_text_banner_normal" -}}'>Browser support changed</span>
+            </td>
+        </tr>
+    </table>
 </div>
 {{- end -}}
 {{- define "banner_generic" -}}
@@ -195,24 +200,28 @@ const bannerComponents = `{{- define "banner_baseline_widely" -}}
 </div>
 {{- end -}}`
 const featureTitleRowComponent = `{{- define "feature_title_row" -}}
-<div style='{{- template "style_feature_title_row_wrapper" -}}'>
-    <div style='{{- template "style_feature_title_row_inner" -}}'>
-        <a href="{{.URL}}" style='{{- template "style_text_feature_link" -}}'>{{.Name}}</a>
-        {{- with .Docs -}}
-            {{- if .MDNDocs -}}
-            <span style='{{- template "style_text_doc_punctuation" -}}'> (</span>
-            {{- range $i, $doc := .MDNDocs }}
-                {{- if $i }}, {{ end -}}
-                <a href="{{$doc.URL}}" style='{{- template "style_text_doc_link" -}}'>MDN</a>
+<table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+    <tr>
+        <td align="left" valign="top">
+            <a href="{{.URL}}" style='{{- template "style_text_feature_link" -}}'>{{.Name}}</a>
+            {{- with .Docs -}}
+                {{- if .MDNDocs -}}
+                <span style='{{- template "style_text_doc_punctuation" -}}'> (</span>
+                {{- range $i, $doc := .MDNDocs }}
+                    {{- if $i }}, {{ end -}}
+                    <a href="{{$doc.URL}}" style='{{- template "style_text_doc_link" -}}'>MDN</a>
+                {{- end -}}
+                <span style='{{- template "style_text_doc_punctuation" -}}'>)</span>
+                {{- end -}}
             {{- end -}}
-            <span style='{{- template "style_text_doc_punctuation" -}}'>)</span>
-            {{- end -}}
+        </td>
+        {{- if .Date -}}
+        <td align="right" valign="top" style="white-space: nowrap; padding-left: 10px;">
+            <div style='{{- template "style_text_date" -}}'>{{.Date}}</div>
+        </td>
         {{- end -}}
-    </div>
-    {{- if .Date -}}
-    <div style='{{- template "style_text_date" -}}'>{{.Date}}</div>
-    {{- end -}}
-</div>
+    </tr>
+</table>
 {{- end -}}`
 
 const browserStatusDetailComponent = `{{- define "browser_status_detail" -}}

--- a/workers/email/pkg/digest/styles.go
+++ b/workers/email/pkg/digest/styles.go
@@ -27,10 +27,11 @@ const styleSnippets = `{{- define "font_family_main" -}}font-family: SF Pro, sys
 {{- define "color_bg_light_neutral" -}}background: #F4F4F5;{{- end -}}`
 
 const layoutStyles = `{{- define "style_body_wrapper" -}}max-width: 600px; margin: 0 auto; padding: 20px;{{- end -}}
-{{- define "style_subject_header" -}}{{- template "style_text_normal" -}}; align-self: stretch; margin: 0;{{- end -}}
-{{- define "style_query_text" -}}{{- template "style_text_normal" -}}; align-self: stretch;{{- end -}}
-{{- define "style_section_wrapper" -}}align-self: stretch; padding-top: 8px; padding-bottom: 8px; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: flex;{{- end -}}
-{{- define "style_card_body" -}}align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;{{- end -}}
+{{- define "style_subject_header" -}}{{- template "style_text_normal" -}}; margin-top: 0; margin-bottom: 0; padding-bottom: 8px; font-weight: 700; font-size: 18px;{{- end -}}
+{{- define "style_query_text" -}}{{- template "style_text_normal" -}}; margin-top: 0; margin-bottom: 0; align-self: stretch;{{- end -}}
+{{- define "style_intro_wrapper" -}}width: auto; padding: 16px; background: #F4F4F5; border-radius: 4px; display: block; margin-bottom: 4px;{{- end -}}
+{{- define "style_section_wrapper" -}}width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;{{- end -}}
+{{- define "style_card_body" -}}width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;{{- end -}}
 {{- define "style_button_link" -}}display: inline-block; padding: 10px 20px; background: #18181B; color: white; text-decoration: none; border-radius: 4px; {{- template "font_family_main" -}}; font-weight: 500; font-size: 14px;{{- end -}}`
 
 const composedTextStyles = `{{- define "style_text_badge_title" -}}{{- template "color_text_dark" -}}; font-size: 14px; {{- template "font_family_main" -}}; {{- template "font_weight_bold" -}}; word-wrap: break-word;{{- end -}}
@@ -43,14 +44,39 @@ const composedTextStyles = `{{- define "style_text_badge_title" -}}{{- template 
 {{- define "style_text_feature_link" -}}{{- template "color_text_dark" -}}; font-size: 16px; {{- template "font_family_main" -}}; {{- template "font_weight_normal" -}}; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;{{- end -}}
 {{- define "style_text_doc_link" -}}{{- template "color_text_medium" -}}; font-size: 14px; {{- template "font_family_main" -}}; {{- template "font_weight_normal" -}}; text-decoration: underline; line-height: 26.60px;{{- end -}}
 {{- define "style_text_doc_punctuation" -}}{{- template "color_text_medium" -}}; font-size: 14px; {{- template "font_family_main" -}}; {{- template "font_weight_normal" -}}; line-height: 26.60px;{{- end -}}
-{{- define "style_text_date" -}}{{- template "color_text_medium" -}}; font-size: 12px; {{- template "font_family_monospace" -}}; {{- template "font_weight_normal" -}}; word-wrap: break-word;{{- end -}}
-{{- define "style_text_browser_item" -}}{{- template "color_text_dark" -}}; font-size: 14px; {{- template "font_family_main" -}}; {{- template "font_weight_normal" -}}; word-wrap: break-word;{{- end -}}
-{{- define "style_text_warning" -}}{{- template "color_text_medium" -}}; font-size: 12px; {{- template "font_family_main" -}}; font-style: italic; margin-top: 4px;{{- end -}}
+{{- define "style_text_date" -}}{{- template "color_text_medium" -}}; font-size: 12px; {{- template "font_family_monospace" -}}; {{- template "font_weight_normal" -}}; word-wrap: break-word; display: inline-block; margin-left: 10px;{{- end -}}
+{{- define "style_text_browser_item" -}}{{- template "color_text_dark" -}}; font-size: 14px; {{- template "font_family_main" -}}; {{- template "font_weight_normal" -}}; word-wrap: break-word; display: inline-block; vertical-align: middle;{{- end -}}
+{{- define "style_text_warning" -}}{{- template "color_text_medium" -}}; font-size: 12px; {{- template "font_family_main" -}}; font-style: italic; margin-top: 4px; display: block;{{- end -}}
 {{- define "style_text_warning_inline" -}}{{- template "color_text_medium" -}}; font-size: 12px; {{- template "font_family_main" -}}; font-style: italic;{{- end -}}
 {{- define "style_text_footer" -}}{{- template "color_text_medium" -}}; font-size: 11px; {{- template "font_weight_normal" -}}; word-wrap: break-word;{{- end -}}
 {{- define "style_text_footer_link" -}}{{- template "color_text_medium" -}}; font-size: 11px; {{- template "font_weight_normal" -}}; text-decoration: underline; word-wrap: break-word;{{- end -}}`
 
+// Replacements for Flexbox structures:
+// - banner_wrapper: block (container), icon/text as inline-block
+// - badge_wrapper: block (container), inner as block
+// - feature_title_row: block (container), items as inline-block
+// - footer: block
+// These ensure better compatibility across email clients.
 const EmailStyles = styleSnippets + layoutStyles + composedTextStyles + `{{- define "style_body" -}}{{- template "font_family_main" -}}; line-height: 1.5; color: #333; margin: 0; padding: 0;{{- end -}}
-{{- define "style_change_detail_div" -}}align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: inline-flex; width: 100%;{{- end -}}
-{{- define "style_change_detail_inner_div" -}}flex: 1 1 0;{{- end -}}
-{{- define "style_split_into" -}}flex: 1 1 0;{{- end -}}`
+{{- define "style_badge_wrapper" -}}width: auto; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;{{- end -}}
+{{- define "style_badge_inner_wrapper" -}}display: block;{{- end -}}
+{{- define "style_change_detail_wrapper" -}}width: 100%; display: block; margin-top: 4px;{{- end -}}
+{{- define "style_change_detail_inner" -}}display: block;{{- end -}}
+{{- define "style_change_detail_div" -}}width: 100%; display: block; margin-top: 4px;{{- end -}}
+{{- define "style_change_detail_inner_div" -}}display: block;{{- end -}}
+{{- define "style_banner_wrapper" -}}width: auto; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;{{- end -}}
+{{- define "style_banner_icon_wrapper_28" -}}height: 28px; width: 28px; display: inline-block; vertical-align: middle; margin-right: 8px;{{- end -}}
+{{- define "style_banner_icon_wrapper_20" -}}height: 20px; width: 20px; display: inline-block; vertical-align: middle; margin-right: 4px;{{- end -}}
+{{- define "style_img_responsive" -}}display: block; width: auto;{{- end -}}
+{{- define "style_banner_text_wrapper" -}}display: inline-block; vertical-align: middle;{{- end -}}
+{{- define "style_banner_browser_logos_wrapper" -}}display: inline-block; vertical-align: middle; margin-right: 8px;{{- end -}}
+{{- define "style_browser_item_row" -}}width: 100%; display: block;{{- end -}}
+{{- define "style_browser_item_logo_wrapper" -}}display: inline-block; vertical-align: middle; margin-right: 10px;{{- end -}}
+{{- define "style_browser_item_feature_link_wrapper" -}}width: 100%; display: block; margin-top: 8px;{{- end -}}
+{{- define "style_button_wrapper" -}}margin: 20px 0; text-align: center;{{- end -}}
+{{- define "style_footer_wrapper" -}}width: 100%; padding-top: 16px; display: block; {{- template "font_family_main" -}};{{- end -}}
+{{- define "style_footer_hr" -}}width: 100%; height: 1px; background: #E4E4E7; margin-bottom: 12px;{{- end -}}
+{{- define "style_footer_text_wrapper" -}}display: block;{{- end -}}
+{{- define "style_feature_title_row_wrapper" -}}width: 100%; display: block;{{- end -}}
+{{- define "style_feature_title_row_inner" -}}display: inline-block; vertical-align: top;{{- end -}}
+{{- define "style_split_into" -}}display: block;{{- end -}}`

--- a/workers/email/pkg/digest/testdata/digest.golden.html
+++ b/workers/email/pkg/digest/testdata/digest.golden.html
@@ -5,151 +5,222 @@
     <title>Weekly digest: group:css</title>
 </head>
 <body style='font-family: SF Pro, system-ui, sans-serif;; line-height: 1.5; color: #333; margin: 0; padding: 0;'>
-    <div style='max-width: 600px; margin: 0 auto; padding: 20px;'><div style='align-self: stretch; padding-top: 8px; padding-bottom: 8px; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: flex;'>
-    <h2 style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 21px; word-wrap: break-word;; align-self: stretch; margin: 0;'>Weekly digest: group:css</h2>
-    <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 21px; word-wrap: break-word;; align-self: stretch;'>
-        Here is your update for the saved search <strong style='font-weight: bold;'>'group:css'</strong>. 
+    <div style='max-width: 600px; margin: 0 auto; padding: 20px;'><div style='width: auto; padding: 16px; background: #F4F4F5; border-radius: 4px; display: block; margin-bottom: 4px;'>
+    <h2 style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 21px; word-wrap: break-word;; margin-top: 0; margin-bottom: 0; padding-bottom: 8px; font-weight: 700; font-size: 18px;'>Weekly digest: group:css</h2>
+    <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 21px; word-wrap: break-word;; margin-top: 0; margin-bottom: 0; align-self: stretch;'>
+        Here is your update for the saved search <strong style='font-weight: bold;'>'group:css'</strong>.
         11 features changed.
     </div>
-</div><div style='align-self: stretch; padding-top: 8px; padding-bottom: 8px; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: flex;'><div style='align-self: stretch; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; justify-content: flex-start; align-items: center; gap: 8px; display: flex;background: #E8F0FE;'>
-    <div style='height: 28px; position: relative; overflow: hidden; display: flex; align-items: center;'>
-        <img src="http://localhost:5555/public/img/email/newly.png" height="28" alt="Newly Available" style='display: block; width: auto;' />
-    </div>
-    <div style='flex: 1 1 0;'>
-        <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Baseline</span>
-        <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'> Newly available </span>
-    </div>
-</div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-    <div style='flex: 1 1 0;'>
-        <a href="http://localhost:5555/features/newly-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Newly Available Feature</a></div><div style='color: #52525B;; font-size: 12px;font-family: Menlo, monospace;;font-weight: 400;; word-wrap: break-word;'>2025-01-01</div></div></div></div><div style='align-self: stretch; padding-top: 8px; padding-bottom: 8px; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: flex;'><div style='align-self: stretch; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; justify-content: flex-start; align-items: center; gap: 8px; display: flex;background: #E6F4EA;'>
-    <div style='height: 28px; position: relative; overflow: hidden; display: flex; align-items: center;'>
-        <img src="http://localhost:5555/public/img/email/widely.png" height="28" alt="Widely Available" style='display: block; width: auto;' />
-    </div>
-    <div style='flex: 1 1 0;'>
-        <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Baseline</span>
-        <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'> Widely available </span>
-    </div>
-</div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-    <div style='flex: 1 1 0;'>
-        <a href="http://localhost:5555/features/container-queries" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Container queries</a><span style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 26.60px;'> (</span><a href="https://developer.mozilla.org/docs/Web/CSS/CSS_Container_Queries" style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 26.60px;'>MDN</a>, <a href="https://developer.mozilla.org/docs/Web/CSS/container-queries" style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 26.60px;'>MDN</a><span style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 26.60px;'>)</span></div><div style='color: #52525B;; font-size: 12px;font-family: Menlo, monospace;;font-weight: 400;; word-wrap: break-word;'>2025-12-27</div></div></div></div><div style='align-self: stretch; padding-top: 8px; padding-bottom: 8px; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: flex;'><div style='align-self: stretch; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; justify-content: flex-start; align-items: center; gap: 8px; display: flex;background: #E4E4E7;'>
-    <div style='height: 28px; position: relative; overflow: hidden; display: flex; align-items: center;'>
-        <img src="http://localhost:5555/public/img/email/limited.png" height="28" alt="Regressed" style='display: block; width: auto;' />
-    </div>
-    <div style='flex: 1 1 0;'>
-        <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Regressed</span>
-        <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'> to limited availability</span>
-    </div>
-</div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-    <div style='flex: 1 1 0;'>
-        <a href="http://localhost:5555/features/regressed-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Regressed Feature</a></div></div><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: inline-flex; width: 100%;'>
-                        <div style='flex: 1 1 0;'>
+</div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;background: #E8F0FE;'>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <tr>
+            <td width="36" align="left" valign="middle">
+                <img src="http://localhost:5555/public/img/email/newly.png" height="28" alt="Newly Available" style='display: block; width: auto;' />
+            </td>
+            <td align="left" valign="middle">
+                <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Baseline</span>
+                <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'> Newly available </span>
+            </td>
+        </tr>
+    </table>
+</div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+    <tr>
+        <td align="left" valign="top">
+            <a href="http://localhost:5555/features/newly-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Newly Available Feature</a></td><td align="right" valign="top" style="white-space: nowrap; padding-left: 10px;">
+            <div style='color: #52525B;; font-size: 12px;font-family: Menlo, monospace;;font-weight: 400;; word-wrap: break-word; display: inline-block; margin-left: 10px;'>2025-01-01</div>
+        </td></tr>
+</table></div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;background: #E6F4EA;'>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <tr>
+            <td width="36" align="left" valign="middle">
+                <img src="http://localhost:5555/public/img/email/widely.png" height="28" alt="Widely Available" style='display: block; width: auto;' />
+            </td>
+            <td align="left" valign="middle">
+                <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Baseline</span>
+                <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'> Widely available </span>
+            </td>
+        </tr>
+    </table>
+</div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+    <tr>
+        <td align="left" valign="top">
+            <a href="http://localhost:5555/features/container-queries" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Container queries</a><span style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 26.60px;'> (</span><a href="https://developer.mozilla.org/docs/Web/CSS/CSS_Container_Queries" style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 26.60px;'>MDN</a>, <a href="https://developer.mozilla.org/docs/Web/CSS/container-queries" style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 26.60px;'>MDN</a><span style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 26.60px;'>)</span></td><td align="right" valign="top" style="white-space: nowrap; padding-left: 10px;">
+            <div style='color: #52525B;; font-size: 12px;font-family: Menlo, monospace;;font-weight: 400;; word-wrap: break-word; display: inline-block; margin-left: 10px;'>2025-12-27</div>
+        </td></tr>
+</table></div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;background: #E4E4E7;'>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <tr>
+            <td width="36" align="left" valign="middle">
+                <img src="http://localhost:5555/public/img/email/limited.png" height="28" alt="Regressed" style='display: block; width: auto;' />
+            </td>
+            <td align="left" valign="middle">
+                <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Regressed</span>
+                <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'> to limited availability</span>
+            </td>
+        </tr>
+    </table>
+</div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+    <tr>
+        <td align="left" valign="top">
+            <a href="http://localhost:5555/features/regressed-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Regressed Feature</a></td></tr>
+</table><div style='width: 100%; display: block; margin-top: 4px;'>
+                        <div style='display: block;'>
                             <span style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 26.60px; word-wrap: break-word;'>From Widely</span>
                         </div>
-                    </div></div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-    <div style='flex: 1 1 0;'>
-        <a href="http://localhost:5555/features/removed-details" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Removed With Details</a></div></div><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: inline-flex; width: 100%;'>
-                        <div style='flex: 1 1 0;'>
+                    </div></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+    <tr>
+        <td align="left" valign="top">
+            <a href="http://localhost:5555/features/removed-details" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Removed With Details</a></td></tr>
+</table><div style='width: 100%; display: block; margin-top: 4px;'>
+                        <div style='display: block;'>
                             <span style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 26.60px; word-wrap: break-word;'>From Newly</span>
                         </div>
-                    </div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;; font-style: italic; margin-top: 4px;'>⚠️ This feature no longer matches your saved search. Please update your saved search if you wish to continue tracking it.</div></div></div><div style='align-self: stretch; padding-top: 8px; padding-bottom: 8px; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: flex;'><div style='align-self: stretch; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; justify-content: flex-start; align-items: center; gap: 8px; display: flex;background: #E4E4E7;'>
-    <div style='justify-content: flex-start; align-items: center; display: flex; margin-right: 8px;'><div style='height: 20px; position: relative; margin-right: 4px;'>
-            <img src="http://localhost:5555/public/img/email/chrome.png" height="20" style='display: block; width: auto;' />
-        </div>
-        <div style='height: 20px; position: relative; margin-right: 4px;'>
-            <img src="http://localhost:5555/public/img/email/edge.png" height="20" style='display: block; width: auto;' />
-        </div>
-        <div style='height: 20px; position: relative; margin-right: 4px;'>
-            <img src="http://localhost:5555/public/img/email/firefox.png" height="20" style='display: block; width: auto;' />
-        </div>
-        <div style='height: 20px; position: relative; margin-right: 4px;'>
-            <img src="http://localhost:5555/public/img/email/safari.png" height="20" style='display: block; width: auto;' />
-        </div>
-    </div>
-    <div style='flex: 1 1 0;;color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>Browser support changed</div>
-</div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-        <div style='justify-content: flex-start; align-items: center; display: flex;'>
-            <img src="http://localhost:5555/public/img/email/chrome.png" height="20" alt="Chrome" style='display: block; width: auto;' />
-        </div>
-        <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>
-            Chrome: Available<span style='color: #52525B;'> in 120</span> &rarr; Unavailable</div>
-    </div><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: inline-flex; margin-top: 8px;'>
-            <div style='flex: 1 1 0;'>
+                    </div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;; font-style: italic; margin-top: 4px; display: block;'>⚠️ This feature no longer matches your saved search. Please update your saved search if you wish to continue tracking it.</div></div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;background: #E4E4E7;'>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <tr>
+            <td width="28" align="left" valign="middle">
+                 <img src="http://localhost:5555/public/img/email/chrome.png" height="20" style='display: block; width: auto;' />
+            </td>
+            <td width="28" align="left" valign="middle">
+                 <img src="http://localhost:5555/public/img/email/edge.png" height="20" style='display: block; width: auto;' />
+            </td>
+            <td width="28" align="left" valign="middle">
+                 <img src="http://localhost:5555/public/img/email/firefox.png" height="20" style='display: block; width: auto;' />
+            </td>
+            <td width="28" align="left" valign="middle">
+                 <img src="http://localhost:5555/public/img/email/safari.png" height="20" style='display: block; width: auto;' />
+            </td>
+            <td align="left" valign="middle" style="padding-left: 8px;">
+                 <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>Browser support changed</span>
+            </td>
+        </tr>
+    </table>
+</div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
+        <table border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+            <tr>
+                <td align="left" valign="middle" style="padding-right: 10px;">
+                    <img src="http://localhost:5555/public/img/email/chrome.png" height="20" alt="Chrome" style='display: block; width: auto;' />
+                </td>
+                <td align="left" valign="middle">
+                    <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
+                        Chrome: Available<span style='color: #52525B;'> in 120</span> &rarr; Unavailable</div>
+                </td>
+            </tr>
+        </table>
+    </div><div style='width: 100%; display: block; margin-top: 8px;'>
+            <div style='display: inline-block; vertical-align: middle;'>
                 <a href="http://localhost:5555/features/regressed-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Regressed Feature</a>
             </div>
-        </div></div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-        <div style='justify-content: flex-start; align-items: center; display: flex;'>
-            <img src="http://localhost:5555/public/img/email/safari.png" height="20" alt="Safari iOS" style='display: block; width: auto;' />
-        </div>
-        <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>
-            Safari iOS: Unavailable &rarr; Available<span style='color: #52525B;'> in 17.2</span></div>
-    </div><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: inline-flex; margin-top: 8px;'>
-            <div style='flex: 1 1 0;'>
+        </div></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
+        <table border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+            <tr>
+                <td align="left" valign="middle" style="padding-right: 10px;">
+                    <img src="http://localhost:5555/public/img/email/safari.png" height="20" alt="Safari iOS" style='display: block; width: auto;' />
+                </td>
+                <td align="left" valign="middle">
+                    <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
+                        Safari iOS: Unavailable &rarr; Available<span style='color: #52525B;'> in 17.2</span></div>
+                </td>
+            </tr>
+        </table>
+    </div><div style='width: 100%; display: block; margin-top: 8px;'>
+            <div style='display: inline-block; vertical-align: middle;'>
                 <a href="http://localhost:5555/features/content-visibility" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>content-visibility</a>
             </div>
-        </div></div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-        <div style='justify-content: flex-start; align-items: center; display: flex;'>
-            <img src="http://localhost:5555/public/img/email/chrome.png" height="20" alt="Chrome" style='display: block; width: auto;' />
-        </div>
-        <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>
-            Chrome: Unavailable &rarr; Available<span style='color: #52525B;'> (on 2025-01-01)</span></div>
-    </div><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: inline-flex; margin-top: 8px;'>
-            <div style='flex: 1 1 0;'>
+        </div></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
+        <table border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+            <tr>
+                <td align="left" valign="middle" style="padding-right: 10px;">
+                    <img src="http://localhost:5555/public/img/email/chrome.png" height="20" alt="Chrome" style='display: block; width: auto;' />
+                </td>
+                <td align="left" valign="middle">
+                    <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
+                        Chrome: Unavailable &rarr; Available<span style='color: #52525B;'> (on 2025-01-01)</span></div>
+                </td>
+            </tr>
+        </table>
+    </div><div style='width: 100%; display: block; margin-top: 8px;'>
+            <div style='display: inline-block; vertical-align: middle;'>
                 <a href="http://localhost:5555/features/another-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>another-feature</a>
             </div>
-        </div></div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-        <div style='justify-content: flex-start; align-items: center; display: flex;'>
-            <img src="http://localhost:5555/public/img/email/firefox.png" height="20" alt="Firefox" style='display: block; width: auto;' />
-        </div>
-        <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>
-            Firefox: Unavailable &rarr; Available<span style='color: #52525B;'> in 123</span><span style='color: #52525B;'> (on 2025-01-01)</span></div>
-    </div><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: inline-flex; margin-top: 8px;'>
-            <div style='flex: 1 1 0;'>
+        </div></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
+        <table border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+            <tr>
+                <td align="left" valign="middle" style="padding-right: 10px;">
+                    <img src="http://localhost:5555/public/img/email/firefox.png" height="20" alt="Firefox" style='display: block; width: auto;' />
+                </td>
+                <td align="left" valign="middle">
+                    <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
+                        Firefox: Unavailable &rarr; Available<span style='color: #52525B;'> in 123</span><span style='color: #52525B;'> (on 2025-01-01)</span></div>
+                </td>
+            </tr>
+        </table>
+    </div><div style='width: 100%; display: block; margin-top: 8px;'>
+            <div style='display: inline-block; vertical-align: middle;'>
                 <a href="http://localhost:5555/features/new-browser-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>new-browser-feature</a>
             </div>
-        </div></div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-        <div style='justify-content: flex-start; align-items: center; display: flex;'>
-            <img src="http://localhost:5555/public/img/email/chrome.png" height="20" alt="Chrome" style='display: block; width: auto;' />
-        </div>
-        <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>
-            Chrome: Available<span style='color: #52525B;'> in 110</span> &rarr; Unavailable</div>
-    </div><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: inline-flex; margin-top: 8px;'>
-            <div style='flex: 1 1 0;'>
+        </div></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
+        <table border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+            <tr>
+                <td align="left" valign="middle" style="padding-right: 10px;">
+                    <img src="http://localhost:5555/public/img/email/chrome.png" height="20" alt="Chrome" style='display: block; width: auto;' />
+                </td>
+                <td align="left" valign="middle">
+                    <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
+                        Chrome: Available<span style='color: #52525B;'> in 110</span> &rarr; Unavailable</div>
+                </td>
+            </tr>
+        </table>
+    </div><div style='width: 100%; display: block; margin-top: 8px;'>
+            <div style='display: inline-block; vertical-align: middle;'>
                 <a href="http://localhost:5555/features/removed-details" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Removed With Details</a>
             </div>
-        </div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;; font-style: italic; margin-top: 4px;'>⚠️ This feature no longer matches your saved search. Please update your saved search if you wish to continue tracking it.</div></div></div><div style='align-self: stretch; padding-top: 8px; padding-bottom: 8px; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: flex;'><div style='align-self: stretch; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; justify-content: flex-start; align-items: center; display: flex;; background:#E6F4EA;'>
-    <div style='flex: 1 1 0; flex-direction: column; justify-content: center; align-items: flex-start; display: inline-flex;'>
+        </div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;; font-style: italic; margin-top: 4px; display: block;'>⚠️ This feature no longer matches your saved search. Please update your saved search if you wish to continue tracking it.</div></div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;; background:#E6F4EA;'>
+    <div style='display: block;'>
         <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Added</div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>These features now match your search criteria.</div></div>
-</div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-    <div style='flex: 1 1 0;'>
-        <a href="http://localhost:5555/features/new-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>New Feature</a></div></div></div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-    <div style='flex: 1 1 0;'>
-        <a href="http://localhost:5555/features/another-new-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Another New Feature</a></div></div></div></div><div style='align-self: stretch; padding-top: 8px; padding-bottom: 8px; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: flex;'><div style='align-self: stretch; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; justify-content: flex-start; align-items: center; display: flex;; background:#E4E4E7;'>
-    <div style='flex: 1 1 0; flex-direction: column; justify-content: center; align-items: flex-start; display: inline-flex;'>
+</div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+    <tr>
+        <td align="left" valign="top">
+            <a href="http://localhost:5555/features/new-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>New Feature</a></td></tr>
+</table></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+    <tr>
+        <td align="left" valign="top">
+            <a href="http://localhost:5555/features/another-new-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Another New Feature</a></td></tr>
+</table></div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;; background:#E4E4E7;'>
+    <div style='display: block;'>
         <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Removed</div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>These features no longer match your search criteria.</div></div>
-</div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-    <div style='flex: 1 1 0;'>
-        <a href="http://localhost:5555/features/removed-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Removed Feature</a></div></div></div></div><div style='align-self: stretch; padding-top: 8px; padding-bottom: 8px; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: flex;'><div style='align-self: stretch; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; justify-content: flex-start; align-items: center; display: flex;; background:#FCE8E6;'>
-    <div style='flex: 1 1 0; flex-direction: column; justify-content: center; align-items: flex-start; display: inline-flex;'>
+</div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+    <tr>
+        <td align="left" valign="top">
+            <a href="http://localhost:5555/features/removed-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Removed Feature</a></td></tr>
+</table></div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;; background:#FCE8E6;'>
+    <div style='display: block;'>
         <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Deleted</div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>These features have been removed from the web platform.</div></div>
-</div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-    <div style='flex: 1 1 0;'>
-        <a href="http://localhost:5555/features/deleted-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Deleted Feature</a></div></div></div></div><div style='align-self: stretch; padding-top: 8px; padding-bottom: 8px; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: flex;'><div style='align-self: stretch; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; justify-content: flex-start; align-items: center; display: flex;; background:#E8F0FE;'>
-    <div style='flex: 1 1 0; flex-direction: column; justify-content: center; align-items: flex-start; display: inline-flex;'>
+</div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+    <tr>
+        <td align="left" valign="top">
+            <a href="http://localhost:5555/features/deleted-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Deleted Feature</a></td></tr>
+</table></div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;; background:#E8F0FE;'>
+    <div style='display: block;'>
         <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Moved</div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>These features have been renamed or merged with another feature.</div></div>
-</div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-    <div style='flex: 1 1 0;'>
-        <a href="http://localhost:5555/features/new-cool-name" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>New Cool Name</a></div></div><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: inline-flex; width: 100%;'>
-    <div style='flex: 1 1 0;'>
+</div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+    <tr>
+        <td align="left" valign="top">
+            <a href="http://localhost:5555/features/new-cool-name" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>New Cool Name</a></td></tr>
+</table><div style='width: 100%; display: block; margin-top: 4px;'>
+    <div style='display: block;'>
         <span style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 30.40px; word-wrap: break-word;'>Moved from</span>
         <span style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 26.60px; word-wrap: break-word;'> (Old Name &rarr; New Cool Name)</span>
     </div>
-</div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;; font-style: italic; margin-top: 4px;'>⚠️ This feature no longer matches your saved search. Please update your saved search if you wish to continue tracking it.</div></div></div><div style='align-self: stretch; padding-top: 8px; padding-bottom: 8px; flex-direction: column; justify-content: flex-start; align-items: flex-start; display: flex;'><div style='align-self: stretch; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; justify-content: flex-start; align-items: center; display: flex;; background:#E8F0FE;'>
-    <div style='flex: 1 1 0; flex-direction: column; justify-content: center; align-items: flex-start; display: inline-flex;'>
+</div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;; font-style: italic; margin-top: 4px; display: block;'>⚠️ This feature no longer matches your saved search. Please update your saved search if you wish to continue tracking it.</div></div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;; background:#E8F0FE;'>
+    <div style='display: block;'>
         <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Split</div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>This feature has been split into multiple, more granular features.</div></div>
-</div><div style='align-self: stretch; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; flex-direction: column; justify-content: center; align-items: flex-start; display: flex; background: #FFFFFF;'><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: flex;'>
-    <div style='flex: 1 1 0;'>
-        <a href="http://localhost:5555/features/feature-to-split" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Feature To Split</a></div></div><div style='align-self: stretch; justify-content: flex-start; align-items: center; gap: 10px; display: inline-flex; width: 100%;'>
-                        <div style='flex: 1 1 0;'>
+</div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+    <tr>
+        <td align="left" valign="top">
+            <a href="http://localhost:5555/features/feature-to-split" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Feature To Split</a></td></tr>
+</table><div style='width: 100%; display: block; margin-top: 4px;'>
+                        <div style='display: block;'>
                             <span style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 30.40px; word-wrap: break-word;'>Split into:</span>
                             <ul style="margin: 4px 0; padding-left: 20px;">
                             <li style="margin-bottom: 4px;">
@@ -157,9 +228,9 @@
                                     <a href="http://localhost:5555/features/sub-feature-2" style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 26.60px;'>Sub Feature 2</a><span style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;; font-style: italic;'> ⚠️ (No longer matches)</span></li></ul>
                         </div>
                     </div>
-                </div></div><div style='align-self: stretch; padding-top: 16px; flex-direction: column; justify-content: flex-start; align-items: flex-start; gap: 12px; display: flex;font-family: SF Pro, system-ui, sans-serif;;'>
-    <div style='align-self: stretch; height: 1px; background: #E4E4E7;'></div>
-    <div style='align-self: stretch;'>
+                </div></div><div style='width: 100%; padding-top: 16px; display: block;font-family: SF Pro, system-ui, sans-serif;;'>
+    <div style='width: 100%; height: 1px; background: #E4E4E7; margin-bottom: 12px;'></div>
+    <div style='display: block;'>
         <span style='color: #52525B;; font-size: 11px;font-weight: 400;; word-wrap: break-word;'>You can </span>
         <a href="http://localhost:5555/settings/subscriptions?unsubscribe=sub-123" style='color: #52525B;; font-size: 11px;font-weight: 400;; text-decoration: underline; word-wrap: break-word;'>unsubscribe</a>
         <span style='color: #52525B;; font-size: 11px;font-weight: 400;; word-wrap: break-word;'> or change any of your alerts on </span>


### PR DESCRIPTION
Refactor the email digest templates to use table-based layouts instead of Flexbox. This ensures consistent rendering across a wider range of email clients, particularly those with poor Flexbox support (e.g., Outlook).

Additionally:

- Update the digest renderer to generate both a truncated subject line (for the email subject header) and a full, untruncated subject line (for the body header). This prevents long saved search queries from being cut off in the email body.
- Replace manual sorting with standard library `slices.Sort` with browser keys.