### PR TITLE
Security: Potential authorization bypass/IDOR risk for saved search retrieval

### DIFF
--- a/backend/pkg/httpserver/get_saved_search.go
+++ b/backend/pkg/httpserver/get_saved_search.go
@@ -30,13 +30,14 @@ import (
 func (s *Server) GetSavedSearch(
 	ctx context.Context, req backend.GetSavedSearchRequestObject) (
 	backend.GetSavedSearchResponseObject, error) {
-	// At this point, the user should be authenticated and in the context.
-	// If for some reason the user is not in the context, treat it as an unauthenticated user
-	var userID *string
 	user, found := httpmiddlewares.AuthenticatedUserFromContext(ctx)
-	if found {
-		userID = &user.ID
+	if !found {
+		return backend.GetSavedSearch404JSONResponse{
+			Code:    http.StatusNotFound,
+			Message: "saved search not found",
+		}, nil
 	}
+	userID := &user.ID
 
 	search, err := s.wptMetricsStorer.GetSavedSearch(ctx, req.SearchId, userID)
 	if err != nil {


### PR DESCRIPTION
## Summary

Security: Potential authorization bypass/IDOR risk for saved search retrieval

## Problem

**Severity**: `Medium` | **File**: `backend/pkg/httpserver/get_saved_search.go:L28`

`GetSavedSearch` allows requests without an authenticated user by passing `userID=nil` to storage lookup. If the storage layer does not strictly enforce visibility rules for unauthenticated access, private saved searches may be retrievable by ID. This pattern creates a potential insecure direct object reference risk.

## Solution

Enforce explicit authorization at the handler boundary: require authentication unless the saved search is marked public, and ensure public/private scope is validated in this handler before returning data. Add tests covering unauthorized access to private saved searches.

## Changes

- `backend/pkg/httpserver/get_saved_search.go` (modified)