### PR TITLE
fix: Update logic to convert feature key to chromium enum

### DIFF
--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher.go
@@ -21,7 +21,7 @@ import (
 )
 
 func NewChromiumCodesearchEnumFetcher(httpClient *http.Client) (*ChromiumCodesearchEnumFetcher, error) {
-	fetcher, err := httputils.NewHTTPFetcher(enumURL, httpClient)
+	fetcher, err := httputils.NewHTTPFetcher(EnumURL, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -38,5 +38,5 @@ type ChromiumCodesearchEnumFetcher struct {
 	*httputils.HTTPFetcher
 }
 
-const enumURL = "https://chromium.googlesource.com/chromium/src/+/main/tools/metrics/histograms/metadata/blink/" +
+const EnumURL = "https://chromium.googlesource.com/chromium/src/+/main/tools/metrics/histograms/metadata/blink/" +
 	"enums.xml?format=TEXT"


### PR DESCRIPTION
This is due to https://crrev.com/c/7595793

Add a temporary unit test that can be enabled whenever we want to test things in the future. It is not enabled by default to prevent blocking of regular PRs in the event one of these sources (git tiles or github) are down / blocking us.