### PR TITLE
feat: use saved search name in email notifications

### DIFF
--- a/lib/event/emailjob/v1/types.go
+++ b/lib/event/emailjob/v1/types.go
@@ -41,6 +41,8 @@ type EmailJobEventMetadata struct {
 	EventID string `json:"event_id"`
 	// SearchID is the ID of the search that generated the event.
 	SearchID string `json:"search_id"`
+	// SearchName is the name of the search that generated the event.
+	SearchName string `json:"search_name"`
 	// Query is the query string used for the search.
 	Query string `json:"query"`
 	// Frequency is the frequency of the job (e.g., "daily", "weekly").

--- a/lib/event/featurediff/v1/types.go
+++ b/lib/event/featurediff/v1/types.go
@@ -43,6 +43,8 @@ type FeatureDiffEvent struct {
 	EventID string `json:"event_id"`
 	// SearchID is the identifier of the saved search that was checked.
 	SearchID string `json:"search_id"`
+	// SearchName is the user-provided name for the saved search.
+	SearchName string `json:"search_name"`
 	// Query is the actual text of the query (e.g. "browsers:chrome").
 	// Provided here so consumers don't need to look it up.
 	Query string `json:"query"`

--- a/lib/event/refreshsearchcommand/v1/types.go
+++ b/lib/event/refreshsearchcommand/v1/types.go
@@ -51,6 +51,9 @@ type RefreshSearchCommand struct {
 	// SearchID is the target saved search to check.
 	SearchID string `json:"search_id"`
 
+	// SearchName is the user-provided name for the saved search.
+	SearchName string `json:"search_name"`
+
 	// Query is the current search filter (e.g. "browsers:chrome").
 	Query string `json:"query"`
 

--- a/lib/event/searchconfigurationchanged/v1/types.go
+++ b/lib/event/searchconfigurationchanged/v1/types.go
@@ -51,6 +51,9 @@ type SearchConfigurationChangedEvent struct {
 	// SearchID is the target saved search.
 	SearchID string `json:"search_id"`
 
+	// SearchName is the user-provided name for the saved search.
+	SearchName string `json:"search_name"`
+
 	// Query is the NEW search filter.
 	Query string `json:"query"`
 

--- a/lib/gcppubsub/gcppubsubadapters/backend.go
+++ b/lib/gcppubsub/gcppubsubadapters/backend.go
@@ -41,6 +41,7 @@ func (p *BackendAdapter) PublishSearchConfigurationChanged(
 
 	evt := searchconfigv1.SearchConfigurationChangedEvent{
 		SearchID:   resp.Id,
+		SearchName: resp.Name,
 		Query:      resp.Query,
 		UserID:     userID,
 		Timestamp:  resp.UpdatedAt,

--- a/lib/gcppubsub/gcppubsubadapters/backend_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/backend_test.go
@@ -57,6 +57,7 @@ func TestSearchConfigurationPublisherAdapter_Publish(t *testing.T) {
 				"kind": "SearchConfigurationChangedEvent",
 				"data": {
 					"search_id": "search-123",
+					"search_name": "",
 					"query": "group:css",
 					"user_id": "user-1",
 					"timestamp": "2025-01-01T00:00:00Z",
@@ -77,6 +78,7 @@ func TestSearchConfigurationPublisherAdapter_Publish(t *testing.T) {
 				"kind": "SearchConfigurationChangedEvent",
 				"data": {
 					"search_id": "search-456",
+					"search_name": "",
 					"query": "group:html",
 					"user_id": "user-1",
 					"timestamp": "2025-01-02T00:00:00Z",

--- a/lib/gcppubsub/gcppubsubadapters/batch_event_producer.go
+++ b/lib/gcppubsub/gcppubsubadapters/batch_event_producer.go
@@ -35,10 +35,11 @@ func NewBatchFanOutPublisherAdapter(client EventPublisher, topicID string) *Batc
 func (a *BatchFanOutPublisherAdapter) PublishRefreshCommand(ctx context.Context,
 	cmd workertypes.RefreshSearchCommand) error {
 	evt := refreshv1.RefreshSearchCommand{
-		SearchID:  cmd.SearchID,
-		Query:     cmd.Query,
-		Frequency: refreshv1.JobFrequency(cmd.Frequency),
-		Timestamp: cmd.Timestamp,
+		SearchID:   cmd.SearchID,
+		SearchName: cmd.SearchName,
+		Query:      cmd.Query,
+		Frequency:  refreshv1.JobFrequency(cmd.Frequency),
+		Timestamp:  cmd.Timestamp,
 	}
 
 	msg, err := event.New(evt)

--- a/lib/gcppubsub/gcppubsubadapters/batch_event_producer_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/batch_event_producer_test.go
@@ -36,10 +36,11 @@ func TestBatchFanOutPublisherAdapter_PublishRefreshCommand(t *testing.T) {
 		{
 			name: "success",
 			cmd: workertypes.RefreshSearchCommand{
-				SearchID:  "search-123",
-				Query:     "query=abc",
-				Frequency: workertypes.FrequencyImmediate,
-				Timestamp: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				SearchID:   "search-123",
+				SearchName: "Test Search",
+				Query:      "query=abc",
+				Frequency:  workertypes.FrequencyImmediate,
+				Timestamp:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			publishErr: nil,
 			wantErr:    false,
@@ -48,6 +49,7 @@ func TestBatchFanOutPublisherAdapter_PublishRefreshCommand(t *testing.T) {
 				"kind": "RefreshSearchCommand",
 				"data": {
 					"search_id": "search-123",
+					"search_name": "Test Search",
 					"query": "query=abc",
 					"frequency": "IMMEDIATE",
 					"timestamp": "2025-01-01T00:00:00Z"
@@ -57,10 +59,11 @@ func TestBatchFanOutPublisherAdapter_PublishRefreshCommand(t *testing.T) {
 		{
 			name: "publish error",
 			cmd: workertypes.RefreshSearchCommand{
-				SearchID:  "search-123",
-				Query:     "query=abc",
-				Frequency: workertypes.FrequencyImmediate,
-				Timestamp: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				SearchID:   "search-123",
+				SearchName: "Test Search",
+				Query:      "query=abc",
+				Frequency:  workertypes.FrequencyImmediate,
+				Timestamp:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
 			publishErr:   errors.New("pubsub error"),
 			wantErr:      true,

--- a/lib/gcppubsub/gcppubsubadapters/email_worker.go
+++ b/lib/gcppubsub/gcppubsubadapters/email_worker.go
@@ -72,6 +72,7 @@ func (a *EmailWorkerSubscriberAdapter) handleEmailJobEvent(
 			Metadata: workertypes.DeliveryMetadata{
 				EventID:     event.Metadata.EventID,
 				SearchID:    event.Metadata.SearchID,
+				SearchName:  event.Metadata.SearchName,
 				Query:       event.Metadata.Query,
 				Frequency:   event.Metadata.Frequency.ToWorkerTypeJobFrequency(),
 				GeneratedAt: event.Metadata.GeneratedAt,

--- a/lib/gcppubsub/gcppubsubadapters/email_worker_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/email_worker_test.go
@@ -107,6 +107,7 @@ func TestEmailWorkerSubscriberAdapter_RoutesEmailJobEvent(t *testing.T) {
 		Metadata: v1.EmailJobEventMetadata{
 			EventID:     "event-789",
 			SearchID:    "search-abc",
+			SearchName:  "My CSS Search",
 			Query:       "is:open",
 			Frequency:   v1.FrequencyMonthly,
 			GeneratedAt: now,
@@ -144,6 +145,7 @@ func TestEmailWorkerSubscriberAdapter_RoutesEmailJobEvent(t *testing.T) {
 			Metadata: workertypes.DeliveryMetadata{
 				EventID:     "event-789",
 				SearchID:    "search-abc",
+				SearchName:  "My CSS Search",
 				Query:       "is:open",
 				Frequency:   workertypes.FrequencyMonthly,
 				GeneratedAt: now,

--- a/lib/gcppubsub/gcppubsubadapters/event_producer.go
+++ b/lib/gcppubsub/gcppubsubadapters/event_producer.go
@@ -27,7 +27,7 @@ import (
 )
 
 type EventProducerSearchMessageHandler interface {
-	ProcessSearch(ctx context.Context, searchID string, query string,
+	ProcessSearch(ctx context.Context, searchID string, searchName string, query string,
 		frequency workertypes.JobFrequency, triggerID string) error
 }
 
@@ -85,7 +85,7 @@ func (a *EventProducerSubscriberAdapter) processRefreshSearchCommand(ctx context
 	eventID string, event refreshv1.RefreshSearchCommand) error {
 	slog.InfoContext(ctx, "received refresh search command", "eventID", eventID, "event", event)
 
-	return a.searchEventHandler.ProcessSearch(ctx, event.SearchID, event.Query,
+	return a.searchEventHandler.ProcessSearch(ctx, event.SearchID, event.SearchName, event.Query,
 		event.Frequency.ToWorkerTypeJobFrequency(), eventID)
 }
 
@@ -93,7 +93,7 @@ func (a *EventProducerSubscriberAdapter) processSearchConfigurationChangedEvent(
 	eventID string, event searchconfigv1.SearchConfigurationChangedEvent) error {
 	slog.InfoContext(ctx, "received search configuration changed event", "eventID", eventID, "event", event)
 
-	return a.searchEventHandler.ProcessSearch(ctx, event.SearchID, event.Query,
+	return a.searchEventHandler.ProcessSearch(ctx, event.SearchID, event.SearchName, event.Query,
 		event.Frequency.ToWorkerTypeJobFrequency(), eventID)
 }
 
@@ -145,6 +145,7 @@ func (a *EventProducerPublisherAdapter) Publish(ctx context.Context,
 	b, err := event.New(featurediffv1.FeatureDiffEvent{
 		EventID:       req.EventID,
 		SearchID:      req.SearchID,
+		SearchName:    req.SearchName,
 		Query:         req.Query,
 		Summary:       req.Summary,
 		StateID:       req.StateID,

--- a/lib/gcppubsub/gcppubsubadapters/event_producer_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/event_producer_test.go
@@ -37,17 +37,18 @@ type mockSearchHandler struct {
 }
 
 type searchCall struct {
-	SearchID  string
-	Query     string
-	Frequency workertypes.JobFrequency
-	TriggerID string
+	SearchID   string
+	SearchName string
+	Query      string
+	Frequency  workertypes.JobFrequency
+	TriggerID  string
 }
 
-func (m *mockSearchHandler) ProcessSearch(_ context.Context, searchID, query string,
+func (m *mockSearchHandler) ProcessSearch(_ context.Context, searchID, searchName, query string,
 	freq workertypes.JobFrequency, triggerID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.calls = append(m.calls, searchCall{searchID, query, freq, triggerID})
+	m.calls = append(m.calls, searchCall{searchID, searchName, query, freq, triggerID})
 
 	return m.err
 }
@@ -179,10 +180,11 @@ func TestSubscribe_RoutesRefreshSearchCommand(t *testing.T) {
 	defer env.stop()
 
 	refreshCmd := refreshv1.RefreshSearchCommand{
-		SearchID:  "s1",
-		Query:     "q1",
-		Frequency: "IMMEDIATE",
-		Timestamp: time.Time{},
+		SearchID:   "s1",
+		SearchName: "Name1",
+		Query:      "q1",
+		Frequency:  "IMMEDIATE",
+		Timestamp:  time.Time{},
 	}
 	ceWrapper := map[string]any{
 		"apiVersion": "v1",
@@ -200,10 +202,11 @@ func TestSubscribe_RoutesRefreshSearchCommand(t *testing.T) {
 	}
 
 	expectedCall := searchCall{
-		SearchID:  "s1",
-		Query:     "q1",
-		Frequency: workertypes.FrequencyImmediate,
-		TriggerID: "msg-1",
+		SearchID:   "s1",
+		SearchName: "Name1",
+		Query:      "q1",
+		Frequency:  workertypes.FrequencyImmediate,
+		TriggerID:  "msg-1",
 	}
 
 	if diff := cmp.Diff(expectedCall, env.searchHandler.calls[0]); diff != "" {
@@ -250,6 +253,7 @@ func TestSubscribe_RoutesSearchConfigurationChanged(t *testing.T) {
 	// We construct the payload manually for the test execution
 	configEventPayload := map[string]any{
 		"search_id":   "s2",
+		"search_name": "Name2",
 		"query":       "q2",
 		"user_id":     "user-1",
 		"timestamp":   "0001-01-01T00:00:00Z",
@@ -273,10 +277,11 @@ func TestSubscribe_RoutesSearchConfigurationChanged(t *testing.T) {
 	}
 
 	expectedCall := searchCall{
-		SearchID:  "s2",
-		Query:     "q2",
-		Frequency: workertypes.FrequencyImmediate,
-		TriggerID: "msg-3",
+		SearchID:   "s2",
+		SearchName: "Name2",
+		Query:      "q2",
+		Frequency:  workertypes.FrequencyImmediate,
+		TriggerID:  "msg-3",
 	}
 
 	if diff := cmp.Diff(expectedCall, env.searchHandler.calls[0]); diff != "" {
@@ -292,6 +297,7 @@ func TestPublisher_Publish(t *testing.T) {
 	req := workertypes.PublishEventRequest{
 		EventID:       "evt-1",
 		SearchID:      "search-1",
+		SearchName:    "Name-1",
 		Query:         "query-1",
 		Frequency:     workertypes.FrequencyImmediate,
 		Reasons:       []workertypes.Reason{workertypes.ReasonDataUpdated},
@@ -321,9 +327,10 @@ func TestPublisher_Publish(t *testing.T) {
 		"apiVersion": "v1",
 		"kind":       "FeatureDiffEvent",
 		"data": map[string]any{
-			"event_id":  "evt-1",
-			"search_id": "search-1",
-			"query":     "query-1",
+			"event_id":    "evt-1",
+			"search_id":   "search-1",
+			"search_name": "Name-1",
+			"query":       "query-1",
 			// go encodes/decodes []byte as base64 strings
 			"summary":         base64.StdEncoding.EncodeToString([]byte(`{"added": 1}`)),
 			"state_id":        "state-id-1",

--- a/lib/gcppubsub/gcppubsubadapters/push_delivery.go
+++ b/lib/gcppubsub/gcppubsubadapters/push_delivery.go
@@ -45,6 +45,7 @@ func (p *PushDeliveryPublisher) PublishEmailJob(ctx context.Context, job workert
 		Metadata: v1.EmailJobEventMetadata{
 			EventID:     job.Metadata.EventID,
 			SearchID:    job.Metadata.SearchID,
+			SearchName:  job.Metadata.SearchName,
 			Query:       job.Metadata.Query,
 			Frequency:   v1.ToJobFrequency(job.Metadata.Frequency),
 			GeneratedAt: job.Metadata.GeneratedAt,
@@ -110,6 +111,7 @@ func (a *PushDeliverySubscriberAdapter) processFeatureDiffEvent(ctx context.Cont
 	metadata := workertypes.DispatchEventMetadata{
 		EventID:     event.EventID,
 		SearchID:    event.SearchID,
+		SearchName:  event.SearchName,
 		Query:       event.Query,
 		Frequency:   event.Frequency.ToWorkertypes(),
 		GeneratedAt: event.GeneratedAt,

--- a/lib/gcppubsub/gcppubsubadapters/push_delivery_test.go
+++ b/lib/gcppubsub/gcppubsubadapters/push_delivery_test.go
@@ -107,6 +107,7 @@ func TestPushDeliveryPublisher_PublishEmailJob(t *testing.T) {
 		Metadata: workertypes.DeliveryMetadata{
 			EventID:     "event-1",
 			SearchID:    "search-1",
+			SearchName:  "",
 			Query:       "query-string",
 			Frequency:   workertypes.FrequencyMonthly,
 			GeneratedAt: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC),
@@ -143,6 +144,7 @@ func TestPushDeliveryPublisher_PublishEmailJob(t *testing.T) {
 			"metadata": map[string]any{
 				"event_id":     "event-1",
 				"search_id":    "search-1",
+				"search_name":  "",
 				"query":        "query-string",
 				"frequency":    "MONTHLY",
 				"generated_at": "2025-01-01T12:00:00Z",
@@ -214,6 +216,7 @@ func TestPushDeliverySubscriber_RoutesFeatureDiffEvent(t *testing.T) {
 	featureDiffEvent := featurediffv1.FeatureDiffEvent{
 		EventID:       "evt-1",
 		SearchID:      "s1",
+		SearchName:    "Search 1",
 		Query:         "q1",
 		Summary:       []byte(`{"added": 1}`),
 		StateID:       "state-id-1",
@@ -242,6 +245,7 @@ func TestPushDeliverySubscriber_RoutesFeatureDiffEvent(t *testing.T) {
 	expectedMetadata := workertypes.DispatchEventMetadata{
 		EventID:     "evt-1",
 		SearchID:    "s1",
+		SearchName:  "Search 1",
 		Query:       "q1",
 		Frequency:   workertypes.FrequencyMonthly,
 		GeneratedAt: now,

--- a/lib/gcpspanner/list_user_saved_searches.go
+++ b/lib/gcpspanner/list_user_saved_searches.go
@@ -170,12 +170,13 @@ func (c *Client) ListUserSavedSearches(
 
 type SavedSearchBriefDetails struct {
 	ID    string `spanner:"ID"`
+	Name  string `spanner:"Name"`
 	Query string `spanner:"Query"`
 }
 
 func (m userSavedSearchListerMapper) SelectAll() spanner.Statement {
 	return spanner.Statement{
-		SQL:    "SELECT ID, Query FROM SavedSearches",
+		SQL:    "SELECT ID, Name, Query FROM SavedSearches",
 		Params: nil,
 	}
 }

--- a/lib/gcpspanner/list_user_saved_searches_test.go
+++ b/lib/gcpspanner/list_user_saved_searches_test.go
@@ -298,7 +298,7 @@ func TestListAllSavedSearches(t *testing.T) {
 		// Build expected details list from created searches (which have generated IDs)
 		expectedDetails := make([]SavedSearchBriefDetails, len(searches))
 		for idx, search := range searches {
-			expectedDetails[idx] = SavedSearchBriefDetails{ID: search.ID, Query: search.Query}
+			expectedDetails[idx] = SavedSearchBriefDetails{ID: search.ID, Name: search.Name, Query: search.Query}
 		}
 
 		slices.SortFunc(expectedDetails, sortSavedSearchBriefDetails)

--- a/lib/gcpspanner/spanneradapters/event_producer.go
+++ b/lib/gcpspanner/spanneradapters/event_producer.go
@@ -252,7 +252,7 @@ func (b *BatchEventProducer) ListAllSavedSearches(ctx context.Context) ([]worker
 
 	jobs := make([]workertypes.SearchJob, 0, len(details))
 	for _, detail := range details {
-		jobs = append(jobs, workertypes.SearchJob{ID: detail.ID, Query: detail.Query})
+		jobs = append(jobs, workertypes.SearchJob{ID: detail.ID, Name: detail.Name, Query: detail.Query})
 	}
 
 	return jobs, nil

--- a/lib/gcpspanner/spanneradapters/event_producer_test.go
+++ b/lib/gcpspanner/spanneradapters/event_producer_test.go
@@ -273,6 +273,7 @@ func TestEventProducer_PublishEvent(t *testing.T) {
 			req: workertypes.PublishEventRequest{
 				EventID:       "event-1",
 				SearchID:      "search-1",
+				SearchName:    "Search 1",
 				StateID:       "state-1",
 				StateBlobPath: "gs://bucket/state",
 				DiffID:        "diff-1",
@@ -312,6 +313,7 @@ func TestEventProducer_PublishEvent(t *testing.T) {
 			req: workertypes.PublishEventRequest{
 				EventID:       "event-1",
 				SearchID:      "search-1",
+				SearchName:    "Search 1",
 				StateID:       "state-1",
 				StateBlobPath: "gs://bucket/state",
 				DiffID:        "diff-1",
@@ -351,6 +353,7 @@ func TestEventProducer_PublishEvent(t *testing.T) {
 			req: workertypes.PublishEventRequest{
 				EventID:       "event-1",
 				SearchID:      "search-1",
+				SearchName:    "Search 1",
 				Summary:       []byte("invalid-json"),
 				Frequency:     workertypes.FrequencyWeekly,
 				StateID:       "",
@@ -684,11 +687,17 @@ func TestBatchEventProducer_ListAllSavedSearches(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			name:           "success with searches",
-			mockResp:       []gcpspanner.SavedSearchBriefDetails{{ID: "s1", Query: "q1"}, {ID: "s2", Query: "q2"}},
-			mockErr:        nil,
-			wantSearchJobs: []workertypes.SearchJob{{ID: "s1", Query: "q1"}, {ID: "s2", Query: "q2"}},
-			wantErr:        false,
+			name: "success with searches",
+			mockResp: []gcpspanner.SavedSearchBriefDetails{
+				{ID: "s1", Name: "Search 1", Query: "q1"},
+				{ID: "s2", Name: "Search 2", Query: "q2"},
+			},
+			mockErr: nil,
+			wantSearchJobs: []workertypes.SearchJob{
+				{ID: "s1", Name: "Search 1", Query: "q1"},
+				{ID: "s2", Name: "Search 2", Query: "q2"},
+			},
+			wantErr: false,
 		},
 		{
 			name:           "success empty list",

--- a/lib/workertypes/types.go
+++ b/lib/workertypes/types.go
@@ -676,6 +676,7 @@ type PublishEventRequest struct {
 	DiffID        string
 	DiffBlobPath  string
 	SearchID      string
+	SearchName    string
 	Query         string
 	Summary       []byte
 	Reasons       []Reason
@@ -699,14 +700,16 @@ const (
 )
 
 type RefreshSearchCommand struct {
-	SearchID  string
-	Query     string
-	Frequency JobFrequency
-	Timestamp time.Time
+	SearchID   string
+	SearchName string
+	Query      string
+	Frequency  JobFrequency
+	Timestamp  time.Time
 }
 
 type SearchJob struct {
 	ID    string
+	Name  string
 	Query string
 }
 
@@ -739,6 +742,7 @@ type SubscriberSet struct {
 type DeliveryMetadata struct {
 	EventID     string
 	SearchID    string
+	SearchName  string
 	Query       string
 	Frequency   JobFrequency
 	GeneratedAt time.Time
@@ -747,6 +751,7 @@ type DeliveryMetadata struct {
 type DispatchEventMetadata struct {
 	EventID     string
 	SearchID    string
+	SearchName  string
 	Frequency   JobFrequency
 	Query       string
 	GeneratedAt time.Time

--- a/workers/email/pkg/digest/components.go
+++ b/workers/email/pkg/digest/components.go
@@ -30,7 +30,7 @@ const introTextComponent = `{{- define "intro_text" -}}
 <div style='{{- template "style_intro_wrapper" -}}'>
     <h2 style='{{- template "style_subject_header" -}}'>{{.FullSubject}}</h2>
     <div style='{{- template "style_query_text" -}}'>
-        Here is your update for the saved search <strong style='font-weight: bold;'>'{{.Query}}'</strong>.
+        Here is your update for the saved search <strong style='font-weight: bold;'>'{{if .SearchName}}{{.SearchName}}{{else}}{{.Query}}{{end}}'</strong>.
         {{.SummaryText}}.
     </div>
 </div>

--- a/workers/email/pkg/digest/renderer.go
+++ b/workers/email/pkg/digest/renderer.go
@@ -152,6 +152,7 @@ type BrowserChangeRenderData struct {
 type templateData struct {
 	Subject                   string
 	FullSubject               string
+	SearchName                string
 	Query                     string
 	SummaryText               string
 	BaselineNewlyChanges      []workertypes.SummaryHighlight
@@ -171,8 +172,8 @@ type templateData struct {
 // RenderDigest processes the delivery job and returns the subject and HTML body.
 func (r *HTMLRenderer) RenderDigest(job workertypes.IncomingEmailDeliveryJob) (string, string, error) {
 	// 1. Generate Subjects
-	subject := r.generateSubject(job.Metadata.Frequency, job.Metadata.Query, true)
-	fullSubject := r.generateSubject(job.Metadata.Frequency, job.Metadata.Query, false)
+	subject := r.generateSubject(job.Metadata.Frequency, job.Metadata.SearchName, job.Metadata.Query, true)
+	fullSubject := r.generateSubject(job.Metadata.Frequency, job.Metadata.SearchName, job.Metadata.Query, false)
 
 	// 2. Prepare Template Data using the visitor
 	generator := new(templateDataGenerator)
@@ -208,6 +209,7 @@ func (g *templateDataGenerator) VisitV1(summary workertypes.EventSummary) error 
 	g.data = templateData{
 		Subject:     g.subject,
 		FullSubject: g.fullSubject,
+		SearchName:  g.job.Metadata.SearchName,
 		Query:       g.job.Metadata.Query,
 		SummaryText: summary.Text,
 		Truncated:   summary.Truncated,
@@ -337,7 +339,7 @@ func filterHighlights(
 }
 
 func (r *HTMLRenderer) generateSubject(
-	frequency workertypes.JobFrequency, query string, truncate bool) string {
+	frequency workertypes.JobFrequency, searchName string, query string, truncate bool) string {
 	prefix := "Update:"
 	switch frequency {
 	case workertypes.FrequencyWeekly:
@@ -350,7 +352,11 @@ func (r *HTMLRenderer) generateSubject(
 		// Do nothing
 	}
 
-	displayQuery := query
+	displayQuery := searchName
+	if displayQuery == "" {
+		displayQuery = query
+	}
+
 	if truncate && len(displayQuery) > 50 {
 		displayQuery = displayQuery[:47] + "..."
 	}

--- a/workers/email/pkg/digest/renderer_test.go
+++ b/workers/email/pkg/digest/renderer_test.go
@@ -335,6 +335,7 @@ func TestRenderDigest_Golden(t *testing.T) {
 			SubscriptionID: "sub-123",
 			ChannelID:      "chan-1",
 			Metadata: workertypes.DeliveryMetadata{
+				SearchName:  "My CSS Search",
 				Query:       "group:css",
 				Frequency:   workertypes.FrequencyWeekly,
 				EventID:     "evt-123",

--- a/workers/email/pkg/digest/testdata/digest.golden.html
+++ b/workers/email/pkg/digest/testdata/digest.golden.html
@@ -2,13 +2,13 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Weekly digest: group:css</title>
+    <title>Weekly digest: My CSS Search</title>
 </head>
 <body style='font-family: SF Pro, system-ui, sans-serif;; line-height: 1.5; color: #333; margin: 0; padding: 0;'>
     <div style='max-width: 600px; margin: 0 auto; padding: 20px;'><div style='width: auto; padding: 16px; background: #F4F4F5; border-radius: 4px; display: block; margin-bottom: 4px;'>
-    <h2 style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 21px; word-wrap: break-word;; margin-top: 0; margin-bottom: 0; padding-bottom: 8px; font-weight: 700; font-size: 18px;'>Weekly digest: group:css</h2>
+    <h2 style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 21px; word-wrap: break-word;; margin-top: 0; margin-bottom: 0; padding-bottom: 8px; font-weight: 700; font-size: 18px;'>Weekly digest: My CSS Search</h2>
     <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 21px; word-wrap: break-word;; margin-top: 0; margin-bottom: 0; align-self: stretch;'>
-        Here is your update for the saved search <strong style='font-weight: bold;'>'group:css'</strong>.
+        Here is your update for the saved search <strong style='font-weight: bold;'>'My CSS Search'</strong>.
         11 features changed.
     </div>
 </div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;background: #E8F0FE;'>

--- a/workers/email/pkg/sender/sender_test.go
+++ b/workers/email/pkg/sender/sender_test.go
@@ -103,6 +103,7 @@ func testMetadata() workertypes.DeliveryMetadata {
 	return workertypes.DeliveryMetadata{
 		EventID:     "event-1",
 		SearchID:    "search-1",
+		SearchName:  "My Search",
 		Query:       "query-string",
 		Frequency:   workertypes.FrequencyMonthly,
 		GeneratedAt: testGeneratedAt(),

--- a/workers/event_producer/pkg/producer/batch_handler.go
+++ b/workers/event_producer/pkg/producer/batch_handler.go
@@ -62,10 +62,11 @@ func (h *BatchUpdateHandler) ProcessBatchUpdate(ctx context.Context, triggerID s
 	// 2. Fan-out
 	for _, search := range searches {
 		cmd := workertypes.RefreshSearchCommand{
-			SearchID:  search.ID,
-			Query:     search.Query,
-			Frequency: frequency,
-			Timestamp: h.now(),
+			SearchID:   search.ID,
+			SearchName: search.Name,
+			Query:      search.Query,
+			Frequency:  frequency,
+			Timestamp:  h.now(),
 		}
 
 		if err := h.publisher.PublishRefreshCommand(ctx, cmd); err != nil {

--- a/workers/event_producer/pkg/producer/batch_handler_test.go
+++ b/workers/event_producer/pkg/producer/batch_handler_test.go
@@ -56,8 +56,8 @@ func TestProcessBatchUpdate(t *testing.T) {
 		{
 			name: "success with searches",
 			searches: []workertypes.SearchJob{
-				{ID: "s1", Query: "q=1"},
-				{ID: "s2", Query: "q=2"},
+				{ID: "s1", Name: "Search 1", Query: "q=1"},
+				{ID: "s2", Name: "Search 2", Query: "q=2"},
 			},
 			listerErr:      nil,
 			pubErr:         nil,
@@ -86,7 +86,7 @@ func TestProcessBatchUpdate(t *testing.T) {
 		{
 			name:           "publisher error",
 			listerErr:      nil,
-			searches:       []workertypes.SearchJob{{ID: "s1", Query: "q=1"}},
+			searches:       []workertypes.SearchJob{{ID: "s1", Name: "Search 1", Query: "q=1"}},
 			pubErr:         errors.New("pub error"),
 			wantErr:        true,
 			transient:      true,
@@ -102,29 +102,40 @@ func TestProcessBatchUpdate(t *testing.T) {
 
 			err := handler.ProcessBatchUpdate(context.Background(), "trigger-1", workertypes.FrequencyImmediate)
 
-			if (err != nil) != tc.wantErr {
-				t.Errorf("ProcessBatchUpdate() error = %v, wantErr %v", err, tc.wantErr)
-			}
-
-			if tc.wantErr && tc.transient {
-				if !errors.Is(err, event.ErrTransientFailure) {
-					t.Errorf("Expected error to be transient")
-				}
-			}
-
-			if len(pub.commands) != tc.expectPubCalls {
-				t.Errorf("Expected %d publish calls, got %d", tc.expectPubCalls, len(pub.commands))
-			}
-
-			// Verify command content for success case
-			if !tc.wantErr && len(tc.searches) > 0 {
-				if pub.commands[0].SearchID != "s1" {
-					t.Errorf("Command data mismatch")
-				}
-				if pub.commands[0].Frequency != workertypes.FrequencyImmediate {
-					t.Errorf("Frequency mismatch")
-				}
-			}
+			// Helper function to process assertions, reducing gocognit complexity
+			verifyBatchUpdateTest(t, err, pub, tc.wantErr, tc.transient, tc.expectPubCalls, len(tc.searches) > 0)
 		})
+	}
+}
+
+func verifyBatchUpdateTest(t *testing.T, err error, pub *mockCommandPublisher,
+	wantErr, transient bool, expectPubCalls int, hasSearches bool) {
+	t.Helper()
+
+	if (err != nil) != wantErr {
+		t.Errorf("ProcessBatchUpdate() error = %v, wantErr %v", err, wantErr)
+	}
+
+	if wantErr && transient {
+		if !errors.Is(err, event.ErrTransientFailure) {
+			t.Errorf("Expected error to be transient")
+		}
+	}
+
+	if len(pub.commands) != expectPubCalls {
+		t.Errorf("Expected %d publish calls, got %d", expectPubCalls, len(pub.commands))
+	}
+
+	// Verify command content for success case
+	if !wantErr && hasSearches {
+		if pub.commands[0].SearchID != "s1" {
+			t.Errorf("Command data mismatch: SearchID")
+		}
+		if pub.commands[0].SearchName != "Search 1" {
+			t.Errorf("Command data mismatch: SearchName")
+		}
+		if pub.commands[0].Frequency != workertypes.FrequencyImmediate {
+			t.Errorf("Frequency mismatch")
+		}
 	}
 }

--- a/workers/event_producer/pkg/producer/producer.go
+++ b/workers/event_producer/pkg/producer/producer.go
@@ -86,7 +86,7 @@ func getDefaultLockTTL() time.Duration {
 
 // ProcessSearch is the main entry point triggered when a search query needs to be checked.
 // triggerID is the unique ID for this execution (e.g., from a Pub/Sub message).
-func (p *EventProducer) ProcessSearch(ctx context.Context, searchID string, query string,
+func (p *EventProducer) ProcessSearch(ctx context.Context, searchID string, searchName string, query string,
 	frequency workertypes.JobFrequency, triggerID string) error {
 	// 0. Acquire Lock
 	// TODO: For now, use the triggerID as the worker ID.
@@ -156,6 +156,7 @@ func (p *EventProducer) ProcessSearch(ctx context.Context, searchID string, quer
 	req := workertypes.PublishEventRequest{
 		EventID:       triggerID,
 		SearchID:      searchID,
+		SearchName:    searchName,
 		StateID:       result.State.ID,
 		StateBlobPath: statePath,
 		DiffID:        result.Diff.ID,

--- a/workers/event_producer/pkg/producer/producer_test.go
+++ b/workers/event_producer/pkg/producer/producer_test.go
@@ -169,6 +169,7 @@ func TestProcessSearch_Success(t *testing.T) {
 			expectedReq: workertypes.PublishEventRequest{
 				EventID:       triggerID,
 				SearchID:      searchID,
+				SearchName:    "Search Name",
 				StateID:       "state-1",
 				StateBlobPath: "full-path/state-1.json",
 				DiffID:        "diff-1",
@@ -212,6 +213,7 @@ func TestProcessSearch_Success(t *testing.T) {
 			expectedReq: workertypes.PublishEventRequest{
 				EventID:       triggerID,
 				SearchID:      searchID,
+				SearchName:    "Search Name",
 				StateID:       "state-2",
 				StateBlobPath: "full-path/state-2.json",
 				DiffID:        "diff-2",
@@ -246,7 +248,7 @@ func TestProcessSearch_Success(t *testing.T) {
 
 			// Execute
 			producer := NewEventProducer(mocks.differ, mocks.blob, mocks.meta, mocks.pub)
-			err := producer.ProcessSearch(ctx, searchID, query, frequency, triggerID)
+			err := producer.ProcessSearch(ctx, searchID, "Search Name", query, frequency, triggerID)
 
 			// Verify
 			if err != nil {
@@ -283,7 +285,7 @@ func TestProcessSearch_NoChanges(t *testing.T) {
 	differMock.runReturns.err = differ.ErrNoChangesDetected
 
 	producer := NewEventProducer(differMock, blobMock, metaMock, pubMock)
-	err := producer.ProcessSearch(ctx, "search-id", "q=test", "asap", "trigger-id")
+	err := producer.ProcessSearch(ctx, "search-id", "Search Name", "q=test", "asap", "trigger-id")
 
 	if err != nil {
 		t.Fatalf("expected nil error for no changes, got %v", err)
@@ -413,7 +415,7 @@ func TestProcessSearch_Failures(t *testing.T) {
 			tc.setup(mocks)
 
 			producer := NewEventProducer(mocks.differ, mocks.blob, mocks.meta, mocks.pub)
-			err := producer.ProcessSearch(ctx, "search-abc", "q=test", "asap", "trigger-123")
+			err := producer.ProcessSearch(ctx, "search-abc", "Search Name", "q=test", "asap", "trigger-123")
 
 			if err == nil {
 				t.Error("ProcessSearch() expected error, got nil")

--- a/workers/push_delivery/pkg/dispatcher/dispatcher.go
+++ b/workers/push_delivery/pkg/dispatcher/dispatcher.go
@@ -137,6 +137,7 @@ func (g *deliveryJobGenerator) VisitV1(s workertypes.EventSummary) error {
 	deliveryMetadata := workertypes.DeliveryMetadata{
 		EventID:     g.metadata.EventID,
 		SearchID:    g.metadata.SearchID,
+		SearchName:  g.metadata.SearchName,
 		Query:       g.metadata.Query,
 		Frequency:   g.metadata.Frequency,
 		GeneratedAt: g.metadata.GeneratedAt,

--- a/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
+++ b/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
@@ -124,6 +124,7 @@ func TestProcessEvent_Success(t *testing.T) {
 	metadata := workertypes.DispatchEventMetadata{
 		EventID:     eventID,
 		SearchID:    searchID,
+		SearchName:  "Test Search",
 		Query:       "q=test",
 		Frequency:   frequency,
 		GeneratedAt: generatedAt,
@@ -209,6 +210,7 @@ func TestProcessEvent_Success(t *testing.T) {
 		Metadata: workertypes.DeliveryMetadata{
 			EventID:     eventID,
 			SearchID:    searchID,
+			SearchName:  "Test Search",
 			Query:       "q=test",
 			Frequency:   frequency,
 			GeneratedAt: generatedAt,
@@ -233,6 +235,7 @@ func TestProcessEvent_NoChanges_FiltersAll(t *testing.T) {
 	metadata := workertypes.DispatchEventMetadata{
 		EventID:     "evt-1",
 		SearchID:    "search-1",
+		SearchName:  "Test Search",
 		Frequency:   workertypes.FrequencyImmediate,
 		Query:       "",
 		GeneratedAt: time.Time{},
@@ -284,6 +287,7 @@ func TestProcessEvent_ParserError(t *testing.T) {
 	metadata := workertypes.DispatchEventMetadata{
 		EventID:     "",
 		SearchID:    "",
+		SearchName:  "",
 		Query:       "",
 		Frequency:   workertypes.FrequencyImmediate,
 		GeneratedAt: time.Time{},
@@ -310,6 +314,7 @@ func TestProcessEvent_FinderError(t *testing.T) {
 	metadata := workertypes.DispatchEventMetadata{
 		EventID:     "",
 		SearchID:    "",
+		SearchName:  "",
 		Query:       "",
 		Frequency:   "",
 		GeneratedAt: time.Time{},
@@ -360,6 +365,7 @@ func TestProcessEvent_PublisherPartialFailure(t *testing.T) {
 	metadata := workertypes.DispatchEventMetadata{
 		EventID:     "",
 		SearchID:    "",
+		SearchName:  "",
 		Query:       "",
 		Frequency:   "",
 		GeneratedAt: time.Time{},
@@ -402,6 +408,7 @@ func TestProcessEvent_JobCount(t *testing.T) {
 	metadata := workertypes.DispatchEventMetadata{
 		EventID:     "",
 		SearchID:    "",
+		SearchName:  "",
 		Query:       "",
 		Frequency:   "",
 		GeneratedAt: time.Time{},


### PR DESCRIPTION
This PR updates the notification pipeline to propagate and use the user-provided saved search name instead of the raw query string in email subjects and introductions.

Fixes #2296