### PR TITLE
Refactor webhook sender to add manager/preparer interfaces

### DIFF
--- a/workers/webhook/pkg/webhook/mocks_test.go
+++ b/workers/webhook/pkg/webhook/mocks_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+type mockHTTPClient struct {
+	doFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return m.doFunc(req)
+}
+
+type mockChannelStateManager struct {
+	successCalls []successCall
+	failureCalls []failureCall
+	recordErr    error
+}
+
+type successCall struct {
+	channelID string
+	timestamp time.Time
+	eventID   string
+}
+
+type failureCall struct {
+	channelID   string
+	err         error
+	timestamp   time.Time
+	isPermanent bool
+	eventID     string
+}
+
+func (m *mockChannelStateManager) RecordSuccess(_ context.Context, channelID string,
+	timestamp time.Time, eventID string) error {
+	m.successCalls = append(m.successCalls, successCall{channelID, timestamp, eventID})
+
+	return m.recordErr
+}
+
+func (m *mockChannelStateManager) RecordFailure(_ context.Context, channelID string,
+	err error, timestamp time.Time, isPermanent bool, eventID string) error {
+	m.failureCalls = append(m.failureCalls, failureCall{channelID, err, timestamp, isPermanent, eventID})
+
+	return m.recordErr
+}
+
+func newTestIncomingWebhookDeliveryJob(url string, wType workertypes.WebhookType,
+	query string, summary []byte) workertypes.IncomingWebhookDeliveryJob {
+	return workertypes.IncomingWebhookDeliveryJob{
+		WebhookEventID: "evt-123",
+		WebhookDeliveryJob: workertypes.WebhookDeliveryJob{
+			ChannelID:      "chan-1",
+			WebhookURL:     url,
+			WebhookType:    wType,
+			SubscriptionID: "sub-456",
+			Triggers:       []workertypes.JobTrigger{},
+			Metadata: workertypes.DeliveryMetadata{
+				EventID:     "evt-123",
+				SearchID:    "search-789",
+				SearchName:  "Test",
+				Query:       query,
+				Frequency:   workertypes.FrequencyWeekly,
+				GeneratedAt: testGeneratedAt(),
+			},
+			SummaryRaw: summary,
+		},
+	}
+}
+
+func newTestResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode:       status,
+		Status:           http.StatusText(status),
+		Proto:            "HTTP/1.1",
+		ProtoMajor:       1,
+		ProtoMinor:       1,
+		Header:           make(http.Header),
+		Body:             io.NopCloser(strings.NewReader(body)),
+		ContentLength:    int64(len(body)),
+		TransferEncoding: []string{},
+		Close:            false,
+		Uncompressed:     false,
+		Trailer:          make(http.Header),
+		Request:          nil,
+		TLS:              nil,
+	}
+}
+
+func testGeneratedAt() time.Time {
+	return time.Date(2026, 3, 12, 0, 0, 0, 0, time.UTC)
+}

--- a/workers/webhook/pkg/webhook/sender.go
+++ b/workers/webhook/pkg/webhook/sender.go
@@ -15,16 +15,14 @@
 package webhook
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/event"
 	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
 )
 
@@ -52,97 +50,69 @@ func NewSender(httpClient HTTPClient, stateManager ChannelStateManager, frontend
 	}
 }
 
-type SlackPayload struct {
-	Text string `json:"text"`
+var (
+	// ErrTransientWebhook is a transient failure that should be retried.
+	ErrTransientWebhook = errors.New("transient webhook failure")
+	// ErrPermanentWebhook is a permanent failure that should not be retried.
+	ErrPermanentWebhook = errors.New("permanent webhook failure")
+)
+
+type webhookSender interface {
+	Send(ctx context.Context) error
 }
 
-type webhookPreparer interface {
-	Prepare(ctx context.Context, job workertypes.IncomingWebhookDeliveryJob) (*http.Request, error)
+// Manager wraps the type-specific webhook logic.
+type Manager struct {
+	sender webhookSender
 }
 
-type slackPreparer struct {
-	frontendBaseURL string
-}
+func (s *Sender) getManager(_ context.Context, job workertypes.IncomingWebhookDeliveryJob) (*Manager, error) {
+	switch job.WebhookType {
+	case workertypes.WebhookTypeSlack:
+		slack, err := newSlackSender(s.frontendBaseURL, s.httpClient, job)
+		if err != nil {
+			return nil, err
+		}
 
-func (s *slackPreparer) Prepare(
-	ctx context.Context, job workertypes.IncomingWebhookDeliveryJob) (*http.Request, error) {
-	parsedURL, err := url.Parse(job.WebhookURL)
-	if err != nil || parsedURL.Scheme != "https" || parsedURL.Host != "hooks.slack.com" {
-		// Record permanent failure due to invalid URL
-		return nil, fmt.Errorf("invalid webhook URL: %s", job.WebhookURL)
+		return &Manager{sender: slack}, nil
+	default:
+		return nil, fmt.Errorf("%w: unsupported type %v", ErrPermanentWebhook, job.WebhookType)
 	}
-
-	var summary workertypes.EventSummary
-	if err := json.Unmarshal(job.SummaryRaw, &summary); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal summary: %w", err)
-	}
-
-	resultsURL := fmt.Sprintf("%s/features?q=%s", s.frontendBaseURL, url.QueryEscape(job.Metadata.Query))
-
-	payload := SlackPayload{
-		Text: fmt.Sprintf("WebStatus.dev Notification: %s\nQuery: %s\nView Results: %s",
-			summary.Text, job.Metadata.Query, resultsURL),
-	}
-
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal slack payload: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, job.WebhookURL, bytes.NewBuffer(payloadBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	return req, nil
 }
 
 func (s *Sender) SendWebhook(ctx context.Context, job workertypes.IncomingWebhookDeliveryJob) error {
 	slog.InfoContext(ctx, "sending webhook", "channelID", job.ChannelID, "url", job.WebhookURL)
 
-	var preparer webhookPreparer
-	switch job.WebhookType {
-	case workertypes.WebhookTypeSlack:
-		preparer = &slackPreparer{frontendBaseURL: s.frontendBaseURL}
-	default:
-		err := fmt.Errorf("unsupported webhook type: %v", job.WebhookType)
-		_ = s.stateManager.RecordFailure(ctx, job.ChannelID, err, time.Now(), true, job.WebhookEventID)
+	mgr, err := s.getManager(ctx, job)
+	if err != nil {
+		// If we fail here, it's permanent when trying to get the manager.
+		s.recordFailure(ctx, job, err, true)
 
-		return err
+		return fmt.Errorf("failed to prepare webhook: %w", err)
 	}
 
-	req, err := preparer.Prepare(ctx, job)
-	if err != nil {
-		// Preparation failures (like invalid payload or URL format) are typically permanent
-		_ = s.stateManager.RecordFailure(ctx, job.ChannelID, err, time.Now(), true, job.WebhookEventID)
+	if err := mgr.sender.Send(ctx); err != nil {
+		isTransient := errors.Is(err, ErrTransientWebhook)
+		s.recordFailure(ctx, job, err, !isTransient)
 
-		return fmt.Errorf("failed to prepare webhook request: %w", err)
-	}
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		// Transient error?
-		_ = s.stateManager.RecordFailure(ctx, job.ChannelID, err, time.Now(), false, job.WebhookEventID)
+		if isTransient {
+			return errors.Join(event.ErrTransientFailure, err)
+		}
 
 		return fmt.Errorf("failed to send webhook: %w", err)
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		// Success
-		_ = s.stateManager.RecordSuccess(ctx, job.ChannelID, time.Now(), job.WebhookEventID)
-
-		return nil
+	if err := s.stateManager.RecordSuccess(ctx, job.ChannelID, time.Now(), job.WebhookEventID); err != nil {
+		slog.WarnContext(ctx, "failed to record success", "error", err)
 	}
 
-	// Failure
-	errorMsg := fmt.Sprintf("webhook returned status code %d", resp.StatusCode)
-	webhookErr := errors.New(errorMsg)
-	isPermanent := resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone ||
-		resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden
+	return nil
+}
 
-	_ = s.stateManager.RecordFailure(ctx, job.ChannelID, webhookErr, time.Now(), isPermanent, job.WebhookEventID)
-
-	return fmt.Errorf("webhook failed: %s", errorMsg)
+func (s *Sender) recordFailure(ctx context.Context, job workertypes.IncomingWebhookDeliveryJob,
+	err error, permanent bool) {
+	if dbErr := s.stateManager.RecordFailure(ctx, job.ChannelID, err, time.Now(),
+		permanent, job.WebhookEventID); dbErr != nil {
+		slog.ErrorContext(ctx, "failed to record failure", "error", dbErr)
+	}
 }

--- a/workers/webhook/pkg/webhook/sender_test.go
+++ b/workers/webhook/pkg/webhook/sender_test.go
@@ -16,229 +16,176 @@ package webhook
 
 import (
 	"context"
-	"encoding/json"
-	"io"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/event"
 	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
 )
 
-type mockHTTPClient struct {
-	doFunc func(req *http.Request) (*http.Response, error)
-}
-
-func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	return m.doFunc(req)
-}
-
-type mockChannelStateManager struct {
-	successCalls []successCall
-	failureCalls []failureCall
-}
-
-type successCall struct {
-	channelID string
-	timestamp time.Time
-	eventID   string
-}
-
-type failureCall struct {
-	channelID   string
-	err         error
-	timestamp   time.Time
-	isPermanent bool
-	eventID     string
-}
-
-func (m *mockChannelStateManager) RecordSuccess(_ context.Context, channelID string,
-	timestamp time.Time, eventID string) error {
-	m.successCalls = append(m.successCalls, successCall{channelID, timestamp, eventID})
-
-	return nil
-}
-
-func (m *mockChannelStateManager) RecordFailure(_ context.Context, channelID string,
-	err error, timestamp time.Time, isPermanent bool, eventID string) error {
-	m.failureCalls = append(m.failureCalls, failureCall{channelID, err, timestamp, isPermanent, eventID})
-
-	return nil
-}
-
 func TestSender_SendWebhook_Success(t *testing.T) {
 	mockHTTP := &mockHTTPClient{
-		doFunc: func(req *http.Request) (*http.Response, error) {
-			if req.URL.String() != "https://hooks.slack.com/services/123" {
-				t.Errorf("unexpected URL: %s", req.URL.String())
-			}
-			if req.Method != http.MethodPost {
-				t.Errorf("unexpected method: %s", req.Method)
-			}
-			body, _ := io.ReadAll(req.Body)
-			var payload SlackPayload
-			if err := json.Unmarshal(body, &payload); err != nil {
-				t.Errorf("failed to unmarshal payload: %v", err)
-			}
-			if !strings.Contains(payload.Text, "Test Body") {
-				t.Errorf("payload does not contain expected text: %s", payload.Text)
-			}
-			expectedLink := "View Results: https://webstatus.dev/features?q=group%3Acss"
-			if !strings.Contains(payload.Text, expectedLink) {
-				t.Errorf("payload missing expected link. Got: %s", payload.Text)
-			}
-
-			return &http.Response{
-				StatusCode:       http.StatusOK,
-				Body:             io.NopCloser(strings.NewReader("ok")),
-				Status:           "200 OK",
-				Proto:            "HTTP/1.1",
-				ProtoMajor:       1,
-				ProtoMinor:       1,
-				Header:           make(http.Header),
-				ContentLength:    2,
-				TransferEncoding: nil,
-				Close:            false,
-				Uncompressed:     false,
-				Trailer:          nil,
-				Request:          nil,
-				TLS:              nil,
-			}, nil
+		doFunc: func(_ *http.Request) (*http.Response, error) {
+			return newTestResponse(http.StatusOK, "ok"), nil
 		},
 	}
 
 	mockState := &mockChannelStateManager{
 		successCalls: nil,
 		failureCalls: nil,
+		recordErr:    nil,
 	}
-	frontendBaseURL := "https://webstatus.dev"
-	sender := NewSender(mockHTTP, mockState, frontendBaseURL)
+	sender := NewSender(mockHTTP, mockState, "https://webstatus.dev")
 
-	summary := workertypes.EventSummary{
-		Text:          "Test Body",
-		SchemaVersion: "v1",
-		Categories: workertypes.SummaryCategories{
-			QueryChanged:    0,
-			Added:           0,
-			Removed:         0,
-			Deleted:         0,
-			Moved:           0,
-			Split:           0,
-			Updated:         0,
-			UpdatedImpl:     0,
-			UpdatedRename:   0,
-			UpdatedBaseline: 0,
-		},
-		Truncated:  false,
-		Highlights: nil,
-	}
-	summaryRaw, _ := json.Marshal(summary)
-
-	job := workertypes.IncomingWebhookDeliveryJob{
-		WebhookDeliveryJob: workertypes.WebhookDeliveryJob{
-			ChannelID:      "chan-1",
-			WebhookURL:     "https://hooks.slack.com/services/123",
-			WebhookType:    workertypes.WebhookTypeSlack,
-			SummaryRaw:     summaryRaw,
-			SubscriptionID: "sub-1",
-			Triggers:       nil,
-			Metadata: workertypes.DeliveryMetadata{
-				EventID:     "evt-1",
-				SearchID:    "search-1",
-				SearchName:  "",
-				Query:       "group:css",
-				Frequency:   workertypes.FrequencyImmediate,
-				GeneratedAt: time.Time{},
-			},
-		},
-		WebhookEventID: "evt-1",
-	}
+	job := newTestIncomingWebhookDeliveryJob(
+		"https://hooks.slack.com/services/123", workertypes.WebhookTypeSlack, "group:css", []byte(`{"text":"test"}`))
 
 	err := sender.SendWebhook(context.Background(), job)
 	if err != nil {
 		t.Fatalf("SendWebhook failed: %v", err)
 	}
 
-	// Verify the payload text contains the link
-	// The mock doFunc already checked basic text, but let's verify exact format if needed.
-	// (Actual check is inside the mock doFunc redefined above if we want to be strict)
+	verifySuccess(t, mockState)
+}
 
-	if len(mockState.successCalls) != 1 {
-		t.Errorf("expected 1 success call, got %d", len(mockState.successCalls))
+func TestSender_SendWebhook_TransientFailure(t *testing.T) {
+	mockHTTP := &mockHTTPClient{
+		doFunc: func(_ *http.Request) (*http.Response, error) {
+			return nil, event.ErrTransientFailure
+		},
 	}
-	if mockState.successCalls[0].channelID != "chan-1" {
-		t.Errorf("unexpected channel ID: %s", mockState.successCalls[0].channelID)
+	mockState := &mockChannelStateManager{
+		successCalls: nil,
+		failureCalls: nil,
+		recordErr:    nil,
+	}
+	sender := NewSender(mockHTTP, mockState, "https://webstatus.dev")
+
+	job := newTestIncomingWebhookDeliveryJob(
+		"https://hooks.slack.com/services/123", workertypes.WebhookTypeSlack, "group:css", []byte(`{"text":"test"}`))
+
+	err := sender.SendWebhook(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !errors.Is(err, event.ErrTransientFailure) {
+		t.Errorf("expected transient failure error, got %v", err)
+	}
+
+	if len(mockState.failureCalls) != 1 {
+		t.Errorf("expected 1 failure call, got %d", len(mockState.failureCalls))
+	}
+	if mockState.failureCalls[0].isPermanent {
+		t.Error("expected transient failure recorded")
 	}
 }
 
 func TestSender_SendWebhook_HTTPFailure(t *testing.T) {
 	mockHTTP := &mockHTTPClient{
 		doFunc: func(_ *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode:       http.StatusNotFound,
-				Body:             io.NopCloser(strings.NewReader("not found")),
-				Status:           "404 Not Found",
-				Proto:            "HTTP/1.1",
-				ProtoMajor:       1,
-				ProtoMinor:       1,
-				Header:           make(http.Header),
-				ContentLength:    9,
-				TransferEncoding: nil,
-				Close:            false,
-				Uncompressed:     false,
-				Trailer:          nil,
-				Request:          nil,
-				TLS:              nil,
-			}, nil
+			return nil, errors.New("network error")
 		},
 	}
-
 	mockState := &mockChannelStateManager{
 		successCalls: nil,
 		failureCalls: nil,
+		recordErr:    nil,
 	}
 	sender := NewSender(mockHTTP, mockState, "https://webstatus.dev")
 
-	summary := workertypes.EventSummary{
-		Text:          "Test Body",
-		SchemaVersion: "v1",
-		Categories: workertypes.SummaryCategories{
-			QueryChanged:    0,
-			Added:           0,
-			Removed:         0,
-			Deleted:         0,
-			Moved:           0,
-			Split:           0,
-			Updated:         0,
-			UpdatedImpl:     0,
-			UpdatedRename:   0,
-			UpdatedBaseline: 0,
-		},
-		Truncated:  false,
-		Highlights: nil,
-	}
-	summaryRaw, _ := json.Marshal(summary)
+	job := newTestIncomingWebhookDeliveryJob(
+		"https://hooks.slack.com/services/123", workertypes.WebhookTypeSlack, "group:css", []byte(`{"text":"test"}`))
 
-	job := workertypes.IncomingWebhookDeliveryJob{
-		WebhookDeliveryJob: workertypes.WebhookDeliveryJob{
-			ChannelID:      "chan-1",
-			WebhookURL:     "https://hooks.slack.com/services/123",
-			WebhookType:    workertypes.WebhookTypeSlack,
-			SummaryRaw:     summaryRaw,
-			SubscriptionID: "sub-1",
-			Triggers:       nil,
-			Metadata: workertypes.DeliveryMetadata{
-				EventID:     "evt-1",
-				SearchID:    "search-1",
-				SearchName:  "",
-				Query:       "group:css",
-				Frequency:   workertypes.FrequencyImmediate,
-				GeneratedAt: time.Time{},
-			},
-		},
-		WebhookEventID: "evt-1",
+	err := sender.SendWebhook(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
+
+	if !errors.Is(err, event.ErrTransientFailure) {
+		t.Errorf("expected transient failure error, got %v", err)
+	}
+
+	if len(mockState.failureCalls) != 1 {
+		t.Errorf("expected 1 failure call, got %d", len(mockState.failureCalls))
+	}
+	if mockState.failureCalls[0].isPermanent {
+		t.Error("expected transient failure recorded")
+	}
+}
+
+func TestSender_SendWebhook_PermanentFailure(t *testing.T) {
+	mockHTTP := &mockHTTPClient{
+		doFunc: func(_ *http.Request) (*http.Response, error) {
+			return newTestResponse(http.StatusNotFound, "not found"), nil
+		},
+	}
+	mockState := &mockChannelStateManager{
+		successCalls: nil,
+		failureCalls: nil,
+		recordErr:    nil,
+	}
+	sender := NewSender(mockHTTP, mockState, "https://webstatus.dev")
+
+	job := newTestIncomingWebhookDeliveryJob(
+		"https://hooks.slack.com/services/123", workertypes.WebhookTypeSlack, "group:css", []byte(`{"text":"test"}`))
+
+	err := sender.SendWebhook(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if errors.Is(err, event.ErrTransientFailure) {
+		t.Error("did not expect transient failure error")
+	}
+
+	if len(mockState.failureCalls) != 1 {
+		t.Errorf("expected 1 failure call, got %d", len(mockState.failureCalls))
+	}
+	if !mockState.failureCalls[0].isPermanent {
+		t.Error("expected permanent failure recorded")
+	}
+}
+
+func TestSender_SendWebhook_UnsupportedType(t *testing.T) {
+	mockState := &mockChannelStateManager{
+		successCalls: nil,
+		failureCalls: nil,
+		recordErr:    nil,
+	}
+	sender := NewSender(nil, mockState, "https://webstatus.dev")
+
+	job := newTestIncomingWebhookDeliveryJob(
+		"https://example.com/webhook", "unknown", "group:css", nil)
+
+	err := sender.SendWebhook(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported type") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+
+	if len(mockState.failureCalls) != 1 {
+		t.Errorf("expected 1 failure call, got %d", len(mockState.failureCalls))
+	}
+	if !mockState.failureCalls[0].isPermanent {
+		t.Error("expected permanent failure for unsupported type")
+	}
+}
+
+func TestSender_SendWebhook_InvalidSlackURL(t *testing.T) {
+	mockState := &mockChannelStateManager{
+		successCalls: nil,
+		failureCalls: nil,
+		recordErr:    nil,
+	}
+	sender := NewSender(nil, mockState, "https://webstatus.dev")
+
+	job := newTestIncomingWebhookDeliveryJob(
+		"https://not-slack.com/hook", workertypes.WebhookTypeSlack, "group:css", nil)
 
 	err := sender.SendWebhook(context.Background(), job)
 	if err == nil {
@@ -249,6 +196,38 @@ func TestSender_SendWebhook_HTTPFailure(t *testing.T) {
 		t.Errorf("expected 1 failure call, got %d", len(mockState.failureCalls))
 	}
 	if !mockState.failureCalls[0].isPermanent {
-		t.Error("expected permanent failure for 404")
+		t.Error("expected permanent failure for invalid URL")
+	}
+}
+
+func TestSender_SendWebhook_InvalidSummary(t *testing.T) {
+	mockState := &mockChannelStateManager{
+		successCalls: nil,
+		failureCalls: nil,
+		recordErr:    nil,
+	}
+	sender := NewSender(nil, mockState, "https://webstatus.dev")
+
+	job := newTestIncomingWebhookDeliveryJob(
+		"https://hooks.slack.com/services/123", workertypes.WebhookTypeSlack, "group:css", nil)
+	job.SummaryRaw = []byte(`invalid json`)
+
+	err := sender.SendWebhook(context.Background(), job)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to unmarshal summary") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func verifySuccess(t *testing.T, mockState *mockChannelStateManager) {
+	t.Helper()
+	if len(mockState.successCalls) != 1 {
+		t.Errorf("expected 1 success call, got %d", len(mockState.successCalls))
+	} else if mockState.successCalls[0].channelID != "chan-1" {
+		t.Errorf("unexpected channel ID: %s", mockState.successCalls[0].channelID)
+	} else if mockState.successCalls[0].eventID != "evt-123" {
+		t.Errorf("unexpected event ID: %s", mockState.successCalls[0].eventID)
 	}
 }

--- a/workers/webhook/pkg/webhook/slack.go
+++ b/workers/webhook/pkg/webhook/slack.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/httputils"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+type SlackPayload struct {
+	Text string `json:"text"`
+}
+
+type slackSender struct {
+	frontendBaseURL string
+	httpClient      HTTPClient
+	job             workertypes.IncomingWebhookDeliveryJob
+}
+
+func newSlackSender(frontendBaseURL string, httpClient HTTPClient,
+	job workertypes.IncomingWebhookDeliveryJob) (*slackSender, error) {
+	if err := httputils.ValidateSlackWebhookURL(job.WebhookURL); err != nil {
+		return nil, fmt.Errorf("%w: invalid webhook URL: %w", ErrPermanentWebhook, err)
+	}
+
+	return &slackSender{
+		frontendBaseURL: frontendBaseURL,
+		httpClient:      httpClient,
+		job:             job,
+	}, nil
+}
+
+func (s *slackSender) Send(ctx context.Context) error {
+	var summary workertypes.EventSummary
+	if err := json.Unmarshal(s.job.SummaryRaw, &summary); err != nil {
+		return fmt.Errorf("%w: failed to unmarshal summary: %w", ErrPermanentWebhook, err)
+	}
+
+	query := s.job.Metadata.Query
+	// Default search results page
+	resultsURL := fmt.Sprintf("%s/features?q=%s", s.frontendBaseURL, url.QueryEscape(query))
+
+	payload := SlackPayload{
+		Text: fmt.Sprintf("WebStatus.dev Notification: %s\nQuery: %s\nView Results: %s",
+			summary.Text, query, resultsURL),
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("%w: failed to marshal slack payload: %w", ErrPermanentWebhook, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.job.WebhookURL, bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return fmt.Errorf("%w: failed to create request: %w", ErrPermanentWebhook, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return errors.Join(ErrTransientWebhook, fmt.Errorf("network error: %w", err))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	webhookErr := fmt.Errorf("webhook returned status code %d", resp.StatusCode)
+	isPermanent := resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone ||
+		resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden
+
+	if !isPermanent {
+		return errors.Join(ErrTransientWebhook, webhookErr)
+	}
+
+	return errors.Join(ErrPermanentWebhook, webhookErr)
+}

--- a/workers/webhook/pkg/webhook/slack_test.go
+++ b/workers/webhook/pkg/webhook/slack_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSlackSender_Send(t *testing.T) {
+	tests := []slackTestCase{
+		{
+			name: "successful send with correct query-based payload",
+			job: newTestIncomingWebhookDeliveryJob(
+				"https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				workertypes.WebhookTypeSlack,
+				"group:css",
+				[]byte(`{"text":"New feature landed"}`),
+			),
+			mockResponse: newTestResponse(http.StatusOK, "ok"),
+			mockErr:      nil,
+			expectedPayload: &SlackPayload{
+				Text: "WebStatus.dev Notification: New feature landed\n" +
+					"Query: group:css\n" +
+					"View Results: https://webstatus.dev/features?q=group%3Acss",
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "successful send with direct feature link",
+			job: newTestIncomingWebhookDeliveryJob(
+				"https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				workertypes.WebhookTypeSlack,
+				"id:\"anchor-positioning\"",
+				[]byte(`{"text":"Test Body"}`),
+			),
+			mockResponse: newTestResponse(http.StatusOK, "ok"),
+			mockErr:      nil,
+			expectedPayload: &SlackPayload{
+				Text: "WebStatus.dev Notification: Test Body\n" +
+					"Query: id:\"anchor-positioning\"\n" +
+					"View Results: https://webstatus.dev/features?q=id%3A%22anchor-positioning%22",
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "network error",
+			job: newTestIncomingWebhookDeliveryJob(
+				"https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				workertypes.WebhookTypeSlack,
+				"",
+				[]byte(`{"text":"retry"}`),
+			),
+			mockResponse:    nil,
+			mockErr:         errors.New("network failure"),
+			expectedPayload: nil,
+			expectedErr:     ErrTransientWebhook,
+		},
+		{
+			name: "permanent error (404)",
+			job: newTestIncomingWebhookDeliveryJob(
+				"https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				workertypes.WebhookTypeSlack,
+				"",
+				[]byte(`{"text":"fail"}`),
+			),
+			mockResponse: newTestResponse(http.StatusNotFound, "not found"),
+			mockErr:      nil,
+			expectedPayload: &SlackPayload{
+				Text: "WebStatus.dev Notification: fail\n" +
+					"Query: \n" +
+					"View Results: https://webstatus.dev/features?q=",
+			},
+			expectedErr: ErrPermanentWebhook,
+		},
+		{
+			name: "transient error (500)",
+			job: newTestIncomingWebhookDeliveryJob(
+				"https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				workertypes.WebhookTypeSlack,
+				"",
+				[]byte(`{"text":"retry"}`),
+			),
+			mockResponse: newTestResponse(http.StatusInternalServerError, "internal error"),
+			mockErr:      nil,
+			expectedPayload: &SlackPayload{
+				Text: "WebStatus.dev Notification: retry\n" +
+					"Query: \n" +
+					"View Results: https://webstatus.dev/features?q=",
+			},
+			expectedErr: ErrTransientWebhook,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capturedBody := tt.runTest(t)
+			tt.verifyPayload(t, capturedBody)
+		})
+	}
+}
+
+func (tc *slackTestCase) runTest(t *testing.T) []byte {
+	var capturedBody []byte
+	mockHTTP := &mockHTTPClient{
+		doFunc: func(req *http.Request) (*http.Response, error) {
+			if tc.mockErr != nil {
+				return nil, tc.mockErr
+			}
+			var err error
+			capturedBody, err = io.ReadAll(req.Body)
+
+			return tc.mockResponse, err
+		},
+	}
+
+	sender, err := newSlackSender("https://webstatus.dev", mockHTTP, tc.job)
+	if err != nil {
+		if tc.expectedErr != nil && errors.Is(err, tc.expectedErr) {
+			return nil
+		}
+		t.Fatalf("unexpected error creating sender: %v", err)
+	}
+
+	err = sender.Send(context.Background())
+	if tc.expectedErr != nil {
+		if !errors.Is(err, tc.expectedErr) {
+			t.Errorf("Send() error = %v, expectedErr %v", err, tc.expectedErr)
+		}
+	} else if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	return capturedBody
+}
+
+func (tc *slackTestCase) verifyPayload(t *testing.T, capturedBody []byte) {
+	var actualPayload *SlackPayload
+	if len(capturedBody) > 0 {
+		actualPayload = new(SlackPayload)
+		if err := json.Unmarshal(capturedBody, actualPayload); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+	}
+
+	if diff := cmp.Diff(tc.expectedPayload, actualPayload); diff != "" {
+		t.Errorf("payload mismatch (-want +got):\n%s", diff)
+	}
+}
+
+type slackTestCase struct {
+	name            string
+	job             workertypes.IncomingWebhookDeliveryJob
+	mockResponse    *http.Response
+	mockErr         error
+	expectedPayload *SlackPayload
+	expectedErr     error
+}


### PR DESCRIPTION
- Split `sender.go` into orchestrator logic and Slack-specific implementation (`slack.go`)
- Introduce `Manager` and `Preparer` interfaces to decouple specific platform logic