### PR TITLE
feat(db): add system global searches support

### DIFF
--- a/infra/storage/spanner/migrations/000031.sql
+++ b/infra/storage/spanner/migrations/000031.sql
@@ -28,6 +28,7 @@ CREATE TABLE SystemGlobalSavedSearches (
     -- Status indicates whether the global saved search is currently active and should be displayed to users.
     -- This allows for easy deprecation of old searches without deleting them from the database, preserving historical data and preventing broken references in user-generated content.
     -- The "all" saved search will also be marked as unlisted to prevent it from showing up in the UI, but it will still be accessible via direct link and can be used as a catch-all query for API requests.
+    -- Valid values are 'LISTED' and 'UNLISTED'. See lib/gcpspanner/system_global_saved_searches.go for constants.
     Status STRING(32) NOT NULL,
     CONSTRAINT FK_SystemGlobal_SavedSearches FOREIGN KEY (SavedSearchID) REFERENCES SavedSearches (ID) ON DELETE CASCADE
 ) PRIMARY KEY (SavedSearchID);
@@ -42,4 +43,12 @@ CREATE TABLE SavedSearchFeatureSortOrder (
     -- by 10 (10, 20, 30) to allow injecting new features comfortably between them over time.
     PositionIndex INT64 NOT NULL,
     CONSTRAINT FK_SavedSearchSort_SavedSearch FOREIGN KEY (SavedSearchID) REFERENCES SavedSearches (ID) ON DELETE CASCADE
+    -- Note: A foreign key constraint on FeatureKey referencing WebFeatures(FeatureKey) was omitted
+    -- to prevent migration failure in environments where referenced features are not yet present.
 ) PRIMARY KEY (SavedSearchID, FeatureKey);
+
+-- Helper query to scan for orphaned sort order records (interim solution maintenance)
+-- SELECT s.SavedSearchID, s.FeatureKey
+-- FROM SavedSearchFeatureSortOrder s
+-- LEFT JOIN WebFeatures f ON s.FeatureKey = f.FeatureKey
+-- WHERE f.FeatureKey IS NULL;

--- a/infra/storage/spanner/migrations/000031.sql
+++ b/infra/storage/spanner/migrations/000031.sql
@@ -1,0 +1,45 @@
+-- Copyright 2026 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- SystemGlobalSavedSearches controls the display of global saved searches that
+-- are visible to all users.
+-- This is intended for use by system-defined searches such as Baselines and
+-- Top Interop issues, which are critical for users to easily discover and track.
+-- By centralizing the management of these global searches in a dedicated table,
+-- we can ensure they are consistently displayed across the application and
+-- prevent accidental modifications or deletions by end users.
+CREATE TABLE SystemGlobalSavedSearches (
+    SavedSearchID STRING(36) NOT NULL,
+    -- DisplayOrder dictates the UI ordering of global searches (e.g. Baseline 2026, Top CSS).
+    -- It is queried using ORDER BY DESC (Highest is Top) so it can scale infinitely forward
+    -- as new years are added without descending into zero or negative integers.
+    DisplayOrder INT64 NOT NULL,
+    -- Status indicates whether the global saved search is currently active and should be displayed to users.
+    -- This allows for easy deprecation of old searches without deleting them from the database, preserving historical data and preventing broken references in user-generated content.
+    -- The "all" saved search will also be marked as unlisted to prevent it from showing up in the UI, but it will still be accessible via direct link and can be used as a catch-all query for API requests.
+    Status STRING(32) NOT NULL,
+    CONSTRAINT FK_SystemGlobal_SavedSearches FOREIGN KEY (SavedSearchID) REFERENCES SavedSearches (ID) ON DELETE CASCADE
+) PRIMARY KEY (SavedSearchID);
+
+-- SavedSearchFeatureSortOrder specifies an explicit UI sort order for features
+-- within a global saved search
+CREATE TABLE SavedSearchFeatureSortOrder (
+    SavedSearchID STRING(36) NOT NULL,
+    FeatureKey STRING(64) NOT NULL,
+    -- PositionIndex dictates the UI ordering of features within a specific curated search.
+    -- It is queried using ORDER BY ASC (Lowest is Top). Start at 10 and explicitly increment
+    -- by 10 (10, 20, 30) to allow injecting new features comfortably between them over time.
+    PositionIndex INT64 NOT NULL,
+    CONSTRAINT FK_SavedSearchSort_SavedSearch FOREIGN KEY (SavedSearchID) REFERENCES SavedSearches (ID) ON DELETE CASCADE
+) PRIMARY KEY (SavedSearchID, FeatureKey);

--- a/infra/storage/spanner/migrations/000032.sql
+++ b/infra/storage/spanner/migrations/000032.sql
@@ -1,0 +1,175 @@
+-- Copyright 2026 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Note: System Global Saved Searches use descriptive string IDs (e.g. 'baseline-2026')
+-- instead of random UUIDs to prevent accidental overwrites of user-generated searches
+-- and to ensure these system records are easily identifiable in the database.
+
+-- BASELINE SEARCHES
+-- These searches rely on the default feature search sorting logic (Baseline Status / Low Date).
+-- Baseline 2026
+INSERT INTO SavedSearches (ID, Name, Description, Query, Scope, AuthorID, CreatedAt, UpdatedAt) VALUES (
+    'baseline-2026',
+    'Baseline 2026',
+    'All features that reached Baseline during 2026',
+    'baseline_date:2026-01-01..2026-12-31',
+    'SYSTEM_GLOBAL',
+    'system',
+    CURRENT_TIMESTAMP(),
+    CURRENT_TIMESTAMP()
+);
+INSERT INTO SystemGlobalSavedSearches (SavedSearchID, DisplayOrder, Status) VALUES ('baseline-2026', 10000, 'LISTED');
+-- Baseline 2025
+INSERT INTO SavedSearches (ID, Name, Description, Query, Scope, AuthorID, CreatedAt, UpdatedAt) VALUES (
+    'baseline-2025',
+    'Baseline 2025',
+    'All features that reached Baseline during 2025',
+    'baseline_date:2025-01-01..2025-12-31',
+    'SYSTEM_GLOBAL',
+    'system',
+    CURRENT_TIMESTAMP(),
+    CURRENT_TIMESTAMP()
+);
+INSERT INTO SystemGlobalSavedSearches (SavedSearchID, DisplayOrder, Status) VALUES ('baseline-2025', 9000, 'LISTED');
+-- Baseline 2024
+INSERT INTO SavedSearches (ID, Name, Description, Query, Scope, AuthorID, CreatedAt, UpdatedAt) VALUES (
+    'baseline-2024',
+    'Baseline 2024',
+    'All features that reached Baseline during 2024.',
+    'baseline_date:2024-01-01..2024-12-31',
+    'SYSTEM_GLOBAL',
+    'system',
+    CURRENT_TIMESTAMP(),
+    CURRENT_TIMESTAMP()
+);
+INSERT INTO SystemGlobalSavedSearches (SavedSearchID, DisplayOrder, Status) VALUES ('baseline-2024', 8000, 'LISTED');
+-- Baseline 2023
+INSERT INTO SavedSearches (ID, Name, Description, Query, Scope, AuthorID, CreatedAt, UpdatedAt) VALUES (
+    'baseline-2023',
+    'Baseline 2023',
+    'All features that reached Baseline during 2023.',
+    'baseline_date:2023-01-01..2023-12-31',
+    'SYSTEM_GLOBAL',
+    'system',
+    CURRENT_TIMESTAMP(),
+    CURRENT_TIMESTAMP()
+);
+INSERT INTO SystemGlobalSavedSearches (SavedSearchID, DisplayOrder, Status) VALUES ('baseline-2023', 7000, 'LISTED');
+-- Baseline 2022
+INSERT INTO SavedSearches (ID, Name, Description, Query, Scope, AuthorID, CreatedAt, UpdatedAt) VALUES (
+    'baseline-2022',
+    'Baseline 2022',
+    'All features that reached Baseline during 2022.',
+    'baseline_date:2022-01-01..2022-12-31',
+    'SYSTEM_GLOBAL',
+    'system',
+    CURRENT_TIMESTAMP(),
+    CURRENT_TIMESTAMP()
+);
+INSERT INTO SystemGlobalSavedSearches (SavedSearchID, DisplayOrder, Status) VALUES ('baseline-2022', 6000, 'LISTED');
+-- Baseline 2021
+INSERT INTO SavedSearches (ID, Name, Description, Query, Scope, AuthorID, CreatedAt, UpdatedAt) VALUES (
+    'baseline-2021',
+    'Baseline 2021',
+    'All features that reached Baseline during 2021.',
+    'baseline_date:2021-01-01..2021-12-31',
+    'SYSTEM_GLOBAL',
+    'system',
+    CURRENT_TIMESTAMP(),
+    CURRENT_TIMESTAMP()
+);
+INSERT INTO SystemGlobalSavedSearches (SavedSearchID, DisplayOrder, Status) VALUES ('baseline-2021', 5000, 'LISTED');
+-- Baseline 2020
+INSERT INTO SavedSearches (ID, Name, Description, Query, Scope, AuthorID, CreatedAt, UpdatedAt) VALUES (
+    'baseline-2020',
+    'Baseline 2020',
+    'All features that reached Baseline during 2020.',
+    'baseline_date:2020-01-01..2020-12-31',
+    'SYSTEM_GLOBAL',
+    'system',
+    CURRENT_TIMESTAMP(),
+    CURRENT_TIMESTAMP()
+);
+INSERT INTO SystemGlobalSavedSearches (SavedSearchID, DisplayOrder, Status) VALUES ('baseline-2020', 4000, 'LISTED');
+
+-- TOP CSS INTEROP ISSUES
+-- The display order of the features within this search is explicitly overridden below to ensure the most critical items surface first.
+INSERT INTO SavedSearches (ID, Name, Description, Query, Scope, AuthorID, CreatedAt, UpdatedAt) VALUES (
+    'top-css-interop',
+    'Top CSS Interop issues',
+    "This list reflects the top 10 interoperability pain points identified by developers in the State of CSS 2025 survey." ||
+        " We have also included their implementation status across Baseline browsers." ||
+        " You will notice that in some cases the items are already Baseline features, but may not have have been Baseline for long enough for developers to use with their target audience's browser support requirements." ||
+        " Since some voted-on pain points involve multiple web features, the list extends beyond 10 individual items for clarity and comprehensive coverage.",
+    'id:anchor-positioning OR id:scroll-driven-animations OR id:view-transitions OR id:cross-document-view-transitions OR id:container-style-queries OR id:nesting OR id:has OR id:container-queries OR id:scope OR id:if OR id:grid',
+    'SYSTEM_GLOBAL',
+    'system',
+    CURRENT_TIMESTAMP(),
+    CURRENT_TIMESTAMP()
+);
+INSERT INTO SystemGlobalSavedSearches (SavedSearchID, DisplayOrder, Status) VALUES ('top-css-interop', 3000, 'LISTED');
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-css-interop', 'anchor-positioning', 10);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-css-interop', 'scroll-driven-animations', 20);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-css-interop', 'view-transitions', 30);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-css-interop', 'cross-document-view-transitions', 40);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-css-interop', 'container-style-queries', 50);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-css-interop', 'nesting', 60);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-css-interop', 'has', 70);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-css-interop', 'container-queries', 80);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-css-interop', 'scope', 90);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-css-interop', 'if', 100);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-css-interop', 'grid', 110);
+
+-- TOP HTML INTEROP ISSUES
+-- The display order of the features within this search is explicitly overridden below to ensure the most critical items surface first.
+INSERT INTO SavedSearches (ID, Name, Description, Query, Scope, AuthorID, CreatedAt, UpdatedAt) VALUES (
+    'top-html-interop',
+    'Top HTML Interop issues',
+    "This list reflects the top 10 interoperability pain points identified by developers in the State of HTML 2025 survey." ||
+        " We have also included their implementation status across Baseline browsers." ||
+        " You will notice that in some cases the items are already Baseline features, but may not have have been Baseline for long enough for developers to use with their target audience's browser support requirements." ||
+        " Since some voted-on pain points involve multiple web features, the list extends beyond 10 individual items for clarity and comprehensive coverage.",
+    'id:customizable-select OR id:popover OR id:anchor-positioning OR id:customized-built-in-elements OR id:shadow-dom OR id:dialog OR id:view-transitions OR id:cross-document-view-transitions OR id:file-system-access OR id:input-date-time OR id:invoker-commands OR id:webusb',
+    'SYSTEM_GLOBAL',
+    'system',
+    CURRENT_TIMESTAMP(),
+    CURRENT_TIMESTAMP()
+);
+INSERT INTO SystemGlobalSavedSearches (SavedSearchID, DisplayOrder, Status) VALUES ('top-html-interop', 2000, 'LISTED');
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-html-interop', 'customizable-select', 10);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-html-interop', 'popover', 20);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-html-interop', 'anchor-positioning', 30);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-html-interop', 'customized-built-in-elements', 40);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-html-interop', 'shadow-dom', 50);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-html-interop', 'dialog', 60);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-html-interop', 'view-transitions', 70);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-html-interop', 'cross-document-view-transitions', 80);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-html-interop', 'file-system-access', 90);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-html-interop', 'input-date-time', 100);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-html-interop', 'invoker-commands', 110);
+INSERT INTO SavedSearchFeatureSortOrder (SavedSearchID, FeatureKey, PositionIndex) VALUES ('top-html-interop', 'webusb', 120);
+
+-- ALL FEATURES
+-- Default ordering implicitly applied. Shown for completeness.
+INSERT INTO SavedSearches (ID, Name, Description, Query, Scope, AuthorID, CreatedAt, UpdatedAt) VALUES (
+    'all',
+    'All Features',
+    'A system defined search containing all features.',
+    '',
+    'SYSTEM_GLOBAL',
+    'system',
+    CURRENT_TIMESTAMP(),
+    CURRENT_TIMESTAMP()
+);
+INSERT INTO SystemGlobalSavedSearches (SavedSearchID, DisplayOrder, Status) VALUES ('all', 1000, 'UNLISTED');

--- a/lib/gcpspanner/client.go
+++ b/lib/gcpspanner/client.go
@@ -1307,14 +1307,13 @@ func newAllByKeysEntityReader[
 	}
 }
 
-func (r *allByKeysEntityReader[M, KeysContainer, SpannerStruct]) readAllByKeys(
+func (r *allByKeysEntityReader[M, KeysContainer, SpannerStruct]) readAllByKeysWithTransaction(
 	ctx context.Context,
 	keys KeysContainer,
+	txn transaction,
 ) ([]SpannerStruct, error) {
 	var mapper M
 	stmt := mapper.SelectAllByKeys(keys)
-	txn := r.Single()
-	defer txn.Close()
 	it := txn.Query(ctx, stmt)
 	defer it.Stop()
 
@@ -1335,6 +1334,16 @@ func (r *allByKeysEntityReader[M, KeysContainer, SpannerStruct]) readAllByKeys(
 	}
 
 	return entities, nil
+}
+
+func (r *allByKeysEntityReader[M, KeysContainer, SpannerStruct]) readAllByKeys(
+	ctx context.Context,
+	keys KeysContainer,
+) ([]SpannerStruct, error) {
+	txn := r.Single()
+	defer txn.Close()
+
+	return r.readAllByKeysWithTransaction(ctx, keys, txn)
 }
 
 // entitySynchronizer handles the synchronization of a Spanner table with a

--- a/lib/gcpspanner/list_user_saved_searches_test.go
+++ b/lib/gcpspanner/list_user_saved_searches_test.go
@@ -283,6 +283,15 @@ func userSavedSearchesPageEquality(left, right *UserSavedSearchesPage) bool {
 
 func TestListAllSavedSearches(t *testing.T) {
 	restartDatabaseContainer(t)
+
+	// Fetch initial searches (e.g. system-seeded searches from migrations) to dynamically
+	// calculate expected count and avoid brittle hardcoding. Note that some migrations
+	// include populating this table with system-wide searches.
+	initialDetails, err := spannerClient.ListAllSavedSearches(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error fetching initial searches. received %s", err)
+	}
+
 	searches := loadFakeSavedSearches(t)
 
 	t.Run("list all saved search IDs", func(t *testing.T) {
@@ -291,15 +300,21 @@ func TestListAllSavedSearches(t *testing.T) {
 			t.Errorf("expected nil error. received %s", err)
 		}
 
-		if len(details) != len(searches) {
-			t.Errorf("expected %d results. received %d", len(searches), len(details))
+		expectedLen := len(searches) + len(initialDetails)
+		if len(details) != expectedLen {
+			t.Errorf("expected %d results. received %d", expectedLen, len(details))
 		}
 
 		// Build expected details list from created searches (which have generated IDs)
-		expectedDetails := make([]SavedSearchBriefDetails, len(searches))
-		for idx, search := range searches {
-			expectedDetails[idx] = SavedSearchBriefDetails{ID: search.ID, Name: search.Name, Query: search.Query}
+		expectedDetails := make([]SavedSearchBriefDetails, 0, len(searches)+len(initialDetails))
+		for _, search := range searches {
+			expectedDetails = append(expectedDetails, SavedSearchBriefDetails{
+				ID:    search.ID,
+				Name:  search.Name,
+				Query: search.Query,
+			})
 		}
+		expectedDetails = append(expectedDetails, initialDetails...)
 
 		slices.SortFunc(expectedDetails, sortSavedSearchBriefDetails)
 		slices.SortFunc(details, sortSavedSearchBriefDetails)

--- a/lib/gcpspanner/saved_search_feature_sort_order.go
+++ b/lib/gcpspanner/saved_search_feature_sort_order.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+)
+
+const savedSearchFeatureSortOrderTable = "SavedSearchFeatureSortOrder"
+
+// SpannerSavedSearchFeatureSortOrder represents a row in the SavedSearchFeatureSortOrder table.
+type SpannerSavedSearchFeatureSortOrder struct {
+	SavedSearchID string `spanner:"SavedSearchID"`
+	FeatureKey    string `spanner:"FeatureKey"`
+	PositionIndex int64  `spanner:"PositionIndex"`
+}
+
+type savedSearchFeatureSortOrderMapper struct{}
+
+func (m savedSearchFeatureSortOrderMapper) Table() string {
+	return savedSearchFeatureSortOrderTable
+}
+
+// SelectAllByKeys returns a statement to query by FeatureKey.
+// Implements readAllByKeysMapper[string].
+func (m savedSearchFeatureSortOrderMapper) SelectAllByKeys(featureKey string) spanner.Statement {
+	stmt := spanner.NewStatement(fmt.Sprintf(`
+		SELECT SavedSearchID, FeatureKey, PositionIndex
+		FROM %s
+		WHERE FeatureKey = @featureKey`, m.Table()))
+	stmt.Params = map[string]any{
+		"featureKey": featureKey,
+	}
+
+	return stmt
+}
+
+// InsertOrUpdateMutation returns a mutation to insert or update a row.
+func (m savedSearchFeatureSortOrderMapper) InsertOrUpdateMutation(item SpannerSavedSearchFeatureSortOrder) (
+	*spanner.Mutation, error) {
+	return spanner.InsertOrUpdateStruct(m.Table(), item)
+}
+
+// DeleteMutation returns a mutation to delete a row.
+func (m savedSearchFeatureSortOrderMapper) DeleteMutation(savedSearchID string, featureKey string) *spanner.Mutation {
+	return spanner.Delete(m.Table(), spanner.Key{savedSearchID, featureKey})
+}
+
+// Client methods to be used by consumers or hooks.
+
+// GetSavedSearchFeatureSortOrderByFeatureKey fetches rows for a feature key using a transaction.
+func (c *Client) GetSavedSearchFeatureSortOrderByFeatureKey(
+	ctx context.Context,
+	txn *spanner.ReadOnlyTransaction,
+	featureKey string,
+) ([]SpannerSavedSearchFeatureSortOrder, error) {
+	reader := newAllByKeysEntityReader[savedSearchFeatureSortOrderMapper, string, SpannerSavedSearchFeatureSortOrder](c)
+
+	return reader.readAllByKeysWithTransaction(ctx, featureKey, txn)
+}

--- a/lib/gcpspanner/saved_searches.go
+++ b/lib/gcpspanner/saved_searches.go
@@ -29,6 +29,8 @@ const (
 	UserPublicScope SavedSearchScope = "USER_PUBLIC"
 	// SystemManagedScope indicates that this is a system managed saved search for a feature.
 	SystemManagedScope SavedSearchScope = "SYSTEM_MANAGED"
+	// SystemGlobalScope indicates that this is a globally shared bookmark defined by the system.
+	SystemGlobalScope SavedSearchScope = "SYSTEM_GLOBAL"
 )
 
 const savedSearchesTable = "SavedSearches"
@@ -52,6 +54,42 @@ func (m savedSearchMapper) Table() string {
 	return savedSearchesTable
 }
 
+// SavedSearchIDOnly is a specialized struct to fetch only IDs from Spanner.
+type SavedSearchIDOnly struct {
+	ID string `spanner:"ID"`
+}
+
+type referencingSavedSearchMapper struct{}
+
+func (m referencingSavedSearchMapper) Table() string {
+	return savedSearchesTable
+}
+
+func (m referencingSavedSearchMapper) SelectList(req referencingSavedSearchRequest) spanner.Statement {
+	savedPattern := "%saved:" + req.ID + "%"
+	hotlistPattern := "%hotlist:" + req.ID + "%"
+	stmt := spanner.NewStatement(`
+		SELECT ID FROM SavedSearches
+		WHERE LOWER(Query) LIKE LOWER(@savedPattern)
+		   OR LOWER(Query) LIKE LOWER(@hotlistPattern)`)
+	stmt.Params["savedPattern"] = savedPattern
+	stmt.Params["hotlistPattern"] = hotlistPattern
+
+	return stmt
+}
+
+func (m referencingSavedSearchMapper) EncodePageToken(_ SavedSearchIDOnly) string {
+	return "" // Not used
+}
+
+type referencingSavedSearchRequest struct {
+	ID string
+}
+
+func (r referencingSavedSearchRequest) GetPageSize() int {
+	return 0 // No pagination
+}
+
 // SelectOne returns a statement to select a single saved search.
 func (m savedSearchMapper) SelectOne(id string) spanner.Statement {
 	stmt := spanner.NewStatement(
@@ -66,4 +104,34 @@ func (m savedSearchMapper) SelectOne(id string) spanner.Statement {
 // GetSavedSearch retrieves a saved search by its ID.
 func (c *Client) GetSavedSearch(ctx context.Context, id string) (*SavedSearch, error) {
 	return newEntityReader[savedSearchMapper, SavedSearch, string](c).readRowByKey(ctx, id)
+}
+
+// GetReferencingSavedSearchIDs finds all saved searches that reference the given ID in their query.
+//
+// WARNING: This function performs a full table scan on the SavedSearches table because it uses
+// a leading wildcard in the LIKE query (e.g., '%saved:ID%').
+// As the number of saved searches grows, the performance of this operation will degrade.
+//
+// Alternatives considered:
+//  1. Exact Matching (WHERE Query = @pattern): Feasible ONLY if queries cannot be combined.
+//     Since users can combine terms (e.g., 'saved:XYZ AND available_on:chrome'), this will miss references.
+//  2. Spanner Search Index: Ideal for fast substring searching. However, Search Indexes
+//     are not supported by the Spanner emulator, which would break the local development workflow.
+//  3. Junction Table: An explicit table mapping references (e.g., SavedSearchReferences).
+//     This is the most scalable approach for strict referential integrity but requires
+//     schema changes and maintenance logic.
+func (c *Client) GetReferencingSavedSearchIDs(ctx context.Context, id string) ([]string, error) {
+	req := referencingSavedSearchRequest{ID: id}
+	lister := newEntityLister[referencingSavedSearchMapper, SavedSearchIDOnly, referencingSavedSearchRequest](c)
+	results, _, err := lister.list(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]string, len(results))
+	for i, r := range results {
+		ids[i] = r.ID
+	}
+
+	return ids, nil
 }

--- a/lib/gcpspanner/saved_searches_test.go
+++ b/lib/gcpspanner/saved_searches_test.go
@@ -17,6 +17,7 @@ package gcpspanner
 import (
 	"context"
 	"reflect"
+	"slices"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -182,4 +183,78 @@ func savedSearchEquality(left, right SavedSearch) bool {
 		// Just make sure the times are non zero.
 		!left.CreatedAt.IsZero() && !right.CreatedAt.IsZero() &&
 		!left.UpdatedAt.IsZero() && !right.UpdatedAt.IsZero()
+}
+
+func TestGetReferencingSavedSearchIDs(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+
+	targetID := uuid.New().String()
+
+	// Note: We don't need to insert a saved search with targetID first because
+	// GetReferencingSavedSearchIDs only performs string matching on the Query field
+	// and does not enforce referential integrity or check for the actual existence
+	// of the referenced search.
+
+	// Insert searches that reference the targetID
+	ref1 := &SavedSearch{
+		ID:          uuid.New().String(),
+		Name:        "ref 1",
+		Query:       "saved:" + targetID,
+		Scope:       UserPublicScope,
+		AuthorID:    "user1",
+		Description: nil,
+		CreatedAt:   spanner.CommitTimestamp,
+		UpdatedAt:   spanner.CommitTimestamp,
+	}
+	ref2 := &SavedSearch{
+		ID:          uuid.New().String(),
+		Name:        "ref 2",
+		Query:       "hotlist:" + targetID,
+		Scope:       UserPublicScope,
+		AuthorID:    "user2",
+		Description: nil,
+		CreatedAt:   spanner.CommitTimestamp,
+		UpdatedAt:   spanner.CommitTimestamp,
+	}
+	// Insert a search that does NOT reference the targetID
+	noref := &SavedSearch{
+		ID:          uuid.New().String(),
+		Name:        "no ref",
+		Query:       "saved:other-id",
+		Scope:       UserPublicScope,
+		AuthorID:    "user3",
+		Description: nil,
+		CreatedAt:   spanner.CommitTimestamp,
+		UpdatedAt:   spanner.CommitTimestamp,
+	}
+
+	_, err := spannerClient.ReadWriteTransaction(ctx, func(_ context.Context, txn *spanner.ReadWriteTransaction) error {
+		m1, _ := spanner.InsertStruct(savedSearchesTable, ref1)
+		m2, _ := spanner.InsertStruct(savedSearchesTable, ref2)
+		m3, _ := spanner.InsertStruct(savedSearchesTable, noref)
+
+		return txn.BufferWrite([]*spanner.Mutation{m1, m2, m3})
+	})
+	if err != nil {
+		t.Fatalf("unexpected error during insert: %s", err)
+	}
+
+	results, err := spannerClient.GetReferencingSavedSearchIDs(ctx, targetID)
+	if err != nil {
+		t.Errorf("expected nil error. received %s", err)
+	}
+
+	expectedIDs := []string{ref1.ID, ref2.ID}
+	if len(results) != len(expectedIDs) {
+		t.Errorf("expected %d results, got %d", len(expectedIDs), len(results))
+	}
+
+	// Check that expected IDs are in results (order might not be guaranteed)
+	for _, id := range expectedIDs {
+		found := slices.Contains(results, id)
+		if !found {
+			t.Errorf("expected result to contain %s", id)
+		}
+	}
 }

--- a/lib/gcpspanner/saved_searches_test.go
+++ b/lib/gcpspanner/saved_searches_test.go
@@ -37,7 +37,7 @@ func TestGetSavedSearch(t *testing.T) {
 	restartDatabaseContainer(t)
 	ctx := context.Background()
 
-	id := uuid.New().String()
+	id := uuid.NewString()
 	desc := systemSearchDesc
 	expectedSavedSearch := &SavedSearch{
 		ID:          id,
@@ -189,7 +189,7 @@ func TestGetReferencingSavedSearchIDs(t *testing.T) {
 	restartDatabaseContainer(t)
 	ctx := context.Background()
 
-	targetID := uuid.New().String()
+	targetID := uuid.NewString()
 
 	// Note: We don't need to insert a saved search with targetID first because
 	// GetReferencingSavedSearchIDs only performs string matching on the Query field
@@ -198,7 +198,7 @@ func TestGetReferencingSavedSearchIDs(t *testing.T) {
 
 	// Insert searches that reference the targetID
 	ref1 := &SavedSearch{
-		ID:          uuid.New().String(),
+		ID:          uuid.NewString(),
 		Name:        "ref 1",
 		Query:       "saved:" + targetID,
 		Scope:       UserPublicScope,
@@ -208,7 +208,7 @@ func TestGetReferencingSavedSearchIDs(t *testing.T) {
 		UpdatedAt:   spanner.CommitTimestamp,
 	}
 	ref2 := &SavedSearch{
-		ID:          uuid.New().String(),
+		ID:          uuid.NewString(),
 		Name:        "ref 2",
 		Query:       "hotlist:" + targetID,
 		Scope:       UserPublicScope,
@@ -219,7 +219,7 @@ func TestGetReferencingSavedSearchIDs(t *testing.T) {
 	}
 	// Insert a search that does NOT reference the targetID
 	noref := &SavedSearch{
-		ID:          uuid.New().String(),
+		ID:          uuid.NewString(),
 		Name:        "no ref",
 		Query:       "saved:other-id",
 		Scope:       UserPublicScope,

--- a/lib/gcpspanner/system_global_saved_searches.go
+++ b/lib/gcpspanner/system_global_saved_searches.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+// SystemGlobalSavedSearch represents a joined row from SystemGlobalSavedSearches and SavedSearches.
+type SystemGlobalSavedSearch struct {
+	ID           string           `spanner:"ID"`
+	Name         string           `spanner:"Name"`
+	Description  *string          `spanner:"Description"`
+	Query        string           `spanner:"Query"`
+	Scope        SavedSearchScope `spanner:"Scope"`
+	AuthorID     string           `spanner:"AuthorID"`
+	CreatedAt    time.Time        `spanner:"CreatedAt"`
+	UpdatedAt    time.Time        `spanner:"UpdatedAt"`
+	DisplayOrder int64            `spanner:"DisplayOrder"`
+	Status       string           `spanner:"Status"`
+}
+
+// SystemGlobalSavedSearchWithSortOption combines SystemGlobalSavedSearch with custom sort order flag.
+type SystemGlobalSavedSearchWithSortOption struct {
+	SystemGlobalSavedSearch
+	HasCustomSortOrder bool `spanner:"HasCustomSortOrder"`
+}
+
+type systemGlobalSavedSearchMapper struct{}
+
+func (m systemGlobalSavedSearchMapper) Table() string {
+	return "SystemGlobalSavedSearches"
+}
+
+func (m systemGlobalSavedSearchMapper) SelectOne(id string) spanner.Statement {
+	stmt := spanner.NewStatement(`
+		SELECT
+			s.ID, s.Name, s.Description, s.Query, s.Scope, s.AuthorID, s.CreatedAt, s.UpdatedAt,
+			g.DisplayOrder, g.Status,
+			EXISTS (SELECT 1 FROM SavedSearchFeatureSortOrder WHERE SavedSearchID = g.SavedSearchID) AS HasCustomSortOrder
+		FROM SystemGlobalSavedSearches g
+		JOIN SavedSearches s ON g.SavedSearchID = s.ID
+		WHERE g.SavedSearchID = @id
+	`)
+	stmt.Params["id"] = id
+
+	return stmt
+}
+
+// ListSystemGlobalSavedSearchesRequest is a request to list system global saved searches.
+type ListSystemGlobalSavedSearchesRequest struct {
+	PageSize  int
+	PageToken *string
+}
+
+// GetPageSize returns the page size for the request.
+func (r ListSystemGlobalSavedSearchesRequest) GetPageSize() int {
+	return r.PageSize
+}
+
+type globalSavedSearchCursor struct {
+	LastID           string `json:"last_id"`
+	LastDisplayOrder int64  `json:"last_display_order"`
+}
+
+type listSystemGlobalSavedSearchesMapper struct{ systemGlobalSavedSearchMapper }
+
+func (m listSystemGlobalSavedSearchesMapper) EncodePageToken(item SystemGlobalSavedSearch) string {
+	return encodeCursor(globalSavedSearchCursor{
+		LastID:           item.ID,
+		LastDisplayOrder: item.DisplayOrder,
+	})
+}
+
+func (m listSystemGlobalSavedSearchesMapper) SelectList(req ListSystemGlobalSavedSearchesRequest) spanner.Statement {
+	var pageFilter string
+	params := map[string]any{
+		"pageSize": req.PageSize,
+	}
+	if req.PageToken != nil {
+		cursor, err := decodeCursor[globalSavedSearchCursor](*req.PageToken)
+		if err == nil {
+			params["lastID"] = cursor.LastID
+			params["lastDisplayOrder"] = cursor.LastDisplayOrder
+			pageFilter = " AND (g.DisplayOrder < @lastDisplayOrder OR " +
+				"(g.DisplayOrder = @lastDisplayOrder AND g.SavedSearchID > @lastID))"
+		}
+	}
+	query := fmt.Sprintf(`
+		SELECT
+			s.ID, s.Name, s.Description, s.Query, s.Scope, s.AuthorID, s.CreatedAt, s.UpdatedAt,
+			g.DisplayOrder, g.Status
+		FROM SystemGlobalSavedSearches g
+		JOIN SavedSearches s ON g.SavedSearchID = s.ID
+		WHERE g.Status = 'LISTED' %s
+		ORDER BY g.DisplayOrder DESC, g.SavedSearchID ASC
+		LIMIT @pageSize`, pageFilter)
+	stmt := spanner.NewStatement(query)
+	stmt.Params = params
+
+	return stmt
+}
+
+// ListSystemGlobalSavedSearches returns the listed global saved searches with pagination.
+func (c *Client) ListSystemGlobalSavedSearches(
+	ctx context.Context,
+	pageSize int,
+	pageToken *string,
+) ([]SystemGlobalSavedSearch, *string, error) {
+	req := ListSystemGlobalSavedSearchesRequest{
+		PageSize:  pageSize,
+		PageToken: pageToken,
+	}
+	lister := newEntityLister[listSystemGlobalSavedSearchesMapper](c)
+	results, nextPageToken, err := lister.list(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return results, nextPageToken, nil
+}
+
+// GetSystemGlobalSavedSearch retrieves a specific global saved search by id.
+func (c *Client) GetSystemGlobalSavedSearch(
+	ctx context.Context,
+	id string,
+) (*SystemGlobalSavedSearchWithSortOption, error) {
+	reader := newEntityReader[systemGlobalSavedSearchMapper, SystemGlobalSavedSearchWithSortOption, string, string](c)
+
+	return reader.readRowByKey(ctx, id)
+}

--- a/lib/gcpspanner/system_global_saved_searches.go
+++ b/lib/gcpspanner/system_global_saved_searches.go
@@ -22,6 +22,11 @@ import (
 	"cloud.google.com/go/spanner"
 )
 
+const (
+	SystemGlobalSavedSearchStatusListed   = "LISTED"
+	SystemGlobalSavedSearchStatusUnlisted = "UNLISTED"
+)
+
 // SystemGlobalSavedSearch represents a joined row from SystemGlobalSavedSearches and SavedSearches.
 type SystemGlobalSavedSearch struct {
 	ID           string           `spanner:"ID"`
@@ -92,6 +97,7 @@ func (m listSystemGlobalSavedSearchesMapper) SelectList(req ListSystemGlobalSave
 	var pageFilter string
 	params := map[string]any{
 		"pageSize": req.PageSize,
+		"status":   SystemGlobalSavedSearchStatusListed,
 	}
 	if req.PageToken != nil {
 		cursor, err := decodeCursor[globalSavedSearchCursor](*req.PageToken)
@@ -108,7 +114,7 @@ func (m listSystemGlobalSavedSearchesMapper) SelectList(req ListSystemGlobalSave
 			g.DisplayOrder, g.Status
 		FROM SystemGlobalSavedSearches g
 		JOIN SavedSearches s ON g.SavedSearchID = s.ID
-		WHERE g.Status = 'LISTED' %s
+		WHERE g.Status = @status %s
 		ORDER BY g.DisplayOrder DESC, g.SavedSearchID ASC
 		LIMIT @pageSize`, pageFilter)
 	stmt := spanner.NewStatement(query)

--- a/lib/gcpspanner/system_global_saved_searches_test.go
+++ b/lib/gcpspanner/system_global_saved_searches_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/api/iterator"
+)
+
+func TestListSystemGlobalSavedSearches(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+
+	// Expected lists defined to catch anyone modifying global structure via migrations without tests
+	expectedListed := []struct {
+		ID                 string
+		HasCustomSortOrder bool
+	}{
+		{"baseline-2026", false},
+		{"baseline-2025", false},
+		{"baseline-2024", false},
+		{"baseline-2023", false},
+		{"baseline-2022", false},
+		{"baseline-2021", false},
+		{"baseline-2020", false},
+		{"top-css-interop", true},
+		{"top-html-interop", true},
+	}
+
+	expectedUnlisted := []string{
+		"all",
+	}
+
+	// 1. Get explicitly LISTED searches via the official func and assert precise order and properties
+	page, _, err := spannerClient.ListSystemGlobalSavedSearches(ctx, 100, nil)
+	if err != nil {
+		t.Fatalf("ListSystemGlobalSavedSearches error: %v", err)
+	}
+
+	if len(page) != len(expectedListed) {
+		t.Fatalf("expected %d page items, got %d", len(expectedListed), len(page))
+	}
+
+	for i, s := range page {
+		expected := expectedListed[i]
+		if s.ID != expected.ID {
+			t.Errorf("at index %d: expected ID %s, got %s", i, expected.ID, s.ID)
+		}
+		res, err := spannerClient.GetSystemGlobalSavedSearch(ctx, s.ID)
+		if err != nil {
+			t.Errorf("at index %d: GetSystemGlobalSavedSearch error for %s: %v", i, s.ID, err)
+		} else if res.HasCustomSortOrder != expected.HasCustomSortOrder {
+			t.Errorf("at index %d (%s): expected HasCustomSortOrder %v, got %v",
+				i, s.ID, expected.HasCustomSortOrder, res.HasCustomSortOrder)
+		}
+	}
+
+	// 2. Fetch UNLISTED separately directly via spanner to assert they correctly exist
+	stmt := spanner.NewStatement("SELECT SavedSearchID FROM SystemGlobalSavedSearches WHERE Status = 'UNLISTED'")
+	iter := spannerClient.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var actualUnlisted []string
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("failed iterating unlisted searches: %v", err)
+		}
+		var id string
+		if err := row.Columns(&id); err != nil {
+			t.Fatalf("failed scanning row: %v", err)
+		}
+		actualUnlisted = append(actualUnlisted, id)
+	}
+
+	sortOpt := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+	if diff := cmp.Diff(expectedUnlisted, actualUnlisted, sortOpt); diff != "" {
+		t.Fatalf("Unlisted System Global Searches mismatch (-want +got):\n%s", diff)
+	}
+
+	// 3. Verify no other unknown status types exist
+	stmtCnt := spanner.NewStatement(
+		"SELECT count(*) FROM SystemGlobalSavedSearches WHERE Status NOT IN ('LISTED', 'UNLISTED')")
+	iterCnt := spannerClient.Single().Query(ctx, stmtCnt)
+	defer iterCnt.Stop()
+	row, err := iterCnt.Next()
+	if err != nil {
+		t.Fatalf("failed iterating unknown status count: %v", err)
+	}
+	var unknownCount int64
+	if err := row.Columns(&unknownCount); err != nil {
+		t.Fatalf("failed scanning unknown status count: %v", err)
+	}
+	if unknownCount > 0 {
+		t.Fatalf(
+			"found %d SystemGlobalSavedSearches with unknown statuses (expected only LISTED or UNLISTED)",
+			unknownCount,
+		)
+	}
+}

--- a/lib/gcpspanner/system_global_saved_searches_test.go
+++ b/lib/gcpspanner/system_global_saved_searches_test.go
@@ -74,7 +74,9 @@ func TestListSystemGlobalSavedSearches(t *testing.T) {
 	}
 
 	// 2. Fetch UNLISTED separately directly via spanner to assert they correctly exist
-	stmt := spanner.NewStatement("SELECT SavedSearchID FROM SystemGlobalSavedSearches WHERE Status = 'UNLISTED'")
+	stmt := spanner.NewStatement(
+		"SELECT SavedSearchID FROM SystemGlobalSavedSearches WHERE Status = '" + SystemGlobalSavedSearchStatusUnlisted + "'",
+	)
 	iter := spannerClient.Single().Query(ctx, stmt)
 	defer iter.Stop()
 
@@ -101,7 +103,9 @@ func TestListSystemGlobalSavedSearches(t *testing.T) {
 
 	// 3. Verify no other unknown status types exist
 	stmtCnt := spanner.NewStatement(
-		"SELECT count(*) FROM SystemGlobalSavedSearches WHERE Status NOT IN ('LISTED', 'UNLISTED')")
+		"SELECT count(*) FROM SystemGlobalSavedSearches WHERE Status NOT IN ('" +
+			SystemGlobalSavedSearchStatusListed + "', '" + SystemGlobalSavedSearchStatusUnlisted + "')",
+	)
 	iterCnt := spannerClient.Single().Query(ctx, stmtCnt)
 	defer iterCnt.Stop()
 	row, err := iterCnt.Next()
@@ -114,7 +118,8 @@ func TestListSystemGlobalSavedSearches(t *testing.T) {
 	}
 	if unknownCount > 0 {
 		t.Fatalf(
-			"found %d SystemGlobalSavedSearches with unknown statuses (expected only LISTED or UNLISTED)",
+			"found %d SystemGlobalSavedSearches with unknown statuses (expected only "+
+				SystemGlobalSavedSearchStatusListed+" or "+SystemGlobalSavedSearchStatusUnlisted+")",
 			unknownCount,
 		)
 	}

--- a/lib/gcpspanner/web_features.go
+++ b/lib/gcpspanner/web_features.go
@@ -357,6 +357,40 @@ func (m webFeatureSpannerMapper) moveLatestFeatureDeveloperSignals(
 	return mutations, nil
 }
 
+func (m webFeatureSpannerMapper) moveSavedSearchFeatureSortOrder(
+	ctx context.Context,
+	c *Client,
+	sourceKey string,
+	targetKey string,
+) ([]*spanner.Mutation, error) {
+	txn := c.ReadOnlyTransaction()
+	defer txn.Close()
+
+	rows, err := c.GetSavedSearchFeatureSortOrderByFeatureKey(ctx, txn, sourceKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var mutations []*spanner.Mutation
+	var mapper savedSearchFeatureSortOrderMapper
+	for _, row := range rows {
+		m, err := mapper.InsertOrUpdateMutation(SpannerSavedSearchFeatureSortOrder{
+			SavedSearchID: row.SavedSearchID,
+			FeatureKey:    targetKey,
+			PositionIndex: row.PositionIndex,
+		})
+		if err != nil {
+			return nil, err
+		}
+		mutations = append(mutations, m)
+
+		deleteMutation := mapper.DeleteMutation(row.SavedSearchID, sourceKey)
+		mutations = append(mutations, deleteMutation)
+	}
+
+	return mutations, nil
+}
+
 func (m webFeatureSpannerMapper) moveSystemManagedSavedSearch(
 	ctx context.Context,
 	c *Client,
@@ -491,6 +525,7 @@ func (m webFeatureSpannerMapper) PreDeleteHook(
 	var latestFeatureDeveloperSignalMutations []*spanner.Mutation
 	var savedSearchMutations []*spanner.Mutation
 	var systemManagedSearchMutations []*spanner.Mutation
+	var savedSearchFeatureSortOrderMutations []*spanner.Mutation
 
 	// The following sections are where the WebFeatureID is the primary key (or part of the primary key).
 	// This requires us to copy the rows (with updated IDs) because Spanner does not allow the modifications of keys.
@@ -552,6 +587,16 @@ func (m webFeatureSpannerMapper) PreDeleteHook(
 
 			return nil, err
 		}
+
+		// Move SavedSearchFeatureSortOrder
+		mutations, err = m.moveSavedSearchFeatureSortOrder(ctx, c, sourceKey, targetKey)
+		if err != nil {
+			slog.ErrorContext(ctx, "unable to move saved search feature sort order",
+				"sourceKey", sourceKey, "targetKey", targetKey, "err", err)
+
+			return nil, err
+		}
+		savedSearchFeatureSortOrderMutations = append(savedSearchFeatureSortOrderMutations, mutations...)
 	}
 
 	var groups []ExtraMutationsGroup
@@ -601,6 +646,13 @@ func (m webFeatureSpannerMapper) PreDeleteHook(
 		groups = append(groups, ExtraMutationsGroup{
 			tableName: systemManagedSavedSearchesTable,
 			mutations: systemManagedSearchMutations,
+		})
+	}
+
+	if len(savedSearchFeatureSortOrderMutations) > 0 {
+		groups = append(groups, ExtraMutationsGroup{
+			tableName: "SavedSearchFeatureSortOrder",
+			mutations: savedSearchFeatureSortOrderMutations,
 		})
 	}
 

--- a/lib/gcpspanner/web_features_test.go
+++ b/lib/gcpspanner/web_features_test.go
@@ -489,6 +489,32 @@ func setupRedirectDataAndAssert(
 	if err != nil {
 		t.Fatalf("Failed to sync latest feature developer signals: %v", err)
 	}
+
+	// Insert dummy SavedSearch to satisfy foreign key constraint
+	_, err = spannerClient.CreateNewUserSavedSearchWithUUID(ctx, CreateUserSavedSearchRequest{
+		Name:        "Test Search",
+		Description: nil,
+		Query:       "query",
+		OwnerUserID: "test-author",
+	}, "test-saved-search-id")
+	if err != nil {
+		t.Fatalf("Failed to insert dummy SavedSearch: %v", err)
+	}
+
+	// Insert SavedSearchFeatureSortOrder for feature-a
+	var mapper savedSearchFeatureSortOrderMapper
+	m, err := mapper.InsertOrUpdateMutation(SpannerSavedSearchFeatureSortOrder{
+		SavedSearchID: "test-saved-search-id",
+		FeatureKey:    "feature-a",
+		PositionIndex: 10,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create mutation for SavedSearchFeatureSortOrder: %v", err)
+	}
+	_, err = spannerClient.Apply(ctx, []*spanner.Mutation{m})
+	if err != nil {
+		t.Fatalf("Failed to insert SavedSearchFeatureSortOrder: %v", err)
+	}
 }
 
 func verifyRedirectDataMovedAndAssert(
@@ -600,6 +626,42 @@ func verifyRedirectDataMovedAndAssert(
 	}
 	if len(signals) != 1 {
 		t.Fatal("expected 1 feature developer signal for feature-b")
+	}
+
+	// Check SavedSearchFeatureSortOrder
+	// Verify that the row for feature-a is gone
+	stmt := spanner.NewStatement("SELECT count(*) FROM SavedSearchFeatureSortOrder WHERE FeatureKey = 'feature-a'")
+	iter := spannerClient.Single().Query(ctx, stmt)
+	defer iter.Stop()
+	row, err := iter.Next()
+	if err != nil {
+		t.Fatalf("failed to query sort order for feature-a: %v", err)
+	}
+	var count int64
+	if err := row.Columns(&count); err != nil {
+		t.Fatalf("failed to scan count for feature-a: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 sort order rows for feature-a, got %d", count)
+	}
+
+	// Verify that a row for feature-b exists with the same PositionIndex
+	stmt = spanner.NewStatement(
+		"SELECT PositionIndex FROM SavedSearchFeatureSortOrder WHERE FeatureKey = 'feature-b' AND " +
+			"SavedSearchID = 'test-saved-search-id'",
+	)
+	iter = spannerClient.Single().Query(ctx, stmt)
+	defer iter.Stop()
+	row, err = iter.Next()
+	if err != nil {
+		t.Fatalf("failed to query sort order for feature-b: %v", err)
+	}
+	var positionIndex int64
+	if err := row.Columns(&positionIndex); err != nil {
+		t.Fatalf("failed to scan position index for feature-b: %v", err)
+	}
+	if positionIndex != 10 {
+		t.Errorf("expected position index 10 for feature-b, got %d", positionIndex)
 	}
 }
 


### PR DESCRIPTION
### Title: feat(db): add system global searches support

### Description
This PR introduces database support and data seeding for System Global Saved Searches. These are curated searches (such as Baseline years and Top Interop issues) that are visible to all users and managed by the system.

### Key Changes
- **Schema**: Added `SystemGlobalSavedSearches` and `SavedSearchFeatureSortOrder` tables in Spanner (Migration 000031).
- **Data**: Seeded initial data for Baseline (2020-2026) and Top CSS/HTML Interop issues (Migration 000032).
- **Go Backend**:
    - Added `SystemGlobalScope` to `SavedSearchScope`.
    - Implemented `ListSystemGlobalSavedSearches` and `GetSystemGlobalSavedSearch` using the project's Mapper pattern.
    - Added `GetReferencingSavedSearchIDs` to find searches that embed a specific search ID.
- **Tests**: Added integration tests to verify listing and retrieval of global searches.

