### PR TITLE
feat: implement spanner and pubsub adapters for webhook execution

### DIFF
--- a/lib/gcppubsub/gcppubsubadapters/push_delivery.go
+++ b/lib/gcppubsub/gcppubsubadapters/push_delivery.go
@@ -20,37 +20,40 @@ import (
 	"log/slog"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/event"
-	v1 "github.com/GoogleChrome/webstatus.dev/lib/event/emailjob/v1"
+	emailjobv1 "github.com/GoogleChrome/webstatus.dev/lib/event/emailjob/v1"
 	featurediffv1 "github.com/GoogleChrome/webstatus.dev/lib/event/featurediff/v1"
+	webhookjobv1 "github.com/GoogleChrome/webstatus.dev/lib/event/webhookjob/v1"
 	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
 )
 
 type PushDeliveryPublisher struct {
-	client     EventPublisher
-	emailTopic string
+	client       EventPublisher
+	emailTopic   string
+	webhookTopic string
 }
 
-func NewPushDeliveryPublisher(client EventPublisher, emailTopic string) *PushDeliveryPublisher {
+func NewPushDeliveryPublisher(client EventPublisher, emailTopic, webhookTopic string) *PushDeliveryPublisher {
 	return &PushDeliveryPublisher{
-		client:     client,
-		emailTopic: emailTopic,
+		client:       client,
+		emailTopic:   emailTopic,
+		webhookTopic: webhookTopic,
 	}
 }
 
 func (p *PushDeliveryPublisher) PublishEmailJob(ctx context.Context, job workertypes.EmailDeliveryJob) error {
-	b, err := event.New(v1.EmailJobEvent{
+	b, err := event.New(emailjobv1.EmailJobEvent{
 		SubscriptionID: job.SubscriptionID,
 		RecipientEmail: job.RecipientEmail,
 		SummaryRaw:     job.SummaryRaw,
-		Metadata: v1.EmailJobEventMetadata{
+		Metadata: emailjobv1.EmailJobEventMetadata{
 			EventID:     job.Metadata.EventID,
 			SearchID:    job.Metadata.SearchID,
 			SearchName:  job.Metadata.SearchName,
 			Query:       job.Metadata.Query,
-			Frequency:   v1.ToJobFrequency(job.Metadata.Frequency),
+			Frequency:   emailjobv1.ToJobFrequency(job.Metadata.Frequency),
 			GeneratedAt: job.Metadata.GeneratedAt,
 		},
-		Triggers:  v1.ToJobTriggers(job.Triggers),
+		Triggers:  emailjobv1.ToJobTriggers(job.Triggers),
 		ChannelID: job.ChannelID,
 	})
 	if err != nil {
@@ -62,6 +65,35 @@ func (p *PushDeliveryPublisher) PublishEmailJob(ctx context.Context, job workert
 		return fmt.Errorf("failed to publish email job: %w", err)
 	}
 	slog.InfoContext(ctx, "published email job", "id", id, "eventID", job.Metadata.EventID)
+
+	return nil
+}
+
+func (p *PushDeliveryPublisher) PublishWebhookJob(ctx context.Context, job workertypes.WebhookDeliveryJob) error {
+	b, err := event.New(webhookjobv1.WebhookJobEvent{
+		SubscriptionID: job.SubscriptionID,
+		WebhookType:    webhookjobv1.ToWebhookType(job.WebhookType),
+		WebhookURL:     job.WebhookURL,
+		SummaryRaw:     job.SummaryRaw,
+		Metadata: webhookjobv1.WebhookJobEventMetadata{
+			EventID:     job.Metadata.EventID,
+			SearchID:    job.Metadata.SearchID,
+			Query:       job.Metadata.Query,
+			Frequency:   webhookjobv1.ToJobFrequency(job.Metadata.Frequency),
+			GeneratedAt: job.Metadata.GeneratedAt,
+		},
+		Triggers:  webhookjobv1.ToJobTriggers(job.Triggers),
+		ChannelID: job.ChannelID,
+	})
+	if err != nil {
+		return err
+	}
+
+	id, err := p.client.Publish(ctx, p.webhookTopic, b)
+	if err != nil {
+		return fmt.Errorf("failed to publish webhook job: %w", err)
+	}
+	slog.InfoContext(ctx, "published webhook job", "id", id, "eventID", job.Metadata.EventID)
 
 	return nil
 }

--- a/lib/gcppubsub/gcppubsubadapters/push_delivery_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/push_delivery_test.go
@@ -96,36 +96,119 @@ func (m *mockPushDeliverySubscriber) Subscribe(ctx context.Context, subID string
 
 // --- Tests ---
 
-func TestPushDeliveryPublisher_PublishEmailJob(t *testing.T) {
-	mockPub := new(mockPushDeliveryPublisher)
-	publisher := NewPushDeliveryPublisher(mockPub, "email-topic")
+func TestPushDeliveryPublisher_PublishJobs(t *testing.T) {
+	now := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	summaryRaw := []byte(`{"text": "Test Body"}`)
+	encodedSummary := base64.StdEncoding.EncodeToString(summaryRaw)
 
-	job := workertypes.EmailDeliveryJob{
-		SubscriptionID: "sub-1",
-		RecipientEmail: "test@example.com",
-		SummaryRaw:     []byte(`{"text": "Test Body"}`),
-		Metadata: workertypes.DeliveryMetadata{
-			EventID:     "event-1",
-			SearchID:    "search-1",
-			SearchName:  "",
-			Query:       "query-string",
-			Frequency:   workertypes.FrequencyMonthly,
-			GeneratedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
+	metadata := workertypes.DeliveryMetadata{
+		EventID:     "event-1",
+		SearchID:    "search-1",
+		SearchName:  "",
+		Query:       "query-string",
+		Frequency:   workertypes.FrequencyMonthly,
+		GeneratedAt: now,
+	}
+
+	triggers := []workertypes.JobTrigger{
+		workertypes.FeaturePromotedToNewly,
+		workertypes.FeaturePromotedToWidely,
+	}
+
+	testCases := []struct {
+		name          string
+		publishFunc   func(p *PushDeliveryPublisher) error
+		expectedTopic string
+		expectedKind  string
+		expectedData  map[string]any
+	}{
+		{
+			name: "Email Job",
+			publishFunc: func(p *PushDeliveryPublisher) error {
+				return p.PublishEmailJob(context.Background(), workertypes.EmailDeliveryJob{
+					SubscriptionID: "sub-1",
+					RecipientEmail: "test@example.com",
+					SummaryRaw:     summaryRaw,
+					Metadata:       metadata,
+					ChannelID:      "chan-1",
+					Triggers:       triggers,
+				})
+			},
+			expectedTopic: "email-topic",
+			expectedKind:  "EmailJobEvent",
+			expectedData: map[string]interface{}{
+				"subscription_id": "sub-1",
+				"recipient_email": "test@example.com",
+				"summary_raw":     encodedSummary,
+				"triggers":        []any{"FEATURE_PROMOTED_TO_NEWLY", "FEATURE_PROMOTED_TO_WIDELY"},
+				"metadata": map[string]interface{}{
+					"event_id":     "event-1",
+					"search_id":    "search-1",
+					"search_name":  "",
+					"query":        "query-string",
+					"frequency":    "MONTHLY",
+					"generated_at": "2025-01-01T12:00:00Z",
+				},
+				"channel_id": "chan-1",
+			},
 		},
-		ChannelID: "chan-1",
-		Triggers: []workertypes.JobTrigger{
-			workertypes.FeaturePromotedToNewly,
-			workertypes.FeaturePromotedToWidely,
+		{
+			name: "Webhook Job",
+			publishFunc: func(p *PushDeliveryPublisher) error {
+				return p.PublishWebhookJob(context.Background(), workertypes.WebhookDeliveryJob{
+					SubscriptionID: "sub-1",
+					WebhookURL:     "https://hooks.slack.com/services/123",
+					WebhookType:    workertypes.WebhookTypeSlack,
+					SummaryRaw:     summaryRaw,
+					Metadata:       metadata,
+					ChannelID:      "chan-1",
+					Triggers:       triggers,
+				})
+			},
+			expectedTopic: "webhook-topic",
+			expectedKind:  "WebhookJobEvent",
+			expectedData: map[string]interface{}{
+				"subscription_id": "sub-1",
+				"webhook_type":    "slack",
+				"webhook_url":     "https://hooks.slack.com/services/123",
+				"summary_raw":     encodedSummary,
+				"triggers":        []any{"FEATURE_PROMOTED_TO_NEWLY", "FEATURE_PROMOTED_TO_WIDELY"},
+				"metadata": map[string]interface{}{
+					"event_id":     "event-1",
+					"search_id":    "search-1",
+					"query":        "query-string",
+					"frequency":    "MONTHLY",
+					"generated_at": "2025-01-01T12:00:00Z",
+				},
+				"channel_id": "chan-1",
+			},
 		},
 	}
 
-	err := publisher.PublishEmailJob(context.Background(), job)
-	if err != nil {
-		t.Fatalf("PublishEmailJob failed: %v", err)
-	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockPub := &mockPushDeliveryPublisher{
+				publishedData:  nil,
+				publishedTopic: "",
+				err:            nil,
+				mu:             sync.Mutex{},
+			}
+			publisher := NewPushDeliveryPublisher(mockPub, "email-topic", "webhook-topic")
 
-	if mockPub.publishedTopic != "email-topic" {
-		t.Errorf("Topic mismatch: got %s, want email-topic", mockPub.publishedTopic)
+			if err := tc.publishFunc(publisher); err != nil {
+				t.Fatalf("Publish function failed: %v", err)
+			}
+
+			verifyPublishedJob(t, mockPub, tc.expectedTopic, tc.expectedKind, tc.expectedData)
+		})
+	}
+}
+
+func verifyPublishedJob(t *testing.T, mockPub *mockPushDeliveryPublisher,
+	expectedTopic, expectedKind string, expectedData map[string]any) {
+	t.Helper()
+	if mockPub.publishedTopic != expectedTopic {
+		t.Errorf("Topic mismatch: got %s, want %s", mockPub.publishedTopic, expectedTopic)
 	}
 
 	var actualEnvelope map[string]any
@@ -135,26 +218,12 @@ func TestPushDeliveryPublisher_PublishEmailJob(t *testing.T) {
 
 	expectedEnvelope := map[string]any{
 		"apiVersion": "v1",
-		"kind":       "EmailJobEvent",
-		"data": map[string]any{
-			"subscription_id": "sub-1",
-			"recipient_email": "test@example.com",
-			"summary_raw":     base64.StdEncoding.EncodeToString([]byte(`{"text": "Test Body"}`)),
-			"triggers":        []any{"FEATURE_PROMOTED_TO_NEWLY", "FEATURE_PROMOTED_TO_WIDELY"},
-			"metadata": map[string]any{
-				"event_id":     "event-1",
-				"search_id":    "search-1",
-				"search_name":  "",
-				"query":        "query-string",
-				"frequency":    "MONTHLY",
-				"generated_at": "2025-01-01T12:00:00Z",
-			},
-			"channel_id": "chan-1",
-		},
+		"kind":       expectedKind,
+		"data":       expectedData,
 	}
 
 	if diff := cmp.Diff(expectedEnvelope, actualEnvelope); diff != "" {
-		t.Errorf("Email job mismatch (-want +got):\n%s", diff)
+		t.Errorf("%s job mismatch (-want +got):\n%s", expectedKind, diff)
 	}
 }
 

--- a/lib/gcppubsub/gcppubsubadapters/webhook_worker.go
+++ b/lib/gcppubsub/gcppubsubadapters/webhook_worker.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file is based on lib/gcppubsub/gcppubsubadapters/email_worker.go.
+// TODO: Consider consolidating shared subscriber/router boilerplate into a generic adapter
+// if additional notification types are added.
+
+package gcppubsubadapters
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/event"
+	v1 "github.com/GoogleChrome/webstatus.dev/lib/event/webhookjob/v1"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+// WebhookSender defines the interface for sending webhooks.
+type WebhookSender interface {
+	SendWebhook(ctx context.Context, job workertypes.IncomingWebhookDeliveryJob) error
+}
+
+type WebhookWorkerSubscriberAdapter struct {
+	sender          WebhookSender
+	eventSubscriber EventSubscriber
+	subscriptionID  string
+	router          *event.Router
+}
+
+func NewWebhookWorkerSubscriberAdapter(
+	sender WebhookSender,
+	eventSubscriber EventSubscriber,
+	subscriptionID string,
+) *WebhookWorkerSubscriberAdapter {
+	router := event.NewRouter()
+
+	ret := &WebhookWorkerSubscriberAdapter{
+		sender:          sender,
+		eventSubscriber: eventSubscriber,
+		subscriptionID:  subscriptionID,
+		router:          router,
+	}
+
+	event.Register(router, ret.processWebhookJobEvent)
+
+	return ret
+}
+
+func (a *WebhookWorkerSubscriberAdapter) Subscribe(ctx context.Context) error {
+	return a.eventSubscriber.Subscribe(ctx, a.subscriptionID, func(ctx context.Context,
+		msgID string, data []byte) error {
+		return a.router.HandleMessage(ctx, msgID, data)
+	})
+}
+
+func (a *WebhookWorkerSubscriberAdapter) processWebhookJobEvent(ctx context.Context,
+	eventID string, event v1.WebhookJobEvent) error {
+	slog.InfoContext(ctx, "received webhook job event", "eventID", eventID)
+
+	job := workertypes.IncomingWebhookDeliveryJob{
+		WebhookDeliveryJob: workertypes.WebhookDeliveryJob{
+			SubscriptionID: event.SubscriptionID,
+			WebhookType:    event.WebhookType.ToWorkerTypeWebhookType(),
+			WebhookURL:     event.WebhookURL,
+			ChannelID:      event.ChannelID,
+			Triggers:       event.ToWorkerTypeJobTriggers(),
+			SummaryRaw:     event.SummaryRaw,
+			Metadata: workertypes.DeliveryMetadata{
+				EventID:     event.Metadata.EventID,
+				SearchID:    event.Metadata.SearchID,
+				SearchName:  "",
+				Query:       event.Metadata.Query,
+				Frequency:   event.Metadata.Frequency.ToWorkerTypeJobFrequency(),
+				GeneratedAt: event.Metadata.GeneratedAt,
+			},
+		},
+		WebhookEventID: eventID,
+	}
+
+	return a.sender.SendWebhook(ctx, job)
+}

--- a/lib/gcpspanner/spanneradapters/push_delivery.go
+++ b/lib/gcpspanner/spanneradapters/push_delivery.go
@@ -48,8 +48,8 @@ func (f *PushDeliverySubscriberFinder) FindSubscribers(ctx context.Context, sear
 	}
 
 	set := &workertypes.SubscriberSet{
-		Webhooks: nil,
 		Emails:   make([]workertypes.EmailSubscriber, 0),
+		Webhooks: make([]workertypes.WebhookSubscriber, 0),
 	}
 
 	for _, dest := range dests {
@@ -60,6 +60,17 @@ func (f *PushDeliverySubscriberFinder) FindSubscribers(ctx context.Context, sear
 				UserID:         dest.UserID,
 				Triggers:       convertSpannerTriggersToJobTriggers(dest.Triggers),
 				EmailAddress:   dest.EmailConfig.Address,
+				ChannelID:      dest.ChannelID,
+			})
+		}
+		// If WebhookConfig is set, it's a webhook subscriber.
+		if dest.WebhookConfig != nil {
+			set.Webhooks = append(set.Webhooks, workertypes.WebhookSubscriber{
+				SubscriptionID: dest.SubscriptionID,
+				UserID:         dest.UserID,
+				Triggers:       convertSpannerTriggersToJobTriggers(dest.Triggers),
+				WebhookURL:     dest.WebhookConfig.URL,
+				WebhookType:    workertypes.WebhookTypeSlack,
 				ChannelID:      dest.ChannelID,
 			})
 		}

--- a/lib/gcpspanner/spanneradapters/push_delivery_test.go
+++ b/lib/gcpspanner/spanneradapters/push_delivery_test.go
@@ -86,7 +86,6 @@ func TestFindSubscribers(t *testing.T) {
 				},
 			},
 			expectedSet: &workertypes.SubscriberSet{
-				Webhooks: nil,
 				Emails: []workertypes.EmailSubscriber{
 					{
 						SubscriptionID: "sub-1",
@@ -99,6 +98,7 @@ func TestFindSubscribers(t *testing.T) {
 						ChannelID: "chan-1",
 					},
 				},
+				Webhooks: []workertypes.WebhookSubscriber{},
 			},
 			clientErr:     nil,
 			expectedError: nil,
@@ -137,7 +137,6 @@ func TestFindSubscribers(t *testing.T) {
 				},
 			},
 			expectedSet: &workertypes.SubscriberSet{
-				Webhooks: nil,
 				Emails: []workertypes.EmailSubscriber{
 					{
 						SubscriptionID: "sub-1",
@@ -149,6 +148,7 @@ func TestFindSubscribers(t *testing.T) {
 						ChannelID: "chan-1",
 					},
 				},
+				Webhooks: []workertypes.WebhookSubscriber{},
 			},
 			expectedError: nil,
 		},
@@ -182,8 +182,8 @@ func TestFindSubscribers(t *testing.T) {
 			},
 			clientErr: nil,
 			expectedSet: &workertypes.SubscriberSet{
-				Webhooks: nil,
 				Emails:   []workertypes.EmailSubscriber{},
+				Webhooks: []workertypes.WebhookSubscriber{},
 			},
 			expectedError: nil,
 		},
@@ -212,7 +212,6 @@ func TestFindSubscribers(t *testing.T) {
 			},
 			clientErr: nil,
 			expectedSet: &workertypes.SubscriberSet{
-				Webhooks: nil,
 				Emails: []workertypes.EmailSubscriber{
 					{
 						UserID:         "user-1",
@@ -224,6 +223,7 @@ func TestFindSubscribers(t *testing.T) {
 						ChannelID: "chan-1",
 					},
 				},
+				Webhooks: []workertypes.WebhookSubscriber{},
 			},
 			expectedError: nil,
 		},

--- a/workers/push_delivery/cmd/job/main.go
+++ b/workers/push_delivery/cmd/job/main.go
@@ -65,6 +65,11 @@ func main() {
 		slog.ErrorContext(ctx, "EMAIL_TOPIC_ID is not set. exiting...")
 		os.Exit(1)
 	}
+	webhookTopicID := os.Getenv("WEBHOOK_TOPIC_ID")
+	if webhookTopicID == "" {
+		slog.ErrorContext(ctx, "WEBHOOK_TOPIC_ID is not set. exiting...")
+		os.Exit(1)
+	}
 
 	queueClient, err := gcppubsub.NewClient(ctx, projectID)
 	if err != nil {
@@ -75,7 +80,7 @@ func main() {
 	listener := gcppubsubadapters.NewPushDeliverySubscriberAdapter(
 		dispatcher.NewDispatcher(
 			spanneradapters.NewPushDeliverySubscriberFinder(spannerClient),
-			gcppubsubadapters.NewPushDeliveryPublisher(queueClient, emailTopicID),
+			gcppubsubadapters.NewPushDeliveryPublisher(queueClient, emailTopicID, webhookTopicID),
 		),
 		queueClient,
 		notificationSubID,


### PR DESCRIPTION
- Updated push delivery Spanner adapter to fetch webhook configurations from NotificationChannels.
- Updated PubSub adapters to handle publishing to the new webhook delivery topic.
- Added webhook worker subscriber adapter to read from the webhook jobs topic.