### PR TITLE
Implement rich RSS feed formatting

### DIFF
--- a/backend/pkg/httpserver/create_notification_channel_test.go
+++ b/backend/pkg/httpserver/create_notification_channel_test.go
@@ -227,6 +227,7 @@ func TestCreateNotificationChannel(t *testing.T) {
 				t:                            t,
 			}
 			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
 				wptMetricsStorer:        mockStorer,
 				baseURL:                 getTestBaseURL(t),
 				metadataStorer:          nil,

--- a/backend/pkg/httpserver/create_saved_search_test.go
+++ b/backend/pkg/httpserver/create_saved_search_test.go
@@ -420,8 +420,15 @@ func TestCreateSavedSearch(t *testing.T) {
 				callCountPublishSearchConfigurationChanged: 0,
 				publishSearchConfigurationChangedCfg:       tc.mockPublishConfig,
 			}
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
-				operationResponseCaches: nil, baseURL: getTestBaseURL(t), eventPublisher: mockPublisher}
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
+				operationResponseCaches: nil,
+				baseURL:                 getTestBaseURL(t),
+				eventPublisher:          mockPublisher,
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 		})

--- a/backend/pkg/httpserver/create_subscription_test.go
+++ b/backend/pkg/httpserver/create_subscription_test.go
@@ -219,6 +219,7 @@ func TestCreateSubscription(t *testing.T) {
 				t:                                t,
 			}
 			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
 				wptMetricsStorer:        mockStorer,
 				metadataStorer:          nil,
 				userGitHubClientFactory: nil,

--- a/backend/pkg/httpserver/delete_notification_channel_test.go
+++ b/backend/pkg/httpserver/delete_notification_channel_test.go
@@ -93,6 +93,7 @@ func TestDeleteNotificationChannel(t *testing.T) {
 				t:                            t,
 			}
 			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
 				wptMetricsStorer:        mockStorer,
 				baseURL:                 getTestBaseURL(t),
 				metadataStorer:          nil,

--- a/backend/pkg/httpserver/delete_subscription_test.go
+++ b/backend/pkg/httpserver/delete_subscription_test.go
@@ -113,6 +113,7 @@ func TestDeleteSubscription(t *testing.T) {
 				t:                                t,
 			}
 			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
 				wptMetricsStorer:        mockStorer,
 				metadataStorer:          nil,
 				userGitHubClientFactory: nil,

--- a/backend/pkg/httpserver/get_feature_metadata_test.go
+++ b/backend/pkg/httpserver/get_feature_metadata_test.go
@@ -123,6 +123,7 @@ func TestGetFeatureMetadata(t *testing.T) {
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
 			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
 				wptMetricsStorer:        mockStorer,
 				metadataStorer:          mockMetadataStorer,
 				userGitHubClientFactory: nil,

--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -452,10 +452,15 @@ func TestGetFeature(t *testing.T) {
 				t:                    t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
 				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t)}
+				baseURL:                 getTestBaseURL(t),
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountGetFeature,
 				"GetFeature", mockCacher)

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -590,10 +590,15 @@ func TestListFeatures(t *testing.T) {
 				t:                 t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
 				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t)}
+				baseURL:                 getTestBaseURL(t),
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountFeaturesSearch,
 				"FeaturesSearch", mockCacher)

--- a/backend/pkg/httpserver/get_notification_channel_test.go
+++ b/backend/pkg/httpserver/get_notification_channel_test.go
@@ -122,6 +122,7 @@ func TestGetNotificationChannel(t *testing.T) {
 				t:                         t,
 			}
 			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
 				wptMetricsStorer:        mockStorer,
 				baseURL:                 getTestBaseURL(t),
 				metadataStorer:          nil,

--- a/backend/pkg/httpserver/get_saved_search_test.go
+++ b/backend/pkg/httpserver/get_saved_search_test.go
@@ -72,9 +72,15 @@ func TestGetSavedSearch(t *testing.T) {
 				getSavedSearchCfg: tc.cfg,
 				t:                 t,
 			}
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
 				eventPublisher:          nil,
-				operationResponseCaches: nil, baseURL: getTestBaseURL(t)}
+				operationResponseCaches: nil,
+				baseURL:                 getTestBaseURL(t),
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 		})

--- a/backend/pkg/httpserver/get_subscription_rss.go
+++ b/backend/pkg/httpserver/get_subscription_rss.go
@@ -17,17 +17,23 @@ package httpserver
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+const (
+	fallbackRSSItemTitle = "WebStatus Update"
+	errorRSSItemTitle    = "Error loading update"
 )
 
 // RSS struct for marshaling.
@@ -56,8 +62,13 @@ type GUID struct {
 	IsPermaLink string `xml:"isPermaLink,attr"`
 }
 
+type CDATA struct {
+	Text string `xml:",cdata"`
+}
+
 type Item struct {
-	Description string `xml:"description"`
+	Title       string `xml:"title"`
+	Description CDATA  `xml:"description"`
 	GUID        GUID   `xml:"guid"`
 	PubDate     string `xml:"pubDate"`
 }
@@ -117,7 +128,11 @@ func (s *Server) GetSubscriptionRSS(
 		}, nil
 	}
 
-	channelLink := s.baseURL.String() + "/features?q=" + url.QueryEscape(search.Query)
+	channelLinkURL := s.baseURL.JoinPath("features")
+	q := channelLinkURL.Query()
+	q.Set("q", search.Query)
+	channelLinkURL.RawQuery = q.Encode()
+	channelLink := channelLinkURL.String()
 
 	rss := RSS{
 		XMLName: xml.Name{Local: "rss", Space: ""},
@@ -163,8 +178,48 @@ func (s *Server) GetSubscriptionRSS(
 	}
 
 	for _, e := range events {
+		var summary workertypes.EventSummary
+		var description string
+		var title string
+		if err := json.Unmarshal(e.Summary, &summary); err != nil {
+			slog.ErrorContext(ctx, "failed to unmarshal summary", "event_id", e.ID, "error", err)
+
+			errorHTML := fmt.Sprintf(
+				"<p>Could not load details for this update. Please contact support with ID: %s</p>",
+				e.ID,
+			)
+
+			rss.Channel.Items = append(rss.Channel.Items, Item{
+				Title:       errorRSSItemTitle,
+				Description: CDATA{Text: errorHTML},
+				GUID: GUID{
+					Value:       e.ID,
+					IsPermaLink: "false",
+				},
+				PubDate: e.Timestamp.Format(time.RFC1123Z),
+			})
+
+			continue
+		}
+
+		richHTML, err := s.rssRenderer.RenderRSSDescription(summary)
+		if err != nil {
+			slog.ErrorContext(ctx, "failed to render RSS description", "event_id", e.ID, "error", err)
+			description = summary.Text
+			if description == "" {
+				description = "Detailed summary unavailable"
+			}
+		} else {
+			description = richHTML
+		}
+		title = summary.Text
+		if title == "" {
+			title = fallbackRSSItemTitle
+		}
+
 		rss.Channel.Items = append(rss.Channel.Items, Item{
-			Description: string(e.Summary),
+			Title:       title,
+			Description: CDATA{Text: description},
 			GUID: GUID{
 				Value:       e.ID,
 				IsPermaLink: "false",

--- a/backend/pkg/httpserver/get_subscription_rss_test.go
+++ b/backend/pkg/httpserver/get_subscription_rss_test.go
@@ -82,10 +82,12 @@ func TestGetSubscriptionRSS(t *testing.T) {
 						SnapshotType:  string(backend.SubscriptionFrequencyImmediate),
 						Timestamp:     time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
 						EventType:     "IMMEDIATE_DIFF",
-						Summary:       []byte(`"summary"`),
-						Reasons:       nil,
-						BlobPath:      "",
-						DiffBlobPath:  "",
+						Summary: []byte(
+							`{"schemaVersion":"v1","text":"Sample update","highlights":[{"type":"Added","feature_name":"Feature A"}]}`,
+						),
+						Reasons:      nil,
+						BlobPath:     "",
+						DiffBlobPath: "",
 					},
 				},
 				outputNextPageToken: nil,
@@ -99,6 +101,11 @@ func TestGetSubscriptionRSS(t *testing.T) {
 				"<guid isPermaLink=\"false\">event-1</guid>",
 				"<pubDate>Thu, 01 Jan 2026 12:00:00 +0000</pubDate>",
 				"<link>http://localhost:8080/features?q=query</link>",
+				"Sample update",
+				"Feature A",
+				"<![CDATA[",
+				"<atom:link rel=\"self\" href=\"http://localhost:8080/v1/subscriptions/sub-id/rss\"></atom:link>",
+				"<h4>Features Added</h4>",
 			},
 		},
 		{
@@ -145,10 +152,12 @@ func TestGetSubscriptionRSS(t *testing.T) {
 						SnapshotType:  string(backend.SubscriptionFrequencyImmediate),
 						Timestamp:     time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
 						EventType:     "IMMEDIATE_DIFF",
-						Summary:       []byte(`"summary"`),
-						Reasons:       nil,
-						BlobPath:      "",
-						DiffBlobPath:  "",
+						Summary: []byte(
+							`{"schemaVersion":"v1","text":"Sample update","highlights":[{"type":"Added","feature_name":"Feature A"}]}`,
+						),
+						Reasons:      nil,
+						BlobPath:     "",
+						DiffBlobPath: "",
 					},
 				},
 				outputNextPageToken: &[]string{"next-token"}[0],
@@ -165,6 +174,11 @@ func TestGetSubscriptionRSS(t *testing.T) {
 				`<atom:link rel="next" ` +
 					`href="http://localhost:8080/v1/subscriptions/sub-id/rss?page_size=100&amp;page_token=next-token">` +
 					`</atom:link>`,
+				"Sample update",
+				"Feature A",
+				"<![CDATA[",
+				"<atom:link rel=\"self\" href=\"http://localhost:8080/v1/subscriptions/sub-id/rss\"></atom:link>",
+				"<h4>Features Added</h4>",
 			},
 		},
 		{
@@ -204,6 +218,7 @@ func TestGetSubscriptionRSS(t *testing.T) {
 			mockStorer.t = t
 
 			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
 				wptMetricsStorer:        &mockStorer,
 				metadataStorer:          nil,
 				userGitHubClientFactory: nil,

--- a/backend/pkg/httpserver/get_subscription_test.go
+++ b/backend/pkg/httpserver/get_subscription_test.go
@@ -140,6 +140,7 @@ func TestGetSubscription(t *testing.T) {
 				t:                             t,
 			}
 			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
 				wptMetricsStorer:        mockStorer,
 				metadataStorer:          nil,
 				userGitHubClientFactory: nil,

--- a/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
+++ b/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
@@ -296,10 +296,15 @@ func TestListAggregatedBaselineStatusCounts(t *testing.T) {
 				t:                           t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
 				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t)}
+				baseURL:                 getTestBaseURL(t),
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListBaselineStatusCounts,
 				"ListBaselineStatusCounts", mockCacher)

--- a/backend/pkg/httpserver/list_aggregated_feature_support_test.go
+++ b/backend/pkg/httpserver/list_aggregated_feature_support_test.go
@@ -313,10 +313,15 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 				t:                                t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
 				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t)}
+				baseURL:                 getTestBaseURL(t),
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListBrowserFeatureCountMetric,
 				"ListBrowserFeatureCountMetric", mockCacher)

--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
@@ -299,10 +299,15 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 				t:            t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
 				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t)}
+				baseURL:                 getTestBaseURL(t),
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(
 				t,

--- a/backend/pkg/httpserver/list_chromium_usage_test.go
+++ b/backend/pkg/httpserver/list_chromium_usage_test.go
@@ -153,10 +153,15 @@ func TestListChromeDailyUsageStats(t *testing.T) {
 				t:                            t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
 				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t)}
+				baseURL:                 getTestBaseURL(t),
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListChromeDailyUsageStats,
 				"ListChromeDailyUsageStats", mockCacher)

--- a/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
@@ -295,10 +295,15 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 				t:          t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
 				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t)}
+				baseURL:                 getTestBaseURL(t),
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(
 				t,

--- a/backend/pkg/httpserver/list_global_saved_searches_test.go
+++ b/backend/pkg/httpserver/list_global_saved_searches_test.go
@@ -224,6 +224,7 @@ func TestListGlobalSavedSearches(t *testing.T) {
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
 				eventPublisher:          nil,
 				baseURL:                 getTestBaseURL(t),
+				rssRenderer:             nil,
 			}
 
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)

--- a/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
@@ -344,10 +344,15 @@ func TestListMissingOneImplementationCounts(t *testing.T) {
 				t:                          t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
 				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t)}
+				baseURL:                 getTestBaseURL(t),
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMissingOneImplCounts,
 				"ListMissingOneImplCounts", mockCacher)

--- a/backend/pkg/httpserver/list_missing_one_implementation_features_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_features_test.go
@@ -197,10 +197,15 @@ func TestListMissingOneImplementationFeatures(t *testing.T) {
 				t:                             t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, nil, nil)
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
 				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
 				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t)}
+				baseURL:                 getTestBaseURL(t),
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMissingOneImplFeatures,
 				"ListMissingOneImplementationFeatures", mockCacher)

--- a/backend/pkg/httpserver/list_notification_channels_test.go
+++ b/backend/pkg/httpserver/list_notification_channels_test.go
@@ -142,6 +142,7 @@ func TestListNotificationChannels(t *testing.T) {
 				t:                           t,
 			}
 			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
 				wptMetricsStorer:        mockStorer,
 				baseURL:                 getTestBaseURL(t),
 				metadataStorer:          nil,

--- a/backend/pkg/httpserver/list_subscriptions_test.go
+++ b/backend/pkg/httpserver/list_subscriptions_test.go
@@ -176,6 +176,7 @@ func TestListSubscriptions(t *testing.T) {
 				t:                               t,
 			}
 			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
 				wptMetricsStorer:        mockStorer,
 				metadataStorer:          nil,
 				userGitHubClientFactory: nil,

--- a/backend/pkg/httpserver/list_user_saved_searches_test.go
+++ b/backend/pkg/httpserver/list_user_saved_searches_test.go
@@ -181,9 +181,15 @@ func TestListUserSavedSearches(t *testing.T) {
 				listUserSavedSearchesCfg: tc.cfg,
 				t:                        t,
 			}
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
-				operationResponseCaches: nil, baseURL: getTestBaseURL(t),
-				eventPublisher: nil}
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
+				operationResponseCaches: nil,
+				baseURL:                 getTestBaseURL(t),
+				eventPublisher:          nil,
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListUserSavedSearches,

--- a/backend/pkg/httpserver/ping_user_test.go
+++ b/backend/pkg/httpserver/ping_user_test.go
@@ -256,6 +256,7 @@ func TestPingUser(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			authMiddlewareOption := withAuthMiddleware(tc.authMiddleware)
 			myServer := Server{
+				rssRenderer: NewRSSRenderer(),
 				// nolint:exhaustruct
 				wptMetricsStorer: &MockWPTMetricsStorer{t: t, syncUserProfileInfoCfg: tc.syncUserProfileInfoCfg},
 				metadataStorer:   nil,

--- a/backend/pkg/httpserver/put_user_saved_search_bookmark_test.go
+++ b/backend/pkg/httpserver/put_user_saved_search_bookmark_test.go
@@ -105,10 +105,15 @@ func TestPutUserSavedSearchBookmark(t *testing.T) {
 				putUserSavedSearchBookmarkCfg: tc.cfg,
 				t:                             t,
 			}
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
 				operationResponseCaches: nil,
 				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t)}
+				baseURL:                 getTestBaseURL(t),
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{authMiddlewareOption}...)
 			assertMocksExpectations(t, 1, mockStorer.callCountPutUserSavedSearchBookmark,

--- a/backend/pkg/httpserver/remove_saved_search_test.go
+++ b/backend/pkg/httpserver/remove_saved_search_test.go
@@ -105,8 +105,15 @@ func TestRemoveSavedSearch(t *testing.T) {
 				deleteUserSavedSearchCfg: tc.cfg,
 				t:                        t,
 			}
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
-				operationResponseCaches: nil, baseURL: getTestBaseURL(t), eventPublisher: nil}
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
+				operationResponseCaches: nil,
+				baseURL:                 getTestBaseURL(t),
+				eventPublisher:          nil,
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{authMiddlewareOption}...)
 			assertMocksExpectations(t, 1, mockStorer.callCountDeleteUserSavedSearch,

--- a/backend/pkg/httpserver/remove_user_saved_search_bookmark_test.go
+++ b/backend/pkg/httpserver/remove_user_saved_search_bookmark_test.go
@@ -105,8 +105,15 @@ func TestRemoveUserSavedSearchBookmark(t *testing.T) {
 				removeUserSavedSearchBookmarkCfg: tc.cfg,
 				t:                                t,
 			}
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
-				operationResponseCaches: nil, baseURL: getTestBaseURL(t), eventPublisher: nil}
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
+				operationResponseCaches: nil,
+				baseURL:                 getTestBaseURL(t),
+				eventPublisher:          nil,
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{authMiddlewareOption}...)
 			assertMocksExpectations(t, 1, mockStorer.callCountRemoveUserSavedSearchBookmark,

--- a/backend/pkg/httpserver/rss_renderer.go
+++ b/backend/pkg/httpserver/rss_renderer.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+const rssItemTemplate = `
+<div>
+    <p>{{.SummaryText}}</p>
+    {{if .Added}}
+    <h4>Features Added</h4>
+    <ul>
+        {{range .Added}}<li>{{.}}</li>{{end}}
+    </ul>
+    {{end}}
+    {{if .Removed}}
+    <h4>Features Removed</h4>
+    <ul>
+        {{range .Removed}}<li>{{.}}</li>{{end}}
+    </ul>
+    {{end}}
+    {{if .Other}}
+    <h4>Other Updates</h4>
+    <ul>
+        {{range .Other}}<li>{{.}}</li>{{end}}
+    </ul>
+    {{end}}
+    {{if .Truncated}}
+    <p><em>Note: This summary has been truncated. View full details on the site.</em></p>
+    {{end}}
+</div>
+`
+
+type RSSItemData struct {
+	SummaryText string
+	Added       []string
+	Removed     []string
+	Other       []string
+	Truncated   bool
+}
+
+type RSSRenderer struct {
+	tmpl *template.Template
+}
+
+// NewRSSRenderer initializes the renderer and parses the template at startup.
+func NewRSSRenderer() *RSSRenderer {
+	tmpl := template.Must(template.New("rss_item").Parse(rssItemTemplate))
+
+	return &RSSRenderer{tmpl: tmpl}
+}
+
+func (r *RSSRenderer) RenderRSSDescription(summary workertypes.EventSummary) (string, error) {
+	data := RSSItemData{
+		SummaryText: summary.Text,
+		Truncated:   summary.Truncated,
+		Added:       []string{},
+		Removed:     []string{},
+		Other:       []string{},
+	}
+
+	// Map highlights to categories using Enums
+	for _, h := range summary.Highlights {
+		switch h.Type {
+		case workertypes.SummaryHighlightTypeAdded:
+			data.Added = append(data.Added, h.FeatureName)
+		case workertypes.SummaryHighlightTypeRemoved:
+			data.Removed = append(data.Removed, h.FeatureName)
+		case workertypes.SummaryHighlightTypeChanged,
+			workertypes.SummaryHighlightTypeMoved,
+			workertypes.SummaryHighlightTypeSplit,
+			workertypes.SummaryHighlightTypeDeleted:
+			data.Other = append(data.Other, fmt.Sprintf("%s (%s)", h.FeatureName, h.Type))
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := r.tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/backend/pkg/httpserver/rss_renderer_test.go
+++ b/backend/pkg/httpserver/rss_renderer_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+func TestNewRSSRenderer(t *testing.T) {
+	renderer := NewRSSRenderer()
+	if renderer == nil {
+		t.Fatal("NewRSSRenderer returned nil")
+	}
+	if renderer.tmpl == nil {
+		t.Fatal("NewRSSRenderer returned renderer with nil template")
+	}
+}
+
+func TestRenderRSSDescription(t *testing.T) {
+	renderer := NewRSSRenderer()
+
+	testCases := []struct {
+		name             string
+		summary          workertypes.EventSummary
+		expectedContains []string
+	}{
+		{
+			name: "Basic Summary with Added Feature",
+			summary: workertypes.EventSummary{
+				SchemaVersion: workertypes.VersionEventSummaryV1,
+				Text:          "1 new feature matched",
+				Categories: workertypes.SummaryCategories{
+					QueryChanged:    0,
+					Added:           0,
+					Removed:         0,
+					Deleted:         0,
+					Moved:           0,
+					Split:           0,
+					Updated:         0,
+					UpdatedImpl:     0,
+					UpdatedRename:   0,
+					UpdatedBaseline: 0,
+				},
+				Truncated:      false,
+				SnapshotOrigin: "",
+				QueryErrors:    nil,
+				Highlights: []workertypes.SummaryHighlight{
+					{
+						Type:           workertypes.SummaryHighlightTypeAdded,
+						FeatureID:      "feature-a",
+						FeatureName:    "Feature A",
+						Docs:           nil,
+						NameChange:     nil,
+						BaselineChange: nil,
+						BrowserChanges: nil,
+						Moved:          nil,
+						Split:          nil,
+					},
+				},
+			},
+			expectedContains: []string{
+				"Feature A",
+				"Features Added",
+			},
+		},
+		{
+			name: "Removed Feature",
+			summary: workertypes.EventSummary{
+				SchemaVersion: workertypes.VersionEventSummaryV1,
+				Text:          "1 feature removed",
+				Categories: workertypes.SummaryCategories{
+					QueryChanged:    0,
+					Added:           0,
+					Removed:         0,
+					Deleted:         0,
+					Moved:           0,
+					Split:           0,
+					Updated:         0,
+					UpdatedImpl:     0,
+					UpdatedRename:   0,
+					UpdatedBaseline: 0,
+				},
+				Truncated:      false,
+				SnapshotOrigin: "",
+				QueryErrors:    nil,
+				Highlights: []workertypes.SummaryHighlight{
+					{
+						Type:           workertypes.SummaryHighlightTypeRemoved,
+						FeatureID:      "feature-b",
+						FeatureName:    "Feature B",
+						Docs:           nil,
+						NameChange:     nil,
+						BaselineChange: nil,
+						BrowserChanges: nil,
+						Moved:          nil,
+						Split:          nil,
+					},
+				},
+			},
+			expectedContains: []string{
+				"Feature B",
+				"Features Removed",
+			},
+		},
+		{
+			name: "Other Update",
+			summary: workertypes.EventSummary{
+				SchemaVersion: workertypes.VersionEventSummaryV1,
+				Text:          "1 feature updated",
+				Categories: workertypes.SummaryCategories{
+					QueryChanged:    0,
+					Added:           0,
+					Removed:         0,
+					Deleted:         0,
+					Moved:           0,
+					Split:           0,
+					Updated:         0,
+					UpdatedImpl:     0,
+					UpdatedRename:   0,
+					UpdatedBaseline: 0,
+				},
+				Truncated:      false,
+				SnapshotOrigin: "",
+				QueryErrors:    nil,
+				Highlights: []workertypes.SummaryHighlight{
+					{
+						Type:           workertypes.SummaryHighlightTypeChanged,
+						FeatureID:      "feature-c",
+						FeatureName:    "Feature C",
+						Docs:           nil,
+						NameChange:     nil,
+						BaselineChange: nil,
+						BrowserChanges: nil,
+						Moved:          nil,
+						Split:          nil,
+					},
+				},
+			},
+			expectedContains: []string{
+				"Feature C",
+				"Other Updates",
+			},
+		},
+		{
+			name: "HTML Escaping in Feature Name",
+			summary: workertypes.EventSummary{
+				SchemaVersion: workertypes.VersionEventSummaryV1,
+				Text:          "HTML escaping test",
+				Categories: workertypes.SummaryCategories{
+					QueryChanged:    0,
+					Added:           0,
+					Removed:         0,
+					Deleted:         0,
+					Moved:           0,
+					Split:           0,
+					Updated:         0,
+					UpdatedImpl:     0,
+					UpdatedRename:   0,
+					UpdatedBaseline: 0,
+				},
+				Truncated:      false,
+				SnapshotOrigin: "",
+				QueryErrors:    nil,
+				Highlights: []workertypes.SummaryHighlight{
+					{
+						Type:           workertypes.SummaryHighlightTypeAdded,
+						FeatureID:      "feature-html",
+						FeatureName:    "<link rel=\"dns-prefetch\">",
+						Docs:           nil,
+						NameChange:     nil,
+						BaselineChange: nil,
+						BrowserChanges: nil,
+						Moved:          nil,
+						Split:          nil,
+					},
+				},
+			},
+			expectedContains: []string{
+				"&lt;link",
+				"dns-prefetch",
+			},
+		},
+		{
+			name: "Truncated Summary",
+			summary: workertypes.EventSummary{
+				SchemaVersion: workertypes.VersionEventSummaryV1,
+				Text:          "Summary text",
+				Categories: workertypes.SummaryCategories{
+					QueryChanged:    0,
+					Added:           0,
+					Removed:         0,
+					Deleted:         0,
+					Moved:           0,
+					Split:           0,
+					Updated:         0,
+					UpdatedImpl:     0,
+					UpdatedRename:   0,
+					UpdatedBaseline: 0,
+				},
+				Truncated:      true,
+				SnapshotOrigin: "",
+				QueryErrors:    nil,
+				Highlights:     []workertypes.SummaryHighlight{},
+			},
+			expectedContains: []string{
+				"This summary has been truncated",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := renderer.RenderRSSDescription(tc.summary)
+			if err != nil {
+				t.Fatalf("RenderRSSDescription failed: %v", err)
+			}
+
+			for _, expected := range tc.expectedContains {
+				if !bytes.Contains([]byte(output), []byte(expected)) {
+					t.Errorf("Expected output to contain %q, but it did not. Output: %s", expected, output)
+				}
+			}
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -201,6 +201,7 @@ type Server struct {
 	baseURL                 *url.URL
 	userGitHubClientFactory UserGitHubClientFactory
 	eventPublisher          EventPublisher
+	rssRenderer             *RSSRenderer
 }
 
 type GitHubUserClient interface {
@@ -276,6 +277,7 @@ func NewHTTPServer(
 		operationResponseCaches: initOperationResponseCaches(rawBytesDataCacher, routeCacheOptions),
 		baseURL:                 baseURL,
 		userGitHubClientFactory: userGitHubClientFactory,
+		rssRenderer:             NewRSSRenderer(),
 	}
 
 	return createOpenAPIServerServer(port, srv, preRequestValidationMiddlewares, authMiddleware)

--- a/backend/pkg/httpserver/update_notification_channel_test.go
+++ b/backend/pkg/httpserver/update_notification_channel_test.go
@@ -268,6 +268,7 @@ func TestUpdateNotificationChannel_Restrictions(t *testing.T) {
 				t:                            t,
 			}
 			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
 				wptMetricsStorer:        mockStorer,
 				baseURL:                 getTestBaseURL(t),
 				metadataStorer:          nil,

--- a/backend/pkg/httpserver/update_saved_search_test.go
+++ b/backend/pkg/httpserver/update_saved_search_test.go
@@ -425,8 +425,15 @@ func TestUpdateSavedSearch(t *testing.T) {
 				callCountPublishSearchConfigurationChanged: 0,
 				publishSearchConfigurationChangedCfg:       tc.publishCfg,
 			}
-			myServer := Server{wptMetricsStorer: mockStorer, metadataStorer: nil, userGitHubClientFactory: nil,
-				operationResponseCaches: nil, baseURL: getTestBaseURL(t), eventPublisher: mockPublisher}
+			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
+				wptMetricsStorer:        mockStorer,
+				metadataStorer:          nil,
+				userGitHubClientFactory: nil,
+				operationResponseCaches: nil,
+				baseURL:                 getTestBaseURL(t),
+				eventPublisher:          mockPublisher,
+			}
 			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 		})

--- a/backend/pkg/httpserver/update_subscription_test.go
+++ b/backend/pkg/httpserver/update_subscription_test.go
@@ -222,6 +222,7 @@ func TestUpdateSubscription(t *testing.T) {
 			}
 
 			myServer := Server{
+				rssRenderer:             NewRSSRenderer(),
 				wptMetricsStorer:        mockStorer,
 				baseURL:                 getTestBaseURL(t),
 				metadataStorer:          nil,


### PR DESCRIPTION
There are two pairs of files that have changes in this PR; the rest are formatting and adding an RSS renderer object to wherever a Server object is initialized. Those two pairs of files are: 
- backend/pkg/httpserver/get_subscription_rss.go
- backend/pkg/httpserver/get_subscription_rss_test.go

and

- backend/pkg/httpserver/rss_renderer.go
- backend/pkg/httpserver/rss_renderer_test.go

Sample (empty) API response:
```
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
  <channel>
    <title>WebStatus.dev - Feature: Molestiae77</title>
    <link>http://localhost:8080/features?q=id%3A%22molestiae77%22</link>
    <description>RSS feed for saved search: Feature: Molestiae77</description>
    <atom:link rel="self" href="http://localhost:8080/v1/subscriptions/b204482d-66d1-4797-9393-919aa84dd9fb/rss"></atom:link>
  </channel>
</rss>
```

I'll follow up with a PR to centralize the creation of Server objects so future field additions doesn't require touching 30 files.