### PR TITLE
[fix] Improve Email Digest Browser Support Design and Grouping

### DIFF
--- a/workers/email/pkg/digest/components.go
+++ b/workers/email/pkg/digest/components.go
@@ -73,16 +73,34 @@ const baselineChangeItemComponent = `{{- define "baseline_change_item" -}}
 
 const browserItemComponent = `{{- define "browser_change_row" -}}
     <div style='{{- template "style_browser_item_row" -}}'>
-        <table border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
             <tr>
-                <td align="left" valign="middle" style="padding-right: 10px;">
+                <td align="left" valign="middle" style="padding-right: 10px; width: 20px;">
                     <img src="{{.LogoURL}}" height="20" alt="{{.Name}}" style='{{- template "style_img_responsive" -}}' />
                 </td>
                 <td align="left" valign="middle">
                     <div style='{{- template "style_text_browser_item" -}}'>
-                        {{.Name}}: {{ template "browser_status_detail" .From }} &rarr; {{ template "browser_status_detail" .To -}}
+                        {{.Name}}:{{ " " }}
+                        {{- $fromStatus := formatBrowserStatus .From.Status -}}
+                        {{- $toStatus := formatBrowserStatus .To.Status -}}
+                        {{- if and (or (eq $fromStatus "Unknown") (eq $fromStatus "Unavailable")) (eq $toStatus "Available") -}}
+                            <span style='{{- template "color_text_medium" -}}'>
+                                {{- if .To.Version -}}
+                                    Became available in {{.To.Version}}
+                                {{- else -}}
+                                    Became available
+                                {{- end -}}
+                            </span>
+                        {{- else -}}
+                            {{ template "browser_status_detail" .From }} &rarr; {{ template "browser_status_detail" .To -}}
+                        {{- end -}}
                     </div>
                 </td>
+                {{- if .To.Date -}}
+                <td align="right" valign="middle" style="white-space: nowrap; padding-left: 10px;">
+                    <div style='{{- template "style_text_date" -}}'>{{ formatDate .To.Date }}</div>
+                </td>
+                {{- end -}}
             </tr>
         </table>
     </div>
@@ -228,9 +246,6 @@ const browserStatusDetailComponent = `{{- define "browser_status_detail" -}}
     {{- formatBrowserStatus .Status -}}
     {{- if .Version -}}
         <span style='{{- template "color_text_medium" -}}'> in {{.Version}}</span>
-    {{- end -}}
-    {{- if .Date -}}
-        <span style='{{- template "color_text_medium" -}}'> (on {{ formatDate .Date -}})</span>
     {{- end -}}
 {{- end -}}`
 

--- a/workers/email/pkg/digest/renderer.go
+++ b/workers/email/pkg/digest/renderer.go
@@ -140,9 +140,50 @@ func badgeBackgroundColor(title string) string {
 	}
 }
 
+// RenderBrowserName extends workertypes.BrowserName to include grouped combo names.
+type RenderBrowserName string
+
+const (
+	// Base Browsers.
+	RenderBrowserChrome         RenderBrowserName = "chrome"
+	RenderBrowserChromeAndroid  RenderBrowserName = "chrome_android"
+	RenderBrowserEdge           RenderBrowserName = "edge"
+	RenderBrowserFirefox        RenderBrowserName = "firefox"
+	RenderBrowserFirefoxAndroid RenderBrowserName = "firefox_android"
+	RenderBrowserSafari         RenderBrowserName = "safari"
+	RenderBrowserSafariIos      RenderBrowserName = "safari_ios"
+
+	// Combined Groupings.
+	RenderBrowserChromeAndAndroid  RenderBrowserName = "chrome_and_android"
+	RenderBrowserFirefoxAndAndroid RenderBrowserName = "firefox_and_android"
+	RenderBrowserSafariAndIos      RenderBrowserName = "safari_and_ios"
+)
+
+func toRenderBrowserName(b workertypes.BrowserName) RenderBrowserName {
+	switch b {
+	case workertypes.BrowserChrome:
+		return RenderBrowserChrome
+	case workertypes.BrowserChromeAndroid:
+		return RenderBrowserChromeAndroid
+	case workertypes.BrowserEdge:
+		return RenderBrowserEdge
+	case workertypes.BrowserFirefox:
+		return RenderBrowserFirefox
+	case workertypes.BrowserFirefoxAndroid:
+		return RenderBrowserFirefoxAndroid
+	case workertypes.BrowserSafari:
+		return RenderBrowserSafari
+	case workertypes.BrowserSafariIos:
+		return RenderBrowserSafariIos
+	}
+
+	// Should not reach here since the input is controlled, but return a default just in case.
+	return RenderBrowserName(b)
+}
+
 // templateData is the struct passed to the HTML template.
 type BrowserChangeRenderData struct {
-	BrowserName workertypes.BrowserName
+	BrowserName RenderBrowserName
 	Change      *workertypes.Change[workertypes.BrowserValue]
 	FeatureName string
 	FeatureID   string
@@ -276,28 +317,8 @@ func (g *templateDataGenerator) routeHighlightToCategory(highlight workertypes.S
 func (g *templateDataGenerator) processChangedData(highlight workertypes.SummaryHighlight) {
 	// Consolidate browser changes into their own list
 	if len(highlight.BrowserChanges) > 0 {
-		// Sort keys to ensure deterministic order in the AllBrowserChanges list
-		browsers := make([]workertypes.BrowserName, 0, len(highlight.BrowserChanges))
-		for b := range highlight.BrowserChanges {
-			browsers = append(browsers, b)
-		}
-
-		slices.Sort(browsers)
-
-		for _, browserName := range browsers {
-			change := highlight.BrowserChanges[browserName]
-			// If a feature regresses AND loses a browser impl, it will be in two sections.
-			if change == nil {
-				continue
-			}
-			g.data.AllBrowserChanges = append(g.data.AllBrowserChanges, BrowserChangeRenderData{
-				BrowserName: browserName,
-				Change:      change,
-				FeatureName: highlight.FeatureName,
-				FeatureID:   highlight.FeatureID,
-				Type:        highlight.Type,
-			})
-		}
+		grouped := groupBrowserChanges(highlight.BrowserChanges, highlight.FeatureName, highlight.FeatureID, highlight.Type)
+		g.data.AllBrowserChanges = append(g.data.AllBrowserChanges, grouped...)
 	}
 
 	if highlight.BaselineChange != nil {
@@ -360,28 +381,21 @@ func (r *HTMLRenderer) generateSubject(
 
 // browserToString helps handle the any passed from templates which could be
 // string or workertypes.BrowserName.
-func (r *HTMLRenderer) browserToString(browser any) string {
-	switch v := browser.(type) {
-	case string:
-		return v
-	case workertypes.BrowserName:
-		return string(v)
-	default:
-		return fmt.Sprintf("%v", v)
-	}
+func (r *HTMLRenderer) browserToString(browser RenderBrowserName) string {
+	return string(browser)
 }
 
 // browserLogoURL returns the URL for the browser logo.
 // Maps mobile browsers to their desktop equivalents since we share logos.
-func (r *HTMLRenderer) browserLogoURL(browser any) string {
+func (r *HTMLRenderer) browserLogoURL(browser RenderBrowserName) string {
 	b := strings.ToLower(r.browserToString(browser))
 
 	switch b {
-	case "chrome_android":
+	case "chrome_android", "chrome_and_android":
 		b = "chrome"
-	case "firefox_android":
+	case "firefox_android", "firefox_and_android":
 		b = "firefox"
-	case "safari_ios":
+	case "safari_ios", "safari_and_ios":
 		b = "safari"
 	}
 
@@ -389,7 +403,7 @@ func (r *HTMLRenderer) browserLogoURL(browser any) string {
 }
 
 // browserDisplayName returns a human-readable name for the browser.
-func (r *HTMLRenderer) browserDisplayName(browser any) string {
+func (r *HTMLRenderer) browserDisplayName(browser RenderBrowserName) string {
 	b := strings.ToLower(r.browserToString(browser))
 
 	switch b {
@@ -397,16 +411,22 @@ func (r *HTMLRenderer) browserDisplayName(browser any) string {
 		return "Chrome"
 	case "chrome_android":
 		return "Chrome Android"
+	case "chrome_and_android":
+		return "Chrome Desktop & Android"
 	case "edge":
 		return "Edge"
 	case "firefox":
 		return "Firefox"
 	case "firefox_android":
 		return "Firefox Android"
+	case "firefox_and_android":
+		return "Firefox Desktop & Android"
 	case "safari":
 		return "Safari"
 	case "safari_ios":
 		return "Safari iOS"
+	case "safari_and_ios":
+		return "Safari Desktop & iOS"
 	}
 	// Fallback for unknown
 	return r.browserToString(browser)
@@ -421,25 +441,82 @@ func (r *HTMLRenderer) statusLogoURL(status string) string {
 // This is used to ensure consistent rendering order in the template.
 func (r *HTMLRenderer) sortedBrowserChanges(
 	changes map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]) []BrowserChangeRenderData {
+
+	return groupBrowserChanges(changes, "", "", "")
+}
+
+func groupBrowserChanges(
+	changes map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue],
+	featureName, featureID string,
+	highlightType workertypes.SummaryHighlightType) []BrowserChangeRenderData {
+
 	if len(changes) == 0 {
 		return nil
 	}
 
-	data := make([]BrowserChangeRenderData, 0, len(changes))
-	for name, change := range changes {
-		if change == nil {
-			continue
+	pending := make(map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue])
+	for k, v := range changes {
+		if v != nil {
+			pending[k] = v
 		}
+	}
+
+	var data []BrowserChangeRenderData
+
+	groupPair := func(desktop, mobile workertypes.BrowserName, combined RenderBrowserName) {
+		dChange, hasDesktop := pending[desktop]
+		mChange, hasMobile := pending[mobile]
+
+		if !hasDesktop || !hasMobile {
+			return
+		}
+
+		// Compare both From and To configurations to ensure they are fully identical
+		if dChange.From.Status != mChange.From.Status || dChange.To.Status != mChange.To.Status {
+			return
+		}
+
+		if dChange.To.Version != nil && mChange.To.Version != nil {
+			if *dChange.To.Version != *mChange.To.Version {
+				return
+			}
+		} else if dChange.To.Version != mChange.To.Version {
+			return
+		}
+
+		if dChange.To.Date != nil && mChange.To.Date != nil {
+			if !dChange.To.Date.Equal(*mChange.To.Date) {
+				return
+			}
+		} else if dChange.To.Date != mChange.To.Date {
+			return
+		}
+
 		data = append(data, BrowserChangeRenderData{
-			BrowserName: name,
+			BrowserName: combined,
+			Change:      dChange,
+			FeatureName: featureName,
+			FeatureID:   featureID,
+			Type:        highlightType,
+		})
+		delete(pending, desktop)
+		delete(pending, mobile)
+	}
+
+	groupPair(workertypes.BrowserChrome, workertypes.BrowserChromeAndroid, RenderBrowserChromeAndAndroid)
+	groupPair(workertypes.BrowserFirefox, workertypes.BrowserFirefoxAndroid, RenderBrowserFirefoxAndAndroid)
+	groupPair(workertypes.BrowserSafari, workertypes.BrowserSafariIos, RenderBrowserSafariAndIos)
+
+	for name, change := range pending {
+		data = append(data, BrowserChangeRenderData{
+			BrowserName: toRenderBrowserName(name),
 			Change:      change,
-			FeatureName: "",
-			FeatureID:   "",
-			Type:        "",
+			FeatureName: featureName,
+			FeatureID:   featureID,
+			Type:        highlightType,
 		})
 	}
 
-	// Sort by BrowserName
 	slices.SortFunc(data, func(a, b BrowserChangeRenderData) int {
 		if a.BrowserName < b.BrowserName {
 			return -1

--- a/workers/email/pkg/digest/renderer_test.go
+++ b/workers/email/pkg/digest/renderer_test.go
@@ -324,6 +324,66 @@ func TestRenderDigest_Golden(t *testing.T) {
 				Moved:      nil,
 				Split:      nil,
 			},
+			{
+				// Case 13: Browser implementation grouping (Desktop & Mobile)
+				Type:        workertypes.SummaryHighlightTypeChanged,
+				FeatureName: "grouped-browser-feature",
+				FeatureID:   "grouped-browser-feature",
+				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+					workertypes.BrowserChrome: {
+						From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnknown,
+							Version: nil, Date: nil},
+						To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
+							Version: new("148"), Date: &newlyDate},
+					},
+					workertypes.BrowserChromeAndroid: {
+						From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnknown,
+							Version: nil, Date: nil},
+						To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
+							Version: new("148"), Date: &newlyDate},
+					},
+					workertypes.BrowserEdge:           nil,
+					workertypes.BrowserFirefox:        nil,
+					workertypes.BrowserFirefoxAndroid: nil,
+					workertypes.BrowserSafari:         nil,
+					workertypes.BrowserSafariIos:      nil,
+				},
+				NameChange:     nil,
+				BaselineChange: nil,
+				Moved:          nil,
+				Split:          nil,
+				Docs:           nil,
+			},
+			{
+				// Case 14: Browser implementation NOT grouping (Different Versions)
+				Type:        workertypes.SummaryHighlightTypeChanged,
+				FeatureName: "ungrouped-browser-feature",
+				FeatureID:   "ungrouped-browser-feature",
+				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+					workertypes.BrowserChrome:         nil,
+					workertypes.BrowserChromeAndroid:  nil,
+					workertypes.BrowserEdge:           nil,
+					workertypes.BrowserFirefox:        nil,
+					workertypes.BrowserFirefoxAndroid: nil,
+					workertypes.BrowserSafari: {
+						From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnknown,
+							Version: nil, Date: nil},
+						To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
+							Version: new("17.0"), Date: &newlyDate},
+					},
+					workertypes.BrowserSafariIos: {
+						From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnknown,
+							Version: nil, Date: nil},
+						To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
+							Version: new("17.2"), Date: &newlyDate},
+					},
+				},
+				NameChange:     nil,
+				BaselineChange: nil,
+				Moved:          nil,
+				Split:          nil,
+				Docs:           nil,
+			},
 		},
 	}
 	summaryBytes, _ := json.Marshal(summary)

--- a/workers/email/pkg/digest/styles.go
+++ b/workers/email/pkg/digest/styles.go
@@ -16,7 +16,6 @@
 package digest
 
 const styleSnippets = `{{- define "font_family_main" -}}font-family: SF Pro, system-ui, sans-serif;{{- end -}}
-{{- define "font_family_monospace" -}}font-family: Menlo, monospace;{{- end -}}
 {{- define "font_weight_bold" -}}font-weight: 700;{{- end -}}
 {{- define "font_weight_normal" -}}font-weight: 400;{{- end -}}
 {{- define "color_text_dark" -}}color: #18181B;{{- end -}}
@@ -44,7 +43,7 @@ const composedTextStyles = `{{- define "style_text_badge_title" -}}{{- template 
 {{- define "style_text_feature_link" -}}{{- template "color_text_dark" -}}; font-size: 16px; {{- template "font_family_main" -}}; {{- template "font_weight_normal" -}}; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;{{- end -}}
 {{- define "style_text_doc_link" -}}{{- template "color_text_medium" -}}; font-size: 14px; {{- template "font_family_main" -}}; {{- template "font_weight_normal" -}}; text-decoration: underline; line-height: 26.60px;{{- end -}}
 {{- define "style_text_doc_punctuation" -}}{{- template "color_text_medium" -}}; font-size: 14px; {{- template "font_family_main" -}}; {{- template "font_weight_normal" -}}; line-height: 26.60px;{{- end -}}
-{{- define "style_text_date" -}}{{- template "color_text_medium" -}}; font-size: 12px; {{- template "font_family_monospace" -}}; {{- template "font_weight_normal" -}}; word-wrap: break-word; display: inline-block; margin-left: 10px;{{- end -}}
+{{- define "style_text_date" -}}{{- template "color_text_medium" -}}; font-size: 12px; {{- template "font_family_main" -}}; {{- template "font_weight_normal" -}}; word-wrap: break-word; display: inline-block; margin-left: 10px;{{- end -}}
 {{- define "style_text_browser_item" -}}{{- template "color_text_dark" -}}; font-size: 14px; {{- template "font_family_main" -}}; {{- template "font_weight_normal" -}}; word-wrap: break-word; display: inline-block; vertical-align: middle;{{- end -}}
 {{- define "style_text_warning" -}}{{- template "color_text_medium" -}}; font-size: 12px; {{- template "font_family_main" -}}; font-style: italic; margin-top: 4px; display: block;{{- end -}}
 {{- define "style_text_warning_inline" -}}{{- template "color_text_medium" -}}; font-size: 12px; {{- template "font_family_main" -}}; font-style: italic;{{- end -}}

--- a/workers/email/pkg/digest/testdata/digest.golden.html
+++ b/workers/email/pkg/digest/testdata/digest.golden.html
@@ -27,7 +27,7 @@
     <tr>
         <td align="left" valign="top">
             <a href="http://localhost:5555/features/newly-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Newly Available Feature</a></td><td align="right" valign="top" style="white-space: nowrap; padding-left: 10px;">
-            <div style='color: #52525B;; font-size: 12px;font-family: Menlo, monospace;;font-weight: 400;; word-wrap: break-word; display: inline-block; margin-left: 10px;'>2025-01-01</div>
+            <div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; margin-left: 10px;'>2025-01-01</div>
         </td></tr>
 </table></div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;background: #E6F4EA;'>
     <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
@@ -45,7 +45,7 @@
     <tr>
         <td align="left" valign="top">
             <a href="http://localhost:5555/features/container-queries" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Container queries</a><span style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 26.60px;'> (</span><a href="https://developer.mozilla.org/docs/Web/CSS/CSS_Container_Queries" style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 26.60px;'>MDN</a>, <a href="https://developer.mozilla.org/docs/Web/CSS/container-queries" style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 26.60px;'>MDN</a><span style='color: #52525B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 26.60px;'>)</span></td><td align="right" valign="top" style="white-space: nowrap; padding-left: 10px;">
-            <div style='color: #52525B;; font-size: 12px;font-family: Menlo, monospace;;font-weight: 400;; word-wrap: break-word; display: inline-block; margin-left: 10px;'>2025-12-27</div>
+            <div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; margin-left: 10px;'>2025-12-27</div>
         </td></tr>
 </table></div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;background: #E4E4E7;'>
     <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
@@ -96,86 +96,136 @@
         </tr>
     </table>
 </div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
-        <table border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
             <tr>
-                <td align="left" valign="middle" style="padding-right: 10px;">
+                <td align="left" valign="middle" style="padding-right: 10px; width: 20px;">
                     <img src="http://localhost:5555/public/img/email/chrome.png" height="20" alt="Chrome" style='display: block; width: auto;' />
                 </td>
                 <td align="left" valign="middle">
                     <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
                         Chrome: Available<span style='color: #52525B;'> in 120</span> &rarr; Unavailable</div>
-                </td>
-            </tr>
+                </td></tr>
         </table>
     </div><div style='width: 100%; display: block; margin-top: 8px;'>
             <div style='display: inline-block; vertical-align: middle;'>
                 <a href="http://localhost:5555/features/regressed-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Regressed Feature</a>
             </div>
         </div></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
-        <table border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
             <tr>
-                <td align="left" valign="middle" style="padding-right: 10px;">
+                <td align="left" valign="middle" style="padding-right: 10px; width: 20px;">
                     <img src="http://localhost:5555/public/img/email/safari.png" height="20" alt="Safari iOS" style='display: block; width: auto;' />
                 </td>
                 <td align="left" valign="middle">
                     <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
-                        Safari iOS: Unavailable &rarr; Available<span style='color: #52525B;'> in 17.2</span></div>
-                </td>
-            </tr>
+                        Safari iOS: <span style='color: #52525B;'>Became available in 17.2</span></div>
+                </td></tr>
         </table>
     </div><div style='width: 100%; display: block; margin-top: 8px;'>
             <div style='display: inline-block; vertical-align: middle;'>
                 <a href="http://localhost:5555/features/content-visibility" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>content-visibility</a>
             </div>
         </div></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
-        <table border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
             <tr>
-                <td align="left" valign="middle" style="padding-right: 10px;">
+                <td align="left" valign="middle" style="padding-right: 10px; width: 20px;">
                     <img src="http://localhost:5555/public/img/email/chrome.png" height="20" alt="Chrome" style='display: block; width: auto;' />
                 </td>
                 <td align="left" valign="middle">
                     <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
-                        Chrome: Unavailable &rarr; Available<span style='color: #52525B;'> (on 2025-01-01)</span></div>
-                </td>
-            </tr>
+                        Chrome: <span style='color: #52525B;'>Became available</span></div>
+                </td><td align="right" valign="middle" style="white-space: nowrap; padding-left: 10px;">
+                    <div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; margin-left: 10px;'>2025-01-01</div>
+                </td></tr>
         </table>
     </div><div style='width: 100%; display: block; margin-top: 8px;'>
             <div style='display: inline-block; vertical-align: middle;'>
                 <a href="http://localhost:5555/features/another-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>another-feature</a>
             </div>
         </div></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
-        <table border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
             <tr>
-                <td align="left" valign="middle" style="padding-right: 10px;">
+                <td align="left" valign="middle" style="padding-right: 10px; width: 20px;">
                     <img src="http://localhost:5555/public/img/email/firefox.png" height="20" alt="Firefox" style='display: block; width: auto;' />
                 </td>
                 <td align="left" valign="middle">
                     <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
-                        Firefox: Unavailable &rarr; Available<span style='color: #52525B;'> in 123</span><span style='color: #52525B;'> (on 2025-01-01)</span></div>
-                </td>
-            </tr>
+                        Firefox: <span style='color: #52525B;'>Became available in 123</span></div>
+                </td><td align="right" valign="middle" style="white-space: nowrap; padding-left: 10px;">
+                    <div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; margin-left: 10px;'>2025-01-01</div>
+                </td></tr>
         </table>
     </div><div style='width: 100%; display: block; margin-top: 8px;'>
             <div style='display: inline-block; vertical-align: middle;'>
                 <a href="http://localhost:5555/features/new-browser-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>new-browser-feature</a>
             </div>
         </div></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
-        <table border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
             <tr>
-                <td align="left" valign="middle" style="padding-right: 10px;">
+                <td align="left" valign="middle" style="padding-right: 10px; width: 20px;">
                     <img src="http://localhost:5555/public/img/email/chrome.png" height="20" alt="Chrome" style='display: block; width: auto;' />
                 </td>
                 <td align="left" valign="middle">
                     <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
                         Chrome: Available<span style='color: #52525B;'> in 110</span> &rarr; Unavailable</div>
-                </td>
-            </tr>
+                </td></tr>
         </table>
     </div><div style='width: 100%; display: block; margin-top: 8px;'>
             <div style='display: inline-block; vertical-align: middle;'>
                 <a href="http://localhost:5555/features/removed-details" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Removed With Details</a>
             </div>
-        </div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;; font-style: italic; margin-top: 4px; display: block;'>⚠️ This feature no longer matches your saved search. Please update your saved search if you wish to continue tracking it.</div></div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;; background:#E6F4EA;'>
+        </div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;; font-style: italic; margin-top: 4px; display: block;'>⚠️ This feature no longer matches your saved search. Please update your saved search if you wish to continue tracking it.</div></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+            <tr>
+                <td align="left" valign="middle" style="padding-right: 10px; width: 20px;">
+                    <img src="http://localhost:5555/public/img/email/chrome.png" height="20" alt="Chrome Desktop &amp; Android" style='display: block; width: auto;' />
+                </td>
+                <td align="left" valign="middle">
+                    <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
+                        Chrome Desktop &amp; Android: <span style='color: #52525B;'>Became available in 148</span></div>
+                </td><td align="right" valign="middle" style="white-space: nowrap; padding-left: 10px;">
+                    <div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; margin-left: 10px;'>2025-01-01</div>
+                </td></tr>
+        </table>
+    </div><div style='width: 100%; display: block; margin-top: 8px;'>
+            <div style='display: inline-block; vertical-align: middle;'>
+                <a href="http://localhost:5555/features/grouped-browser-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>grouped-browser-feature</a>
+            </div>
+        </div></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+            <tr>
+                <td align="left" valign="middle" style="padding-right: 10px; width: 20px;">
+                    <img src="http://localhost:5555/public/img/email/safari.png" height="20" alt="Safari" style='display: block; width: auto;' />
+                </td>
+                <td align="left" valign="middle">
+                    <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
+                        Safari: <span style='color: #52525B;'>Became available in 17.0</span></div>
+                </td><td align="right" valign="middle" style="white-space: nowrap; padding-left: 10px;">
+                    <div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; margin-left: 10px;'>2025-01-01</div>
+                </td></tr>
+        </table>
+    </div><div style='width: 100%; display: block; margin-top: 8px;'>
+            <div style='display: inline-block; vertical-align: middle;'>
+                <a href="http://localhost:5555/features/ungrouped-browser-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>ungrouped-browser-feature</a>
+            </div>
+        </div></div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><div style='width: 100%; display: block;'>
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+            <tr>
+                <td align="left" valign="middle" style="padding-right: 10px; width: 20px;">
+                    <img src="http://localhost:5555/public/img/email/safari.png" height="20" alt="Safari iOS" style='display: block; width: auto;' />
+                </td>
+                <td align="left" valign="middle">
+                    <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; vertical-align: middle;'>
+                        Safari iOS: <span style='color: #52525B;'>Became available in 17.2</span></div>
+                </td><td align="right" valign="middle" style="white-space: nowrap; padding-left: 10px;">
+                    <div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word; display: inline-block; margin-left: 10px;'>2025-01-01</div>
+                </td></tr>
+        </table>
+    </div><div style='width: 100%; display: block; margin-top: 8px;'>
+            <div style='display: inline-block; vertical-align: middle;'>
+                <a href="http://localhost:5555/features/ungrouped-browser-feature" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>ungrouped-browser-feature</a>
+            </div>
+        </div></div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;; background:#E6F4EA;'>
     <div style='display: block;'>
         <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Added</div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>These features now match your search criteria.</div></div>
 </div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">


### PR DESCRIPTION
This PR improves the usability and layout of "Browser support changed" entries in the email digest template.

Changes Made:
- [Feature] Browser Grouping: In workers/email/pkg/digest/renderer.go, identical support transitions for matching desktop and mobile browsers (e.g., Chrome & Chrome Android) are now grouped into a single unified row (e.g., "Chrome Desktop & Android") to reduce visual clutter.
- [Design] Clarified Availability Phrasing: In workers/email/pkg/digest/components.go, the generic `Unknown -> Available` transition text has been replaced with the more intuitive `Became available in {{.To.Version}}` or `Became available` phrasing.
- [Design] Date Column Alignment: The transition date is now rendered in its own right-aligned column within the browser change template, using the main font and matching the style of the baseline section. The unused `font_family_monospace` was removed from styles.go.

Related Issues:
Fixes #2299
Fixes #2300