### PR TITLE
fix: add lang="en" attribute to html element

### DIFF
--- a/frontend/src/static/index.html
+++ b/frontend/src/static/index.html
@@ -15,7 +15,7 @@
  limitations under the License.
 -->
 
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link


### PR DESCRIPTION
  ## Summary
This PR adds `lang="en"` to the `<html>` element in `frontend/src/static/index.html`

`frontend/placeholder/static/index.html` (used only as a Docker placeholder target) and `workers/email/pkg/digest/testdata/digest.golden.html` (golden file test data)
  were intentionally left unchanged.

  ## Motivation

  The `lang` attribute is missing from the root HTML element. this is useful for:
  - Accessibility: screen readers use it to select the correct language profile for pronunciation
  - SEO: search engines use it to serve the page to the right audience
  - Browser behavior: automatic translation prompts work correctly when the language is declared