### PR TITLE
feat(api): expose global saved searches via backend API

### DIFF
--- a/backend/pkg/httpserver/cache.go
+++ b/backend/pkg/httpserver/cache.go
@@ -151,6 +151,10 @@ type operationResponseCaches struct {
 		backend.ListAggregatedBaselineStatusCountsRequestObject,
 		backend.ListAggregatedBaselineStatusCounts200JSONResponse,
 	]
+	listGlobalSavedSearchesCache operationResponseCache[
+		backend.ListGlobalSavedSearchesRequestObject,
+		backend.ListGlobalSavedSearches200JSONResponse,
+	]
 }
 
 // initOperationResponseCaches initializes and configures each
@@ -206,6 +210,12 @@ func initOperationResponseCaches(dataCacher RawBytesDataCacher,
 			backend.ListAggregatedBaselineStatusCountsRequestObject,
 			backend.ListAggregatedBaselineStatusCounts200JSONResponse,
 		]{cacher: dataCacher, operationID: "listAggregatedBaselineStatusCounts",
+			overrideCacheOptions: routeCacheOptions.AggregatedFeatureStatsOptions},
+
+		listGlobalSavedSearchesCache: operationResponseCache[
+			backend.ListGlobalSavedSearchesRequestObject,
+			backend.ListGlobalSavedSearches200JSONResponse,
+		]{cacher: dataCacher, operationID: "listGlobalSavedSearches",
 			overrideCacheOptions: routeCacheOptions.AggregatedFeatureStatsOptions},
 	}
 }

--- a/backend/pkg/httpserver/create_saved_search.go
+++ b/backend/pkg/httpserver/create_saved_search.go
@@ -118,6 +118,29 @@ func validateSavedSearch(input *backend.SavedSearch) *fieldValidationErrors {
 	return nil
 }
 
+// sanitizeValidationError inspects the error chain for known validation errors.
+// If found, it returns the base sentinel error to ensure we only expose safe,
+// non-leaking error messages to the client. It returns nil if the error is not
+// a recognized validation error.
+func sanitizeValidationError(err error) error {
+	switch {
+	case errors.Is(err, backendtypes.ErrSavedSearchNotFound):
+		return backendtypes.ErrSavedSearchNotFound
+	case errors.Is(err, backendtypes.ErrHotlistNotFound):
+		return backendtypes.ErrHotlistNotFound
+	case errors.Is(err, backendtypes.ErrSavedSearchCycleDetected):
+		return backendtypes.ErrSavedSearchCycleDetected
+	case errors.Is(err, backendtypes.ErrSavedSearchMaxDepthExceeded):
+		return backendtypes.ErrSavedSearchMaxDepthExceeded
+	case errors.Is(err, backendtypes.ErrQueryConsistsEntirelyOfSavedSearch):
+		return backendtypes.ErrQueryConsistsEntirelyOfSavedSearch
+	case errors.Is(err, errQueryDoesNotMatchGrammar):
+		return errQueryDoesNotMatchGrammar
+	default:
+		return nil
+	}
+}
+
 // CreateSavedSearch implements backend.StrictServerInterface.
 // nolint: ireturn // Name generated from openapi
 func (s *Server) CreateSavedSearch(ctx context.Context, request backend.CreateSavedSearchRequestObject) (
@@ -142,6 +165,22 @@ func (s *Server) CreateSavedSearch(ctx context.Context, request backend.CreateSa
 			Message: "input validation errors",
 			Errors:  validationErr.fieldErrorMap,
 		}, nil
+	}
+
+	err := s.wptMetricsStorer.ValidateQueryReferences(ctx, request.Body.Query, nil)
+	if err != nil {
+		if safeErr := sanitizeValidationError(err); safeErr != nil {
+			// nolint:nilerr // WONTFIX - false positive when returning structured 400 response instead of Go error.
+			return backend.CreateSavedSearch400JSONResponse{
+				Code:    http.StatusBadRequest,
+				Message: safeErr.Error(),
+				Errors:  nil,
+			}, nil
+		}
+
+		slog.ErrorContext(ctx, "unexpected error during query validation", "error", err)
+
+		return nil, err
 	}
 
 	output, err := s.wptMetricsStorer.CreateUserSavedSearch(ctx, user.ID, *request.Body)

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -547,6 +547,40 @@ func TestListFeatures(t *testing.T) {
 				nil,
 			),
 		},
+		{
+			name: "400 case - query consists entirely of saved search",
+			mockConfig: &MockFeaturesSearchConfig{
+				expectedPageToken:     nil,
+				expectedPageSize:      100,
+				expectedSearchNode:    nil,
+				expectedSortBy:        nil,
+				expectedWPTMetricView: backend.TestCounts,
+				expectedBrowsers: []backend.BrowserPathParam{
+					backend.Chrome,
+					backend.Edge,
+					backend.Firefox,
+					backend.Safari,
+					backend.ChromeAndroid,
+					backend.FirefoxAndroid,
+					backend.SafariIos,
+				},
+				page: nil,
+				err:  backendtypes.ErrQueryConsistsEntirelyOfSavedSearch,
+			},
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key:   `listFeatures-{"Params":{}}`,
+					Value: nil,
+					Err:   cachetypes.ErrCachedDataNotFound,
+				},
+			},
+			expectedCacheCalls: nil,
+			expectedCallCount:  1,
+			expectedResponse: testJSONResponse(400,
+				`{"code":400,"message":"query cannot consist entirely of a single saved search or hotlist"}`,
+			),
+			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/v1/features", nil),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/pkg/httpserver/list_features.go
+++ b/backend/pkg/httpserver/list_features.go
@@ -82,6 +82,25 @@ func (s *Server) ListFeatures(
 			}, nil
 		}
 
+		if errors.Is(err, backendtypes.ErrSavedSearchNotFound) ||
+			errors.Is(err, backendtypes.ErrHotlistNotFound) ||
+			errors.Is(err, backendtypes.ErrSavedSearchCycleDetected) ||
+			errors.Is(err, backendtypes.ErrSavedSearchMaxDepthExceeded) ||
+			errors.Is(err, backendtypes.ErrQueryConsistsEntirelyOfSavedSearch) {
+			slog.WarnContext(ctx, "invalid saved search query", "error", err)
+
+			safeErr := sanitizeValidationError(err)
+			message := "invalid request"
+			if safeErr != nil {
+				message = safeErr.Error()
+			}
+
+			return backend.ListFeatures400JSONResponse{
+				Code:    400,
+				Message: message,
+			}, nil
+		}
+
 		slog.ErrorContext(ctx, "unable to get list of features", "error", err)
 
 		return backend.ListFeatures500JSONResponse{

--- a/backend/pkg/httpserver/list_global_saved_searches.go
+++ b/backend/pkg/httpserver/list_global_saved_searches.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// ListGlobalSavedSearches implements backend.StrictServerInterface.
+// nolint:ireturn // Expected ireturn for openapi generation.
+func (s *Server) ListGlobalSavedSearches(
+	ctx context.Context,
+	req backend.ListGlobalSavedSearchesRequestObject,
+) (backend.ListGlobalSavedSearchesResponseObject, error) {
+	var cachedResponse backend.ListGlobalSavedSearches200JSONResponse
+	found := s.operationResponseCaches.listGlobalSavedSearchesCache.Lookup(ctx, req, &cachedResponse)
+	if found {
+		return cachedResponse, nil
+	}
+
+	page, err := s.wptMetricsStorer.ListGlobalSavedSearches(
+		ctx,
+		getPageSizeOrDefault(req.Params.PageSize),
+		req.Params.PageToken,
+	)
+
+	if err != nil {
+		if errors.Is(err, backendtypes.ErrInvalidPageToken) {
+			slog.WarnContext(ctx, "invalid page token", "token", req.Params.PageToken, "error", err)
+
+			return backend.ListGlobalSavedSearches400JSONResponse{
+				Code:    400,
+				Message: "invalid page token",
+			}, nil
+		}
+
+		slog.ErrorContext(ctx, "unable to get list of global saved searches", "error", err)
+
+		return backend.ListGlobalSavedSearches500JSONResponse{
+			Code:    500,
+			Message: "unable to get list of global saved searches",
+		}, nil
+	}
+
+	resp := backend.ListGlobalSavedSearches200JSONResponse{
+		Metadata: page.Metadata,
+		Data:     page.Data,
+	}
+	s.operationResponseCaches.listGlobalSavedSearchesCache.AttemptCache(ctx, req, &resp)
+
+	return resp, nil
+}

--- a/backend/pkg/httpserver/list_global_saved_searches_test.go
+++ b/backend/pkg/httpserver/list_global_saved_searches_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestListGlobalSavedSearches(t *testing.T) {
+	testTime := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	token := "next-page-token"
+
+	testCases := []struct {
+		name               string
+		mockCfg            *MockListGlobalSavedSearchesConfig
+		expectedCallCount  int
+		expectedGetCalls   []*ExpectedGetCall
+		expectedCacheCalls []*ExpectedCacheCall
+		request            *http.Request
+		expectedResponse   *http.Response
+	}{
+		{
+			name: "Success - Cache Miss - return list of global saved searches",
+			mockCfg: &MockListGlobalSavedSearchesConfig{
+				expectedPageSize:  100, // default page size
+				expectedPageToken: nil,
+				output: &backend.GlobalSavedSearchPage{
+					Metadata: &backend.PageMetadata{
+						NextPageToken: &token,
+					},
+					Data: &[]backend.GlobalSavedSearch{
+						{
+							Id:           new("id-1"),
+							Name:         "Search 1",
+							Description:  new("Description 1"),
+							Query:        "q1",
+							CreatedAt:    &testTime,
+							UpdatedAt:    &testTime,
+							DisplayOrder: new(int64(1)),
+						},
+					},
+				},
+				err: nil,
+			},
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key:   `listGlobalSavedSearches-{"Params":{}}`,
+					Value: nil,
+					Err:   cachetypes.ErrCachedDataNotFound,
+				},
+			},
+			expectedCacheCalls: []*ExpectedCacheCall{
+				{
+					Key: `listGlobalSavedSearches-{"Params":{}}`,
+					Value: []byte(
+						`{"data":[{"created_at":"2026-01-01T00:00:00Z","description":"Description 1","display_order":1,` +
+							`"id":"id-1","name":"Search 1","query":"q1","updated_at":"2026-01-01T00:00:00Z"}],` +
+							`"metadata":{"next_page_token":"next-page-token"}}`,
+					),
+					CacheCfg: getTestAggregatedCacheConfig(),
+				},
+			},
+			expectedCallCount: 1,
+			request: httptest.NewRequestWithContext(
+				t.Context(),
+				http.MethodGet,
+				"/v1/global-saved-searches",
+				nil,
+			),
+			expectedResponse: testJSONResponse(200, `
+{
+	"data": [
+		{
+			"created_at": "2026-01-01T00:00:00Z",
+			"description": "Description 1",
+			"display_order": 1,
+			"id": "id-1",
+			"name": "Search 1",
+			"query": "q1",
+			"updated_at": "2026-01-01T00:00:00Z"
+		}
+	],
+	"metadata": {
+		"next_page_token": "next-page-token"
+	}
+}
+`),
+		},
+		{
+			name:    "Success - Cache Hit - return list of global saved searches from cache",
+			mockCfg: nil, // Should not call DB
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key: `listGlobalSavedSearches-{"Params":{}}`,
+					Value: []byte(
+						`{"data":[{"created_at":"2026-01-01T00:00:00Z","description":"Description 1","display_order":1,` +
+							`"id":"id-1","name":"Search 1","query":"q1","updated_at":"2026-01-01T00:00:00Z"}],` +
+							`"metadata":{"next_page_token":"next-page-token"}}`,
+					),
+					Err: nil,
+				},
+			},
+			expectedCacheCalls: nil,
+			expectedCallCount:  0,
+			request: httptest.NewRequestWithContext(
+				t.Context(),
+				http.MethodGet,
+				"/v1/global-saved-searches",
+				nil,
+			),
+			expectedResponse: testJSONResponse(200, `
+{
+	"data": [
+		{
+			"created_at": "2026-01-01T00:00:00Z",
+			"description": "Description 1",
+			"display_order": 1,
+			"id": "id-1",
+			"name": "Search 1",
+			"query": "q1",
+			"updated_at": "2026-01-01T00:00:00Z"
+		}
+	],
+	"metadata": {
+		"next_page_token": "next-page-token"
+	}
+}
+`),
+		},
+		{
+			name: "Error - invalid page token maps to 400 (Cache Miss)",
+			mockCfg: &MockListGlobalSavedSearchesConfig{
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				output:            nil,
+				err:               backendtypes.ErrInvalidPageToken,
+			},
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key:   `listGlobalSavedSearches-{"Params":{}}`,
+					Value: nil,
+					Err:   cachetypes.ErrCachedDataNotFound,
+				},
+			},
+			expectedCacheCalls: nil,
+			expectedCallCount:  1,
+			request: httptest.NewRequestWithContext(
+				t.Context(),
+				http.MethodGet,
+				"/v1/global-saved-searches",
+				nil,
+			),
+			expectedResponse: testJSONResponse(400, `
+{
+	"code": 400,
+	"message": "invalid page token"
+}
+`),
+		},
+		{
+			name: "Error - other errors map to 500 (Cache Miss)",
+			mockCfg: &MockListGlobalSavedSearchesConfig{
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				output:            nil,
+				err:               errors.New("db error"),
+			},
+			expectedGetCalls: []*ExpectedGetCall{
+				{
+					Key:   `listGlobalSavedSearches-{"Params":{}}`,
+					Value: nil,
+					Err:   cachetypes.ErrCachedDataNotFound,
+				},
+			},
+			expectedCacheCalls: nil,
+			expectedCallCount:  1,
+			request: httptest.NewRequestWithContext(
+				t.Context(),
+				http.MethodGet,
+				"/v1/global-saved-searches",
+				nil,
+			),
+			expectedResponse: testJSONResponse(500, `
+{
+	"code": 500,
+	"message": "unable to get list of global saved searches"
+}
+`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// nolint:exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				listGlobalSavedSearchesCfg: tc.mockCfg,
+				t:                          t,
+			}
+			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
+			myServer := Server{
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
+				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
+				eventPublisher:          nil,
+				baseURL:                 getTestBaseURL(t),
+			}
+
+			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListGlobalSavedSearches,
+				"ListGlobalSavedSearches", mockCacher)
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -136,11 +136,25 @@ type WPTMetricsStorer interface {
 		userID string,
 		savedSearch *backend.SavedSearchUpdateRequest,
 	) (*backend.SavedSearchResponse, error)
+	ValidateQueryReferences(
+		ctx context.Context,
+		query string,
+		updateID *string,
+	) error
 	PutUserSavedSearchBookmark(
 		ctx context.Context,
 		userID string,
 		savedSearchID string,
 	) error
+	ListGlobalSavedSearches(
+		ctx context.Context,
+		pageSize int,
+		pageToken *string,
+	) (*backend.GlobalSavedSearchPage, error)
+	GetGlobalSavedSearch(
+		ctx context.Context,
+		searchID string,
+	) (*backend.GlobalSavedSearch, error)
 	RemoveUserSavedSearchBookmark(
 		ctx context.Context,
 		userID string,

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -220,6 +220,18 @@ type MockListUserSavedSeachesConfig struct {
 	err               error
 }
 
+type MockValidateQueryReferencesConfig struct {
+	expectedQuery string
+	err           error
+}
+
+type MockListGlobalSavedSearchesConfig struct {
+	expectedPageSize  int
+	expectedPageToken *string
+	output            *backend.GlobalSavedSearchPage
+	err               error
+}
+
 type MockUpdateUserSavedSearchConfig struct {
 	expectedSavedSearchID string
 	expectedUserID        string
@@ -356,6 +368,8 @@ type MockWPTMetricsStorer struct {
 	getSavedSearchSubscriptionCfg                     *MockGetSavedSearchSubscriptionConfig
 	listSavedSearchSubscriptionsCfg                   *MockListSavedSearchSubscriptionsConfig
 	updateSavedSearchSubscriptionCfg                  *MockUpdateSavedSearchSubscriptionConfig
+	validateQueryReferencesCfg                        *MockValidateQueryReferencesConfig
+	listGlobalSavedSearchesCfg                        *MockListGlobalSavedSearchesConfig
 	t                                                 *testing.T
 	callCountListMissingOneImplCounts                 int
 	callCountListMissingOneImplFeatures               int
@@ -387,6 +401,9 @@ type MockWPTMetricsStorer struct {
 	callCountGetSavedSearchPublic                     int
 	callCountGetSavedSearchSubscriptionPublic         int
 	callCountListSavedSearchNotificationEvents        int
+	callCountValidateQueryReferences                  int
+	callCountListGlobalSavedSearches                  int
+	callCountGetGlobalSavedSearch                     int
 }
 
 func (m *MockWPTMetricsStorer) GetIDFromFeatureKey(
@@ -1046,6 +1063,54 @@ func (m *MockWPTMetricsStorer) UpdateNotificationChannel(
 	return m.updateNotificationChannelCfg.output, m.updateNotificationChannelCfg.err
 }
 
+func (m *MockWPTMetricsStorer) ValidateQueryReferences(
+	_ context.Context,
+	query string,
+	_ *string,
+) error {
+	m.callCountValidateQueryReferences++
+	if m.validateQueryReferencesCfg != nil && query != m.validateQueryReferencesCfg.expectedQuery {
+		m.t.Errorf("unexpected query %s", query)
+	}
+
+	if m.validateQueryReferencesCfg == nil {
+		return nil
+	}
+
+	return m.validateQueryReferencesCfg.err
+}
+
+func (m *MockWPTMetricsStorer) ListGlobalSavedSearches(
+	_ context.Context,
+	pageSize int,
+	pageToken *string,
+) (*backend.GlobalSavedSearchPage, error) {
+	m.callCountListGlobalSavedSearches++
+
+	if m.listGlobalSavedSearchesCfg == nil {
+		return nil, errors.New("basic mock")
+	}
+
+	if pageSize != m.listGlobalSavedSearchesCfg.expectedPageSize {
+		m.t.Errorf("unexpected page size %d", pageSize)
+	}
+
+	if !reflect.DeepEqual(pageToken, m.listGlobalSavedSearchesCfg.expectedPageToken) {
+		m.t.Errorf("unexpected page token %+v", pageToken)
+	}
+
+	return m.listGlobalSavedSearchesCfg.output, m.listGlobalSavedSearchesCfg.err
+}
+
+func (m *MockWPTMetricsStorer) GetGlobalSavedSearch(
+	_ context.Context,
+	_ string,
+) (*backend.GlobalSavedSearch, error) {
+	m.callCountGetGlobalSavedSearch++
+
+	return nil, errors.New("basic mock") // basic mock
+}
+
 type MockPublishSearchConfigurationChangedConfig struct {
 	expectedResp       *backend.SavedSearchResponse
 	expectedUserID     string
@@ -1519,6 +1584,17 @@ func (m *mockServerInterface) ListNotificationChannels(
 	panic("unimplemented")
 }
 
+// ListGlobalSavedSearches implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) ListGlobalSavedSearches(
+	ctx context.Context,
+	_ backend.ListGlobalSavedSearchesRequestObject,
+) (backend.ListGlobalSavedSearchesResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
 // PingUser implements backend.StrictServerInterface.
 // nolint: ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) PingUser(
@@ -1581,6 +1657,15 @@ func (m *mockServerInterface) GetSubscription(ctx context.Context,
 	panic("unimplemented")
 }
 
+// GetSubscriptionRSS implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) GetSubscriptionRSS(ctx context.Context, _ backend.GetSubscriptionRSSRequestObject) (
+	backend.GetSubscriptionRSSResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
 // DeleteSubscription implements backend.StrictServerInterface.
 // nolint: ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) DeleteSubscription(ctx context.Context,
@@ -1589,19 +1674,6 @@ func (m *mockServerInterface) DeleteSubscription(ctx context.Context,
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
 	m.callCount++
 	panic("unimplemented")
-}
-
-// GetSubscriptionRSS implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
-func (m *mockServerInterface) GetSubscriptionRSS(_ context.Context,
-	_ backend.GetSubscriptionRSSRequestObject) (
-	backend.GetSubscriptionRSSResponseObject, error) {
-	m.callCount++
-
-	return backend.GetSubscriptionRSS200ApplicationrssXmlResponse{
-		Body:          strings.NewReader(""),
-		ContentLength: 0,
-	}, nil
 }
 
 func (m *mockServerInterface) assertCallCount(expectedCallCount int) {

--- a/backend/pkg/httpserver/update_saved_search.go
+++ b/backend/pkg/httpserver/update_saved_search.go
@@ -107,6 +107,25 @@ func (s *Server) UpdateSavedSearch(
 			Errors:  validationErr.fieldErrorMap,
 		}, nil
 	}
+
+	if request.Body.Query != nil {
+		err := s.wptMetricsStorer.ValidateQueryReferences(ctx, *request.Body.Query, &request.SearchId)
+		if err != nil {
+			if safeErr := sanitizeValidationError(err); safeErr != nil {
+				// nolint:nilerr // WONTFIX - false positive when returning structured 400 response instead of Go error.
+				return backend.UpdateSavedSearch400JSONResponse{
+					Code:    http.StatusBadRequest,
+					Message: safeErr.Error(),
+					Errors:  nil,
+				}, nil
+			}
+
+			slog.ErrorContext(ctx, "unexpected error during query validation", "error", err)
+
+			return nil, err
+		}
+	}
+
 	output, err := s.wptMetricsStorer.UpdateUserSavedSearch(ctx, request.SearchId, user.ID, request.Body)
 	if err != nil {
 		if errors.Is(err, backendtypes.ErrUserNotAuthorizedForAction) {

--- a/lib/backendtypes/types.go
+++ b/lib/backendtypes/types.go
@@ -75,7 +75,9 @@ var (
 	ErrHotlistNotFound = errors.New("hotlist not found")
 
 	// ErrQueryConsistsEntirelyOfSavedSearch indicates the query consists entirely of a saved search.
-	ErrQueryConsistsEntirelyOfSavedSearch = errors.New("query consists entirely of a saved search")
+	ErrQueryConsistsEntirelyOfSavedSearch = errors.New(
+		"query cannot consist entirely of a single saved search or hotlist",
+	)
 )
 
 type UserProfile struct {

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -2098,3 +2098,67 @@ func toBackendSubscription(sub *gcpspanner.SavedSearchSubscriptionView) *backend
 		UpdatedAt: sub.UpdatedAt,
 	}
 }
+
+func (s *Backend) ListGlobalSavedSearches(
+	ctx context.Context,
+	pageSize int,
+	pageToken *string,
+) (*backend.GlobalSavedSearchPage, error) {
+	page, nextPageToken, err := s.client.ListSystemGlobalSavedSearches(ctx, pageSize, pageToken)
+	if err != nil {
+		if errors.Is(err, gcpspanner.ErrInvalidCursorFormat) {
+			return nil, errors.Join(err, backendtypes.ErrInvalidPageToken)
+		}
+
+		return nil, err
+	}
+	var metadata *backend.PageMetadata
+	if nextPageToken != nil {
+		metadata = &backend.PageMetadata{
+			NextPageToken: nextPageToken,
+		}
+	}
+	var results []backend.GlobalSavedSearch
+	if len(page) > 0 {
+		for _, savedSearch := range page {
+			results = append(results, backend.GlobalSavedSearch{
+				Id:           &savedSearch.ID,
+				DisplayOrder: &savedSearch.DisplayOrder,
+				Name:         savedSearch.Name,
+				Description:  savedSearch.Description,
+				Query:        savedSearch.Query,
+				CreatedAt:    &savedSearch.CreatedAt,
+				UpdatedAt:    &savedSearch.UpdatedAt,
+			})
+		}
+	}
+
+	return &backend.GlobalSavedSearchPage{
+		Metadata: metadata,
+		Data:     &results,
+	}, nil
+}
+
+func (s *Backend) GetGlobalSavedSearch(
+	ctx context.Context,
+	searchID string,
+) (*backend.GlobalSavedSearch, error) {
+	savedSearch, err := s.client.GetSystemGlobalSavedSearch(ctx, searchID)
+	if err != nil {
+		if errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {
+			return nil, errors.Join(err, backendtypes.ErrEntityDoesNotExist)
+		}
+
+		return nil, err
+	}
+
+	return &backend.GlobalSavedSearch{
+		Id:           &savedSearch.ID,
+		DisplayOrder: &savedSearch.DisplayOrder,
+		Name:         savedSearch.Name,
+		Description:  savedSearch.Description,
+		Query:        savedSearch.Query,
+		CreatedAt:    &savedSearch.CreatedAt,
+		UpdatedAt:    &savedSearch.UpdatedAt,
+	}, nil
+}

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -335,6 +335,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasicErrorModel'
+  /v1/global-saved-searches:
+    get:
+      summary: List global saved searches
+      operationId: listGlobalSavedSearches
+      parameters:
+        - $ref: '#/components/parameters/paginationTokenParam'
+        - $ref: '#/components/parameters/paginationSizeParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GlobalSavedSearchPage'
+        '400':
+          description: Bad Input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Service Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
   /v1/stats/features/browsers/{browser}/feature_counts:
     parameters:
       - $ref: '#/components/parameters/browserPathParam'
@@ -2165,6 +2191,35 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SavedSearchResponse'
+    GlobalSavedSearch:
+      description: A system global saved search with its UI display order.
+      allOf:
+        - $ref: '#/components/schemas/SavedSearch'
+        - type: object
+          properties:
+            id:
+              description: Unique string identifier for the saved search.
+              type: string
+            display_order:
+              description: The UI sorting order for displaying in the sidebar.
+              type: integer
+              format: int64
+            created_at:
+              type: string
+              format: date-time
+            updated_at:
+              type: string
+              format: date-time
+    GlobalSavedSearchPage:
+      description: A page of global saved searches.
+      type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/PageMetadata'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/GlobalSavedSearch'
     VendorPosition:
       type: object
       description: >


### PR DESCRIPTION
### What
- Added a new GET endpoint `/v1/global-saved-searches` to list system-wide global saved searches.
- Added query validation in `CreateSavedSearch` and `UpdateSavedSearch` to prevent circular references and invalid searches.
- Updated error handling in `ListFeatures` to return 400 for saved search errors.

### Why
- To provide a way to retrieve global saved searches for UI display.
- To ensure that saved search queries are valid and do not cause cycles or infinite depth resolution when evaluated.

### How
- Defined the new endpoint and schemas in `openapi/backend/openapi.yaml`.
- Implemented the endpoint in `backend/pkg/httpserver/list_global_saved_searches.go` using the existing operation response cache.
- Added `ValidateQueryReferences` to the `WPTMetricsStorer` interface and implemented it in Spanner adapter.
- Updated `ListFeatures` to check for specific saved search sentinel errors and return a 400 response.

### Corrected Assumptions / Learnings
- Identified that returning `err.Error()` directly in `ListFeatures` might leak internal details if errors are wrapped. A follow-up task should be created to sanitize these errors similarly to how it is done in `CreateSavedSearch`.
