### PR TITLE
Remove automatic port forwarding for gcloud CLI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -78,10 +78,6 @@
       ]
     }
   },
-  "forwardPorts": [
-    // gcloud CLI
-    8085
-  ],
   "runArgs": [
     "--env-file",
     ".devcontainer/devcontainer.env",


### PR DESCRIPTION
Removed automatic forwarding of port 8085 for gcloud CLI.

This was to help with automatic port forwarding. However, it holds the port for other environments and forces developers to close the devcontainer.

As a side effect of this change, users may have to manually add the port in the Ports tab in the devcontainer.