### PR TITLE
Display human-readable feature names on subscriptions page

### DIFF
--- a/backend/pkg/httpserver/create_subscription_test.go
+++ b/backend/pkg/httpserver/create_subscription_test.go
@@ -55,9 +55,12 @@ func TestCreateSubscription(t *testing.T) {
 					Frequency: "immediate",
 				},
 				output: &backend.SubscriptionResponse{
-					Id:            "sub-id",
-					ChannelId:     "channel-id",
-					SavedSearchId: "search-id",
+					Id: "sub-id",
+					Subscribable: backend.SavedSearchInfo{
+						Id:   "search-id",
+						Name: "Feature name",
+					},
+					ChannelId: "channel-id",
 					Triggers: []backend.SubscriptionTriggerResponseItem{
 						{
 							Value: backendtypes.AttemptToStoreSubscriptionTrigger(
@@ -85,8 +88,8 @@ func TestCreateSubscription(t *testing.T) {
 			),
 			expectedResponse: testJSONResponse(http.StatusCreated, `{
 				"id":"sub-id",
+				"subscribable": {"id":"search-id", "name":"Feature name"},
 				"channel_id":"channel-id",
-				"saved_search_id":"search-id",
 				"triggers": [{"value":"feature_browser_implementation_any_complete"}],
 				"frequency":"immediate",
 				"created_at":"`+now.Format(time.RFC3339Nano)+`",

--- a/backend/pkg/httpserver/get_subscription_test.go
+++ b/backend/pkg/httpserver/get_subscription_test.go
@@ -46,9 +46,9 @@ func TestGetSubscription(t *testing.T) {
 				expectedUserID:         "test-user",
 				expectedSubscriptionID: "sub-id",
 				output: &backend.SubscriptionResponse{
-					Id:            "sub-id",
-					ChannelId:     "channel-id",
-					SavedSearchId: "search-id",
+					Id:           "sub-id",
+					ChannelId:    "channel-id",
+					Subscribable: backend.SavedSearchInfo{Id: "search-id", Name: "Feature name"},
 					Triggers: []backend.SubscriptionTriggerResponseItem{
 						{
 							Value:    backendtypes.AttemptToStoreSubscriptionTrigger("trigger"),
@@ -71,7 +71,7 @@ func TestGetSubscription(t *testing.T) {
 			expectedResponse: testJSONResponse(http.StatusOK,
 				`{
 					"id":"sub-id","channel_id":"channel-id",
-					"saved_search_id":"search-id",
+					"subscribable":{"id":"search-id","name":"Feature name"},
 					"triggers":[{"value":"trigger"}],
 					"frequency":"daily",
 					"created_at":"`+now.Format(time.RFC3339Nano)+`",

--- a/backend/pkg/httpserver/list_subscriptions_test.go
+++ b/backend/pkg/httpserver/list_subscriptions_test.go
@@ -48,9 +48,9 @@ func TestListSubscriptions(t *testing.T) {
 				output: &backend.SubscriptionPage{
 					Data: &[]backend.SubscriptionResponse{
 						{
-							Id:            "sub-id",
-							ChannelId:     "channel-id",
-							SavedSearchId: "search-id",
+							Id:           "sub-id",
+							ChannelId:    "channel-id",
+							Subscribable: backend.SavedSearchInfo{Id: "search-id", Name: "Feature name"},
 							Triggers: []backend.SubscriptionTriggerResponseItem{
 								{
 									Value:    backendtypes.AttemptToStoreSubscriptionTrigger("trigger"),
@@ -80,7 +80,7 @@ func TestListSubscriptions(t *testing.T) {
 						{
 							"id":"sub-id",
 							"channel_id":"channel-id",
-							"saved_search_id":"search-id",
+							"subscribable":{"id":"search-id","name":"Feature name"},
 							"triggers":[{"value":"trigger"}],
 							"frequency":"daily",
 							"created_at":"`+now.Format(time.RFC3339Nano)+`",
@@ -122,9 +122,9 @@ func TestListSubscriptions(t *testing.T) {
 				output: &backend.SubscriptionPage{
 					Data: &[]backend.SubscriptionResponse{
 						{
-							Id:            "sub-id-2",
-							ChannelId:     "channel-id-2",
-							SavedSearchId: "search-id-2",
+							Id:           "sub-id-2",
+							ChannelId:    "channel-id-2",
+							Subscribable: backend.SavedSearchInfo{Id: "search-id-2", Name: "Feature name 2"},
 							Triggers: []backend.SubscriptionTriggerResponseItem{
 								{
 									Value:    backendtypes.AttemptToStoreSubscriptionTrigger("trigger-2"),
@@ -153,7 +153,7 @@ func TestListSubscriptions(t *testing.T) {
 						{
 							"id":"sub-id-2",
 							"channel_id":"channel-id-2",
-							"saved_search_id":"search-id-2",
+							"subscribable":{"id":"search-id-2","name":"Feature name 2"},
 							"triggers":[{"value":"trigger-2"}],
 							"frequency":"weekly",
 							"created_at":"`+now.Format(time.RFC3339Nano)+`",

--- a/backend/pkg/httpserver/update_subscription_test.go
+++ b/backend/pkg/httpserver/update_subscription_test.go
@@ -56,9 +56,9 @@ func TestUpdateSubscription(t *testing.T) {
 					Frequency: nil,
 				},
 				output: &backend.SubscriptionResponse{
-					Id:            "sub-id",
-					ChannelId:     "channel-id",
-					SavedSearchId: "search-id",
+					Id:           "sub-id",
+					ChannelId:    "channel-id",
+					Subscribable: backend.SavedSearchInfo{Id: "search-id", Name: "Feature name"},
 					Triggers: []backend.SubscriptionTriggerResponseItem{
 						{
 							Value: backendtypes.AttemptToStoreSubscriptionTrigger(
@@ -86,7 +86,7 @@ func TestUpdateSubscription(t *testing.T) {
 				`{
 					"id":"sub-id",
 					"channel_id":"channel-id",
-					"saved_search_id":"search-id",
+					"subscribable":{"id":"search-id","name":"Feature name"},
 					"triggers": [{"value":"feature_browser_implementation_any_complete"}],
 					"frequency":"daily",
 					"created_at":"`+now.Format(time.RFC3339Nano)+`",

--- a/frontend/src/static/js/components/test/webstatus-manage-subscriptions-dialog.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-manage-subscriptions-dialog.test.ts
@@ -69,7 +69,7 @@ describe('webstatus-manage-subscriptions-dialog', () => {
 
   const mockInitialSubscription: backend['schemas']['SubscriptionResponse'] = {
     id: 'initial-sub-id',
-    saved_search_id: 'test-search-id',
+    subscribable: {id: 'test-search-id', name: 'Test Search'},
     channel_id: 'test-channel-id',
     frequency: 'weekly',
     triggers: [{value: 'feature_baseline_to_newly'}],
@@ -79,7 +79,7 @@ describe('webstatus-manage-subscriptions-dialog', () => {
 
   const mockOtherSubscription: backend['schemas']['SubscriptionResponse'] = {
     id: 'other-sub-id',
-    saved_search_id: 'test-search-id',
+    subscribable: {id: 'test-search-id', name: 'Test Search'},
     channel_id: 'other-channel-id',
     frequency: 'monthly',
     triggers: [{value: 'feature_baseline_to_widely'}],

--- a/frontend/src/static/js/components/test/webstatus-subscriptions-page.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-subscriptions-page.test.ts
@@ -42,7 +42,7 @@ describe('webstatus-subscriptions-page', () => {
   const mockSubscriptions: components['schemas']['SubscriptionResponse'][] = [
     {
       id: 'sub1',
-      saved_search_id: 'search1',
+      subscribable: {id: 'search1', name: 'Search 1'},
       channel_id: 'channel1',
       frequency: 'weekly',
       triggers: [],
@@ -51,17 +51,6 @@ describe('webstatus-subscriptions-page', () => {
     },
   ];
 
-  const mockSavedSearches: components['schemas']['SavedSearchResponse'][] = [
-    {
-      id: 'search1',
-      name: 'Test Search 1',
-      query: 'is:test',
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-      permissions: {role: 'saved_search_owner'},
-      bookmark_status: {status: 'bookmark_none'},
-    },
-  ];
   const mockNotificationChannels: components['schemas']['NotificationChannelResponse'][] =
     [
       {
@@ -79,7 +68,6 @@ describe('webstatus-subscriptions-page', () => {
     sandbox = sinon.createSandbox();
     apiClient = {
       listSubscriptions: sandbox.stub().resolves(mockSubscriptions),
-      getAllUserSavedSearches: sandbox.stub().resolves(mockSavedSearches),
       listNotificationChannels: sandbox
         .stub()
         .resolves(mockNotificationChannels),
@@ -125,11 +113,8 @@ describe('webstatus-subscriptions-page', () => {
     await element.updateComplete;
 
     expect(apiClient.listSubscriptions).to.have.been.calledWith('test-token');
-    expect(apiClient.getAllUserSavedSearches).to.have.been.calledWith(
-      'test-token',
-    );
     const renderedText = element.shadowRoot?.textContent;
-    expect(renderedText).to.include('Test Search 1');
+    expect(renderedText).to.include('Search 1');
     expect(renderedText).to.include('test@example.com');
     expect(renderedText).to.include('Weekly'); // Check for title-cased
   });

--- a/frontend/src/static/js/components/webstatus-manage-subscriptions-dialog.ts
+++ b/frontend/src/static/js/components/webstatus-manage-subscriptions-dialog.ts
@@ -354,7 +354,7 @@ export class ManageSubscriptionsDialog extends LitElement {
           promises.push(
             apiClient.listSubscriptions(token).then(r => {
               this._subscriptionsForSavedSearch =
-                r.filter(s => s.saved_search_id === savedSearchId) || [];
+                r.filter(s => s.subscribable.id === savedSearchId) || [];
             }),
           );
         }

--- a/lib/gcpspanner/saved_search_subscription.go
+++ b/lib/gcpspanner/saved_search_subscription.go
@@ -38,6 +38,12 @@ type SavedSearchSubscription struct {
 	UpdatedAt     time.Time               `spanner:"UpdatedAt"`
 }
 
+// SavedSearchSubscriptionView represents the joined result for display.
+type SavedSearchSubscriptionView struct {
+	SavedSearchSubscription
+	SavedSearchName string `spanner:"SavedSearchName"`
+}
+
 type SubscriptionTrigger string
 
 const (
@@ -96,6 +102,7 @@ func (m baseSavedSearchSubscriptionMapper) Table() string {
 }
 
 // savedSearchSubscriptionMapper implements the necessary interfaces for the generic helpers.
+// This mapper is intended for write operations on the base table.
 type savedSearchSubscriptionMapper struct {
 	baseSavedSearchSubscriptionMapper
 }
@@ -165,8 +172,59 @@ type savedSearchSubscriptionCursor struct {
 	LastUpdatedAt time.Time `json:"last_updated_at"`
 }
 
-// EncodePageToken returns the ID of the subscription as a page token.
-func (m savedSearchSubscriptionMapper) EncodePageToken(item SavedSearchSubscription) string {
+// savedSearchSubscriptionViewMapper implements the necessary interfaces for the generic helpers
+// to read the joined view of subscriptions.
+type savedSearchSubscriptionViewMapper struct {
+	baseSavedSearchSubscriptionMapper
+}
+
+func (m savedSearchSubscriptionViewMapper) SelectOne(key string) spanner.Statement {
+	stmt := spanner.NewStatement(`
+	SELECT
+		sc.ID, sc.ChannelID, sc.SavedSearchID, ss.Name AS SavedSearchName,
+		sc.Triggers, sc.Frequency, sc.CreatedAt, sc.UpdatedAt
+	FROM SavedSearchSubscriptions sc
+	JOIN SavedSearches ss ON sc.SavedSearchID = ss.ID
+	WHERE sc.ID = @id
+	LIMIT 1`)
+	parameters := map[string]interface{}{
+		"id": key,
+	}
+	stmt.Params = parameters
+
+	return stmt
+}
+
+func (m savedSearchSubscriptionViewMapper) SelectList(req ListSavedSearchSubscriptionsRequest) spanner.Statement {
+	var pageFilter string
+	params := map[string]interface{}{
+		"userID":   req.UserID,
+		"pageSize": req.PageSize,
+	}
+	if req.PageToken != nil {
+		cursor, err := decodeCursor[savedSearchSubscriptionCursor](*req.PageToken)
+		if err == nil {
+			params["lastID"] = cursor.LastID
+			params["lastUpdatedAt"] = cursor.LastUpdatedAt
+			pageFilter = " AND (sc.UpdatedAt < @lastUpdatedAt OR (sc.UpdatedAt = @lastUpdatedAt AND sc.ID > @lastID))"
+		}
+	}
+	query := fmt.Sprintf(`SELECT
+		sc.ID, sc.ChannelID, sc.SavedSearchID, ss.Name AS SavedSearchName,
+		sc.Triggers, sc.Frequency, sc.CreatedAt, sc.UpdatedAt
+	FROM SavedSearchSubscriptions sc
+	JOIN NotificationChannels nc ON sc.ChannelID = nc.ID
+	JOIN SavedSearches ss ON sc.SavedSearchID = ss.ID
+	WHERE nc.UserID = @userID %s
+	ORDER BY sc.UpdatedAt DESC, sc.ID ASC LIMIT @pageSize`, pageFilter)
+
+	stmt := spanner.NewStatement(query)
+	stmt.Params = params
+
+	return stmt
+}
+
+func (m savedSearchSubscriptionViewMapper) EncodePageToken(item SavedSearchSubscriptionView) string {
 	return encodeCursor(savedSearchSubscriptionCursor{
 		LastID:        item.ID,
 		LastUpdatedAt: item.UpdatedAt,
@@ -187,8 +245,8 @@ func (m savedSearchSubscriptionMapper) NewEntity(
 	}, nil
 }
 
-func (c *Client) checkNotificationChannelOwnershipBySubscriptionID(
-	ctx context.Context, subscriptionID string, userID string, txn *spanner.ReadWriteTransaction,
+func (c *Client) checkNotificationChannelOwnershipBySubscriptionIDReadOnly(
+	ctx context.Context, subscriptionID string, userID string, txn transaction,
 ) error {
 	stmt := spanner.Statement{
 		// Join the SavedSearchSubscriptions and NotificationChannels tables to verify ownership.
@@ -219,6 +277,12 @@ func (c *Client) checkNotificationChannelOwnershipBySubscriptionID(
 	}
 
 	return nil
+}
+
+func (c *Client) checkNotificationChannelOwnershipBySubscriptionID(
+	ctx context.Context, subscriptionID string, userID string, txn *spanner.ReadWriteTransaction,
+) error {
+	return c.checkNotificationChannelOwnershipBySubscriptionIDReadOnly(ctx, subscriptionID, userID, txn)
 }
 
 // CreateSavedSearchSubscription creates a new saved search subscription.
@@ -289,15 +353,15 @@ func (c *Client) createSavedSearchSubscription(
 
 // GetSavedSearchSubscription retrieves a subscription if it belongs to the specified user.
 func (c *Client) GetSavedSearchSubscription(
-	ctx context.Context, subscriptionID string, userID string) (*SavedSearchSubscription, error) {
-	var ret *SavedSearchSubscription
+	ctx context.Context, subscriptionID string, userID string) (*SavedSearchSubscriptionView, error) {
+	var ret *SavedSearchSubscriptionView
 	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 		err := c.checkNotificationChannelOwnershipBySubscriptionID(ctx, subscriptionID, userID, txn)
 		if err != nil {
 			return err
 		}
-		sub, err := newEntityReader[savedSearchSubscriptionMapper,
-			SavedSearchSubscription, string](c).readRowByKeyWithTransaction(ctx, subscriptionID, txn)
+		sub, err := newEntityReader[savedSearchSubscriptionViewMapper,
+			SavedSearchSubscriptionView, string](c).readRowByKeyWithTransaction(ctx, subscriptionID, txn)
 		if err != nil {
 			return err
 		}
@@ -359,8 +423,8 @@ func (c *Client) DeleteSavedSearchSubscription(
 
 // ListSavedSearchSubscriptions retrieves a list of subscriptions for a user with pagination.
 func (c *Client) ListSavedSearchSubscriptions(
-	ctx context.Context, req ListSavedSearchSubscriptionsRequest) ([]SavedSearchSubscription, *string, error) {
-	return newEntityLister[savedSearchSubscriptionMapper](c).list(ctx, req)
+	ctx context.Context, req ListSavedSearchSubscriptionsRequest) ([]SavedSearchSubscriptionView, *string, error) {
+	return newEntityLister[savedSearchSubscriptionViewMapper](c).list(ctx, req)
 }
 
 type spannerSubscriberDestination struct {

--- a/lib/gcpspanner/saved_search_subscription_test.go
+++ b/lib/gcpspanner/saved_search_subscription_test.go
@@ -73,25 +73,32 @@ func TestCreateAndGetSavedSearchSubscription(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSavedSearchSubscription failed: %v", err)
 	}
-	expected := &SavedSearchSubscription{
-		ID:            subID,
-		ChannelID:     createReq.ChannelID,
-		SavedSearchID: createReq.SavedSearchID,
-		Triggers:      createReq.Triggers,
-		Frequency:     createReq.Frequency,
-		CreatedAt:     time.Time{},
-		UpdatedAt:     time.Time{},
-	}
-	if diff := cmp.Diff(expected, retrieved,
-		cmpopts.IgnoreFields(SavedSearchSubscription{
-			ID:            "",
-			ChannelID:     "",
-			SavedSearchID: "",
-			Triggers:      nil,
-			Frequency:     "",
+	expected := &SavedSearchSubscriptionView{
+		SavedSearchSubscription: SavedSearchSubscription{
+			ID:            subID,
+			ChannelID:     createReq.ChannelID,
+			SavedSearchID: createReq.SavedSearchID,
+			Triggers:      createReq.Triggers,
+			Frequency:     createReq.Frequency,
 			CreatedAt:     time.Time{},
 			UpdatedAt:     time.Time{},
-		}, "CreatedAt", "UpdatedAt")); diff != "" {
+		},
+		SavedSearchName: "Test Search",
+	}
+	if diff := cmp.Diff(expected, retrieved,
+		cmpopts.IgnoreFields(SavedSearchSubscriptionView{
+			SavedSearchSubscription: SavedSearchSubscription{
+				ID:            "",
+				ChannelID:     "",
+				SavedSearchID: "",
+				Triggers:      nil,
+				Frequency:     "",
+				CreatedAt:     time.Time{},
+				UpdatedAt:     time.Time{},
+			},
+			SavedSearchName: "",
+		},
+			"SavedSearchSubscription.CreatedAt", "SavedSearchSubscription.UpdatedAt")); diff != "" {
 		t.Errorf("GetSavedSearchSubscription mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -208,6 +215,9 @@ func TestUpdateSavedSearchSubscription(t *testing.T) {
 	}
 	if retrieved.Frequency != SavedSearchSnapshotTypeWeekly {
 		t.Errorf("expected updated frequency, got %s", retrieved.Frequency)
+	}
+	if retrieved.SavedSearchName != "Test Search" {
+		t.Errorf("expected SavedSearchName to be 'Test Search', got '%s'", retrieved.SavedSearchName)
 	}
 	expectedTriggers := []SubscriptionTrigger{SubscriptionTriggerBrowserImplementationAnyComplete}
 	if diff := cmp.Diff(expectedTriggers, retrieved.Triggers); diff != "" {
@@ -328,6 +338,11 @@ func TestListSavedSearchSubscriptions(t *testing.T) {
 	}
 	if len(results1) != 2 {
 		t.Errorf("expected 2 results on page 1, got %d", len(results1))
+	}
+	for _, sub := range results1 {
+		if sub.SavedSearchName != "Test Search" {
+			t.Errorf("expected SavedSearchName to be 'Test Search', got '%s'", sub.SavedSearchName)
+		}
 	}
 	if nextPageToken1 == nil {
 		t.Fatal("expected a next page token on page 1, got nil")

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -144,11 +144,11 @@ type BackendSpannerClient interface {
 	CreateSavedSearchSubscription(
 		ctx context.Context, req gcpspanner.CreateSavedSearchSubscriptionRequest) (*string, error)
 	GetSavedSearchSubscription(ctx context.Context, subscriptionID string, userID string) (
-		*gcpspanner.SavedSearchSubscription, error)
+		*gcpspanner.SavedSearchSubscriptionView, error)
 	UpdateSavedSearchSubscription(ctx context.Context, req gcpspanner.UpdateSavedSearchSubscriptionRequest) error
 	DeleteSavedSearchSubscription(ctx context.Context, subscriptionID string, userID string) error
 	ListSavedSearchSubscriptions(ctx context.Context, req gcpspanner.ListSavedSearchSubscriptionsRequest) (
-		[]gcpspanner.SavedSearchSubscription, *string, error)
+		[]gcpspanner.SavedSearchSubscriptionView, *string, error)
 	GetNotificationChannel(
 		ctx context.Context, channelID string, userID string) (*gcpspanner.NotificationChannel, error)
 	ListNotificationChannels(ctx context.Context, req gcpspanner.ListNotificationChannelsRequest) (
@@ -1593,18 +1593,21 @@ func (s *Backend) DeleteSavedSearchSubscription(ctx context.Context, userID, sub
 	return nil
 }
 
-func toBackendSubscription(sub *gcpspanner.SavedSearchSubscription) *backend.SubscriptionResponse {
+func toBackendSubscription(sub *gcpspanner.SavedSearchSubscriptionView) *backend.SubscriptionResponse {
 	if sub == nil {
 		return nil
 	}
 
 	return &backend.SubscriptionResponse{
-		Id:            sub.ID,
-		ChannelId:     sub.ChannelID,
-		SavedSearchId: sub.SavedSearchID,
-		Triggers:      spannerTriggersToBackendTriggers(sub.Triggers),
-		Frequency:     toBackendSubscriptionFrequency(sub.Frequency),
-		CreatedAt:     sub.CreatedAt,
-		UpdatedAt:     sub.UpdatedAt,
+		Id: sub.ID,
+		Subscribable: backend.SavedSearchInfo{
+			Id:   sub.SavedSearchID,
+			Name: sub.SavedSearchName,
+		},
+		ChannelId: sub.ChannelID,
+		Triggers:  spannerTriggersToBackendTriggers(sub.Triggers),
+		Frequency: toBackendSubscriptionFrequency(sub.Frequency),
+		CreatedAt: sub.CreatedAt,
+		UpdatedAt: sub.UpdatedAt,
 	}
 }

--- a/lib/gcpspanner/system_managed_saved_searches.go
+++ b/lib/gcpspanner/system_managed_saved_searches.go
@@ -284,7 +284,7 @@ func (c *Client) reconcileSystemManagedSavedSearch(
 		return nil, err
 	}
 
-	expectedName := systemSavedSearchName(f.FeatureKey)
+	expectedName := systemSavedSearchName(f.Name)
 	expectedQuery := systemSavedSearchQuery(f.FeatureKey)
 	if savedSearch.Name != expectedName || savedSearch.Query != expectedQuery {
 		savedSearch.Name = expectedName

--- a/lib/gcpspanner/system_managed_saved_searches_test.go
+++ b/lib/gcpspanner/system_managed_saved_searches_test.go
@@ -236,8 +236,8 @@ func TestSyncSystemManagedSavedQuery(t *testing.T) {
 	savedSearch2ID := m2.SavedSearchID
 
 	s1, _ := spannerClient.GetSavedSearch(ctx, m1.SavedSearchID)
-	if s1.Name != systemSavedSearchName("f1") {
-		t.Errorf("expected name %s, got %s", systemSavedSearchName("f1"), s1.Name)
+	if s1.Name != systemSavedSearchName("Feature 1") {
+		t.Errorf("expected name %s, got %s", systemSavedSearchName("Feature 1"), s1.Name)
 	}
 
 	// 3. Update a feature key. Sync should update the saved search.
@@ -264,8 +264,8 @@ func TestSyncSystemManagedSavedQuery(t *testing.T) {
 	}
 
 	s1updated, _ := spannerClient.GetSavedSearch(ctx, m1.SavedSearchID)
-	if s1updated.Name != systemSavedSearchName("f1-new") {
-		t.Errorf("expected updated name %s, got %s", systemSavedSearchName("f1-new"), s1updated.Name)
+	if s1updated.Name != systemSavedSearchName("Feature 1 New") {
+		t.Errorf("expected updated name %s, got %s", systemSavedSearchName("Feature 1 New"), s1updated.Name)
 	}
 	if s1updated.Query != systemSavedSearchQuery("f1-new") {
 		t.Errorf("expected updated query %s, got %s", systemSavedSearchQuery("f1-new"), s1updated.Query)

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -1854,42 +1854,46 @@ components:
             is 'unknown', allowing clients to identify and manage deprecated triggers.
       required:
         - value
-    SubscriptionBase:
+    Subscription:
       type: object
-      description: Base properties common to both subscription requests and responses.
       properties:
         saved_search_id:
           type: string
         channel_id:
           type: string
+        frequency:
+          $ref: '#/components/schemas/SubscriptionFrequency'
+        triggers:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubscriptionTriggerWritable'
       required:
         - saved_search_id
         - channel_id
-    Subscription:
-      allOf:
-        - $ref: '#/components/schemas/SubscriptionBase'
-        - type: object
-          properties:
-            frequency:
-              $ref: '#/components/schemas/SubscriptionFrequency'
-            triggers:
-              type: array
-              items:
-                $ref: '#/components/schemas/SubscriptionTriggerWritable'
-          required:
-            - frequency
-            - triggers
-      required:
-        - saved_search_id
-        - channel_id
-        - triggers
         - frequency
+        - triggers
+    SavedSearchInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+      required:
+        - id
+        - name
+
     SubscriptionResponse:
       allOf:
         - $ref: '#/components/schemas/GenericUpdatableUniqueModel'
-        - $ref: '#/components/schemas/SubscriptionBase'
         - type: object
           properties:
+            # We're calling this 'subscribable' to be generic for the future,
+            # even though it will only contain SavedSearchInfo for now.
+            subscribable:
+              $ref: '#/components/schemas/SavedSearchInfo'
+            channel_id:
+              type: string
             frequency:
               $ref: '#/components/schemas/SubscriptionFrequency'
             triggers:
@@ -1899,6 +1903,8 @@ components:
           required:
             - triggers
             - frequency
+            - subscribable
+            - channel_id
     SubscriptionPage:
       type: object
       properties:


### PR DESCRIPTION
This is done by fetching the feature name via the GetFeature API. Until the GetFeature API returns, the saved search name is displayed.