### PR TITLE
event_producer: Ensure differ is thread-safe

### DIFF
--- a/workers/event_producer/pkg/differ/differ_test.go
+++ b/workers/event_producer/pkg/differ/differ_test.go
@@ -372,12 +372,12 @@ func TestRun(t *testing.T) {
 
 			// Create the differ with mocked dependencies
 			d := &FeatureDiffer[testDiff]{
-				client:         fetcher,
-				workflow:       workflow,
-				stateAdapter:   adapter,
-				diffSerializer: serializer,
-				idGenerator:    &mockIDGenerator{stateID: "state-id", diffID: "diff-id"},
-				timeNow:        func() time.Time { return fixedTime },
+				client:          fetcher,
+				workflowFactory: func() StateCompareWorkflow[testDiff] { return workflow },
+				stateAdapter:    adapter,
+				diffSerializer:  serializer,
+				idGenerator:     &mockIDGenerator{stateID: "state-id", diffID: "diff-id"},
+				timeNow:         func() time.Time { return fixedTime },
 			}
 
 			// Run the method under test

--- a/workers/event_producer/pkg/differ/types.go
+++ b/workers/event_producer/pkg/differ/types.go
@@ -49,12 +49,12 @@ type StateCompareWorkflow[D any] interface {
 }
 
 type FeatureDiffer[D any] struct {
-	client         FeatureFetcher
-	stateAdapter   StateAdapter
-	diffSerializer DiffSerializer[D]
-	workflow       StateCompareWorkflow[D]
-	idGenerator    idGenerator
-	timeNow        func() time.Time
+	client          FeatureFetcher
+	stateAdapter    StateAdapter
+	diffSerializer  DiffSerializer[D]
+	workflowFactory func() StateCompareWorkflow[D]
+	idGenerator     idGenerator
+	timeNow         func() time.Time
 }
 
 // StateAdapter defines the contract for loading and serializing the versioned state snapshot.
@@ -88,15 +88,19 @@ type DiffMetadata struct {
 	PreviousStateID string
 }
 
-func NewFeatureDiffer[D any](client FeatureFetcher, workflow StateCompareWorkflow[D], stateAdapter StateAdapter,
-	diffSerializer DiffSerializer[D]) *FeatureDiffer[D] {
+func NewFeatureDiffer[D any](
+	client FeatureFetcher,
+	workflowFactory func() StateCompareWorkflow[D],
+	stateAdapter StateAdapter,
+	diffSerializer DiffSerializer[D],
+) *FeatureDiffer[D] {
 	return &FeatureDiffer[D]{
-		client:         client,
-		workflow:       workflow,
-		stateAdapter:   stateAdapter,
-		diffSerializer: diffSerializer,
-		idGenerator:    &defaultIDGenerator{},
-		timeNow:        time.Now,
+		client:          client,
+		workflowFactory: workflowFactory,
+		stateAdapter:    stateAdapter,
+		diffSerializer:  diffSerializer,
+		idGenerator:     &defaultIDGenerator{},
+		timeNow:         time.Now,
 	}
 }
 

--- a/workers/event_producer/pkg/producer/diff.go
+++ b/workers/event_producer/pkg/producer/diff.go
@@ -181,9 +181,12 @@ func NewDiffer(client FeatureFetcher) *differ.FeatureDiffer[featurelistdiffv1.Fe
 	stateAdapter := newGenericStateAdapter(v1MigrationFunc, convertV1SnapshotToComparable, v1StateSerializerFunc)
 
 	diffSerializer := NewV1DiffSerializer()
-	workflow := featurelistdiffv1.NewFeatureDiffWorkflow(client, &workertypes.FeatureDiffV1SummaryGenerator{})
 
-	return differ.NewFeatureDiffer[featurelistdiffv1.FeatureDiff](client, workflow, stateAdapter, diffSerializer)
+	workflowFactory := func() differ.StateCompareWorkflow[featurelistdiffv1.FeatureDiff] {
+		return featurelistdiffv1.NewFeatureDiffWorkflow(client, &workertypes.FeatureDiffV1SummaryGenerator{})
+	}
+
+	return differ.NewFeatureDiffer[featurelistdiffv1.FeatureDiff](client, workflowFactory, stateAdapter, diffSerializer)
 }
 
 // convertV1FeatureToComparable maps a V1 feature struct to the canonical comparables.Feature.


### PR DESCRIPTION
The FeatureDiffer's `Run` method is executed concurrently by a Pub/Sub subscription. The differ held a singleton instance of a stateful StateCompareWorkflow, leading to a data race as multiple goroutines could modify the same workflow object simultaneously.

This change introduces a `workflowFactory` function. A new, isolated StateCompareWorkflow instance is now created for each invocation of `Run`, ensuring that each concurrent execution has its own state and eliminating the data race.