### PR TITLE
Revert "Comment out failing test"

### DIFF
--- a/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher_test.go
+++ b/workflows/steps/services/chromium_histogram_enums/workflow/chromium_codesearch_enum_fetcher_test.go
@@ -26,7 +26,6 @@ import (
 
 // This is more of an integration test to ensure the data is actually base64 encoded.
 func TestChromiumCodesearchEnumFetcher_Fetch_Base64Encoded(t *testing.T) {
-	t.Skip("Temporarily skipping due to responses being 403s")
 	ctx := context.Background()
 	httpClient := http.DefaultClient
 	fetcher, err := NewChromiumCodesearchEnumFetcher(httpClient)


### PR DESCRIPTION
This reverts commit ccd750e9408b0059c9b09dcad51647922ef1120a.

The URL is now back up!