### PR TITLE
fix: Dynamically decide QR code box background/fill colors

### DIFF
--- a/frontend/src/static/js/components/webstatus-saved-search-share-dialog.ts
+++ b/frontend/src/static/js/components/webstatus-saved-search-share-dialog.ts
@@ -16,7 +16,9 @@
 
 import {LitElement, TemplateResult, css, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
+import {consume} from '@lit/context';
 import {UserSavedSearch} from '../utils/constants.js';
+import {themeContext, type Theme} from '../contexts/theme-context.js';
 import {Toast} from '../utils/toast.js';
 import {SHARED_STYLES} from '../css/shared-css.js';
 
@@ -24,6 +26,10 @@ import {SHARED_STYLES} from '../css/shared-css.js';
 export class WebstatusSavedSearchShareDialog extends LitElement {
   @property({type: Object})
   savedSearch?: UserSavedSearch;
+
+  @consume({context: themeContext, subscribe: true})
+  @property({attribute: false})
+  theme?: Theme;
 
   @property({type: String})
   shareableUrl: string = '';
@@ -179,6 +185,10 @@ export class WebstatusSavedSearchShareDialog extends LitElement {
   }
 
   render(): TemplateResult {
+    const isDark = this.theme === 'dark';
+    const fill = isDark ? 'white' : 'black';
+    const background = isDark ? 'black' : 'white';
+
     return html`
       <sl-dialog
         label="Share bookmark"
@@ -191,8 +201,8 @@ export class WebstatusSavedSearchShareDialog extends LitElement {
             <sl-qr-code
               value="${this.effectiveUrl}"
               size="180"
-              fill="white"
-              background="black"
+              fill="${fill}"
+              background="${background}"
               radius="0"
               error-correction="H"
               @sl-after-render=${(e: CustomEvent) => {
@@ -231,7 +241,15 @@ export async function openShareDialog(
 ): Promise<WebstatusSavedSearchShareDialog> {
   if (!shareDialogEl) {
     shareDialogEl = new WebstatusSavedSearchShareDialog();
-    document.body.appendChild(shareDialogEl);
+    const app = document.querySelector('webstatus-app');
+    const servicesContainer = app?.shadowRoot?.querySelector(
+      'webstatus-services-container',
+    );
+    if (servicesContainer) {
+      servicesContainer.appendChild(shareDialogEl);
+    } else {
+      document.body.appendChild(shareDialogEl);
+    }
     await shareDialogEl.updateComplete;
   }
   await shareDialogEl.openWithContext(savedSearch, shareableUrl);


### PR DESCRIPTION
The current QR codes surprisingly can't be scanned by Pixel phones (but works on iPhones surprisingly) due to the corner boxes (which the camera uses for alignment when scanning QR codes) not being present. And the boxes aren't present because of currently inverted values for the QR code's fill/background values.

This change makes it so the website correctly decides the fill/background color for the QR code depending on whether the user is in light/dark mode. And as a result, the corner boxes are always present.

Before (where light mode does NOT work on Pixels but dark mode DOES):
<img width="388" height="387" alt="Screenshot 2026-05-13 at 10 35 10 AM" src="https://github.com/user-attachments/assets/3d1c8f92-a28e-4d01-b8bc-389649e2eaa8" />
<img width="391" height="395" alt="Screenshot 2026-05-13 at 10 34 59 AM" src="https://github.com/user-attachments/assets/6a0db5fa-84ed-4b30-b4f0-e065bf39ad23" />


After (light mode changed, dark mode stays the same):
<img width="385" height="373" alt="Screenshot 2026-05-13 at 10 18 08 AM" src="https://github.com/user-attachments/assets/c396bbf2-4ecf-41a7-b07c-c0d53864d1b7" />
<img width="386" height="385" alt="Screenshot 2026-05-13 at 10 18 01 AM" src="https://github.com/user-attachments/assets/b9f3586c-6a94-4165-b7db-564ef3a10e92" />