### PR TITLE
docs: standardize agent processes and e2e testing rules

### DIFF
--- a/.agent/skills/webstatus-backend/SKILL.md
+++ b/.agent/skills/webstatus-backend/SKILL.md
@@ -35,6 +35,7 @@ We use a Hexagonal-style **Adapter Pattern** to decouple application logic from 
 
 ## General Do's and Don'ts
 
+- **DO** cross-reference all code against the official Google Go Style Guide. If you are unsure about a specific style rule, DO NOT assume; you MUST ask the user for clarification.
 - **DO** use `spanneradapters` for DB interactions in the API.
 - **DON'T** call `gcpspanner.Client` directly from `httpserver` handlers.
 - **DO** use `row.ToStruct(&yourStruct)` instead of manual column scanning.

--- a/.agent/skills/webstatus-e2e/SKILL.md
+++ b/.agent/skills/webstatus-e2e/SKILL.md
@@ -19,11 +19,15 @@ For a detailed technical guide on the local development environment (Skaffold/Mi
 
 ## Guidelines (Do's and Don'ts)
 
+- **DO** cross-reference all code against the official Google TypeScript Style Guide. If you are unsure about a specific style rule, DO NOT assume; you MUST ask the user for clarification.
 - **DO** add E2E tests for critical user journeys (e.g., login flows, complex search operations, saving a search).
 - **DON'T** write E2E tests for small component-level interactions; those belong in frontend unit tests (`frontend/src/**/*.test.ts`).
 - **DO** use resilient locators. Prefer using `data-testid` attributes (e.g., `page.getByTestId('submit-btn')`) over brittle CSS classes or XPath.
 - **DO** move the mouse to a neutral position (e.g., `page.mouse.move(0, 0)`) before taking visual snapshots to avoid flaky tests caused by unintended hover effects on UI elements.
 - **DO** use **Wiremock** (available at `localhost:8080` via port-forward) to mock GitHub API responses, such as user profiles and email lookups during login.
+- **DO** use `waitForChartCompletion` and `waitForTabbedChartCompletion` hooks (from `utils.ts`) for Google Charts instead of naive `.waitForSelector` to avoid timeout races.
+- **DO** use `toBeAttached()` instead of `toBeVisible()` to cleanly bypass WebKit strict-mode 0px bounding box quirks for inline host elements or absolutely positioned fragments.
+- **DO** explicitly use `await` on asynchronous Playwright matchers like `toBeChecked()` to prevent tests from skipping past Lit hydration cycles synchronously.
 
 ## Configuration & Stability
 

--- a/.agent/skills/webstatus-frontend/SKILL.md
+++ b/.agent/skills/webstatus-frontend/SKILL.md
@@ -20,6 +20,7 @@ For a technical breakdown of the Lit component hierarchy, frontend identity flow
 
 ## Guidelines (Do's and Don'ts)
 
+- **DO** cross-reference all TypeScript and CSS against the official Google TypeScript/HTML/CSS Style Guides. If you are unsure about a specific style rule, DO NOT assume; you MUST ask the user for clarification.
 - **DO** create new UI elements as custom elements extending Lit's `LitElement`.
 - **DO** leverage Shoelace components for common UI patterns.
 - **DON'T** introduce other UI frameworks like React or Vue.

--- a/.agent/skills/webstatus-ingestion/SKILL.md
+++ b/.agent/skills/webstatus-ingestion/SKILL.md
@@ -32,6 +32,7 @@ Ingestion jobs must be decoupled from the core DB logic and the "Backend" API.
 
 ## General Do's and Don'ts
 
+- **DO** cross-reference all code against the official Google Go Style Guide. If you are unsure about a specific style rule, DO NOT assume; you MUST ask the user for clarification.
 - **DO** use consumer-specific `spanneradapters` (e.g. `BCDConsumer`).
 - **DON'T** call the `Backend` spanner adapter from a workflow.
 - **DO** separate data fetching/parsing from the main workflow processor (use `pkg/data/downloader.go` and `parser.go`).

--- a/.agent/skills/webstatus-maintenance/SKILL.md
+++ b/.agent/skills/webstatus-maintenance/SKILL.md
@@ -11,6 +11,10 @@ This skill provides guidance for updating the core toolchain versions across the
 
 For a technical overview of synchronized upgrades and infrastructure maintenance, see [references/architecture.md](references/architecture.md).
 
+## General Guidelines
+
+- **DO** cross-reference all infrastructure/scripts against the official Google Style Guides (e.g. for Shell Scripts, YAML). If you are unsure about a specific style rule, DO NOT assume; you MUST ask the user for clarification.
+
 ## Synchronized Upgrades
 
 When asked to update a specific language or tool, you must update it in all of its respective locations to prevent environment drift.

--- a/.agent/skills/webstatus-pr-creation/SKILL.md
+++ b/.agent/skills/webstatus-pr-creation/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: webstatus-pr-creation
+description: How to commit code and create a Pull Request
+---
+
+# Creating a Pull Request (PR)
+
+When you have finished implementing a feature or fixing a bug and the user asks you to "create a PR" or "commit these changes", you MUST follow these specific steps to ensure the repository remains clean and PRs are descriptive.
+
+1. **Verify the State**: Run `git status` to see what files have been modified.
+2. **Review the Diffs**: Before committing, use `git diff` to quickly review the changes. Ensure you haven't left any stray `console.log` statements, commented-out debugger code, or unresolved merge conflict markers.
+3. **Format, Lint, and Style**: Run standard project linters (`make precommit`, `make go-lint`, or `make node-lint`). Additionally, cross-reference your changes against the project's specific skills (e.g., `webstatus-backend`, `webstatus-frontend`) and standard Google Style Guides (e.g., Google Go Style Guide, Google TypeScript Style Guide). If you are unsure about a style rule, you may search for it or ask the user.
+4. **Create a New Branch**: NEVER commit directly to `main`.
+   - Run `git checkout -b feature/<short-description>` or `git checkout -b fix/<short-description>`
+5. **Stage Files**: Add the specific files you modified using `git add <file1> <file2>`. Try to avoid `git add .` unless you are absolutely certain no unrelated files (like local IDE configs) are present.
+6. **Write a Descriptive Commit Message**: You MUST use the Conventional Commits format (`type(scope): subject`). Make sure to prefix the commit with `feat:`, `fix:`, `chore:`, `docs:`, `test:`, or `refactor:`.
+   - _Example_: `feat: implement dark mode component`
+   - _Example_: `fix(api): handle missing search name in payload`
+   - _Example_: `docs: update knowledge base and skills`
+7. **Commit the Changes**: Run `git commit -m "<your message>"`. You can omit the `-m` flag and let it open an editor if you prefer to write a multi-line body explaining _why_ the change was made (encouraged for complex bug fixes!).
+8. **Prompt for Issue Number**: Before creating the PR, ask the user if there is an associated GitHub issue number for this work, if they haven't already provided one.
+9. **Push the Branch**: Run `git push -u origin <branch-name>`
+10. **Create the PR**: Use the GitHub CLI (`gh`) to create the PR.
+    - Run `gh pr create --title "<Commit Subject>" --body "<Detailed Description>"`
+    - **CRITICAL**: The `--body` must explain:
+      - **What** was changed.
+      - **Why** it was changed (context, bugs fixed).
+      - **How** it was implemented (architectural decisions).
+      - **Corrected Assumptions / Learnings**: Document any edge cases, architecture rules, or misconceptions discovered during the process that the AI should learn from.
+      - Include the issue number provided by the user (e.g., `Fixes #123`).
+
+> [!IMPORTANT]
+> A PR with just "fixed the bug" in the body is unacceptable. Take the time to write a body that a human reviewer can immediately understand without having to read every line of code first.
+
+## Dependent PRs (Splitting Big Changes)
+
+When tasked with a massive feature or refactor, always aim to split the work into smaller, focused PRs that build upon each other (dependent PRs). This makes reviewing significantly easier for humans.
+
+### Creating Dependent PRs
+
+1. Branch off `main` for the first piece of work (`PR 1`).
+2. Once the first PR is submitted for review, create your next branch _directly off of_ the first branch (e.g., `git checkout -b feature/pr2`).
+3. If you need a chain of 4 PRs, branch `pr4` off of `pr3`, `pr3` off of `pr2`, etc.
+
+### Updating Dependent PRs After Merges
+
+When the base branch (`origin/main`) advances (e.g., after `PR 1` merges), you must rebase your dependent branches so they stack cleanly on the new `main`. Use the `git rebase --onto` strategy.
+
+1. Fetch latest: `git fetch`
+2. Determine how many commits belong to your current branch (e.g., `N=2` if `PR 2` added 2 commits on top of `PR 1`).
+3. Rebase onto the new base: `git rebase --onto origin/main HEAD~<N> <BranchName>`
+4. Repeat this for subsequent stacked branches, swapping out `origin/main` for the new base branch as needed.

--- a/.agent/skills/webstatus-search-grammar/SKILL.md
+++ b/.agent/skills/webstatus-search-grammar/SKILL.md
@@ -16,6 +16,10 @@ For a technical breakdown of the ANTLR grammar, search node transformation, and 
 - The canonical source of truth for the search syntax is `antlr/FeatureSearch.g4`.
 - **DON'T** edit the generated parser files in `lib/gen/featuresearch/parser/` directly.
 
+## General Guidelines
+
+- **DO** cross-reference all Go and test code against the official Google Go Style Guide. If you are unsure about a specific style rule, DO NOT assume; you MUST ask the user for clarification.
+
 ## How to Add a New Search Term (e.g., `is:discouraged`)
 
 1. **Update Grammar (`antlr/FeatureSearch.g4`)**:

--- a/.agent/skills/webstatus-workers/SKILL.md
+++ b/.agent/skills/webstatus-workers/SKILL.md
@@ -13,9 +13,15 @@ For a detailed breakdown of the notification pipeline architecture, including th
 
 For guidance on adding future integrations (like Webhooks), see [references/how-to-add-a-worker.md](references/how-to-add-a-worker.md).
 
-## Canonical Data Transport
+## Canonical Data Transport & Event Semantics
 
 Workers must use the shared structs in [lib/workertypes/types.go](../../lib/workertypes/types.go) for all incoming and outgoing messages. This ensures that a change in the Spanner schema or API doesn't immediately break the worker pipeline (decoupling).
+
+**Strict Rules for Data Sync:**
+
+- **Event Payload Purity**: Do not add display metadata (e.g., human-readable `SearchName` or user PII) to core data-sync pub/sub event schemas (e.g., `FeatureDiffEvent`, `RefreshSearchCommand`). Core events should represent the raw state change via canonical IDs (`SearchID`, `EventID`). Any display data needed for emails or UI should be fetched from Spanner at the last possible moment (Delivery/Render phase).
+- **Feature Differ "Added" Semantics**: Within a `FeatureDiff`, the `Added` array represents features that _newly matched_ the search query since the last run. It does NOT mean the feature just entered the web platform. **Do not attempt to calculate baseline or status transitions against a "zero state" for features in the `Added` array**, as this falsely reports them as "becoming" newly/widely available when they merely entered the search results.
+- **Browser Implementation Grouping**: When formatting browser data for consumption (like combining Chrome Desktop and Chrome Android into a single row), the two implementations can ONLY be grouped if their entire transition state is identical. You must verify that `From.Status`, `To.Status`, `To.Version`, and `To.Date` perfectly match before combining them.
 
 ## Local Development
 
@@ -32,6 +38,7 @@ All workers must be decoupled from GCP-specific SDKs.
 
 ## General Guidelines
 
+- **DO** cross-reference all code against the official Google Go Style Guide. If you are unsure about a specific style rule, DO NOT assume; you MUST ask the user for clarification.
 - **DO** write tests for all new parsers, generators, and differ logic using table-driven tests.
 - **DO** use the `generic.OptionallySet[T]` pattern when defining blob structures or canonical in-memory state to handle forward/backward compatibility gracefully (quiet rollouts).
 - **DON'T** modify generated code.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # Gemini Code Assist Configuration for webstatus.dev
 
-<!-- Last analyzed commit: c3beadb0b4f8b7b6e38c089aa770a2123b4ee017 -->
+<!-- Last analyzed commit: 505072794fc44613c87cd35a31cb726cd795d55c -->
 
 This document provides context to Gemini Code Assist to help it generate more accurate and project-specific code suggestions.
 
@@ -41,6 +41,7 @@ The available skills are:
 - `webstatus-ingestion`: Scheduled data ingestion workflows.
 - `webstatus-workers`: Pub/Sub notification pipeline.
 - `webstatus-search-grammar`: ANTLR search query parsing.
+- `webstatus-pr-creation`: Agent workflows for creating PRs and commits.
 
 ## 4. Updating the Knowledge Base
 
@@ -58,6 +59,6 @@ When you give me this prompt, I will:
 
 1.  Read the `GEMINI.md` file to find the last analyzed commit SHA.
 2.  Use `git log` to find all the commits that have been made since that SHA.
-3.  Analyze the new commits, applying the "Verify, Don't Assume" principle by consulting relevant sources of truth (e.g., `openapi.yaml` for API changes, migration files for schema changes). Use the `get_pull_request` and `get_pull_request_comments` tools to get the pull request information for **every relevant PR** found in the commits. Read the comments to understand the context and architectural decisions.
+3.  Analyze the new commits, applying the "Verify, Don't Assume" principle by consulting relevant sources of truth (e.g., `openapi.yaml` for API changes, migration files for schema changes). Use the `get_pull_request` and `get_pull_request_comments` tools to get the pull request information for **every relevant PR** found in the commits. Read the comments and strictly pay attention to any **"Corrected Assumptions / Learnings"** section in the PR description or commit message to understand context and architectural decisions.
 4.  Update the relevant Skill files in `skills/` first.
 5.  Update the last analyzed commit SHA near the top of this file only after all other updates are complete.


### PR DESCRIPTION
1. Adds a create-pr workflow to standardize PR creation, enforce conventional commits, prompt for issues, and require a 'Corrected Assumptions / Learnings' section.
2. Implements strict Google Style Guidelines across all 7 domain skills (frontend, backend, workers, e2e, etc.).
3. Documents event payload purity and strict feature differ metrics in the webstatus-workers skill.
4. Adds new Playwright E2E chart execution and matcher best practices learned from PR 2308 to the webstatus-e2e skill.
5. Updates GEMINI.md to instruct the agent to parse the new PR learnings section during knowledge base updates.