### PR TITLE
feat: implement subscription limit for users

### DIFF
--- a/backend/pkg/httpserver/create_subscription.go
+++ b/backend/pkg/httpserver/create_subscription.go
@@ -174,6 +174,13 @@ func (s *Server) CreateSubscription(
 					Message: "user not authorized to create this subscription using the specified channel",
 				},
 			), nil
+		} else if errors.Is(err, backendtypes.ErrUserMaxSubscriptions) {
+			return backend.CreateSubscription403JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusForbidden,
+					Message: "user has reached the maximum number of allowed subscriptions",
+				},
+			), nil
 		}
 		slog.ErrorContext(ctx, "failed to create subscription", "error", err)
 

--- a/backend/pkg/httpserver/create_subscription_test.go
+++ b/backend/pkg/httpserver/create_subscription_test.go
@@ -147,6 +147,36 @@ func TestCreateSubscription(t *testing.T) {
 			}`),
 		},
 		{
+			name: "forbidden - user max subscriptions reached",
+			cfg: &MockCreateSavedSearchSubscriptionConfig{
+				expectedUserID: "test-user",
+				expectedSubscription: backend.Subscription{
+					ChannelId:     "channel-id",
+					SavedSearchId: "search-id",
+					Triggers: []backend.SubscriptionTriggerWritable{
+						backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete},
+					Frequency: "immediate",
+				},
+				output: nil,
+				err:    backendtypes.ErrUserMaxSubscriptions,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequest(
+				http.MethodPost,
+				"/v1/users/me/subscriptions",
+				strings.NewReader(`{
+					"channel_id": "channel-id",
+					"saved_search_id": "search-id",
+					"triggers": ["feature_browser_implementation_any_complete"],
+					"frequency": "immediate"
+				}`)),
+			expectedResponse: testJSONResponse(http.StatusForbidden, `{
+				"code":403,
+				"message":"user has reached the maximum number of allowed subscriptions"
+			}`),
+		},
+		{
 			name: "internal server error",
 			cfg: &MockCreateSavedSearchSubscriptionConfig{
 				expectedUserID: "test-user",

--- a/frontend/src/static/js/components/webstatus-manage-subscriptions-dialog.ts
+++ b/frontend/src/static/js/components/webstatus-manage-subscriptions-dialog.ts
@@ -28,6 +28,7 @@ import {
 } from '../contexts/firebase-user-context.js';
 import {SlCheckbox, SlDialog, SlRadioGroup} from '@shoelace-style/shoelace';
 import {FREQUENCY_DISPLAY_NAMES} from '../utils/format.js';
+import {ApiError} from '../api/errors.js';
 
 const FREQUENCY_CONFIG: ReadonlyArray<
   components['schemas']['SubscriptionFrequency']
@@ -637,11 +638,19 @@ export class ManageSubscriptionsDialog extends LitElement {
         message: 'Subscription saved.',
       };
     } catch (e) {
-      const error = e instanceof Error ? e : new Error('Unknown error saving');
+      let message: string;
+      let error: Error;
+      if (e instanceof ApiError) {
+        message = e.message;
+        error = e;
+      } else {
+        error = e instanceof Error ? e : new Error('Unknown error saving');
+        message = `Error saving subscription: ${error.message}`;
+      }
       this.dispatchEvent(new SubscriptionSaveErrorEvent(error));
       this._actionState = {
         phase: 'error',
-        message: `Error saving subscription: ${error.message}`,
+        message: message,
       };
     }
   }

--- a/lib/backendtypes/types.go
+++ b/lib/backendtypes/types.go
@@ -35,6 +35,10 @@ var (
 	// number of allowed bookmarks.
 	ErrUserMaxBookmarks = errors.New("user has reached the maximum number of allowed bookmarks")
 
+	// ErrUserMaxSubscriptions indicates the user has reached the maximum
+	// number of allowed subscriptions.
+	ErrUserMaxSubscriptions = errors.New("user has reached the maximum number of allowed subscriptions")
+
 	// ErrUserNotAuthorizedForAction indicates the user is not authorized to execute the requested action.
 	ErrUserNotAuthorizedForAction = errors.New("user not authorized to execute action")
 

--- a/lib/gcpspanner/client.go
+++ b/lib/gcpspanner/client.go
@@ -139,6 +139,8 @@ type searchConfig struct {
 	maxOwnedSearchesPerUser uint32
 	// Max number of bookmarks per user (excluding the saved searches they own)
 	maxBookmarksPerUser uint32
+	// Max number of subscriptions per user
+	maxSubscriptionsPerUser uint32
 }
 
 // notificationConfig holds the application configuation for notifications.
@@ -149,6 +151,7 @@ type notificationConfig struct {
 
 const defaultMaxOwnedSearchesPerUser = 25
 const defaultMaxBookmarksPerUser = 25
+const defaultMaxSubscriptionsPerUser = 25
 const defaultBatchSize = 5000
 const defaultBatchWriters = 8
 const defaultMaxConsecutiveFailuresPerChannel = 5
@@ -226,6 +229,7 @@ func NewSpannerClient(projectID string, instanceID string, name string) (*Client
 		searchConfig{
 			maxOwnedSearchesPerUser: defaultMaxOwnedSearchesPerUser,
 			maxBookmarksPerUser:     defaultMaxBookmarksPerUser,
+			maxSubscriptionsPerUser: defaultMaxSubscriptionsPerUser,
 		},
 		notificationConfig{
 			maxConsecutiveFailuresPerChannel: defaultMaxConsecutiveFailuresPerChannel,

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -1474,6 +1474,8 @@ func (s *Backend) CreateSavedSearchSubscription(ctx context.Context,
 	if err != nil {
 		if errors.Is(err, gcpspanner.ErrMissingRequiredRole) {
 			return nil, errors.Join(err, backendtypes.ErrUserNotAuthorizedForAction)
+		} else if errors.Is(err, gcpspanner.ErrSubscriptionLimitExceeded) {
+			return nil, errors.Join(err, backendtypes.ErrUserMaxSubscriptions)
 		}
 
 		return nil, err


### PR DESCRIPTION
- Add `ErrUserMaxSubscriptions` to `lib/backendtypes/types.go` to signal when a user has reached their subscription limit.
- Add `ErrSubscriptionLimitExceeded` to `lib/gcpspanner/saved_search_subscription.go` for the database layer.
- Update `searchConfig` in `lib/gcpspanner/client.go` to include `maxSubscriptionsPerUser`, defaulting to 25.
- Update `createSavedSearchSubscription` in `lib/gcpspanner/saved_search_subscription.go` to enforce the subscription limit before creation.
- Update `CreateSavedSearchSubscription` adapter in `lib/gcpspanner/spanneradapters/backend.go` to map the database limit error to the backend type error.
- Update `CreateSubscription` handler in `backend/pkg/httpserver/create_subscription.go` to return a 403 Forbidden status when the limit is exceeded similar to the error and status for the limit for CreateSavedSearch.
- Update frontend component `ManageSubscriptionsDialog` in `frontend/src/static/js/components/webstatus-manage-subscriptions-dialog.ts` to gracefully handle the error and display a user-friendly message.
- Add tests covering the limit logic in:
  - `backend/pkg/httpserver/create_subscription_test.go`
  - `lib/gcpspanner/saved_search_subscription_test.go`
  - `lib/gcpspanner/spanneradapters/backend_test.go`
  - `frontend/src/static/js/components/test/webstatus-manage-subscriptions-dialog.test.ts`