### PR TITLE
build: generate TypeScript ANTLR parser workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,8 @@ frontend/.postinstall
 *.gen.go
 lib/gen/*/*/*.go
 lib/gen/*/*/*.ts
+lib/gen/antlrv4/ts-antlrv4/*.interp
+lib/gen/antlrv4/ts-antlrv4/*.tokens
 lib/gen/featuresearch/**
 
 # Ignore coverage files

--- a/Makefile
+++ b/Makefile
@@ -311,11 +311,16 @@ node-test: playwright-install
 ################################
 # ANTLR
 ################################
+ANTLR4_VERSION ?= 4.13.2
+ANTLR_JAR ?= /usr/local/lib/antlr-$(ANTLR4_VERSION)-complete.jar
+
 antlr-gen: clean-antlr
-	java -jar /usr/local/lib/antlr-$${ANTLR4_VERSION}-complete.jar -Dlanguage=Go -o lib/gen/featuresearch/parser -visitor -no-listener antlr/FeatureSearch.g4
+	java -jar $(ANTLR_JAR) -Dlanguage=Go -o lib/gen/featuresearch/parser -visitor -no-listener antlr/FeatureSearch.g4
+	java -jar $(ANTLR_JAR) -Dlanguage=TypeScript -Xexact-output-dir -o lib/gen/antlrv4/ts-antlrv4 -visitor -no-listener antlr/FeatureSearch.g4
 
 clean-antlr:
 	rm -rf lib/gen/featuresearch/parser
+	find lib/gen/antlrv4/ts-antlrv4 -mindepth 1 -maxdepth 1 ! -name package.json -exec rm -rf {} +
 
 ################################
 # License

--- a/lib/gen/antlrv4/ts-antlrv4/package.json
+++ b/lib/gen/antlrv4/ts-antlrv4/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@webstatus.dev/feature-search-antlr",
+  "version": "1.0.0",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "antlr4": "4.13.2"
+  },
+  "scripts": {
+    "clean": "find . -mindepth 1 ! -name package.json -exec rm -rf {} +",
+    "test": "test -f FeatureSearchLexer.ts && test -f FeatureSearchParser.ts && test -f FeatureSearchVisitor.ts"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "workspaces": [
         "frontend",
+        "lib/gen/antlrv4/ts-antlrv4",
         "lib/gen/jsonschema/web-platform-dx_web-features-mappings-ts",
         "lib/gen/openapi/ts-webstatus.dev-backend-types"
       ],
@@ -613,6 +614,14 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "lib/gen/antlrv4/ts-antlrv4": {
+      "name": "@webstatus.dev/feature-search-antlr",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "antlr4": "4.13.2"
       }
     },
     "lib/gen/jsonschema/web-platform-dx_web-features-mappings-ts": {
@@ -4997,6 +5006,10 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@webstatus.dev/feature-search-antlr": {
+      "resolved": "lib/gen/antlrv4/ts-antlrv4",
+      "link": true
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -5148,6 +5161,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/antlr4": {
+      "version": "4.13.2",
+      "resolved": "https://registry.npmmirror.com/antlr4/-/antlr4-4.13.2.tgz",
+      "integrity": "sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/arg": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "Apache-2.0",
   "workspaces": [
     "frontend",
+    "lib/gen/antlrv4/ts-antlrv4",
     "lib/gen/jsonschema/web-platform-dx_web-features-mappings-ts",
     "lib/gen/openapi/ts-webstatus.dev-backend-types"
   ],


### PR DESCRIPTION
## Summary

- add a generated TypeScript ANTLR workspace for FeatureSearch
- update `antlr-gen` to emit TypeScript parser output alongside the existing Go parser
- keep generated parser artifacts ignored while preserving the workspace package metadata

## Related issue

Fixes #716

## Verification

- `ANTLR_JAR=/tmp/webstatus-antlr/antlr-4.13.2-complete.jar make antlr-gen`
- `npm run test -w @webstatus.dev/feature-search-antlr`
- `npx prettier --check package.json package-lock.json lib/gen/antlrv4/ts-antlrv4/package.json`
- `git diff --check`

## Notes

This PR was AI-assisted and manually reviewed before submission. The full frontend test suite was not run because this change only wires generated workspace metadata and the ANTLR generation target.
