### PR TITLE
Refactor Feature Summary Generation and Add Baseline Reporting

### DIFF
--- a/lib/workertypes/types.go
+++ b/lib/workertypes/types.go
@@ -271,6 +271,56 @@ func (g FeatureDiffV1SummaryGenerator) GenerateJSONSummary(
 	return b, nil
 }
 
+func pluralize(count int, singular, plural string) string {
+	if count == 1 {
+		return fmt.Sprintf("1 %s", singular)
+	}
+
+	return fmt.Sprintf("%d %s", count, plural)
+}
+
+func checkBaseline(change *v1.Change[v1.BaselineState], newlyCount, widelyCount *int) {
+	if change != nil && change.To.Status.IsSet {
+		switch change.To.Status.Value {
+		case v1.Newly:
+			*newlyCount++
+		case v1.Widely:
+			*widelyCount++
+		case v1.Limited:
+			// Do nothing for now.
+		}
+	}
+}
+
+func buildBaselineDetails(newlyCount, widelyCount int) []string {
+	var details []string
+	if newlyCount > 0 {
+		details = append(details, fmt.Sprintf("%d became Baseline newly available", newlyCount))
+	}
+	if widelyCount > 0 {
+		details = append(details, fmt.Sprintf("%d became Baseline widely available", widelyCount))
+	}
+
+	return details
+}
+
+func buildCategoryText(base string, details []string) string {
+	if len(details) > 0 {
+		return fmt.Sprintf("%s (%s)", base, strings.Join(details, ", "))
+	}
+
+	return base
+}
+
+func generateCategoryDetails(modifications []v1.FeatureModified) []string {
+	var newlyCount, widelyCount int
+	for _, m := range modifications {
+		checkBaseline(m.BaselineChange, &newlyCount, &widelyCount)
+	}
+
+	return buildBaselineDetails(newlyCount, widelyCount)
+}
+
 func (g FeatureDiffV1SummaryGenerator) calculateCategoriesAndText(d v1.FeatureDiff) (SummaryCategories, string) {
 	var c SummaryCategories
 	var parts []string
@@ -281,28 +331,49 @@ func (g FeatureDiffV1SummaryGenerator) calculateCategoriesAndText(d v1.FeatureDi
 		c.QueryChanged = 1
 	}
 	if len(d.Added) > 0 {
-		parts = append(parts, fmt.Sprintf("%d features added", len(d.Added)))
+		// NOTE: We do not currently track Baseline status transitions for "Added" features.
+		// Features in the "Added" list simply newly matched the query criteria.
+		// We do not diff them against a zero-state because that would falsely report that they
+		// "became" newly/widely available, when in reality they just entered the search results.
+		// Future iterations could potentially:
+		// 1. Inspect the event "trigger" (e.g., if a Baseline sync job triggered this event)
+		//    to infer intent, though broad triggers may lack determinism.
+		// 2. Pass the previous global state of all features to the differ, enabling us to
+		//    calculate true property transitions even if the feature was outside the old query snapshot.
+		//    However, we do not currently track the global state of all features for now.
+		base := pluralize(len(d.Added), "new feature matched your search", "new features matched your search")
+		parts = append(parts, base)
 		c.Added = len(d.Added)
 	}
 	if len(d.Removed) > 0 {
-		parts = append(parts, fmt.Sprintf("%d features removed", len(d.Removed)))
+		var removedMods []v1.FeatureModified
+		for _, r := range d.Removed {
+			if r.Diff != nil {
+				removedMods = append(removedMods, *r.Diff)
+			}
+		}
+		base := pluralize(len(d.Removed), "feature no longer matched your search",
+			"features no longer matched your search")
+		details := generateCategoryDetails(removedMods)
+		parts = append(parts, buildCategoryText(base, details))
 		c.Removed = len(d.Removed)
 	}
 	if len(d.Deleted) > 0 {
-		parts = append(parts, fmt.Sprintf("%d features deleted", len(d.Deleted)))
+		base := pluralize(len(d.Deleted), "feature deleted", "features deleted")
+		parts = append(parts, base)
 		c.Deleted = len(d.Deleted)
 	}
 	if len(d.Moves) > 0 {
-		parts = append(parts, fmt.Sprintf("%d features moved/renamed", len(d.Moves)))
+		base := pluralize(len(d.Moves), "feature moved/renamed", "features moved/renamed")
+		parts = append(parts, base)
 		c.Moved = len(d.Moves)
 	}
 	if len(d.Splits) > 0 {
-		parts = append(parts, fmt.Sprintf("%d features split", len(d.Splits)))
+		base := pluralize(len(d.Splits), "feature split", "features split")
+		parts = append(parts, base)
 		c.Split = len(d.Splits)
 	}
 	if len(d.Modified) > 0 {
-		parts = append(parts, fmt.Sprintf("%d features updated", len(d.Modified)))
-		c.Updated = len(d.Modified)
 		for _, m := range d.Modified {
 			if len(m.BrowserChanges) > 0 {
 				c.UpdatedImpl++
@@ -314,6 +385,11 @@ func (g FeatureDiffV1SummaryGenerator) calculateCategoriesAndText(d v1.FeatureDi
 				c.UpdatedBaseline++
 			}
 		}
+
+		base := pluralize(len(d.Modified), "feature updated", "features updated")
+		details := generateCategoryDetails(d.Modified)
+		parts = append(parts, buildCategoryText(base, details))
+		c.Updated = len(d.Modified)
 	}
 
 	text := "No changes detected"

--- a/lib/workertypes/types_test.go
+++ b/lib/workertypes/types_test.go
@@ -273,8 +273,9 @@ func TestGenerateJSONSummaryFeatureDiffV1(t *testing.T) {
 
 			expected: `{
     "schemaVersion": "v1",
-    "text": "Search criteria updated, 2 features added, 2 features removed, ` +
-				`1 features deleted, 1 features moved/renamed, 1 features split, 3 features updated",
+    "text": "Search criteria updated, 2 new features matched your search, 2 features no longer matched your search ` +
+				`(1 became Baseline newly available), 1 feature deleted, 1 feature moved/renamed, 1 feature split, ` +
+				`3 features updated (1 became Baseline newly available)",
     "categories": {
         "query_changed": 1,
         "added": 2,
@@ -455,5 +456,139 @@ func compareJSONBodies(t *testing.T, actualBody, expectedBody []byte) {
 
 	if diff := cmp.Diff(expectedObj, actualObj); diff != "" {
 		t.Errorf("JSON mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGenerateCategoryDetails(t *testing.T) {
+	newlyDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	widelyDate := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name          string
+		modifications []v1.FeatureModified
+		expected      []string
+	}{
+		{
+			name:          "Empty list",
+			modifications: []v1.FeatureModified{},
+			// generateCategoryDetails builds a slice, if empty conditions, it returns nil from buildBaselineDetails
+			expected: nil,
+		},
+		{
+			name: "Only Newly",
+			modifications: []v1.FeatureModified{
+				{
+					ID:             "1",
+					Name:           "A",
+					NameChange:     nil,
+					BrowserChanges: nil,
+					Docs:           nil,
+					DocsChange:     nil,
+					BaselineChange: &v1.Change[v1.BaselineState]{
+						From: v1.BaselineState{
+							Status:   generic.UnsetOpt[v1.BaselineInfoStatus](),
+							LowDate:  generic.UnsetOpt[*time.Time](),
+							HighDate: generic.UnsetOpt[*time.Time](),
+						},
+						To: v1.BaselineState{
+							Status:   generic.SetOpt(v1.Newly),
+							LowDate:  generic.SetOpt(&newlyDate),
+							HighDate: generic.UnsetOpt[*time.Time](),
+						},
+					},
+				},
+				{
+					ID:             "2",
+					Name:           "B",
+					NameChange:     nil,
+					BrowserChanges: nil,
+					Docs:           nil,
+					DocsChange:     nil,
+					BaselineChange: &v1.Change[v1.BaselineState]{
+						From: v1.BaselineState{
+							Status:   generic.UnsetOpt[v1.BaselineInfoStatus](),
+							LowDate:  generic.UnsetOpt[*time.Time](),
+							HighDate: generic.UnsetOpt[*time.Time](),
+						},
+						To: v1.BaselineState{
+							Status:   generic.SetOpt(v1.Newly),
+							LowDate:  generic.SetOpt(&newlyDate),
+							HighDate: generic.UnsetOpt[*time.Time](),
+						},
+					},
+				},
+			},
+			expected: []string{"2 became Baseline newly available"},
+		},
+		{
+			name: "Newly and Widely",
+			modifications: []v1.FeatureModified{
+				{
+					ID:             "3",
+					Name:           "C",
+					NameChange:     nil,
+					BrowserChanges: nil,
+					Docs:           nil,
+					DocsChange:     nil,
+					BaselineChange: &v1.Change[v1.BaselineState]{
+						From: v1.BaselineState{
+							Status:   generic.UnsetOpt[v1.BaselineInfoStatus](),
+							LowDate:  generic.UnsetOpt[*time.Time](),
+							HighDate: generic.UnsetOpt[*time.Time](),
+						},
+						To: v1.BaselineState{
+							Status:   generic.SetOpt(v1.Newly),
+							LowDate:  generic.SetOpt(&newlyDate),
+							HighDate: generic.UnsetOpt[*time.Time](),
+						},
+					},
+				},
+				{
+					ID:             "4",
+					Name:           "D",
+					NameChange:     nil,
+					BrowserChanges: nil,
+					Docs:           nil,
+					DocsChange:     nil,
+					BaselineChange: &v1.Change[v1.BaselineState]{
+						From: v1.BaselineState{
+							Status:   generic.UnsetOpt[v1.BaselineInfoStatus](),
+							LowDate:  generic.UnsetOpt[*time.Time](),
+							HighDate: generic.UnsetOpt[*time.Time](),
+						},
+						To: v1.BaselineState{
+							Status:   generic.SetOpt(v1.Widely),
+							LowDate:  generic.SetOpt(&newlyDate),
+							HighDate: generic.SetOpt(&widelyDate),
+						},
+					},
+				},
+			},
+			expected: []string{"1 became Baseline newly available", "1 became Baseline widely available"},
+		},
+		{
+			name: "No baseline changes",
+			modifications: []v1.FeatureModified{
+				{
+					ID:             "5",
+					Name:           "E",
+					NameChange:     &v1.Change[string]{From: "A", To: "B"},
+					BaselineChange: nil,
+					BrowserChanges: nil,
+					Docs:           nil,
+					DocsChange:     nil,
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := generateCategoryDetails(tc.modifications)
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Errorf("generateCategoryDetails() mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR focuses on improving the feature digest summary text generated by the worker. We have refactored the text generation logic to be cleaner and more extensible, and we now explicitly report when features become 'Baseline newly available' or 'Baseline widely available'.

Changes Made
- **[Refactor]: Text Generation Logic** Introduced new helper functions (`buildBaselineDetails`, `buildCategoryText`, `generateCategoryDetails`, `checkBaseline`) at the package level in `lib/workertypes/types.go`. This centralizes the detail string generation, ensuring future details like browser support can be tracked in one place and applied universally.
- **[Feature]: Baseline Counts** Added logic to iterate over `Modified` and `Removed` features to extract their Baseline state transitions, which are now appended within parentheticals for their respective categories (e.g., `1 feature no longer matched your search (1 became Baseline newly available)`).
- **[Fix]: Pluralization & Text Alignment** Re-worded category templates to be more grammatically correct and consistent (e.g., changing "features added" to "new features matched your search", and "features removed" to "features no longer matched your search"). Added standard pluralization to all categories (e.g. `1 feature` vs `2 features`).

Fixes #2297
Fixes #2298
Fixes #2301