### PR TITLE
Refactor httpserver test setups to use new setupTestServer helper

### DIFF
--- a/backend/pkg/httpserver/create_notification_channel_test.go
+++ b/backend/pkg/httpserver/create_notification_channel_test.go
@@ -226,17 +226,9 @@ func TestCreateNotificationChannel(t *testing.T) {
 				createNotificationChannelCfg: tc.storerCfg,
 				t:                            t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				baseURL:                 getTestBaseURL(t),
-				metadataStorer:          nil,
-				operationResponseCaches: nil,
-				userGitHubClientFactory: nil,
-				eventPublisher:          nil,
-			}
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
 
-			assertTestServerRequest(t, &myServer, req, tc.expectedResponse,
+			assertTestServerRequest(t, myServer, req, tc.expectedResponse,
 				withAuthMiddleware(mockAuthMiddleware(testUser)))
 			assertMocksExpectations(t, tc.expectedCallCount,
 				mockStorer.callCountCreateNotificationChannel, "CreateNotificationChannel", nil)

--- a/backend/pkg/httpserver/create_saved_search_test.go
+++ b/backend/pkg/httpserver/create_saved_search_test.go
@@ -420,16 +420,8 @@ func TestCreateSavedSearch(t *testing.T) {
 				callCountPublishSearchConfigurationChanged: 0,
 				publishSearchConfigurationChangedCfg:       tc.mockPublishConfig,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: nil,
-				baseURL:                 getTestBaseURL(t),
-				eventPublisher:          mockPublisher,
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+			myServer := setupTestServer(t, withCustomStorer(mockStorer), withCustomEventPublisher(mockPublisher))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 		})
 	}

--- a/backend/pkg/httpserver/create_subscription_test.go
+++ b/backend/pkg/httpserver/create_subscription_test.go
@@ -218,16 +218,8 @@ func TestCreateSubscription(t *testing.T) {
 				createSavedSearchSubscriptionCfg: tc.cfg,
 				t:                                t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: nil,
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
 			assertMocksExpectations(t,
 				tc.expectedCallCount,
 				mockStorer.callCountCreateSavedSearchSubscription,

--- a/backend/pkg/httpserver/delete_notification_channel_test.go
+++ b/backend/pkg/httpserver/delete_notification_channel_test.go
@@ -92,16 +92,8 @@ func TestDeleteNotificationChannel(t *testing.T) {
 				deleteNotificationChannelCfg: tc.cfg,
 				t:                            t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				baseURL:                 getTestBaseURL(t),
-				metadataStorer:          nil,
-				operationResponseCaches: nil,
-				userGitHubClientFactory: nil,
-				eventPublisher:          nil,
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountDeleteNotificationChannel,
 				"DeleteNotificationChannel", nil)

--- a/backend/pkg/httpserver/delete_subscription_test.go
+++ b/backend/pkg/httpserver/delete_subscription_test.go
@@ -112,16 +112,8 @@ func TestDeleteSubscription(t *testing.T) {
 				deleteSavedSearchSubscriptionCfg: tc.cfg,
 				t:                                t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: nil,
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
 			assertMocksExpectations(t,
 				tc.expectedCallCount,
 				mockStorer.callCountDeleteSavedSearchSubscription,

--- a/backend/pkg/httpserver/get_feature_metadata_test.go
+++ b/backend/pkg/httpserver/get_feature_metadata_test.go
@@ -122,16 +122,12 @@ func TestGetFeatureMetadata(t *testing.T) {
 				t:                         t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          mockMetadataStorer,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
-				baseURL:                 getTestBaseURL(t),
-				eventPublisher:          nil,
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			myServer := setupTestServer(t,
+				withCustomStorer(mockStorer),
+				withCustomMetadataStorer(mockMetadataStorer),
+				withCustomCaches(initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())),
+			)
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse)
 			mockCacher.AssertExpectations()
 			// TODO: Start tracking call count and assert call count.
 		})

--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -452,16 +452,11 @@ func TestGetFeature(t *testing.T) {
 				t:                    t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			myServer := setupTestServer(t,
+				withCustomStorer(mockStorer),
+				withCustomCaches(initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())),
+			)
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountGetFeature,
 				"GetFeature", mockCacher)
 		})

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -590,16 +590,11 @@ func TestListFeatures(t *testing.T) {
 				t:                 t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			myServer := setupTestServer(t,
+				withCustomStorer(mockStorer),
+				withCustomCaches(initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())),
+			)
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountFeaturesSearch,
 				"FeaturesSearch", mockCacher)
 		})

--- a/backend/pkg/httpserver/get_notification_channel_test.go
+++ b/backend/pkg/httpserver/get_notification_channel_test.go
@@ -121,16 +121,8 @@ func TestGetNotificationChannel(t *testing.T) {
 				getNotificationChannelCfg: tc.cfg,
 				t:                         t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				baseURL:                 getTestBaseURL(t),
-				metadataStorer:          nil,
-				operationResponseCaches: nil,
-				userGitHubClientFactory: nil,
-				eventPublisher:          nil,
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountGetNotificationChannel,
 				"GetNotificationChannel", nil)

--- a/backend/pkg/httpserver/get_saved_search_test.go
+++ b/backend/pkg/httpserver/get_saved_search_test.go
@@ -72,16 +72,8 @@ func TestGetSavedSearch(t *testing.T) {
 				getSavedSearchCfg: tc.cfg,
 				t:                 t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				eventPublisher:          nil,
-				operationResponseCaches: nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 		})
 	}

--- a/backend/pkg/httpserver/get_subscription_rss_test.go
+++ b/backend/pkg/httpserver/get_subscription_rss_test.go
@@ -217,15 +217,7 @@ func TestGetSubscriptionRSS(t *testing.T) {
 			mockStorer.listSavedSearchNotificationEventsCfg = tc.eventsCfg
 			mockStorer.t = t
 
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        &mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				eventPublisher:          nil,
-				operationResponseCaches: nil,
-				baseURL:                 getTestBaseURL(t),
-			}
+			myServer := setupTestServer(t, withCustomStorer(&mockStorer))
 
 			req := httptest.NewRequestWithContext(
 				context.Background(),
@@ -235,7 +227,7 @@ func TestGetSubscriptionRSS(t *testing.T) {
 			)
 
 			// Fix createOpenAPIServerServer call
-			srv := createOpenAPIServerServer("", &myServer, nil, noopMiddleware)
+			srv := createOpenAPIServerServer("", myServer, nil, noopMiddleware)
 
 			w := httptest.NewRecorder()
 

--- a/backend/pkg/httpserver/get_subscription_test.go
+++ b/backend/pkg/httpserver/get_subscription_test.go
@@ -139,16 +139,8 @@ func TestGetSubscription(t *testing.T) {
 				getSavedSearchSubscriptionCfg: tc.cfg,
 				t:                             t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: nil,
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
 			assertMocksExpectations(t,
 				tc.expectedCallCount,
 				mockStorer.callCountGetSavedSearchSubscription,

--- a/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
+++ b/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
@@ -296,16 +296,11 @@ func TestListAggregatedBaselineStatusCounts(t *testing.T) {
 				t:                           t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			myServer := setupTestServer(t,
+				withCustomStorer(mockStorer),
+				withCustomCaches(initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())),
+			)
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListBaselineStatusCounts,
 				"ListBaselineStatusCounts", mockCacher)
 		})

--- a/backend/pkg/httpserver/list_aggregated_feature_support_test.go
+++ b/backend/pkg/httpserver/list_aggregated_feature_support_test.go
@@ -313,16 +313,11 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 				t:                                t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			myServer := setupTestServer(t,
+				withCustomStorer(mockStorer),
+				withCustomCaches(initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())),
+			)
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListBrowserFeatureCountMetric,
 				"ListBrowserFeatureCountMetric", mockCacher)
 		})

--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
@@ -299,16 +299,11 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 				t:            t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			myServer := setupTestServer(t,
+				withCustomStorer(mockStorer),
+				withCustomCaches(initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())),
+			)
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(
 				t,
 				tc.expectedCallCount,

--- a/backend/pkg/httpserver/list_chromium_usage_test.go
+++ b/backend/pkg/httpserver/list_chromium_usage_test.go
@@ -153,16 +153,11 @@ func TestListChromeDailyUsageStats(t *testing.T) {
 				t:                            t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			myServer := setupTestServer(t,
+				withCustomStorer(mockStorer),
+				withCustomCaches(initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())),
+			)
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListChromeDailyUsageStats,
 				"ListChromeDailyUsageStats", mockCacher)
 		})

--- a/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
@@ -295,16 +295,11 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 				t:          t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			myServer := setupTestServer(t,
+				withCustomStorer(mockStorer),
+				withCustomCaches(initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())),
+			)
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(
 				t,
 				tc.expectedCallCount,

--- a/backend/pkg/httpserver/list_global_saved_searches_test.go
+++ b/backend/pkg/httpserver/list_global_saved_searches_test.go
@@ -217,17 +217,12 @@ func TestListGlobalSavedSearches(t *testing.T) {
 				t:                          t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-				rssRenderer:             nil,
-			}
+			myServer := setupTestServer(t,
+				withCustomStorer(mockStorer),
+				withCustomCaches(initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())),
+			)
 
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListGlobalSavedSearches,
 				"ListGlobalSavedSearches", mockCacher)
 		})

--- a/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
@@ -344,16 +344,11 @@ func TestListMissingOneImplementationCounts(t *testing.T) {
 				t:                          t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, tc.expectedCacheCalls, tc.expectedGetCalls)
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			myServer := setupTestServer(t,
+				withCustomStorer(mockStorer),
+				withCustomCaches(initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())),
+			)
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMissingOneImplCounts,
 				"ListMissingOneImplCounts", mockCacher)
 		})

--- a/backend/pkg/httpserver/list_missing_one_implementation_features_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_features_test.go
@@ -197,16 +197,11 @@ func TestListMissingOneImplementationFeatures(t *testing.T) {
 				t:                             t,
 			}
 			mockCacher := NewMockRawBytesDataCacher(t, nil, nil)
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: initOperationResponseCaches(mockCacher, getTestRouteCacheOptions()),
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse)
+			myServer := setupTestServer(t,
+				withCustomStorer(mockStorer),
+				withCustomCaches(initOperationResponseCaches(mockCacher, getTestRouteCacheOptions())),
+			)
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListMissingOneImplFeatures,
 				"ListMissingOneImplementationFeatures", mockCacher)
 		})

--- a/backend/pkg/httpserver/list_notification_channels_test.go
+++ b/backend/pkg/httpserver/list_notification_channels_test.go
@@ -141,16 +141,8 @@ func TestListNotificationChannels(t *testing.T) {
 				listNotificationChannelsCfg: tc.cfg,
 				t:                           t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				baseURL:                 getTestBaseURL(t),
-				metadataStorer:          nil,
-				operationResponseCaches: nil,
-				userGitHubClientFactory: nil,
-				eventPublisher:          nil,
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListNotificationChannels,
 				"ListNotificationChannels", nil)

--- a/backend/pkg/httpserver/list_subscriptions_test.go
+++ b/backend/pkg/httpserver/list_subscriptions_test.go
@@ -175,16 +175,8 @@ func TestListSubscriptions(t *testing.T) {
 				listSavedSearchSubscriptionsCfg: tc.cfg,
 				t:                               t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: nil,
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
 			assertMocksExpectations(t,
 				tc.expectedCallCount,
 				mockStorer.callCountListSavedSearchSubscriptions,

--- a/backend/pkg/httpserver/list_user_saved_searches_test.go
+++ b/backend/pkg/httpserver/list_user_saved_searches_test.go
@@ -181,16 +181,8 @@ func TestListUserSavedSearches(t *testing.T) {
 				listUserSavedSearchesCfg: tc.cfg,
 				t:                        t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: nil,
-				baseURL:                 getTestBaseURL(t),
-				eventPublisher:          nil,
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListUserSavedSearches,
 				"ListUserSavedSearches", nil)

--- a/backend/pkg/httpserver/ping_user_test.go
+++ b/backend/pkg/httpserver/ping_user_test.go
@@ -255,25 +255,20 @@ func TestPingUser(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			authMiddlewareOption := withAuthMiddleware(tc.authMiddleware)
-			myServer := Server{
-				rssRenderer: NewRSSRenderer(),
+			myServer := setupTestServer(t,
 				// nolint:exhaustruct
-				wptMetricsStorer: &MockWPTMetricsStorer{t: t, syncUserProfileInfoCfg: tc.syncUserProfileInfoCfg},
-				metadataStorer:   nil,
-				userGitHubClientFactory: setupMockGitHubUserClient(
+				withCustomStorer(&MockWPTMetricsStorer{t: t, syncUserProfileInfoCfg: tc.syncUserProfileInfoCfg}),
+				withCustomGitHubClientFactory(setupMockGitHubUserClient(
 					t,
 					"foo",
 					tc.getCurrentUserCfg,
 					tc.listEmailsCfg,
-				),
-				operationResponseCaches: nil,
-				baseURL:                 getTestBaseURL(t),
-				eventPublisher:          nil,
-			}
+				)),
+			)
 
 			req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/v1/users/me/ping", tc.body)
 			req.Header.Set("Content-Type", "application/json")
-			assertTestServerRequest(t, &myServer, req, tc.expectedResponse, authMiddlewareOption)
+			assertTestServerRequest(t, myServer, req, tc.expectedResponse, authMiddlewareOption)
 		})
 	}
 }

--- a/backend/pkg/httpserver/put_user_saved_search_bookmark_test.go
+++ b/backend/pkg/httpserver/put_user_saved_search_bookmark_test.go
@@ -105,16 +105,8 @@ func TestPutUserSavedSearchBookmark(t *testing.T) {
 				putUserSavedSearchBookmarkCfg: tc.cfg,
 				t:                             t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: nil,
-				eventPublisher:          nil,
-				baseURL:                 getTestBaseURL(t),
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{authMiddlewareOption}...)
 			assertMocksExpectations(t, 1, mockStorer.callCountPutUserSavedSearchBookmark,
 				"PutUserSavedSearchBookmark", nil)

--- a/backend/pkg/httpserver/remove_saved_search_test.go
+++ b/backend/pkg/httpserver/remove_saved_search_test.go
@@ -105,16 +105,8 @@ func TestRemoveSavedSearch(t *testing.T) {
 				deleteUserSavedSearchCfg: tc.cfg,
 				t:                        t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: nil,
-				baseURL:                 getTestBaseURL(t),
-				eventPublisher:          nil,
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{authMiddlewareOption}...)
 			assertMocksExpectations(t, 1, mockStorer.callCountDeleteUserSavedSearch,
 				"DeleteUserSavedSearch", nil)

--- a/backend/pkg/httpserver/remove_user_saved_search_bookmark_test.go
+++ b/backend/pkg/httpserver/remove_user_saved_search_bookmark_test.go
@@ -105,16 +105,8 @@ func TestRemoveUserSavedSearchBookmark(t *testing.T) {
 				removeUserSavedSearchBookmarkCfg: tc.cfg,
 				t:                                t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: nil,
-				baseURL:                 getTestBaseURL(t),
-				eventPublisher:          nil,
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{authMiddlewareOption}...)
 			assertMocksExpectations(t, 1, mockStorer.callCountRemoveUserSavedSearchBookmark,
 				"RemoveUserSavedSearchBookmark", nil)

--- a/backend/pkg/httpserver/test_utils_test.go
+++ b/backend/pkg/httpserver/test_utils_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"testing"
+)
+
+// TestServerOption defines a function type to override Server fields in tests.
+type TestServerOption func(*Server)
+
+// setupTestServer creates a Server instance initialized with safe defaults for testing.
+func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
+	t.Helper()
+
+	// Default mock implementation
+	mockStorer := &MockWPTMetricsStorer{
+		t:                                                 t,
+		featureCfg:                                        nil,
+		aggregateCfg:                                      nil,
+		listChromeDailyUsageStatsCfg:                      nil,
+		featuresSearchCfg:                                 nil,
+		getFeatureByIDConfig:                              nil,
+		listBrowserFeatureCountMetricCfg:                  nil,
+		getIDFromFeatureKeyConfig:                         nil,
+		listMissingOneImplCountCfg:                        nil,
+		listMissingOneImplFeaturesCfg:                     nil,
+		listBaselineStatusCountsCfg:                       nil,
+		createUserSavedSearchCfg:                          nil,
+		deleteUserSavedSearchCfg:                          nil,
+		getSavedSearchCfg:                                 nil,
+		listUserSavedSearchesCfg:                          nil,
+		getSavedSearchPublicCfg:                           nil,
+		updateUserSavedSearchCfg:                          nil,
+		putUserSavedSearchBookmarkCfg:                     nil,
+		removeUserSavedSearchBookmarkCfg:                  nil,
+		syncUserProfileInfoCfg:                            nil,
+		getNotificationChannelCfg:                         nil,
+		listNotificationChannelsCfg:                       nil,
+		deleteNotificationChannelCfg:                      nil,
+		createNotificationChannelCfg:                      nil,
+		updateNotificationChannelCfg:                      nil,
+		createSavedSearchSubscriptionCfg:                  nil,
+		deleteSavedSearchSubscriptionCfg:                  nil,
+		getSavedSearchSubscriptionCfg:                     nil,
+		getSavedSearchSubscriptionPublicCfg:               nil,
+		listSavedSearchSubscriptionsCfg:                   nil,
+		listSavedSearchNotificationEventsCfg:              nil,
+		updateSavedSearchSubscriptionCfg:                  nil,
+		validateQueryReferencesCfg:                        nil,
+		listGlobalSavedSearchesCfg:                        nil,
+		callCountListMetricsForFeatureIDBrowserAndChannel: 0,
+		callCountListMetricsOverTimeWithAggregatedTotals:  0,
+		callCountListChromeDailyUsageStats:                0,
+		callCountFeaturesSearch:                           0,
+		callCountGetFeature:                               0,
+		callCountListBrowserFeatureCountMetric:            0,
+		callCountListMissingOneImplCounts:                 0,
+		callCountListMissingOneImplFeatures:               0,
+		callCountListBaselineStatusCounts:                 0,
+		callCountCreateUserSavedSearch:                    0,
+		callCountDeleteUserSavedSearch:                    0,
+		callCountGetSavedSearch:                           0,
+		callCountListUserSavedSearches:                    0,
+		callCountGetSavedSearchPublic:                     0,
+		callCountUpdateUserSavedSearch:                    0,
+		callCountPutUserSavedSearchBookmark:               0,
+		callCountRemoveUserSavedSearchBookmark:            0,
+		callCountSyncUserProfileInfo:                      0,
+		callCountGetNotificationChannel:                   0,
+		callCountListNotificationChannels:                 0,
+		callCountDeleteNotificationChannel:                0,
+		callCountCreateNotificationChannel:                0,
+		callCountUpdateNotificationChannel:                0,
+		callCountCreateSavedSearchSubscription:            0,
+		callCountDeleteSavedSearchSubscription:            0,
+		callCountGetSavedSearchSubscription:               0,
+		callCountListSavedSearchSubscriptions:             0,
+		callCountUpdateSavedSearchSubscription:            0,
+		callCountListSavedSearchNotificationEvents:        0,
+		callCountValidateQueryReferences:                  0,
+		callCountListGlobalSavedSearches:                  0,
+		callCountGetGlobalSavedSearch:                     0,
+		callCountGetSavedSearchSubscriptionPublic:         0,
+	}
+
+	srv := &Server{
+		metadataStorer:          nil,
+		wptMetricsStorer:        mockStorer,
+		operationResponseCaches: nil,
+		baseURL:                 getTestBaseURL(t),
+		userGitHubClientFactory: nil,
+		eventPublisher:          nil,
+		rssRenderer:             NewRSSRenderer(),
+	}
+
+	// Apply Functional Options to override defaults
+	for _, option := range options {
+		option(srv)
+	}
+
+	return srv
+}
+
+// Helper options to set specialized mocks if needed in tests
+
+func withCustomStorer(s WPTMetricsStorer) TestServerOption {
+	return func(srv *Server) {
+		srv.wptMetricsStorer = s
+	}
+}
+
+func withCustomMetadataStorer(m WebFeatureMetadataStorer) TestServerOption {
+	return func(srv *Server) {
+		srv.metadataStorer = m
+	}
+}
+
+func withCustomEventPublisher(p EventPublisher) TestServerOption {
+	return func(srv *Server) {
+		srv.eventPublisher = p
+	}
+}
+
+func withCustomCaches(c *operationResponseCaches) TestServerOption {
+	return func(srv *Server) {
+		srv.operationResponseCaches = c
+	}
+}
+
+func withCustomGitHubClientFactory(f UserGitHubClientFactory) TestServerOption {
+	return func(srv *Server) {
+		srv.userGitHubClientFactory = f
+	}
+}

--- a/backend/pkg/httpserver/update_notification_channel_test.go
+++ b/backend/pkg/httpserver/update_notification_channel_test.go
@@ -267,19 +267,11 @@ func TestUpdateNotificationChannel_Restrictions(t *testing.T) {
 				updateNotificationChannelCfg: updateCfg,
 				t:                            t,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				baseURL:                 getTestBaseURL(t),
-				metadataStorer:          nil,
-				operationResponseCaches: nil,
-				userGitHubClientFactory: nil,
-				eventPublisher:          nil,
-			}
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
 
 			assertTestServerRequest(
 				t,
-				&myServer,
+				myServer,
 				req,
 				expectedResponse,
 				withAuthMiddleware(mockAuthMiddleware(testUser)),

--- a/backend/pkg/httpserver/update_saved_search_test.go
+++ b/backend/pkg/httpserver/update_saved_search_test.go
@@ -425,16 +425,8 @@ func TestUpdateSavedSearch(t *testing.T) {
 				callCountPublishSearchConfigurationChanged: 0,
 				publishSearchConfigurationChangedCfg:       tc.publishCfg,
 			}
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				metadataStorer:          nil,
-				userGitHubClientFactory: nil,
-				operationResponseCaches: nil,
-				baseURL:                 getTestBaseURL(t),
-				eventPublisher:          mockPublisher,
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse,
+			myServer := setupTestServer(t, withCustomStorer(mockStorer), withCustomEventPublisher(mockPublisher))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse,
 				[]testServerOption{tc.authMiddlewareOption}...)
 		})
 	}

--- a/backend/pkg/httpserver/update_subscription_test.go
+++ b/backend/pkg/httpserver/update_subscription_test.go
@@ -221,16 +221,8 @@ func TestUpdateSubscription(t *testing.T) {
 				t:                                t,
 			}
 
-			myServer := Server{
-				rssRenderer:             NewRSSRenderer(),
-				wptMetricsStorer:        mockStorer,
-				baseURL:                 getTestBaseURL(t),
-				metadataStorer:          nil,
-				operationResponseCaches: nil,
-				userGitHubClientFactory: nil,
-				eventPublisher:          nil,
-			}
-			assertTestServerRequest(t, &myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
+			myServer := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, myServer, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
 			assertMocksExpectations(t,
 				tc.expectedCallCount,
 				mockStorer.callCountUpdateSavedSearchSubscription,


### PR DESCRIPTION
A follow up I wanted to do from https://github.com/GoogleChrome/webstatus.dev/pull/2443. 

The reason for this change is so that every time a new field is added to the Server object, we shouldn't have to update ~30 files. This centralizes the creation of the object in backend/pkg/httpserver/test_utils_test.go.