### PR TITLE
db: add indexes for channel querying by UserId and enforcing 1 RSS feed per user

### DIFF
--- a/infra/storage/spanner/migrations/000033.sql
+++ b/infra/storage/spanner/migrations/000033.sql
@@ -1,0 +1,26 @@
+-- Copyright 2026 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- 1. General index to speed up ListNotificationChannels.
+CREATE INDEX IDX_NotificationChannels_UserID ON NotificationChannels (UserID);
+
+-- 2. Add generated column that is ONLY populated for RSS channels.
+-- For non-RSS channels, this column will be NULL.
+ALTER TABLE NotificationChannels ADD COLUMN RSSUserID STRING(MAX) AS (CASE WHEN Type = 'rss' THEN UserID ELSE NULL END) STORED;
+
+-- 3. Filtered Unique index on the single column.
+-- Since it's a single column index and NULL_FILTERED, rows where RSSUserID is NULL (non-RSS)
+-- will be excluded from the index entirely, allowing duplicates for non-RSS channels.
+CREATE UNIQUE NULL_FILTERED INDEX IDX_UniqueRSSChannelPerUser
+ON NotificationChannels (RSSUserID);


### PR DESCRIPTION
The index for UserId is unrelated to this change just seems to have been missing, so I'm adding that now so queries can be efficiently done on that table.

For context on the RSS part of this change, see
[go/webstatus-rss-ux-proposal](http://goto.google.com/webstatus-rss-ux-proposal) for context and 
https://github.com/GoogleChrome/webstatus.dev/pull/2504 for the API contract level changes that the chain of commits work to make happen.