### PR TITLE
infra: tune worker scaling and add manual instance configuration

### DIFF
--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -117,3 +117,9 @@ chime_details = {
   bcc_secret_ref          = "chime-bcc-addresses"
   from_address_secret_ref = "chime-from-address"
 }
+
+worker_manual_instance_counts = {
+  event_producer = 4
+  push_delivery  = 2
+  email          = 2
+}

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -121,3 +121,9 @@ chime_details = {
   bcc_secret_ref          = "chime-bcc-addresses"
   from_address_secret_ref = "chime-from-address"
 }
+
+worker_manual_instance_counts = {
+  event_producer = 2
+  push_delivery  = 1
+  email          = 1
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -194,9 +194,9 @@ module "workers" {
   }
 
   worker_instance_count = {
-    event_producer_count = 1
-    push_delivery_count  = 1
-    email_count          = 1
+    event_producer_count = var.worker_manual_instance_counts.event_producer
+    push_delivery_count  = var.worker_manual_instance_counts.push_delivery
+    email_count          = var.worker_manual_instance_counts.email
   }
   frontend_base_url = var.frontend_base_url
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -224,3 +224,17 @@ variable "chime_details" {
     from_address_secret_ref = string
   })
 }
+
+# The cloud run worker pool service does not support "AUTOMATIC" scaling, despite the documentation mentioning it as an option.
+# Terraform docs: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_worker_pool#scaling_mode-1
+# In the future, we can leverage CREMA to autoscale workers instead of using manual instance counts.
+# For now, we will use manual instance counts for simplicity.
+# More info about CREMA: https://docs.cloud.google.com/run/docs/tutorials/autoscale-workerpools-pubsub
+variable "worker_manual_instance_counts" {
+  description = "Manual instance counts for background workers."
+  type = object({
+    event_producer = number
+    push_delivery  = number
+    email          = number
+  })
+}


### PR DESCRIPTION
Updates infrastructure configuration to support manual scaling of Cloud Run worker pools per environment. This addresses "High Latency" alerts observed in Pub/Sub metrics, which track the oldest unacked message across all ingestion, notification, and delivery queues.

Changes:
- **Variables**: Added `worker_manual_instance_counts` to control scaling for `event_producer`, `push_delivery`, and `email` independently.
- **Staging**: Increased `event_producer` from 1 to 2 instances to resolve occasional backlog alerts during batch processing.
- **Prod**: Scaled up workers significantly (Event Producer: 4, Push Delivery: 2, Email: 2) to ensure the system can clear the daily/weekly diff backlogs within the 15-minute "Immediate" cron interval.

Note: Cloud Run Worker Pools currently rely on manual scaling for Pull subscriptions. Future iterations could explore CREMA (Cloud Run Event-driven Autoscaling) to automatically scale based on Pub/Sub metrics, though this would introduce additional architectural complexity.

In the future, we could also configure [MaxOutstandingMessages](https://pkg.go.dev/cloud.google.com/go/pubsub#FlowControlSettings) per type of worker. 