### PR TITLE
feat(search): add query expansion for saved searches

### DIFF
--- a/.agent/skills/webstatus-backend/references/spanner-best-practices.md
+++ b/.agent/skills/webstatus-backend/references/spanner-best-practices.md
@@ -19,3 +19,16 @@
 
 - **DO** look for existing mappers in [`lib/gcpspanner/`](../../../lib/gcpspanner/) (e.g. `webFeatureSpannerMapper`) before creating new ones.
 - **DO** translate business keys to internal IDs inside the `gcpspanner` client so that adapters/workflows remain unaware of internal DB IDs.
+
+## Sorting & Order Strategies
+
+When implementing integer-based explicit ordering columns, choose an approach based on the growth pattern of the data:
+
+- **Chronological / Infinite Growth Lists (e.g. Years, Global Baselines)**
+  - Use `ORDER BY Column DESC` (Highest is Top).
+  - Start seeding at high values (e.g. 10,000) and step downwards.
+  - **Why**: This prevents integer exhaustion at `0`. When new, more recent items launch, they naturally increment (e.g., 11,000) and take the top spot securely.
+- **Curated / Bounded Lists (e.g. Top Issues, Fixed Categorizations)**
+  - Use `ORDER BY Column ASC` (Lowest is Top).
+  - Start at `10` and increment by `10`s (10, 20, 30).
+  - **Why**: If you need to reorder or inject an item between two priorities without shifting the entire list, you can safely use intermediate values (e.g., `15`).

--- a/lib/backendtypes/types.go
+++ b/lib/backendtypes/types.go
@@ -61,6 +61,21 @@ var (
 	// was valid but empty (e.g., an empty array or object). This allows callers to distinguish
 	// between a missing value and an explicitly empty one.
 	ErrEmptyJSONValue = errors.New("JSON value is empty")
+
+	// ErrSavedSearchMaxDepthExceeded indicates that the saved search expansion exceeded the maximum depth.
+	ErrSavedSearchMaxDepthExceeded = errors.New("saved search expansion exceeded maximum depth")
+
+	// ErrSavedSearchCycleDetected indicates a cycle was detected in saved search expansion.
+	ErrSavedSearchCycleDetected = errors.New("cycle detected in saved search expansion")
+
+	// ErrSavedSearchNotFound indicates the saved search was not found.
+	ErrSavedSearchNotFound = errors.New("saved search not found")
+
+	// ErrHotlistNotFound indicates the hotlist was not found.
+	ErrHotlistNotFound = errors.New("hotlist not found")
+
+	// ErrQueryConsistsEntirelyOfSavedSearch indicates the query consists entirely of a saved search.
+	ErrQueryConsistsEntirelyOfSavedSearch = errors.New("query consists entirely of a saved search")
 )
 
 type UserProfile struct {

--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -46,6 +46,8 @@ var (
 	gcpFSBrowserImplementationStatusTemplate BaseQueryTemplate
 	// gcpFSBrowserFeatureSupportTemplate is the compiled version of gcpFSBrowserFeatureSupportRawTemplate.
 	gcpFSBrowserFeatureSupportTemplate BaseQueryTemplate
+	// gcpFSSearchIDOrderTemplate is the compiled version of gcpFSSearchIDOrderRawTemplate.
+	gcpFSSearchIDOrderTemplate BaseQueryTemplate
 
 	// localFSMetricsSubQueryTemplate is the compiled version of localFSMetricsSubQueryRawTemplate.
 	localFSMetricsSubQueryTemplate BaseQueryTemplate
@@ -68,6 +70,7 @@ func init() {
 	gcpFSPassRateForBrowserTemplate = NewQueryTemplate(gcpFSPassRateForBrowserRawTemplate)
 	gcpFSBrowserImplementationStatusTemplate = NewQueryTemplate(gcpFSBrowserImplementationStatusRawTemplate)
 	gcpFSBrowserFeatureSupportTemplate = NewQueryTemplate(gcpFSBrowserFeatureSupportRawTemplate)
+	gcpFSSearchIDOrderTemplate = NewQueryTemplate(gcpFSSearchIDOrderRawTemplate)
 
 	localFSMetricsSubQueryTemplate = NewQueryTemplate(localFSMetricsSubQueryRawTemplate)
 	localFSCountQueryTemplate = NewQueryTemplate(localFSCountQueryRawTemplate)
@@ -167,6 +170,12 @@ type LocalFSBrowserFeatureSupportTemplateData struct {
 	BrowserNameParam string
 }
 
+// CommonFSSearchIDOrderTemplateData contains the template data for SearchID ordering.
+type CommonFSSearchIDOrderTemplateData struct {
+	SearchIDParam   string
+	DefaultPosition int
+}
+
 // GCPFSMetricsTemplateData contains the template data for gcpFSMetricsSubQueryTemplate.
 type GCPFSMetricsTemplateData struct {
 	Channel        string
@@ -237,6 +246,12 @@ type SortByBrowserFeatureSupportDetails struct {
 	BrowserName string
 }
 
+// SortBySearchIDOrderDetails contains parameter data for the SearchID sort templates.
+type SortBySearchIDOrderDetails struct {
+	SearchID        string
+	DefaultPosition int
+}
+
 type FeatureSearchQueryArgs struct {
 	MetricView                  WPTMetricView
 	Filters                     []string
@@ -247,6 +262,7 @@ type FeatureSearchQueryArgs struct {
 	SortByStableBrowserImpl     *SortByBrowserImplDetails
 	SortByExpBrowserImpl        *SortByBrowserImplDetails
 	SortByBrowserFeatureSupport *SortByBrowserFeatureSupportDetails
+	SortBySearchIDOrder         *SortBySearchIDOrderDetails
 	Browsers                    []string
 }
 
@@ -322,6 +338,12 @@ func (f GCPFeatureSearchBaseQuery) CountQuery(args FeatureSearchCountArgs) strin
 		},
 	})
 }
+
+// defaultSortPosition is a large number used as the default PositionIndex for features
+// that do not have a custom sort order defined in SavedSearchFeatureSortOrder.
+// This ensures that un-ordered features appear at the end of the list when sorting
+// in ascending order.
+const defaultSortPosition = 999999999
 
 const (
 	// commonFSBaseQueryTemplate provides the core of a Spanner query, joining
@@ -424,6 +446,19 @@ COALESCE(
 	`
 	gcpFSBrowserFeatureSupportRawTemplate   = commonFSBrowserFeatureSupportRawTemplate
 	localFSBrowserFeatureSupportRawTemplate = commonFSBrowserFeatureSupportRawTemplate
+
+	commonFSSearchIDOrderRawTemplate = `
+COALESCE(
+    (
+        SELECT PositionIndex
+        FROM SavedSearchFeatureSortOrder
+        WHERE FeatureKey = wf.FeatureKey
+          AND SavedSearchID = @{{ .SearchIDParam }}
+    ),
+    {{ .DefaultPosition }}
+) AS PositionIndex
+`
+	gcpFSSearchIDOrderRawTemplate = commonFSSearchIDOrderRawTemplate
 
 	// commonCountQueryRawTemplate returns the count of items, using the base query fragment
 	// for consistency.
@@ -684,6 +719,17 @@ func (f GCPFeatureSearchBaseQuery) Query(args FeatureSearchQueryArgs) (
 				}),
 			Alias: derivedTableSortBrowserFeatureSupport,
 		})
+	} else if args.SortBySearchIDOrder != nil {
+		searchIDParamName := "sortSearchIDParam"
+		params[searchIDParamName] = args.SortBySearchIDOrder.SearchID
+		optionalJoins = append(optionalJoins, JoinData{
+			Template: gcpFSSearchIDOrderTemplate.Execute(
+				CommonFSSearchIDOrderTemplateData{
+					SearchIDParam:   searchIDParamName,
+					DefaultPosition: args.SortBySearchIDOrder.DefaultPosition,
+				}),
+			Alias: "sort_search_id_order_calcs",
+		})
 	} else if args.SortByStableBrowserImpl != nil {
 		browserNameParamName := "sortStableBrowserNameMetricParam"
 		params[browserNameParamName] = args.SortByStableBrowserImpl.BrowserName
@@ -830,6 +876,17 @@ func (f LocalFeatureBaseQuery) Query(args FeatureSearchQueryArgs) (
 					BrowserNameParam: browserNameParamName,
 				}),
 			Alias: derivedTableSortBrowserFeatureSupport,
+		})
+	} else if args.SortBySearchIDOrder != nil {
+		searchIDParamName := "sortSearchIDParam"
+		params[searchIDParamName] = args.SortBySearchIDOrder.SearchID
+		optionalJoins = append(optionalJoins, JoinData{
+			Template: gcpFSSearchIDOrderTemplate.Execute(
+				CommonFSSearchIDOrderTemplateData{
+					SearchIDParam:   searchIDParamName,
+					DefaultPosition: args.SortBySearchIDOrder.DefaultPosition,
+				}),
+			Alias: "sort_search_id_order_calcs",
 		})
 	}
 

--- a/lib/gcpspanner/feature_search_query.go
+++ b/lib/gcpspanner/feature_search_query.go
@@ -101,84 +101,135 @@ func (b *FeatureSearchFilterBuilder) Build(node *searchtypes.SearchNode) (*Featu
 }
 
 func (b *FeatureSearchFilterBuilder) traverseAndGenerateFilters(node *searchtypes.SearchNode) ([]string, error) {
-	var filters []string
-
 	switch {
-	case node.IsKeyword(): // Handle AND/OR keyword
-		childFilters := make([]string, 0, len(node.Children)) // Collect child filters first
-		for _, child := range node.Children {
-			res, err := b.traverseAndGenerateFilters(child)
-			if err != nil {
-				return nil, err
-			}
-			childFilters = append(childFilters, res...)
-		}
-
-		// Join child filters using the current node's operator
-		if len(childFilters) > 0 {
-			joiner := " AND "
-			if node.Keyword == searchtypes.KeywordOR {
-				joiner = " OR "
-			}
-			filterString := strings.Join(childFilters, joiner)
-
-			if strings.TrimSpace(filterString) != "" {
-				filters = append(filters, filterString)
-			}
-
-		}
-
+	case node.IsKeyword():
+		return b.handleKeywordNode(node)
 	case node.Keyword == searchtypes.KeywordParens:
-		// Handle parenthesized sub-expressions.
-		childFilters := make([]string, 0, len(node.Children))
-		for _, child := range node.Children {
-			res, err := b.traverseAndGenerateFilters(child)
-			if err != nil {
-				return nil, err
-			}
-			childFilters = append(childFilters, res...)
-		}
-
-		// Join without spaces because if there are multiple terms, they will
-		// currently fall under a parent keyword node (AND/OR), which
-		// takes care of adding the necessary spaces.
-		filter := strings.Join(childFilters, "")
-
-		filter = "(" + filter + ")"
-
-		filters = append(filters, filter)
-
+		return b.handleParensNode(node)
 	case node.Term != nil && (node.Keyword == searchtypes.KeywordNone):
-		var filter string
-		switch node.Term.Identifier {
-		case searchtypes.IdentifierAvailableDate:
-			// Currently not a terminal identifier.
+		return b.handleTermNode(node)
+	default:
+		return nil, nil
+	}
+}
+
+func (b *FeatureSearchFilterBuilder) handleKeywordNode(node *searchtypes.SearchNode) ([]string, error) {
+	var filters []string
+	var hotlistIDs []string
+	var otherChildren []*searchtypes.SearchNode
+
+	for _, child := range node.Children {
+		// Check if it is a direct hotlist term
+		if child.Term != nil && child.Term.Identifier == searchtypes.IdentifierHotlist {
+			hotlistIDs = append(hotlistIDs, child.Term.Value)
+		} else {
+			otherChildren = append(otherChildren, child)
+		}
+	}
+
+	childFilters := make([]string, 0, len(otherChildren)+1)
+	for _, child := range otherChildren {
+		res, err := b.traverseAndGenerateFilters(child)
+		if err != nil {
+			return nil, err
+		}
+		childFilters = append(childFilters, res...)
+	}
+
+	if len(hotlistIDs) == 1 {
+		paramName := b.addParamGetName(hotlistIDs[0])
+		query := "wf.FeatureKey IN (SELECT FeatureKey FROM SavedSearchFeatureSortOrder WHERE SavedSearchID = @%s)"
+		childFilters = append(childFilters, fmt.Sprintf(query, paramName))
+	} else if len(hotlistIDs) > 1 {
+		paramName := b.addParamGetName(hotlistIDs)
+		switch node.Keyword {
+		case searchtypes.KeywordOR:
+			query := "wf.FeatureKey IN (SELECT FeatureKey FROM SavedSearchFeatureSortOrder WHERE SavedSearchID IN UNNEST(@%s))"
+			childFilters = append(childFilters, fmt.Sprintf(query, paramName))
+		case searchtypes.KeywordAND:
+			query := "wf.FeatureKey IN (SELECT FeatureKey FROM SavedSearchFeatureSortOrder " +
+				"WHERE SavedSearchID IN UNNEST(@%s) GROUP BY FeatureKey HAVING COUNT(DISTINCT SavedSearchID) = %d)"
+			childFilters = append(childFilters, fmt.Sprintf(query, paramName, len(hotlistIDs)))
+		case searchtypes.KeywordRoot, searchtypes.KeywordParens, searchtypes.KeywordNone:
+			// Should not happen as handleKeywordNode is only called for AND/OR keywords.
 			break
-		case searchtypes.IdentifierSavedSearch, searchtypes.IdentifierHotlist:
-			// Handled upstream by ValidateQueryReferences and recursive expansion.
-			return nil, fmt.Errorf("%w: '%s'", ErrUnexpandedSearchTerm, node.Term.Identifier)
-		case searchtypes.IdentifierAvailableOn:
-			filter = b.availabilityFilter(node.Term.Value, node.Term.Operator)
-		case searchtypes.IdentifierName:
-			filter = b.featureNameFilter(node.Term.Value, node.Term.Operator)
-		case searchtypes.IdentifierDescription:
-			filter = b.featureDescriptionFilter(node.Term.Value, node.Term.Operator)
-		case searchtypes.IdentifierGroup:
-			filter = b.groupFilter(node.Term.Value, node.Term.Operator)
-		case searchtypes.IdentifierSnapshot:
-			filter = b.snapshotFilter(node.Term.Value, node.Term.Operator)
-		case searchtypes.IdentifierID:
-			filter = b.idFilter(node.Term.Value, node.Term.Operator)
-		case searchtypes.IdentifierBaselineStatus:
-			filter = b.baselineStatusFilter(node.Term.Value, node.Term.Operator)
-		case searchtypes.IdentifierBaselineDate:
-			filter = b.baselineDateFilter(node.Term.Value, node.Term.Operator)
-		case searchtypes.IdentifierAvailableBrowserDate:
-			filter = b.handleIdentifierAvailableBrowserDateTerm(node)
 		}
-		if filter != "" {
-			filters = append(filters, filter)
+	}
+
+	// Join child filters using the current node's operator
+	if len(childFilters) > 0 {
+		joiner := " AND "
+		if node.Keyword == searchtypes.KeywordOR {
+			joiner = " OR "
 		}
+		filterString := strings.Join(childFilters, joiner)
+
+		if strings.TrimSpace(filterString) != "" {
+			filters = append(filters, filterString)
+		}
+
+	}
+
+	return filters, nil
+}
+
+func (b *FeatureSearchFilterBuilder) handleParensNode(node *searchtypes.SearchNode) ([]string, error) {
+	var filters []string
+	// Handle parenthesized sub-expressions.
+	childFilters := make([]string, 0, len(node.Children))
+	for _, child := range node.Children {
+		res, err := b.traverseAndGenerateFilters(child)
+		if err != nil {
+			return nil, err
+		}
+		childFilters = append(childFilters, res...)
+	}
+
+	filter := strings.Join(childFilters, "")
+
+	if strings.TrimSpace(filter) != "" {
+		filter = "(" + filter + ")"
+		filters = append(filters, filter)
+	}
+
+	return filters, nil
+}
+
+func (b *FeatureSearchFilterBuilder) handleTermNode(node *searchtypes.SearchNode) ([]string, error) {
+	var filters []string
+	var filter string
+	switch node.Term.Identifier {
+	case searchtypes.IdentifierSavedSearch:
+		// Handled upstream by ValidateQueryReferences and recursive expansion.
+		return nil, fmt.Errorf("%w: '%s'", ErrUnexpandedSearchTerm, node.Term.Identifier)
+	case searchtypes.IdentifierHotlist:
+		paramName := b.addParamGetName(node.Term.Value)
+		query := "wf.FeatureKey IN (SELECT FeatureKey FROM SavedSearchFeatureSortOrder WHERE SavedSearchID = @%s)"
+		filter = fmt.Sprintf(query, paramName)
+	case searchtypes.IdentifierAvailableDate:
+		// Currently not a terminal identifier.
+		break
+	case searchtypes.IdentifierAvailableOn:
+		filter = b.availabilityFilter(node.Term.Value, node.Term.Operator)
+	case searchtypes.IdentifierName:
+		filter = b.featureNameFilter(node.Term.Value, node.Term.Operator)
+	case searchtypes.IdentifierDescription:
+		filter = b.featureDescriptionFilter(node.Term.Value, node.Term.Operator)
+	case searchtypes.IdentifierGroup:
+		filter = b.groupFilter(node.Term.Value, node.Term.Operator)
+	case searchtypes.IdentifierSnapshot:
+		filter = b.snapshotFilter(node.Term.Value, node.Term.Operator)
+	case searchtypes.IdentifierID:
+		filter = b.idFilter(node.Term.Value, node.Term.Operator)
+	case searchtypes.IdentifierBaselineStatus:
+		filter = b.baselineStatusFilter(node.Term.Value, node.Term.Operator)
+	case searchtypes.IdentifierBaselineDate:
+		filter = b.baselineDateFilter(node.Term.Value, node.Term.Operator)
+	case searchtypes.IdentifierAvailableBrowserDate:
+		filter = b.handleIdentifierAvailableBrowserDateTerm(node)
+	}
+	if filter != "" {
+		filters = append(filters, filter)
 	}
 
 	return filters, nil
@@ -483,6 +534,7 @@ func (q FeatureSearchQueryBuilder) Build(
 
 	var stableBrowserImplDetails, expBrowserImplDetails *SortByBrowserImplDetails
 	var browserFeatureSupportDetails *SortByBrowserFeatureSupportDetails
+	var searchIDOrderDetails *SortBySearchIDOrderDetails
 
 	switch sort.SortTarget() {
 	case StableImplSort:
@@ -496,6 +548,11 @@ func (q FeatureSearchQueryBuilder) Build(
 	case BrowserFeatureSupportSort:
 		browserFeatureSupportDetails = &SortByBrowserFeatureSupportDetails{
 			BrowserName: sort.BrowserTarget(),
+		}
+	case SearchIDOrderSort:
+		searchIDOrderDetails = &SortBySearchIDOrderDetails{
+			SearchID:        sort.SearchIDTarget(),
+			DefaultPosition: defaultSortPosition,
 		}
 	case ChromiumUsageSort, IDSort, NameSort, StatusSort, DeveloperSignalUpvotesSort:
 		break // do nothing.
@@ -514,6 +571,7 @@ func (q FeatureSearchQueryBuilder) Build(
 		SortByStableBrowserImpl:     stableBrowserImplDetails,
 		SortByExpBrowserImpl:        expBrowserImplDetails,
 		SortByBrowserFeatureSupport: browserFeatureSupportDetails,
+		SortBySearchIDOrder:         searchIDOrderDetails,
 	}
 
 	if q.offsetCursor != nil {
@@ -541,6 +599,15 @@ type Sortable struct {
 	sortTarget     FeaturesSearchSortTarget
 	ascendingOrder bool
 	browserTarget  *string
+	searchIDTarget *string
+}
+
+func (s Sortable) SearchIDTarget() string {
+	if s.searchIDTarget == nil {
+		return ""
+	}
+
+	return *s.searchIDTarget
 }
 
 func (s Sortable) BrowserTarget() string {
@@ -589,7 +656,8 @@ func (f FeatureSearchColumn) ToFilterColumn() string {
 		featureSearchStatusColumn,
 		featureSearchChromiumUsageColumn,
 		featureSearchBrowserFeatureSupportDateColumn,
-		featureSearchUpvotesColumn:
+		featureSearchUpvotesColumn,
+		featureSearchSearchIDOrderColumn:
 		return string(f)
 	}
 
@@ -609,6 +677,7 @@ const (
 	ChromiumUsageSort          FeaturesSearchSortTarget = "chromium_usage"
 	BrowserFeatureSupportSort  FeaturesSearchSortTarget = "browser_feature_support"
 	DeveloperSignalUpvotesSort FeaturesSearchSortTarget = "developer_signal_upvotes"
+	SearchIDOrderSort          FeaturesSearchSortTarget = "search_id_order"
 )
 
 const (
@@ -622,6 +691,7 @@ const (
 	featureSearchChromiumUsageColumn             FeatureSearchColumn = "chromium_usage_metrics.ChromiumUsage"
 	featureSearchBrowserFeatureSupportDateColumn FeatureSearchColumn = "sort_browser_feature_support_calcs.SortDate"
 	featureSearchUpvotesColumn                   FeatureSearchColumn = "lfds.Upvotes"
+	featureSearchSearchIDOrderColumn             FeatureSearchColumn = "sort_search_id_order_calcs.PositionIndex"
 )
 
 const (
@@ -638,6 +708,7 @@ func NewFeatureNameSort(isAscending bool) Sortable {
 		ascendingOrder: isAscending,
 		sortTarget:     NameSort,
 		browserTarget:  nil,
+		searchIDTarget: nil,
 	}
 }
 
@@ -654,6 +725,7 @@ func NewBaselineStatusSort(isAscending bool) Sortable {
 		ascendingOrder: isAscending,
 		sortTarget:     StatusSort,
 		browserTarget:  nil,
+		searchIDTarget: nil,
 	}
 }
 
@@ -681,6 +753,7 @@ func NewBrowserImplSort(isAscending bool, browserName string, isStable bool) Sor
 			},
 		),
 		browserTarget:  &browserName,
+		searchIDTarget: nil,
 		ascendingOrder: isAscending,
 		sortTarget:     sortTarget,
 	}
@@ -697,6 +770,7 @@ func NewChromiumUsageSort(isAscending bool) Sortable {
 		ascendingOrder: isAscending,
 		sortTarget:     ChromiumUsageSort,
 		browserTarget:  nil,
+		searchIDTarget: nil,
 	}
 }
 
@@ -718,6 +792,7 @@ func NewBrowserFeatureSupportSort(isAscending bool, browserName string) Sortable
 			},
 		),
 		browserTarget:  &browserName,
+		searchIDTarget: nil,
 		ascendingOrder: isAscending,
 		sortTarget:     sortTarget,
 	}
@@ -734,5 +809,21 @@ func NewDeveloperSignalUpvotesSort(isAscending bool) Sortable {
 		ascendingOrder: isAscending,
 		sortTarget:     DeveloperSignalUpvotesSort,
 		browserTarget:  nil,
+		searchIDTarget: nil,
+	}
+}
+
+// NewSearchIDOrderSort creates a Sortable for Search ID order.
+func NewSearchIDOrderSort(isAscending bool, searchID string) Sortable {
+	return Sortable{
+		clause: buildFullClause(
+			[]string{
+				buildSortableOrderClause(isAscending, featureSearchSearchIDOrderColumn),
+			},
+		),
+		ascendingOrder: isAscending,
+		sortTarget:     SearchIDOrderSort,
+		browserTarget:  nil,
+		searchIDTarget: &searchID,
 	}
 }

--- a/lib/gcpspanner/feature_search_query.go
+++ b/lib/gcpspanner/feature_search_query.go
@@ -102,6 +102,8 @@ func (b *FeatureSearchFilterBuilder) Build(node *searchtypes.SearchNode) (*Featu
 
 func (b *FeatureSearchFilterBuilder) traverseAndGenerateFilters(node *searchtypes.SearchNode) ([]string, error) {
 	switch {
+	case node == nil:
+		return nil, nil
 	case node.IsKeyword():
 		return b.handleKeywordNode(node)
 	case node.Keyword == searchtypes.KeywordParens:
@@ -119,6 +121,9 @@ func (b *FeatureSearchFilterBuilder) handleKeywordNode(node *searchtypes.SearchN
 	var otherChildren []*searchtypes.SearchNode
 
 	for _, child := range node.Children {
+		if child == nil {
+			continue
+		}
 		// Check if it is a direct hotlist term
 		if child.Term != nil && child.Term.Identifier == searchtypes.IdentifierHotlist {
 			hotlistIDs = append(hotlistIDs, child.Term.Value)

--- a/lib/gcpspanner/feature_search_query_test.go
+++ b/lib/gcpspanner/feature_search_query_test.go
@@ -553,6 +553,55 @@ WHERE BrowserName = @param0) AND (fbs.Status = @param1 OR fbs.Status = @param2))
 				"param3": "%" + "grid" + "%",
 			},
 		},
+		// This case simulates a tree after search expansion where an expanded
+		// saved search returned nil and was appended to the children list of a keyword node.
+		{
+			inputTestTree: TestTree{
+				Query: "nil child in AND",
+				InputTree: &searchtypes.SearchNode{
+					Keyword: searchtypes.KeywordRoot,
+					Term:    nil,
+					Children: []*searchtypes.SearchNode{
+						{
+							Keyword: searchtypes.KeywordAND,
+							Term:    nil,
+							Children: []*searchtypes.SearchNode{
+								nil,
+								{
+									Keyword: searchtypes.KeywordNone,
+									Term: &searchtypes.SearchTerm{
+										Identifier: searchtypes.IdentifierName,
+										Operator:   searchtypes.OperatorEq,
+										Value:      "feat1",
+									},
+									Children: nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedClauses: []string{`(wf.Name_Lowercase = @param0 OR wf.FeatureKey_Lowercase = @param0)`},
+			expectedParams: map[string]any{
+				"param0": "feat1",
+			},
+		},
+		// This case simulates a tree after search expansion where the root node's
+		// only child was expanded to nil.
+		{
+			inputTestTree: TestTree{
+				Query: "nil root child",
+				InputTree: &searchtypes.SearchNode{
+					Keyword: searchtypes.KeywordRoot,
+					Term:    nil,
+					Children: []*searchtypes.SearchNode{
+						nil,
+					},
+				},
+			},
+			expectedClauses: nil,
+			expectedParams:  map[string]any{},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.inputTestTree.Query, func(t *testing.T) {

--- a/lib/gcpspanner/feature_search_test.go
+++ b/lib/gcpspanner/feature_search_test.go
@@ -1193,6 +1193,62 @@ func testFeatureCommonFilterCombos(ctx context.Context, t *testing.T, client *Cl
 				},
 			},
 		},
+		{
+			name: "Nil child in AND during expansion simulation",
+			// Simulate post-expansion tree with a nil child.
+			// available on barBrowser AND nil child
+			searchNode: &searchtypes.SearchNode{
+				Keyword: searchtypes.KeywordRoot,
+				Term:    nil,
+				Children: []*searchtypes.SearchNode{
+					{
+						Keyword: searchtypes.KeywordAND,
+						Term:    nil,
+						Children: []*searchtypes.SearchNode{
+							nil, // The nil child we want to test
+							{
+								Children: nil,
+								Term: &searchtypes.SearchTerm{
+									Identifier: searchtypes.IdentifierAvailableOn,
+									Value:      "barBrowser",
+									Operator:   searchtypes.OperatorEq,
+								},
+								Keyword: searchtypes.KeywordNone,
+							},
+						},
+					},
+				},
+			},
+			expectedPage: &FeatureResultPage{
+				Total:         2,
+				NextPageToken: nil,
+				Features: []FeatureResult{
+					getFeatureSearchTestFeature(FeatureSearchTestFId1),
+					getFeatureSearchTestFeature(FeatureSearchTestFId2),
+				},
+			},
+		},
+		{
+			name: "Nil root child during expansion simulation",
+			// Simulate post-expansion tree with a nil root child.
+			searchNode: &searchtypes.SearchNode{
+				Keyword: searchtypes.KeywordRoot,
+				Term:    nil,
+				Children: []*searchtypes.SearchNode{
+					nil,
+				},
+			},
+			expectedPage: &FeatureResultPage{
+				Total:         4,
+				NextPageToken: nil,
+				Features: []FeatureResult{
+					getFeatureSearchTestFeature(FeatureSearchTestFId1),
+					getFeatureSearchTestFeature(FeatureSearchTestFId2),
+					getFeatureSearchTestFeature(FeatureSearchTestFId3),
+					getFeatureSearchTestFeature(FeatureSearchTestFId4),
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/lib/gcpspanner/get_feature_query.go
+++ b/lib/gcpspanner/get_feature_query.go
@@ -63,6 +63,7 @@ func (q GetFeatureQueryBuilder) Build(
 		SortByStableBrowserImpl:     nil,
 		SortByExpBrowserImpl:        nil,
 		SortByBrowserFeatureSupport: nil,
+		SortBySearchIDOrder:         nil,
 	}
 	queryArgs.Filters = defaultFeatureSearchFilters()
 	if filter != nil {

--- a/lib/gcpspanner/hotlist_subquery_test.go
+++ b/lib/gcpspanner/hotlist_subquery_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestFeaturesSearch_HotlistSubquery_AllBuilders(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+
+	// 1. Insert mock features
+	insertMockFeatures(ctx, t, map[string]bool{
+		"feat-sub1": true,
+		"feat-sub2": true,
+		"feat-sub3": true,
+	})
+
+	// 2. Insert a Hotlist SavedSearch with EMPTY query
+	hotlistID := "hotlist-subquery-test"
+	_, err := spannerClient.ReadWriteTransaction(ctx, func(_ context.Context, txn *spanner.ReadWriteTransaction) error {
+		m, err := spanner.InsertStruct(savedSearchesTable, &SavedSearch{
+			ID:          hotlistID,
+			Name:        "Hotlist Subquery Test",
+			Description: nil,
+			Query:       "", // Empty query triggers subquery path
+			Scope:       SystemGlobalScope,
+			AuthorID:    "system",
+			CreatedAt:   time.Now(),
+			UpdatedAt:   time.Now(),
+		})
+		if err != nil {
+			return err
+		}
+
+		return txn.BufferWrite([]*spanner.Mutation{m})
+	})
+	if err != nil {
+		t.Fatalf("failed to insert hotlist saved search: %v", err)
+	}
+
+	for i, featID := range []string{"feat-sub1", "feat-sub2"} {
+		m := spanner.Insert("SavedSearchFeatureSortOrder",
+			[]string{"SavedSearchID", "FeatureKey", "PositionIndex"},
+			[]any{hotlistID, featID, int64((i + 1) * 10)},
+		)
+		_, err = spannerClient.Apply(ctx, []*spanner.Mutation{m})
+		if err != nil {
+			t.Fatalf("failed to insert saved search feature sort order: %v", err)
+		}
+	}
+
+	builders := []FeatureSearchBaseQuery{
+		GCPFeatureSearchBaseQuery{},
+		LocalFeatureBaseQuery{},
+	}
+
+	parser := searchtypes.FeaturesSearchQueryParser{}
+	node, err := parser.Parse("hotlist:" + hotlistID)
+	if err != nil {
+		t.Fatalf("failed to parse hotlist query: %v", err)
+	}
+
+	for _, builder := range builders {
+		t.Run(fmt.Sprintf("%T", builder), func(t *testing.T) {
+			spannerClient.SetFeatureSearchBaseQuery(builder)
+
+			page, err := spannerClient.FeaturesSearch(
+				ctx,
+				nil,
+				100,
+				node,
+				NewFeatureNameSort(true),
+				WPTSubtestView,
+				[]string{},
+			)
+			if err != nil {
+				t.Fatalf("FeaturesSearch error: %v", err)
+			}
+
+			actualKeys := make([]string, 0, len(page.Features))
+			for _, f := range page.Features {
+				actualKeys = append(actualKeys, f.FeatureKey)
+			}
+
+			expectedKeys := []string{"feat-sub1", "feat-sub2"}
+			sortOpt := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+
+			if diff := cmp.Diff(expectedKeys, actualKeys, sortOpt); diff != "" {
+				t.Fatalf("Hotlist subquery results mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+	// Reset to default
+	spannerClient.SetFeatureSearchBaseQuery(GCPFeatureSearchBaseQuery{})
+}
+
+func TestFeaturesSearch_HotlistAll(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+
+	// 1. Insert mock features
+	insertMockFeatures(ctx, t, map[string]bool{
+		"feat-all1": true,
+		"feat-all2": true,
+		"feat-all3": true,
+	})
+
+	builders := []FeatureSearchBaseQuery{
+		GCPFeatureSearchBaseQuery{},
+		LocalFeatureBaseQuery{},
+	}
+
+	// In production, 'hotlist:all' is expanded to an empty query by the Backend layer.
+	// This yields a nil node.
+	// We test that AST directly here because Client does not perform expansion.
+	// See TestExpandSavedSearches_Success in lib/gcpspanner/spanneradapters/backend_test.go
+	// for the test that verifies 'hotlist:all' expands to this AST.
+	// If this behavior changes, update both tests!
+	node := searchtypes.EmptySearchNode()
+
+	for _, builder := range builders {
+		t.Run(fmt.Sprintf("%T", builder), func(t *testing.T) {
+			spannerClient.SetFeatureSearchBaseQuery(builder)
+
+			page, err := spannerClient.FeaturesSearch(
+				ctx,
+				nil,
+				100,
+				node,
+				NewFeatureNameSort(true),
+				WPTSubtestView,
+				[]string{},
+			)
+			if err != nil {
+				t.Fatalf("FeaturesSearch error: %v", err)
+			}
+
+			actualKeys := make([]string, 0, len(page.Features))
+			for _, f := range page.Features {
+				actualKeys = append(actualKeys, f.FeatureKey)
+			}
+
+			expectedKeys := []string{"feat-all1", "feat-all2", "feat-all3"}
+			sortOpt := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+
+			if diff := cmp.Diff(expectedKeys, actualKeys, sortOpt); diff != "" {
+				t.Fatalf("Hotlist all results mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/lib/gcpspanner/saved_search_sort_order_test.go
+++ b/lib/gcpspanner/saved_search_sort_order_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/iterator"
+)
+
+type sortOrderResult struct {
+	SavedSearchID string
+	FeatureKey    string
+	PositionIndex int64
+}
+
+func TestFeaturesSearch_SavedSearchSortOrder(t *testing.T) {
+	restartDatabaseContainer(t)
+	ctx := context.Background()
+
+	// Expected exact mapping results. If a PR adds another saved search sort order,
+	// this test will explicitly break here until they document the expected order.
+	expectedCustomSortOrders := map[string][]string{
+		"top-css-interop": {
+			"anchor-positioning",
+			"scroll-driven-animations",
+			"view-transitions",
+			"cross-document-view-transitions",
+			"container-style-queries",
+			"nesting",
+			"has",
+			"container-queries",
+			"scope",
+			"if",
+			"grid",
+		},
+		"top-html-interop": {
+			"customizable-select",
+			"popover",
+			"anchor-positioning",
+			"customized-built-in-elements",
+			"shadow-dom",
+			"dialog",
+			"view-transitions",
+			"cross-document-view-transitions",
+			"file-system-access",
+			"input-date-time",
+			"invoker-commands",
+			"webusb",
+		},
+	}
+
+	sortOrders := getSavedSearchSortOrders(ctx, t)
+	uniqueFeatureKeys := getUniqueFeatureKeys(sortOrders)
+	insertMockFeatures(ctx, t, uniqueFeatureKeys)
+
+	actualSearchIDs := make(map[string]bool)
+	for _, s := range sortOrders {
+		actualSearchIDs[s.SavedSearchID] = true
+	}
+
+	// Fail the test if the DB migration contains a saved search mapping that the test isn't tracking!
+	for actualID := range actualSearchIDs {
+		if _, ok := expectedCustomSortOrders[actualID]; !ok {
+			t.Fatalf("Integration test failure: found unexpected SavedSearchID '%s'."+
+				" Please add its expected order to expectedCustomSortOrders.", actualID)
+		}
+	}
+	for expectedID := range expectedCustomSortOrders {
+		if _, ok := actualSearchIDs[expectedID]; !ok {
+			t.Fatalf("Integration test failure: expected SavedSearchID '%s'"+
+				" is missing from the database migration mapping.", expectedID)
+		}
+	}
+
+	builders := []FeatureSearchBaseQuery{
+		GCPFeatureSearchBaseQuery{},
+		LocalFeatureBaseQuery{},
+	}
+
+	for _, builder := range builders {
+		t.Run(fmt.Sprintf("%T", builder), func(t *testing.T) {
+			spannerClient.SetFeatureSearchBaseQuery(builder)
+			assertCustomSortOrders(ctx, t, expectedCustomSortOrders)
+		})
+	}
+	// Reset to default
+	spannerClient.SetFeatureSearchBaseQuery(GCPFeatureSearchBaseQuery{})
+}
+
+func getSavedSearchSortOrders(ctx context.Context, t *testing.T) []sortOrderResult {
+	stmt := spanner.NewStatement(
+		"SELECT SavedSearchID, FeatureKey, PositionIndex " +
+			"FROM SavedSearchFeatureSortOrder ORDER BY SavedSearchID, PositionIndex ASC")
+	iter := spannerClient.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var sortOrders []sortOrderResult
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("failed iterating SavedSearchFeatureSortOrder: %v", err)
+		}
+		var s sortOrderResult
+		if err := row.Columns(&s.SavedSearchID, &s.FeatureKey, &s.PositionIndex); err != nil {
+			t.Fatalf("failed scanning row: %v", err)
+		}
+		sortOrders = append(sortOrders, s)
+	}
+
+	return sortOrders
+}
+
+func getUniqueFeatureKeys(sortOrders []sortOrderResult) map[string]bool {
+	uniqueFeatureKeys := make(map[string]bool)
+	for _, s := range sortOrders {
+		uniqueFeatureKeys[s.FeatureKey] = true
+	}
+
+	return uniqueFeatureKeys
+}
+
+func insertMockFeatures(ctx context.Context, t *testing.T, keys map[string]bool) {
+	_, err := spannerClient.ReadWriteTransaction(ctx, func(_ context.Context, txn *spanner.ReadWriteTransaction) error {
+		var mutations []*spanner.Mutation
+		for key := range keys {
+			m, err := spanner.InsertStruct(webFeaturesTable, &SpannerWebFeature{
+				ID: "id-" + key,
+				WebFeature: WebFeature{
+					FeatureKey:      key,
+					Name:            "Name for " + key,
+					Description:     "",
+					DescriptionHTML: "",
+				},
+			})
+			if err != nil {
+				return err
+			}
+			mutations = append(mutations, m)
+		}
+
+		return txn.BufferWrite(mutations)
+	})
+	if err != nil {
+		t.Fatalf("failed to insert fake features: %v", err)
+	}
+}
+
+func assertCustomSortOrders(ctx context.Context, t *testing.T, expected map[string][]string) {
+	for searchID, expectedOrderedKeys := range expected {
+		sortParam := NewSearchIDOrderSort(true, searchID)
+
+		page, err := spannerClient.FeaturesSearch(
+			ctx,
+			nil,
+			1000,
+			nil, // nil search node equals 'all wildcard'
+			sortParam,
+			WPTSubtestView,
+			[]string{})
+
+		if err != nil {
+			t.Fatalf("FeaturesSearch error for %s: %v", searchID, err)
+		}
+
+		expectedSet := make(map[string]bool)
+		for _, k := range expectedOrderedKeys {
+			expectedSet[k] = true
+		}
+
+		var actualOrderedKeys []string
+		for _, f := range page.Features {
+			if expectedSet[f.FeatureKey] {
+				actualOrderedKeys = append(actualOrderedKeys, f.FeatureKey)
+			}
+		}
+
+		if diff := cmp.Diff(expectedOrderedKeys, actualOrderedKeys); diff != "" {
+			t.Fatalf("Search %s sort order mismatch (-want +got):\n%s", searchID, diff)
+		}
+	}
+}

--- a/lib/gcpspanner/searchtypes/searchtypes.go
+++ b/lib/gcpspanner/searchtypes/searchtypes.go
@@ -80,6 +80,17 @@ type SearchNode struct {
 	Children []*SearchNode
 }
 
+// EmptySearchNode returns the representation of an empty search query AST.
+// Currently, an empty query is represented by nil.
+func EmptySearchNode() *SearchNode {
+	return nil
+}
+
+// IsEmptySearchNode returns true if the node represents an empty search query.
+func IsEmptySearchNode(node *SearchNode) bool {
+	return node == nil
+}
+
 func (n SearchNode) IsKeyword() bool {
 	return n.Keyword == KeywordAND || n.Keyword == KeywordOR
 }

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -19,9 +19,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
+	"maps"
 	"math/big"
 	"slices"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/spanner"
@@ -133,6 +136,19 @@ type BackendSpannerClient interface {
 		authenticatedUserID *string) (*gcpspanner.UserSavedSearch, error)
 	GetSavedSearch(ctx context.Context, id string) (*gcpspanner.SavedSearch, error)
 	DeleteUserSavedSearch(ctx context.Context, req gcpspanner.DeleteUserSavedSearchRequest) error
+	ListSystemGlobalSavedSearches(
+		ctx context.Context,
+		pageSize int,
+		pageToken *string,
+	) ([]gcpspanner.SystemGlobalSavedSearch, *string, error)
+	GetSystemGlobalSavedSearch(
+		ctx context.Context,
+		id string,
+	) (*gcpspanner.SystemGlobalSavedSearchWithSortOption, error)
+	GetReferencingSavedSearchIDs(
+		ctx context.Context,
+		id string,
+	) ([]string, error)
 	ListUserSavedSearches(
 		ctx context.Context,
 		userID string,
@@ -1341,6 +1357,231 @@ func (b BrowserList) ToStringList() []string {
 	return ret
 }
 
+// expandSavedSearches recursively expands IdentifierSavedSearch nodes by looking up the actual
+// saved search from the database and parsing its query. It limits recursion depth to prevent
+// abuse/DoS and checks seenIDs to prevent infinite cycles.
+func (s *Backend) expandSavedSearches(
+	ctx context.Context,
+	node *searchtypes.SearchNode,
+	depth int,
+	seenIDs map[string]struct{},
+) (*searchtypes.SearchNode, *string, error) {
+	if node == nil {
+		return nil, nil, nil
+	}
+
+	const maxDepth = 2
+	if depth > maxDepth {
+		return nil, nil, backendtypes.ErrSavedSearchMaxDepthExceeded
+	}
+
+	var injectedSortTarget *string
+
+	if node.Term == nil ||
+		(node.Term.Identifier != searchtypes.IdentifierSavedSearch &&
+			node.Term.Identifier != searchtypes.IdentifierHotlist) {
+		return s.expandNonSavedSearchChildren(ctx, node, depth, seenIDs)
+	}
+
+	savedSearchID := node.Term.Value
+	isHotlist := node.Term.Identifier == searchtypes.IdentifierHotlist
+	// 1. Cycle detection
+	if _, exists := seenIDs[savedSearchID]; exists {
+		return nil, nil, backendtypes.ErrSavedSearchCycleDetected
+	}
+
+	// Fetch the query for the saved search. Hotlists map to system global searches.
+	query, sortTgt, err := s.fetchQueryForSavedSearch(ctx, savedSearchID, isHotlist)
+	if err != nil {
+		return nil, nil, err
+	}
+	if sortTgt != nil {
+		injectedSortTarget = sortTgt
+	}
+
+	if strings.TrimSpace(query) == "" {
+		return searchtypes.EmptySearchNode(), injectedSortTarget, nil
+	}
+
+	// 3. Parse its string query
+	parser := searchtypes.FeaturesSearchQueryParser{}
+	childAST, err := parser.Parse(query)
+	if err != nil {
+		// If a saved search has an invalid grammar, it is fundamentally broken.
+		return nil, nil, err
+	}
+
+	// 4. Recurse down into the newly expanded AST
+	newSeen := make(map[string]struct{}, len(seenIDs)+1)
+	maps.Copy(newSeen, seenIDs)
+	newSeen[savedSearchID] = struct{}{}
+
+	expandedChild, sortTgt, err := s.expandSavedSearches(ctx, childAST, depth+1, newSeen)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if sortTgt != nil {
+		injectedSortTarget = sortTgt
+	}
+
+	childToWrap := expandedChild
+	if expandedChild != nil && expandedChild.Keyword == searchtypes.KeywordRoot && len(expandedChild.Children) == 1 {
+		childToWrap = expandedChild.Children[0]
+	}
+
+	// Wrap the expanded AST in parentheses just to be functionally isolated in the tree.
+	return &searchtypes.SearchNode{
+		Keyword:  searchtypes.KeywordParens,
+		Children: []*searchtypes.SearchNode{childToWrap},
+		Term:     nil,
+	}, injectedSortTarget, nil
+}
+
+func (s *Backend) expandNonSavedSearchChildren(
+	ctx context.Context,
+	node *searchtypes.SearchNode,
+	depth int,
+	seenIDs map[string]struct{},
+) (*searchtypes.SearchNode, *string, error) {
+	var injectedSortTarget *string
+	var expandedChildren []*searchtypes.SearchNode
+	if node.Children != nil {
+		expandedChildren = make([]*searchtypes.SearchNode, 0, len(node.Children))
+		for _, child := range node.Children {
+			expandedChild, sortTgt, err := s.expandSavedSearches(ctx, child, depth, seenIDs)
+			if err != nil {
+				return nil, nil, err
+			}
+			if sortTgt != nil {
+				injectedSortTarget = sortTgt
+			}
+			expandedChildren = append(expandedChildren, expandedChild)
+		}
+	}
+
+	// Create a new node to avoid mutating the original
+	newNode := &searchtypes.SearchNode{
+		Keyword:  node.Keyword,
+		Term:     node.Term,
+		Children: expandedChildren,
+	}
+
+	return newNode, injectedSortTarget, nil
+}
+
+func (s *Backend) fetchSystemHotlistQuery(
+	ctx context.Context,
+	savedSearchID string,
+) (string, *string, error) {
+	systemSearch, err := s.client.GetSystemGlobalSavedSearch(ctx, savedSearchID)
+	if err != nil {
+		if errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {
+			return "", nil, backendtypes.ErrHotlistNotFound
+		}
+
+		return "", nil, err
+	}
+	var injectedSortTarget *string
+	if systemSearch.HasCustomSortOrder {
+		idCopy := savedSearchID
+		injectedSortTarget = &idCopy
+	}
+
+	return systemSearch.Query, injectedSortTarget, nil
+}
+
+func (s *Backend) fetchUserSearchQuery(
+	ctx context.Context,
+	savedSearchID string,
+) (string, error) {
+	userSearch, err := s.client.GetSavedSearch(ctx, savedSearchID)
+	if err != nil {
+		if errors.Is(err, gcpspanner.ErrQueryReturnedNoResults) {
+			return "", backendtypes.ErrSavedSearchNotFound
+		}
+
+		return "", err
+	}
+
+	return userSearch.Query, nil
+}
+
+func (s *Backend) fetchQueryForSavedSearch(
+	ctx context.Context,
+	savedSearchID string,
+	isHotlist bool,
+) (string, *string, error) {
+	if isHotlist {
+		return s.fetchSystemHotlistQuery(ctx, savedSearchID)
+	}
+	query, err := s.fetchUserSearchQuery(ctx, savedSearchID)
+
+	return query, nil, err
+}
+
+func (s *Backend) ValidateQueryReferences(ctx context.Context, query string, updateID *string) error {
+	parser := searchtypes.FeaturesSearchQueryParser{}
+	node, err := parser.Parse(query)
+	if err != nil {
+		return err
+	}
+
+	// Unwrap ROOT and PARENS nodes if present to find the actual term.
+	checkNode := node
+	for checkNode != nil &&
+		(checkNode.Keyword == searchtypes.KeywordRoot || checkNode.Keyword == searchtypes.KeywordParens) &&
+		len(checkNode.Children) == 1 {
+		checkNode = checkNode.Children[0]
+	}
+
+	if checkNode != nil && checkNode.Keyword == searchtypes.KeywordNone &&
+		checkNode.Term != nil &&
+		(checkNode.Term.Identifier == searchtypes.IdentifierSavedSearch ||
+			checkNode.Term.Identifier == searchtypes.IdentifierHotlist) {
+		return fmt.Errorf("%w, please subscribe to the existing search directly",
+			backendtypes.ErrQueryConsistsEntirelyOfSavedSearch)
+	}
+
+	maxAncestorDist := 0
+	if updateID != nil {
+		maxAncestorDist, err = s.getMaxAncestorDistance(ctx, *updateID, 0)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Run expansion as a dry-run check mechanism.
+	// Starting with depth = maxAncestorDist ensures that any transitive ancestors
+	// won't exceed the global depth limit of 2.
+	_, _, err = s.expandSavedSearches(ctx, node, maxAncestorDist, map[string]struct{}{})
+
+	return err
+}
+
+func (s *Backend) getMaxAncestorDistance(ctx context.Context, id string, currentDist int) (int, error) {
+	// Global limit is 2. If we're already at 2, we can stop.
+	if currentDist >= 2 {
+		return currentDist, nil
+	}
+	referrers, err := s.client.GetReferencingSavedSearchIDs(ctx, id)
+	if err != nil {
+		return 0, err
+	}
+	maxDist := currentDist
+	for _, refID := range referrers {
+		dist, err := s.getMaxAncestorDistance(ctx, refID, currentDist+1)
+		if err != nil {
+			return 0, err
+		}
+		if dist > maxDist {
+			maxDist = dist
+		}
+	}
+
+	return maxDist, nil
+}
+
 func (s *Backend) FeaturesSearch(
 	ctx context.Context,
 	pageToken *string,
@@ -1350,8 +1591,18 @@ func (s *Backend) FeaturesSearch(
 	wptMetricView backend.WPTMetricView,
 	browsers []backend.BrowserPathParam,
 ) (*backend.FeaturePage, error) {
+
+	expandedAST, injectedSortTarget, err := s.expandSavedSearches(ctx, searchNode, 0, map[string]struct{}{})
+	if err != nil {
+		return nil, err
+	}
+
 	spannerSortOrder := getFeatureSearchSortOrder(sortOrder)
-	page, err := s.client.FeaturesSearch(ctx, pageToken, pageSize, searchNode,
+	if sortOrder == nil && injectedSortTarget != nil {
+		spannerSortOrder = gcpspanner.NewSearchIDOrderSort(true, *injectedSortTarget)
+	}
+
+	page, err := s.client.FeaturesSearch(ctx, pageToken, pageSize, expandedAST,
 		spannerSortOrder, getSpannerWPTMetricView(wptMetricView),
 		BrowserList(browsers).ToStringList())
 	if err != nil {
@@ -1383,7 +1634,8 @@ func (s *Backend) FeaturesSearch(
 // nolint: gocyclo // WONTFIX. Keep all the cases here so that the exhaustive
 // linter can catch a missing case.
 func getFeatureSearchSortOrder(
-	sortOrder *backend.ListFeaturesParamsSort) gcpspanner.Sortable {
+	sortOrder *backend.ListFeaturesParamsSort,
+) gcpspanner.Sortable {
 	if sortOrder == nil {
 		return gcpspanner.NewBaselineStatusSort(false)
 	}

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -196,12 +196,6 @@ type mockDeleteSavedSearchSubscriptionConfig struct {
 	returnedError          error
 }
 
-type mockGetSavedSearchConfig struct {
-	expectedID    string
-	result        *gcpspanner.SavedSearch
-	returnedError error
-}
-
 type mockGetSavedSearchSubscriptionPublicConfig struct {
 	expectedSubscriptionID string
 	result                 *gcpspanner.SavedSearchSubscriptionView
@@ -225,6 +219,21 @@ type mockListSavedSearchSubscriptionsConfig struct {
 	returnedError   error
 }
 
+type mockGetSystemGlobalSavedSearchConfig struct {
+	results map[string]*gcpspanner.SystemGlobalSavedSearchWithSortOption
+	errs    map[string]error
+}
+
+type mockGetSavedSearchConfig struct {
+	results map[string]*gcpspanner.SavedSearch
+	errs    map[string]error
+}
+
+type mockGetReferencingSavedSearchIDsConfig struct {
+	results map[string][]string
+	errs    map[string]error
+}
+
 type mockBackendSpannerClient struct {
 	t                                        *testing.T
 	aggregationData                          []gcpspanner.WPTRunAggregationMetricWithTime
@@ -237,7 +246,6 @@ type mockBackendSpannerClient struct {
 	mockListMissingOneImplCountsCfg          mockListMissingOneImplCountsConfig
 	mockListMissingOneImplFeaturesCfg        mockListMissingOneImplFeaturesConfig
 	mockListBaselineStatusCountsCfg          mockListBaselineStatusCountsConfig
-	mockGetSavedSearchCfg                    mockGetSavedSearchConfig
 	mockGetNotificationChannelCfg            *mockGetNotificationChannelConfig
 	mockDeleteNotificationChannelCfg         *mockDeleteNotificationChannelConfig
 	mockListNotificationChannelsCfg          *mockListNotificationChannelsConfig
@@ -257,6 +265,9 @@ type mockBackendSpannerClient struct {
 	mockUpdateSavedSearchSubscriptionCfg     *mockUpdateSavedSearchSubscriptionConfig
 	mockDeleteSavedSearchSubscriptionCfg     *mockDeleteSavedSearchSubscriptionConfig
 	mockListSavedSearchSubscriptionsCfg      *mockListSavedSearchSubscriptionsConfig
+	mockGetSystemGlobalSavedSearchCfg        *mockGetSystemGlobalSavedSearchConfig
+	mockGetSavedSearchCfg                    *mockGetSavedSearchConfig
+	mockGetReferencingSavedSearchIDsCfg      *mockGetReferencingSavedSearchIDsConfig
 	pageToken                                *string
 	err                                      error
 
@@ -277,6 +288,62 @@ func (c mockBackendSpannerClient) SyncUserProfileInfo(
 	}
 
 	return c.mockSyncUserProfileInfoCfg.returnedError
+}
+
+func (c mockBackendSpannerClient) GetSystemGlobalSavedSearch(
+	_ context.Context,
+	id string,
+) (*gcpspanner.SystemGlobalSavedSearchWithSortOption, error) {
+	if c.mockGetSystemGlobalSavedSearchCfg != nil {
+		if err, ok := c.mockGetSystemGlobalSavedSearchCfg.errs[id]; ok {
+			return nil, err
+		}
+		if res, ok := c.mockGetSystemGlobalSavedSearchCfg.results[id]; ok {
+			return res, nil
+		}
+	}
+
+	return nil, gcpspanner.ErrQueryReturnedNoResults
+}
+
+func (c mockBackendSpannerClient) ListSystemGlobalSavedSearches(
+	_ context.Context,
+	_ int,
+	_ *string,
+) ([]gcpspanner.SystemGlobalSavedSearch, *string, error) {
+	return nil, nil, nil
+}
+
+func (c mockBackendSpannerClient) GetSavedSearch(
+	_ context.Context,
+	id string,
+) (*gcpspanner.SavedSearch, error) {
+	if c.mockGetSavedSearchCfg != nil {
+		if err, ok := c.mockGetSavedSearchCfg.errs[id]; ok {
+			return nil, err
+		}
+		if res, ok := c.mockGetSavedSearchCfg.results[id]; ok {
+			return res, nil
+		}
+	}
+
+	return nil, gcpspanner.ErrQueryReturnedNoResults
+}
+
+func (c mockBackendSpannerClient) GetReferencingSavedSearchIDs(
+	_ context.Context,
+	id string,
+) ([]string, error) {
+	if c.mockGetReferencingSavedSearchIDsCfg != nil {
+		if err, ok := c.mockGetReferencingSavedSearchIDsCfg.errs[id]; ok {
+			return nil, err
+		}
+		if res, ok := c.mockGetReferencingSavedSearchIDsCfg.results[id]; ok {
+			return res, nil
+		}
+	}
+
+	return nil, nil
 }
 
 // GetMovedWebFeatureDetailsByOriginalFeatureKey implements BackendSpannerClient.
@@ -587,14 +654,6 @@ func (c mockBackendSpannerClient) ListBaselineStatusCounts(
 	}
 
 	return c.mockListBaselineStatusCountsCfg.result, c.mockListBaselineStatusCountsCfg.returnedError
-}
-
-func (c mockBackendSpannerClient) GetSavedSearch(_ context.Context, id string) (*gcpspanner.SavedSearch, error) {
-	if id != c.mockGetSavedSearchCfg.expectedID {
-		c.t.Errorf("unexpected ID. want %s, got %s", c.mockGetSavedSearchCfg.expectedID, id)
-	}
-
-	return c.mockGetSavedSearchCfg.result, c.mockGetSavedSearchCfg.returnedError
 }
 
 func (c mockBackendSpannerClient) GetUserSavedSearch(
@@ -4895,4 +4954,318 @@ func newTestUpdateNotificationChannelRequestConfig(
 	}
 
 	return &c
+}
+
+func TestValidateQueryReferences(t *testing.T) {
+	testCases := []struct {
+		name                string
+		query               string
+		updateID            *string
+		systemSearches      map[string]*gcpspanner.SystemGlobalSavedSearchWithSortOption
+		userSearches        map[string]*gcpspanner.SavedSearch
+		referencingSearches map[string][]string
+		expectedError       error
+	}{
+		{
+			name:                "valid simple query",
+			query:               "name:\"flexbox\"",
+			updateID:            nil,
+			systemSearches:      nil,
+			userSearches:        nil,
+			referencingSearches: nil,
+			expectedError:       nil,
+		},
+		{
+			name:           "valid saved search reference",
+			query:          "(saved:search1) name:\"flexbox\"",
+			updateID:       nil,
+			systemSearches: nil,
+			userSearches: map[string]*gcpspanner.SavedSearch{
+				"search1": {Query: "name:\"flexbox\""},
+			},
+			referencingSearches: nil,
+			expectedError:       nil,
+		},
+		{
+			name:     "valid hotlist reference",
+			query:    "(hotlist:search1) name:\"flexbox\"",
+			updateID: nil,
+			systemSearches: map[string]*gcpspanner.SystemGlobalSavedSearchWithSortOption{
+				"search1": {SystemGlobalSavedSearch: gcpspanner.SystemGlobalSavedSearch{
+					ID:           "",
+					Name:         "",
+					Description:  nil,
+					Scope:        "",
+					AuthorID:     "",
+					CreatedAt:    time.Time{},
+					UpdatedAt:    time.Time{},
+					DisplayOrder: 0,
+					Status:       "",
+					Query:        "name:\"flexbox\"",
+				}},
+			},
+			userSearches:        nil,
+			referencingSearches: nil,
+			expectedError:       nil,
+		},
+		{
+			name:                "invalid saved search - missing",
+			query:               "(saved:missing) name:\"flexbox\"",
+			updateID:            nil,
+			systemSearches:      nil,
+			userSearches:        nil,
+			referencingSearches: nil,
+			expectedError:       backendtypes.ErrSavedSearchNotFound,
+		},
+		{
+			name:                "invalid hotlist - missing",
+			query:               "(hotlist:missing) name:\"flexbox\"",
+			updateID:            nil,
+			systemSearches:      nil,
+			userSearches:        nil,
+			referencingSearches: nil,
+			expectedError:       backendtypes.ErrHotlistNotFound,
+		},
+		{
+			name:           "invalid depth - 3 levels",
+			query:          "(saved:search1) name:\"flexbox\"",
+			updateID:       nil,
+			systemSearches: nil,
+			userSearches: map[string]*gcpspanner.SavedSearch{
+				"search1": {Query: "saved:search2"},
+				"search2": {Query: "saved:search3"},
+				"search3": {Query: "name:\"flexbox\""},
+			},
+			referencingSearches: nil,
+			expectedError:       backendtypes.ErrSavedSearchMaxDepthExceeded,
+		},
+		{
+			name:           "valid depth - 2 levels",
+			query:          "(saved:search1) name:\"flexbox\"",
+			updateID:       nil,
+			systemSearches: nil,
+			userSearches: map[string]*gcpspanner.SavedSearch{
+				"search1": {Query: "saved:search2"},
+				"search2": {Query: "name:\"flexbox\""},
+			},
+			referencingSearches: nil,
+			expectedError:       nil,
+		},
+		{
+			name:           "cycle detection - direct",
+			query:          "(saved:search1) name:\"flexbox\"",
+			updateID:       nil,
+			systemSearches: nil,
+			userSearches: map[string]*gcpspanner.SavedSearch{
+				"search1": {Query: "saved:search1"},
+			},
+			referencingSearches: nil,
+			expectedError:       backendtypes.ErrSavedSearchCycleDetected,
+		},
+		{
+			name:           "cycle detection - indirect",
+			query:          "(saved:search1) name:\"flexbox\"",
+			updateID:       nil,
+			systemSearches: nil,
+			userSearches: map[string]*gcpspanner.SavedSearch{
+				"search1": {Query: "saved:search2"},
+				"search2": {Query: "saved:search1"},
+			},
+			referencingSearches: nil,
+			expectedError:       backendtypes.ErrSavedSearchCycleDetected,
+		},
+		{
+			name:           "transitive depth violation during update",
+			query:          "(saved:child) name:\"flexbox\"",
+			updateID:       new("parent"),
+			systemSearches: nil,
+			userSearches: map[string]*gcpspanner.SavedSearch{
+				"child":      {Query: "saved:grandchild"},
+				"grandchild": {Query: "name:\"flexbox\""},
+			},
+			referencingSearches: map[string][]string{
+				"parent": {"ancestor"},
+			},
+			expectedError: backendtypes.ErrSavedSearchMaxDepthExceeded,
+		},
+		{
+			name:                "entirely single saved search",
+			query:               "saved:search1",
+			updateID:            nil,
+			systemSearches:      nil,
+			userSearches:        nil,
+			referencingSearches: nil,
+			expectedError:       backendtypes.ErrQueryConsistsEntirelyOfSavedSearch,
+		},
+		{
+			name:                "entirely single hotlist",
+			query:               "hotlist:search1",
+			updateID:            nil,
+			systemSearches:      nil,
+			userSearches:        nil,
+			referencingSearches: nil,
+			expectedError:       backendtypes.ErrQueryConsistsEntirelyOfSavedSearch,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint: exhaustruct
+			mock := mockBackendSpannerClient{
+				t: t,
+				mockGetSystemGlobalSavedSearchCfg: &mockGetSystemGlobalSavedSearchConfig{
+					results: tc.systemSearches,
+				},
+				mockGetSavedSearchCfg: &mockGetSavedSearchConfig{
+					results: tc.userSearches,
+				},
+				mockGetReferencingSavedSearchIDsCfg: &mockGetReferencingSavedSearchIDsConfig{
+					results: tc.referencingSearches,
+				},
+			}
+			backend := NewBackend(mock)
+			err := backend.ValidateQueryReferences(context.Background(), tc.query, tc.updateID)
+			if (tc.expectedError != nil || err != nil) && !errors.Is(err, tc.expectedError) {
+				t.Errorf("expected error %v, got %v", tc.expectedError, err)
+			}
+		})
+	}
+}
+
+func newMockSystemGlobalSavedSearchWithSortOption(
+	id string, query string, hasCustomSortOrder bool) *gcpspanner.SystemGlobalSavedSearchWithSortOption {
+	return &gcpspanner.SystemGlobalSavedSearchWithSortOption{
+		SystemGlobalSavedSearch: gcpspanner.SystemGlobalSavedSearch{
+			ID:           id,
+			Name:         "Mock Name",
+			Description:  nil,
+			Query:        query,
+			Scope:        gcpspanner.SystemGlobalScope,
+			AuthorID:     "system",
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
+			DisplayOrder: 0,
+			Status:       "LISTED",
+		},
+		HasCustomSortOrder: hasCustomSortOrder,
+	}
+}
+
+func TestExpandSavedSearches_Success(t *testing.T) {
+	customID := "h-custom"
+	testCases := []struct {
+		name               string
+		id                 string
+		globalSearches     map[string]*gcpspanner.SystemGlobalSavedSearchWithSortOption
+		expectedNode       *searchtypes.SearchNode
+		expectedSortTarget *string
+	}{
+		// This test case verifies that 'hotlist:all' expands to an empty query AST.
+		// This AST is used directly in TestFeaturesSearch_HotlistAll in lib/gcpspanner/hotlist_subquery_test.go.
+		// If this behavior changes, update both tests!
+		{
+			name: "empty query returns special node",
+			id:   "all",
+			globalSearches: map[string]*gcpspanner.SystemGlobalSavedSearchWithSortOption{
+				"all": newMockSystemGlobalSavedSearchWithSortOption("all", "", false),
+			},
+			expectedNode:       searchtypes.EmptySearchNode(),
+			expectedSortTarget: nil,
+		},
+		{
+			name: "hotlist with custom sort order and empty query",
+			id:   "h-custom",
+			globalSearches: map[string]*gcpspanner.SystemGlobalSavedSearchWithSortOption{
+				"h-custom": newMockSystemGlobalSavedSearchWithSortOption("h-custom", "", true),
+			},
+			expectedNode:       searchtypes.EmptySearchNode(),
+			expectedSortTarget: &customID,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint: exhaustruct
+			mock := mockBackendSpannerClient{
+				t: t,
+				mockGetSystemGlobalSavedSearchCfg: &mockGetSystemGlobalSavedSearchConfig{
+					results: tc.globalSearches,
+				},
+			}
+			backend := NewBackend(mock)
+			node := &searchtypes.SearchNode{
+				Keyword: searchtypes.KeywordNone,
+				Term: &searchtypes.SearchTerm{
+					Identifier: searchtypes.IdentifierHotlist,
+					Operator:   searchtypes.OperatorNone,
+					Value:      tc.id,
+				},
+				Children: nil,
+			}
+
+			expanded, sortTgt, err := backend.expandSavedSearches(context.Background(), node, 0, map[string]struct{}{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(expanded, tc.expectedNode) {
+				t.Errorf("expected node %+v, got %+v", tc.expectedNode, expanded)
+			}
+			if !reflect.DeepEqual(sortTgt, tc.expectedSortTarget) {
+				t.Errorf("expected sort target %+v, got %+v", tc.expectedSortTarget, sortTgt)
+			}
+		})
+	}
+}
+
+func TestExpandSavedSearches_Error(t *testing.T) {
+	testCases := []struct {
+		name           string
+		id             string
+		globalSearches map[string]*gcpspanner.SystemGlobalSavedSearchWithSortOption
+		expectedError  error
+	}{
+		{
+			name: "max depth exceeded",
+			id:   "h1",
+			globalSearches: map[string]*gcpspanner.SystemGlobalSavedSearchWithSortOption{
+				"h1": newMockSystemGlobalSavedSearchWithSortOption("h1", "hotlist:h2", false),
+				"h2": newMockSystemGlobalSavedSearchWithSortOption("h2", "hotlist:h3", false),
+				"h3": newMockSystemGlobalSavedSearchWithSortOption("h3", "feat1", false),
+			},
+			expectedError: backendtypes.ErrSavedSearchMaxDepthExceeded,
+		},
+		{
+			name:           "hotlist not found",
+			id:             "nonexistent",
+			globalSearches: map[string]*gcpspanner.SystemGlobalSavedSearchWithSortOption{},
+			expectedError:  backendtypes.ErrHotlistNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint: exhaustruct
+			mock := mockBackendSpannerClient{
+				t: t,
+				mockGetSystemGlobalSavedSearchCfg: &mockGetSystemGlobalSavedSearchConfig{
+					results: tc.globalSearches,
+				},
+			}
+			backend := NewBackend(mock)
+			node := &searchtypes.SearchNode{
+				Keyword: searchtypes.KeywordNone,
+				Term: &searchtypes.SearchTerm{
+					Identifier: searchtypes.IdentifierHotlist,
+					Operator:   searchtypes.OperatorNone,
+					Value:      tc.id,
+				},
+				Children: nil,
+			}
+
+			_, _, err := backend.expandSavedSearches(context.Background(), node, 0, map[string]struct{}{})
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("expected error %v, got %v", tc.expectedError, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
feat(search): add support for saved search expansion and custom sort order

This PR implements the expansion of saved searches (hotlists) within the search query parser and builder. It also adds support for sorting features based on their position in a specific saved search.

Key changes:
- Added `expandSavedSearches` to recursively expand `saved:` and `hotlist:` identifiers in the search AST.
- Implemented cycle detection and a maximum depth limit (2) for expansion to prevent DoS.
- Added support for sorting by `SearchIDOrderSort` in `FeatureSearchQueryBuilder`.
- Updated `FeatureSearchFilterBuilder` to handle hotlist subqueries efficiently, including AND/OR combinations of hotlists.
- Added unit and integration tests for hotlist expansion and sorting.

Dependencies:
- This PR depends on schema changes introduced in PR #2419 (table `SavedSearchFeatureSortOrder` and column `HasCustomSortOrder`).
