### PR TITLE
Use disabled availability icons on feature page

### DIFF
--- a/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
+++ b/frontend/src/static/js/components/test/webstatus-feature-page.test.ts
@@ -216,6 +216,56 @@ describe('webstatus-feature-page', () => {
     });
   });
 
+  describe('renderOneWPTCard', () => {
+    let element: FeaturePage;
+    let hostElement: HTMLDivElement;
+
+    beforeEach(async () => {
+      element = await fixture(
+        html`<webstatus-feature-page
+          .location=${location}
+        ></webstatus-feature-page>`,
+      );
+      hostElement = document.createElement('div');
+    });
+
+    it('marks unavailable browser implementation cards as disabled', async () => {
+      element.feature = {
+        feature_id: 'id',
+        name: 'name',
+        browser_implementations: {
+          chrome: {status: 'unavailable'},
+        },
+      };
+
+      const actual = element.renderOneWPTCard('chrome', 'chrome_24x24.png');
+      render(actual, hostElement);
+      const host = await fixture(hostElement);
+      const card = host.querySelector('sl-card');
+
+      expect(card).to.exist;
+      expect(card!.classList.contains('browser-impl-unavailable')).to.be.true;
+    });
+
+    it('marks available browser implementation cards as available', async () => {
+      element.feature = {
+        feature_id: 'id',
+        name: 'name',
+        browser_implementations: {
+          chrome: {status: 'available', version: '123'},
+        },
+      };
+
+      const actual = element.renderOneWPTCard('chrome', 'chrome_24x24.png');
+      render(actual, hostElement);
+      const host = await fixture(hostElement);
+      const card = host.querySelector('sl-card');
+
+      expect(card).to.exist;
+      expect(card!.classList.contains('browser-impl-available')).to.be.true;
+    });
+  });
+
   describe('renderDeveloperSignal', () => {
     let element: FeaturePage;
     let hostElement: HTMLDivElement;

--- a/frontend/src/static/js/components/webstatus-feature-page.ts
+++ b/frontend/src/static/js/components/webstatus-feature-page.ts
@@ -223,6 +223,10 @@ export class FeaturePage extends BaseChartsPage {
         .wptScore .icon {
           float: right;
         }
+        .wptScore.browser-impl-unavailable .icon {
+          filter: grayscale(1);
+          opacity: 50%;
+        }
         .wptScore .score {
           font-size: 150%;
           white-space: nowrap;
@@ -711,6 +715,8 @@ export class FeaturePage extends BaseChartsPage {
     browser: components['parameters']['browserPathParam'],
     icon: string,
   ): TemplateResult {
+    const browserImpl = this.feature?.browser_implementations?.[browser];
+    const browserImplStatus = browserImpl?.status || 'unavailable';
     const scorePart = this.feature
       ? renderBrowserQuality(
           this.feature,
@@ -718,10 +724,11 @@ export class FeaturePage extends BaseChartsPage {
           {browser: browser, fallbackText: 'N/A'},
         )
       : html`<sl-skeleton effect="sheen"></sl-skeleton>`;
-    const browserImpl = this.feature?.browser_implementations?.[browser];
 
     return html`
-      <sl-card class="halign-stretch wptScore">
+      <sl-card
+        class="halign-stretch wptScore browser-impl-${browserImplStatus}"
+      >
         <img height="32" src="/public/img/${icon}" class="icon" />
         <div>${BROWSER_ID_TO_LABEL[browser]}</div>
         <div class="score">${scorePart}</div>


### PR DESCRIPTION
## Summary
- add browser implementation status classes to feature-page WPT cards
- gray out unavailable browser icons on the feature detail page to match overview availability cells
- add focused tests for available and unavailable card states

Fixes #1000

## Tests
- `npx prettier frontend/src/static/js/components/webstatus-feature-page.ts frontend/src/static/js/components/test/webstatus-feature-page.test.ts --check`
- `cd frontend && npx eslint src/static/js/components/webstatus-feature-page.ts src/static/js/components/test/webstatus-feature-page.test.ts`
- `cd frontend && npx lit-analyzer src/static/js/components/webstatus-feature-page.ts`
- `cd frontend && npx tsc --noEmit`
- `npm run build --workspace frontend`
- `cd frontend && BUILD_ENV=local npx wtr build/static/js/components/test/webstatus-feature-page.test.js --coverage`