### PR TITLE
fix: Prevent orphan changes from go fmt/tidy/fix in precommit checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ build: gen go-build node-install
 
 clean: clean-gen clean-node port-forward-terminate minikube-delete
 
-precommit: license-check lint unstaged-changes test
+precommit: license-check  go-fix go-tidy lint test unstaged-changes
 
 ################################
 # Local Environment
@@ -352,7 +352,14 @@ license-fix: go-install-tools
 	go tool addlicense $(ADDLICENSE_ARGS) .
 
 unstaged-changes:
-	git diff --exit-code
+	@if ! git diff --exit-code; then \
+		echo -e "\n\n======================================================="; \
+		echo "ERROR: Unstaged changes detected in the workspace!"; \
+		echo "This often happens if 'go mod tidy', 'go fix', etc modified files during the precommit checks."; \
+		echo "Please review the git diff, commit the changes, and try again."; \
+		echo -e "=======================================================\n\n"; \
+		exit 1; \
+	fi
 
 ################################
 # Playwright

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	firebase.google.com/go/v4 v4.19.0
 	github.com/GoogleChrome/webstatus.dev/lib v0.0.0-20260304140458-b3ea38597351
-	github.com/GoogleChrome/webstatus.dev/lib/gen v0.0.0-00010101000000-000000000000
+	github.com/GoogleChrome/webstatus.dev/lib/gen v0.0.0-20251119220853-b545639c35ae
 	github.com/go-chi/cors v1.2.2
 	github.com/google/go-cmp v0.7.0
 	github.com/oapi-codegen/runtime v1.2.0


### PR DESCRIPTION
Previously, `make precommit` did not automatically run Go code formatting or tidy module dependencies before validating unstaged changes. This allowed dirty module states and formatting issues to quietly slip past local validation and CI into the main branch. Any test failures from the unstaged-changes check also lacked clarity for developers.

This commit introduces the following improvements to the `Makefile`:
- Appends `go-tidy` and  `go-fix` to the main `precommit` check to execute these actions sequentially.
- Enhances the `unstaged-changes` target with a human-readable print statement that clearly identifies when background `tidy` or `fmt` rules modified tracked files, blocking the commit pipeline until the user adds the clean code.

This effectively ensures that all contributors run `go fix/tidy` correctly before merging their code.