### PR TITLE
fix(api): correct RSS JSON extraction and trigger filtering

### DIFF
--- a/backend/pkg/httpserver/get_subscription_rss.go
+++ b/backend/pkg/httpserver/get_subscription_rss.go
@@ -178,10 +178,12 @@ func (s *Server) GetSubscriptionRSS(
 	}
 
 	for _, e := range events {
-		var summary workertypes.EventSummary
+		var wrapper struct {
+			Summary workertypes.EventSummary `json:"summary"`
+		}
 		var description string
 		var title string
-		if err := json.Unmarshal(e.Summary, &summary); err != nil {
+		if err := json.Unmarshal(e.Summary, &wrapper); err != nil {
 			slog.ErrorContext(ctx, "failed to unmarshal summary", "event_id", e.ID, "error", err)
 
 			errorHTML := fmt.Sprintf(
@@ -199,6 +201,11 @@ func (s *Server) GetSubscriptionRSS(
 				PubDate: e.Timestamp.Format(time.RFC1123Z),
 			})
 
+			continue
+		}
+		summary := wrapper.Summary
+
+		if !rssShouldNotifyV1(sub.Triggers, summary) {
 			continue
 		}
 
@@ -247,4 +254,50 @@ func (s *Server) GetSubscriptionRSS(
 		Body:          bytes.NewReader(buf.Bytes()),
 		ContentLength: int64(buf.Len()),
 	}, nil
+}
+
+func rssShouldNotifyV1(triggers []backend.SubscriptionTriggerResponseItem, summary workertypes.EventSummary) bool {
+	hasChanges := summary.Categories.Added > 0 ||
+		summary.Categories.Removed > 0 ||
+		summary.Categories.Updated > 0 ||
+		summary.Categories.Moved > 0 ||
+		summary.Categories.Split > 0 ||
+		summary.Categories.QueryChanged > 0
+
+	if !hasChanges {
+		return false
+	}
+
+	if len(triggers) == 0 {
+		return false
+	}
+
+	for _, triggerItem := range triggers {
+		triggerVal, err := triggerItem.Value.AsSubscriptionTriggerWritable()
+		if err != nil {
+			continue
+		}
+
+		var jobTrigger workertypes.JobTrigger
+		switch triggerVal {
+		case backend.SubscriptionTriggerFeatureBaselineToNewly:
+			jobTrigger = workertypes.FeaturePromotedToNewly
+		case backend.SubscriptionTriggerFeatureBaselineToWidely:
+			jobTrigger = workertypes.FeaturePromotedToWidely
+		case backend.SubscriptionTriggerFeatureBaselineRegressionToLimited:
+			jobTrigger = workertypes.FeatureRegressedToLimited
+		case backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete:
+			jobTrigger = workertypes.BrowserImplementationAnyComplete
+		default:
+			continue
+		}
+
+		for _, h := range summary.Highlights {
+			if h.MatchesTrigger(jobTrigger) {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/backend/pkg/httpserver/get_subscription_rss.go
+++ b/backend/pkg/httpserver/get_subscription_rss.go
@@ -17,7 +17,6 @@ package httpserver
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -110,12 +109,12 @@ func (s *Server) GetSubscriptionRSS(
 		}, nil
 	}
 
-	snapshotType := string(sub.Frequency)
+	frequency := sub.Frequency
 	pageSize := getPageSizeOrDefault(request.Params.PageSize)
 	events, nextPageToken, err := s.wptMetricsStorer.ListSavedSearchNotificationEvents(
 		ctx,
 		search.Id,
-		snapshotType,
+		frequency,
 		pageSize,
 		request.Params.PageToken,
 	)
@@ -177,13 +176,22 @@ func (s *Server) GetSubscriptionRSS(
 		})
 	}
 
-	for _, e := range events {
-		var wrapper struct {
-			Summary workertypes.EventSummary `json:"summary"`
+	var jobTriggers []workertypes.JobTrigger
+	for _, triggerItem := range sub.Triggers {
+		triggerVal, err := triggerItem.Value.AsSubscriptionTriggerWritable()
+		if err != nil {
+			continue
 		}
+		if jobTrigger, ok := workertypes.ToJobTrigger(triggerVal); ok {
+			jobTriggers = append(jobTriggers, jobTrigger)
+		}
+	}
+
+	for _, e := range events {
+		visitor := newRSSVisitor(jobTriggers)
 		var description string
 		var title string
-		if err := json.Unmarshal(e.Summary, &wrapper); err != nil {
+		if err := workertypes.ParseEventSummary(e.Summary, visitor); err != nil {
 			slog.ErrorContext(ctx, "failed to unmarshal summary", "event_id", e.ID, "error", err)
 
 			errorHTML := fmt.Sprintf(
@@ -203,23 +211,22 @@ func (s *Server) GetSubscriptionRSS(
 
 			continue
 		}
-		summary := wrapper.Summary
 
-		if !rssShouldNotifyV1(sub.Triggers, summary) {
+		if !visitor.HasContent() {
 			continue
 		}
 
-		richHTML, err := s.rssRenderer.RenderRSSDescription(summary)
+		richHTML, err := s.rssRenderer.RenderRSSDescription(visitor.data)
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to render RSS description", "event_id", e.ID, "error", err)
-			description = summary.Text
+			description = visitor.data.SummaryText
 			if description == "" {
 				description = "Detailed summary unavailable"
 			}
 		} else {
 			description = richHTML
 		}
-		title = summary.Text
+		title = visitor.data.SummaryText
 		if title == "" {
 			title = fallbackRSSItemTitle
 		}
@@ -254,50 +261,4 @@ func (s *Server) GetSubscriptionRSS(
 		Body:          bytes.NewReader(buf.Bytes()),
 		ContentLength: int64(buf.Len()),
 	}, nil
-}
-
-func rssShouldNotifyV1(triggers []backend.SubscriptionTriggerResponseItem, summary workertypes.EventSummary) bool {
-	hasChanges := summary.Categories.Added > 0 ||
-		summary.Categories.Removed > 0 ||
-		summary.Categories.Updated > 0 ||
-		summary.Categories.Moved > 0 ||
-		summary.Categories.Split > 0 ||
-		summary.Categories.QueryChanged > 0
-
-	if !hasChanges {
-		return false
-	}
-
-	if len(triggers) == 0 {
-		return false
-	}
-
-	for _, triggerItem := range triggers {
-		triggerVal, err := triggerItem.Value.AsSubscriptionTriggerWritable()
-		if err != nil {
-			continue
-		}
-
-		var jobTrigger workertypes.JobTrigger
-		switch triggerVal {
-		case backend.SubscriptionTriggerFeatureBaselineToNewly:
-			jobTrigger = workertypes.FeaturePromotedToNewly
-		case backend.SubscriptionTriggerFeatureBaselineToWidely:
-			jobTrigger = workertypes.FeaturePromotedToWidely
-		case backend.SubscriptionTriggerFeatureBaselineRegressionToLimited:
-			jobTrigger = workertypes.FeatureRegressedToLimited
-		case backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete:
-			jobTrigger = workertypes.BrowserImplementationAnyComplete
-		default:
-			continue
-		}
-
-		for _, h := range summary.Highlights {
-			if h.MatchesTrigger(jobTrigger) {
-				return true
-			}
-		}
-	}
-
-	return false
 }

--- a/backend/pkg/httpserver/get_subscription_rss_test.go
+++ b/backend/pkg/httpserver/get_subscription_rss_test.go
@@ -52,8 +52,15 @@ func TestGetSubscriptionRSS(t *testing.T) {
 					ChannelType: backend.SubscriptionResponseChannelTypeRss,
 					CreatedAt:   time.Time{},
 					Frequency:   backend.SubscriptionFrequencyImmediate,
-					Triggers:    nil,
-					UpdatedAt:   time.Time{},
+					Triggers: []backend.SubscriptionTriggerResponseItem{
+						{
+							RawValue: nil,
+							Value: backendtypes.AttemptToStoreSubscriptionTrigger(
+								backend.SubscriptionTriggerFeatureBaselineToNewly,
+							),
+						},
+					},
+					UpdatedAt: time.Time{},
 				},
 				err: nil,
 			},
@@ -84,7 +91,8 @@ func TestGetSubscriptionRSS(t *testing.T) {
 						Timestamp:     time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
 						EventType:     "IMMEDIATE_DIFF",
 						Summary: []byte(
-							`{"schemaVersion":"v1","text":"Sample update","highlights":[{"type":"Added","feature_name":"Feature A"}]}`,
+							`{"summary":{"schemaVersion":"v1","categories":{"added":1},"text":"Sample update",` +
+								`"highlights":[{"type":"Added","feature_name":"Feature A","baseline_change":{"to":{"status":"newly"}}}]}}`,
 						),
 						Reasons:      nil,
 						BlobPath:     "",
@@ -123,8 +131,15 @@ func TestGetSubscriptionRSS(t *testing.T) {
 					ChannelType: backend.SubscriptionResponseChannelTypeRss,
 					CreatedAt:   time.Time{},
 					Frequency:   backend.SubscriptionFrequencyImmediate,
-					Triggers:    nil,
-					UpdatedAt:   time.Time{},
+					Triggers: []backend.SubscriptionTriggerResponseItem{
+						{
+							RawValue: nil,
+							Value: backendtypes.AttemptToStoreSubscriptionTrigger(
+								backend.SubscriptionTriggerFeatureBaselineToNewly,
+							),
+						},
+					},
+					UpdatedAt: time.Time{},
 				},
 				err: nil,
 			},
@@ -155,7 +170,8 @@ func TestGetSubscriptionRSS(t *testing.T) {
 						Timestamp:     time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
 						EventType:     "IMMEDIATE_DIFF",
 						Summary: []byte(
-							`{"schemaVersion":"v1","text":"Sample update","highlights":[{"type":"Added","feature_name":"Feature A"}]}`,
+							`{"summary":{"schemaVersion":"v1","categories":{"added":1},"text":"Sample update",` +
+								`"highlights":[{"type":"Added","feature_name":"Feature A","baseline_change":{"to":{"status":"newly"}}}]}}`,
 						),
 						Reasons:      nil,
 						BlobPath:     "",

--- a/backend/pkg/httpserver/get_subscription_rss_test.go
+++ b/backend/pkg/httpserver/get_subscription_rss_test.go
@@ -80,7 +80,7 @@ func TestGetSubscriptionRSS(t *testing.T) {
 			},
 			eventsCfg: &MockListSavedSearchNotificationEventsConfig{
 				expectedSavedSearchID: "search-id",
-				expectedSnapshotType:  string(backend.SubscriptionFrequencyImmediate),
+				expectedFrequency:     backend.SubscriptionFrequencyImmediate,
 				expectedPageSize:      100,
 				expectedPageToken:     nil,
 				output: []backendtypes.SavedSearchNotificationEvent{
@@ -91,8 +91,8 @@ func TestGetSubscriptionRSS(t *testing.T) {
 						Timestamp:     time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
 						EventType:     "IMMEDIATE_DIFF",
 						Summary: []byte(
-							`{"summary":{"schemaVersion":"v1","categories":{"added":1},"text":"Sample update",` +
-								`"highlights":[{"type":"Added","feature_name":"Feature A","baseline_change":{"to":{"status":"newly"}}}]}}`,
+							`{"schemaVersion":"v1","categories":{"added":1},"text":"Sample update",` +
+								`"highlights":[{"type":"Added","feature_name":"Feature A","baseline_change":{"to":{"status":"newly"}}}]}`,
 						),
 						Reasons:      nil,
 						BlobPath:     "",
@@ -159,7 +159,7 @@ func TestGetSubscriptionRSS(t *testing.T) {
 			},
 			eventsCfg: &MockListSavedSearchNotificationEventsConfig{
 				expectedSavedSearchID: "search-id",
-				expectedSnapshotType:  string(backend.SubscriptionFrequencyImmediate),
+				expectedFrequency:     backend.SubscriptionFrequencyImmediate,
 				expectedPageSize:      100,
 				expectedPageToken:     nil,
 				output: []backendtypes.SavedSearchNotificationEvent{
@@ -170,8 +170,8 @@ func TestGetSubscriptionRSS(t *testing.T) {
 						Timestamp:     time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
 						EventType:     "IMMEDIATE_DIFF",
 						Summary: []byte(
-							`{"summary":{"schemaVersion":"v1","categories":{"added":1},"text":"Sample update",` +
-								`"highlights":[{"type":"Added","feature_name":"Feature A","baseline_change":{"to":{"status":"newly"}}}]}}`,
+							`{"schemaVersion":"v1","categories":{"added":1},"text":"Sample update",` +
+								`"highlights":[{"type":"Added","feature_name":"Feature A","baseline_change":{"to":{"status":"newly"}}}]}`,
 						),
 						Reasons:      nil,
 						BlobPath:     "",
@@ -197,6 +197,210 @@ func TestGetSubscriptionRSS(t *testing.T) {
 				"<![CDATA[",
 				"<atom:link rel=\"self\" href=\"http://localhost:8080/v1/subscriptions/sub-id/rss\"></atom:link>",
 				"<h4>Features Added</h4>",
+			},
+		},
+		{
+			name: "empty triggers exclude all events",
+			subCfg: &MockGetSavedSearchSubscriptionPublicConfig{
+				expectedSubscriptionID: "sub-id",
+				output: &backend.SubscriptionResponse{
+					Id: "sub-id",
+					Subscribable: backend.SavedSearchInfo{
+						Id:   "search-id",
+						Name: "",
+					},
+					ChannelId:   "channel-id",
+					ChannelType: backend.SubscriptionResponseChannelTypeRss,
+					CreatedAt:   time.Time{},
+					Frequency:   backend.SubscriptionFrequencyImmediate,
+					Triggers:    []backend.SubscriptionTriggerResponseItem{},
+					UpdatedAt:   time.Time{},
+				},
+				err: nil,
+			},
+			searchCfg: &MockGetSavedSearchPublicConfig{
+				expectedSavedSearchID: "search-id",
+				output: &backend.SavedSearchResponse{
+					Id:             "search-id",
+					Name:           "test search",
+					Query:          "query",
+					BookmarkStatus: nil,
+					CreatedAt:      time.Time{},
+					Description:    nil,
+					Permissions:    nil,
+					UpdatedAt:      time.Time{},
+				},
+				err: nil,
+			},
+			eventsCfg: &MockListSavedSearchNotificationEventsConfig{
+				expectedSavedSearchID: "search-id",
+				expectedFrequency:     backend.SubscriptionFrequencyImmediate,
+				expectedPageSize:      100,
+				expectedPageToken:     nil,
+				output: []backendtypes.SavedSearchNotificationEvent{
+					{
+						ID:            "event-1",
+						SavedSearchID: "search-id",
+						SnapshotType:  string(backend.SubscriptionFrequencyImmediate),
+						Timestamp:     time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+						EventType:     "IMMEDIATE_DIFF",
+						Summary: []byte(
+							`{"schemaVersion":"v1","categories":{"added":1},"text":"Sample update",` +
+								`"highlights":[{"type":"Added","feature_name":"Feature A","baseline_change":{"to":{"status":"newly"}}}]}`,
+						),
+						Reasons:      nil,
+						BlobPath:     "",
+						DiffBlobPath: "",
+					},
+				},
+				outputNextPageToken: nil,
+				err:                 nil,
+			},
+			expectedStatusCode:  200,
+			expectedContentType: "application/rss+xml",
+			expectedBodyContains: []string{
+				"<title>WebStatus.dev - test search</title>",
+			},
+		},
+		{
+			name: "unmatched trigger exclude event",
+			subCfg: &MockGetSavedSearchSubscriptionPublicConfig{
+				expectedSubscriptionID: "sub-id",
+				output: &backend.SubscriptionResponse{
+					Id: "sub-id",
+					Subscribable: backend.SavedSearchInfo{
+						Id:   "search-id",
+						Name: "",
+					},
+					ChannelId:   "channel-id",
+					ChannelType: backend.SubscriptionResponseChannelTypeRss,
+					CreatedAt:   time.Time{},
+					Frequency:   backend.SubscriptionFrequencyImmediate,
+					Triggers: []backend.SubscriptionTriggerResponseItem{
+						{
+							RawValue: nil,
+							Value: backendtypes.AttemptToStoreSubscriptionTrigger(
+								backend.SubscriptionTriggerFeatureBaselineRegressionToLimited,
+							),
+						},
+					},
+					UpdatedAt: time.Time{},
+				},
+				err: nil,
+			},
+			searchCfg: &MockGetSavedSearchPublicConfig{
+				expectedSavedSearchID: "search-id",
+				output: &backend.SavedSearchResponse{
+					Id:             "search-id",
+					Name:           "test search",
+					Query:          "query",
+					BookmarkStatus: nil,
+					CreatedAt:      time.Time{},
+					Description:    nil,
+					Permissions:    nil,
+					UpdatedAt:      time.Time{},
+				},
+				err: nil,
+			},
+			eventsCfg: &MockListSavedSearchNotificationEventsConfig{
+				expectedSavedSearchID: "search-id",
+				expectedFrequency:     backend.SubscriptionFrequencyImmediate,
+				expectedPageSize:      100,
+				expectedPageToken:     nil,
+				output: []backendtypes.SavedSearchNotificationEvent{
+					{
+						ID:            "event-1",
+						SavedSearchID: "search-id",
+						SnapshotType:  string(backend.SubscriptionFrequencyImmediate),
+						Timestamp:     time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+						EventType:     "IMMEDIATE_DIFF",
+						Summary: []byte(
+							`{"schemaVersion":"v1","categories":{"added":1},"text":"Sample update",` +
+								`"highlights":[{"type":"Added","feature_name":"Feature A","baseline_change":{"to":{"status":"newly"}}}]}`,
+						),
+						Reasons:      nil,
+						BlobPath:     "",
+						DiffBlobPath: "",
+					},
+				},
+				outputNextPageToken: nil,
+				err:                 nil,
+			},
+			expectedStatusCode:  200,
+			expectedContentType: "application/rss+xml",
+			expectedBodyContains: []string{
+				"<title>WebStatus.dev - test search</title>",
+			},
+		},
+		{
+			name: "malformed json returns error item",
+			subCfg: &MockGetSavedSearchSubscriptionPublicConfig{
+				expectedSubscriptionID: "sub-id",
+				output: &backend.SubscriptionResponse{
+					Id: "sub-id",
+					Subscribable: backend.SavedSearchInfo{
+						Id:   "search-id",
+						Name: "",
+					},
+					ChannelId:   "channel-id",
+					ChannelType: backend.SubscriptionResponseChannelTypeRss,
+					CreatedAt:   time.Time{},
+					Frequency:   backend.SubscriptionFrequencyImmediate,
+					Triggers: []backend.SubscriptionTriggerResponseItem{
+						{
+							RawValue: nil,
+							Value: backendtypes.AttemptToStoreSubscriptionTrigger(
+								backend.SubscriptionTriggerFeatureBaselineToNewly,
+							),
+						},
+					},
+					UpdatedAt: time.Time{},
+				},
+				err: nil,
+			},
+			searchCfg: &MockGetSavedSearchPublicConfig{
+				expectedSavedSearchID: "search-id",
+				output: &backend.SavedSearchResponse{
+					Id:             "search-id",
+					Name:           "test search",
+					Query:          "query",
+					BookmarkStatus: nil,
+					CreatedAt:      time.Time{},
+					Description:    nil,
+					Permissions:    nil,
+					UpdatedAt:      time.Time{},
+				},
+				err: nil,
+			},
+			eventsCfg: &MockListSavedSearchNotificationEventsConfig{
+				expectedSavedSearchID: "search-id",
+				expectedFrequency:     backend.SubscriptionFrequencyImmediate,
+				expectedPageSize:      100,
+				expectedPageToken:     nil,
+				output: []backendtypes.SavedSearchNotificationEvent{
+					{
+						ID:            "event-1",
+						SavedSearchID: "search-id",
+						SnapshotType:  string(backend.SubscriptionFrequencyImmediate),
+						Timestamp:     time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC),
+						EventType:     "IMMEDIATE_DIFF",
+						Summary: []byte(
+							`malformed json`,
+						),
+						Reasons:      nil,
+						BlobPath:     "",
+						DiffBlobPath: "",
+					},
+				},
+				outputNextPageToken: nil,
+				err:                 nil,
+			},
+			expectedStatusCode:  200,
+			expectedContentType: "application/rss+xml",
+			expectedBodyContains: []string{
+				"<title>WebStatus.dev - test search</title>",
+				"Could not load details for this update",
+				"event-1",
 			},
 		},
 		{

--- a/backend/pkg/httpserver/rss_renderer.go
+++ b/backend/pkg/httpserver/rss_renderer.go
@@ -16,10 +16,7 @@ package httpserver
 
 import (
 	"bytes"
-	"fmt"
 	"html/template"
-
-	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
 )
 
 const rssItemTemplate = `
@@ -68,30 +65,7 @@ func NewRSSRenderer() *RSSRenderer {
 	return &RSSRenderer{tmpl: tmpl}
 }
 
-func (r *RSSRenderer) RenderRSSDescription(summary workertypes.EventSummary) (string, error) {
-	data := RSSItemData{
-		SummaryText: summary.Text,
-		Truncated:   summary.Truncated,
-		Added:       []string{},
-		Removed:     []string{},
-		Other:       []string{},
-	}
-
-	// Map highlights to categories using Enums
-	for _, h := range summary.Highlights {
-		switch h.Type {
-		case workertypes.SummaryHighlightTypeAdded:
-			data.Added = append(data.Added, h.FeatureName)
-		case workertypes.SummaryHighlightTypeRemoved:
-			data.Removed = append(data.Removed, h.FeatureName)
-		case workertypes.SummaryHighlightTypeChanged,
-			workertypes.SummaryHighlightTypeMoved,
-			workertypes.SummaryHighlightTypeSplit,
-			workertypes.SummaryHighlightTypeDeleted:
-			data.Other = append(data.Other, fmt.Sprintf("%s (%s)", h.FeatureName, h.Type))
-		}
-	}
-
+func (r *RSSRenderer) RenderRSSDescription(data RSSItemData) (string, error) {
 	var buf bytes.Buffer
 	if err := r.tmpl.Execute(&buf, data); err != nil {
 		return "", err

--- a/backend/pkg/httpserver/rss_renderer_test.go
+++ b/backend/pkg/httpserver/rss_renderer_test.go
@@ -17,8 +17,6 @@ package httpserver
 import (
 	"bytes"
 	"testing"
-
-	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
 )
 
 func TestNewRSSRenderer(t *testing.T) {
@@ -36,42 +34,17 @@ func TestRenderRSSDescription(t *testing.T) {
 
 	testCases := []struct {
 		name             string
-		summary          workertypes.EventSummary
+		data             RSSItemData
 		expectedContains []string
 	}{
 		{
 			name: "Basic Summary with Added Feature",
-			summary: workertypes.EventSummary{
-				SchemaVersion: workertypes.VersionEventSummaryV1,
-				Text:          "1 new feature matched",
-				Categories: workertypes.SummaryCategories{
-					QueryChanged:    0,
-					Added:           0,
-					Removed:         0,
-					Deleted:         0,
-					Moved:           0,
-					Split:           0,
-					Updated:         0,
-					UpdatedImpl:     0,
-					UpdatedRename:   0,
-					UpdatedBaseline: 0,
-				},
-				Truncated:      false,
-				SnapshotOrigin: "",
-				QueryErrors:    nil,
-				Highlights: []workertypes.SummaryHighlight{
-					{
-						Type:           workertypes.SummaryHighlightTypeAdded,
-						FeatureID:      "feature-a",
-						FeatureName:    "Feature A",
-						Docs:           nil,
-						NameChange:     nil,
-						BaselineChange: nil,
-						BrowserChanges: nil,
-						Moved:          nil,
-						Split:          nil,
-					},
-				},
+			data: RSSItemData{
+				SummaryText: "1 new feature matched",
+				Added:       []string{"Feature A"},
+				Removed:     nil,
+				Other:       nil,
+				Truncated:   false,
 			},
 			expectedContains: []string{
 				"Feature A",
@@ -80,37 +53,12 @@ func TestRenderRSSDescription(t *testing.T) {
 		},
 		{
 			name: "Removed Feature",
-			summary: workertypes.EventSummary{
-				SchemaVersion: workertypes.VersionEventSummaryV1,
-				Text:          "1 feature removed",
-				Categories: workertypes.SummaryCategories{
-					QueryChanged:    0,
-					Added:           0,
-					Removed:         0,
-					Deleted:         0,
-					Moved:           0,
-					Split:           0,
-					Updated:         0,
-					UpdatedImpl:     0,
-					UpdatedRename:   0,
-					UpdatedBaseline: 0,
-				},
-				Truncated:      false,
-				SnapshotOrigin: "",
-				QueryErrors:    nil,
-				Highlights: []workertypes.SummaryHighlight{
-					{
-						Type:           workertypes.SummaryHighlightTypeRemoved,
-						FeatureID:      "feature-b",
-						FeatureName:    "Feature B",
-						Docs:           nil,
-						NameChange:     nil,
-						BaselineChange: nil,
-						BrowserChanges: nil,
-						Moved:          nil,
-						Split:          nil,
-					},
-				},
+			data: RSSItemData{
+				SummaryText: "1 feature removed",
+				Added:       nil,
+				Removed:     []string{"Feature B"},
+				Other:       nil,
+				Truncated:   false,
 			},
 			expectedContains: []string{
 				"Feature B",
@@ -119,37 +67,12 @@ func TestRenderRSSDescription(t *testing.T) {
 		},
 		{
 			name: "Other Update",
-			summary: workertypes.EventSummary{
-				SchemaVersion: workertypes.VersionEventSummaryV1,
-				Text:          "1 feature updated",
-				Categories: workertypes.SummaryCategories{
-					QueryChanged:    0,
-					Added:           0,
-					Removed:         0,
-					Deleted:         0,
-					Moved:           0,
-					Split:           0,
-					Updated:         0,
-					UpdatedImpl:     0,
-					UpdatedRename:   0,
-					UpdatedBaseline: 0,
-				},
-				Truncated:      false,
-				SnapshotOrigin: "",
-				QueryErrors:    nil,
-				Highlights: []workertypes.SummaryHighlight{
-					{
-						Type:           workertypes.SummaryHighlightTypeChanged,
-						FeatureID:      "feature-c",
-						FeatureName:    "Feature C",
-						Docs:           nil,
-						NameChange:     nil,
-						BaselineChange: nil,
-						BrowserChanges: nil,
-						Moved:          nil,
-						Split:          nil,
-					},
-				},
+			data: RSSItemData{
+				SummaryText: "1 feature updated",
+				Added:       nil,
+				Removed:     nil,
+				Other:       []string{"Feature C (Changed)"},
+				Truncated:   false,
 			},
 			expectedContains: []string{
 				"Feature C",
@@ -158,37 +81,12 @@ func TestRenderRSSDescription(t *testing.T) {
 		},
 		{
 			name: "HTML Escaping in Feature Name",
-			summary: workertypes.EventSummary{
-				SchemaVersion: workertypes.VersionEventSummaryV1,
-				Text:          "HTML escaping test",
-				Categories: workertypes.SummaryCategories{
-					QueryChanged:    0,
-					Added:           0,
-					Removed:         0,
-					Deleted:         0,
-					Moved:           0,
-					Split:           0,
-					Updated:         0,
-					UpdatedImpl:     0,
-					UpdatedRename:   0,
-					UpdatedBaseline: 0,
-				},
-				Truncated:      false,
-				SnapshotOrigin: "",
-				QueryErrors:    nil,
-				Highlights: []workertypes.SummaryHighlight{
-					{
-						Type:           workertypes.SummaryHighlightTypeAdded,
-						FeatureID:      "feature-html",
-						FeatureName:    "<link rel=\"dns-prefetch\">",
-						Docs:           nil,
-						NameChange:     nil,
-						BaselineChange: nil,
-						BrowserChanges: nil,
-						Moved:          nil,
-						Split:          nil,
-					},
-				},
+			data: RSSItemData{
+				SummaryText: "HTML escaping test",
+				Added:       []string{"<link rel=\"dns-prefetch\">"},
+				Removed:     nil,
+				Other:       nil,
+				Truncated:   false,
 			},
 			expectedContains: []string{
 				"&lt;link",
@@ -197,25 +95,12 @@ func TestRenderRSSDescription(t *testing.T) {
 		},
 		{
 			name: "Truncated Summary",
-			summary: workertypes.EventSummary{
-				SchemaVersion: workertypes.VersionEventSummaryV1,
-				Text:          "Summary text",
-				Categories: workertypes.SummaryCategories{
-					QueryChanged:    0,
-					Added:           0,
-					Removed:         0,
-					Deleted:         0,
-					Moved:           0,
-					Split:           0,
-					Updated:         0,
-					UpdatedImpl:     0,
-					UpdatedRename:   0,
-					UpdatedBaseline: 0,
-				},
-				Truncated:      true,
-				SnapshotOrigin: "",
-				QueryErrors:    nil,
-				Highlights:     []workertypes.SummaryHighlight{},
+			data: RSSItemData{
+				SummaryText: "Summary text",
+				Added:       nil,
+				Removed:     nil,
+				Other:       nil,
+				Truncated:   true,
 			},
 			expectedContains: []string{
 				"This summary has been truncated",
@@ -225,7 +110,7 @@ func TestRenderRSSDescription(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := renderer.RenderRSSDescription(tc.summary)
+			output, err := renderer.RenderRSSDescription(tc.data)
 			if err != nil {
 				t.Fatalf("RenderRSSDescription failed: %v", err)
 			}

--- a/backend/pkg/httpserver/rss_visitor.go
+++ b/backend/pkg/httpserver/rss_visitor.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"fmt"
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+type rssVisitor struct {
+	triggers []workertypes.JobTrigger
+	data     RSSItemData
+}
+
+func newRSSVisitor(triggers []workertypes.JobTrigger) *rssVisitor {
+	return &rssVisitor{
+		triggers: triggers,
+		data: RSSItemData{
+			SummaryText: "",
+			Added:       []string{},
+			Removed:     []string{},
+			Other:       []string{},
+			Truncated:   false,
+		},
+	}
+}
+
+func (v *rssVisitor) VisitV1(summary workertypes.EventSummary) error {
+	v.data.SummaryText = summary.Text
+	v.data.Truncated = summary.Truncated
+
+	// 1. Filter highlights against user triggers using shared workertypes helper
+	highlights := workertypes.FilterHighlights(summary.Highlights, v.triggers)
+
+	// 2. Populate current RSS categories
+	for _, h := range highlights {
+		switch h.Type {
+		case workertypes.SummaryHighlightTypeAdded:
+			v.data.Added = append(v.data.Added, h.FeatureName)
+		case workertypes.SummaryHighlightTypeRemoved:
+			v.data.Removed = append(v.data.Removed, h.FeatureName)
+		case workertypes.SummaryHighlightTypeChanged,
+			workertypes.SummaryHighlightTypeMoved,
+			workertypes.SummaryHighlightTypeSplit,
+			workertypes.SummaryHighlightTypeDeleted:
+			v.data.Other = append(v.data.Other, fmt.Sprintf("%s (%s)", h.FeatureName, h.Type))
+		}
+	}
+
+	return nil
+}
+
+func (v *rssVisitor) HasContent() bool {
+	return len(v.data.Added) > 0 || len(v.data.Removed) > 0 || len(v.data.Other) > 0
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -183,7 +183,7 @@ type WPTMetricsStorer interface {
 	ListSavedSearchNotificationEvents(
 		ctx context.Context,
 		savedSearchID string,
-		snapshotType string,
+		frequency backend.SubscriptionFrequency,
 		pageSize int,
 		pageToken *string,
 	) ([]backendtypes.SavedSearchNotificationEvent, *string, error)

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -204,7 +204,7 @@ type MockGetSavedSearchSubscriptionPublicConfig struct {
 
 type MockListSavedSearchNotificationEventsConfig struct {
 	expectedSavedSearchID string
-	expectedSnapshotType  string
+	expectedFrequency     backend.SubscriptionFrequency
 	expectedPageSize      int
 	expectedPageToken     *string
 	output                []backendtypes.SavedSearchNotificationEvent
@@ -799,7 +799,7 @@ func (m *MockWPTMetricsStorer) GetSavedSearchSubscriptionPublic(
 func (m *MockWPTMetricsStorer) ListSavedSearchNotificationEvents(
 	_ context.Context,
 	savedSearchID string,
-	snapshotType string,
+	frequency backend.SubscriptionFrequency,
 	pageSize int,
 	pageToken *string,
 ) ([]backendtypes.SavedSearchNotificationEvent, *string, error) {
@@ -814,11 +814,11 @@ func (m *MockWPTMetricsStorer) ListSavedSearchNotificationEvents(
 			savedSearchID,
 		)
 	}
-	if m.listSavedSearchNotificationEventsCfg.expectedSnapshotType != snapshotType {
+	if m.listSavedSearchNotificationEventsCfg.expectedFrequency != frequency {
 		m.t.Fatalf(
-			"unexpected snapshotType. want %s, got %s",
-			m.listSavedSearchNotificationEventsCfg.expectedSnapshotType,
-			snapshotType,
+			"unexpected frequency. want %v, got %v",
+			m.listSavedSearchNotificationEventsCfg.expectedFrequency,
+			frequency,
 		)
 	}
 	if m.listSavedSearchNotificationEventsCfg.expectedPageSize != pageSize {

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -205,10 +205,11 @@ func (s *Backend) ListSavedSearchNotificationEvents(
 	pageSize int,
 	pageToken *string,
 ) ([]backendtypes.SavedSearchNotificationEvent, *string, error) {
+	spannerSnapshotType := toSpannerSubscriptionFrequency(backend.SubscriptionFrequency(snapshotType))
 	notifEvents, nextPageToken, err := s.client.ListSavedSearchNotificationEvents(
 		ctx,
 		savedSearchID,
-		snapshotType,
+		string(spannerSnapshotType),
 		pageSize,
 		pageToken,
 	)

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -198,14 +198,37 @@ func NewBackend(client BackendSpannerClient) *Backend {
 	return &Backend{client: client}
 }
 
+func extractSummaryBytes(summary spanner.NullJSON, eventID string) ([]byte, error) {
+	if !summary.Valid {
+		return nil, nil
+	}
+	if m, ok := summary.Value.(map[string]any); ok {
+		if innerSummary, exists := m["summary"]; exists {
+			summaryBytes, err := json.Marshal(innerSummary)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal summary for event %s: %w", eventID, err)
+			}
+
+			return summaryBytes, nil
+		}
+	}
+	summaryBytes, err := json.Marshal(summary.Value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal summary for event %s: %w", eventID, err)
+	}
+
+	return summaryBytes, nil
+}
+
 func (s *Backend) ListSavedSearchNotificationEvents(
+
 	ctx context.Context,
 	savedSearchID string,
-	snapshotType string,
+	frequency backend.SubscriptionFrequency,
 	pageSize int,
 	pageToken *string,
 ) ([]backendtypes.SavedSearchNotificationEvent, *string, error) {
-	spannerSnapshotType := toSpannerSubscriptionFrequency(backend.SubscriptionFrequency(snapshotType))
+	spannerSnapshotType := toSpannerSubscriptionFrequency(frequency)
 	notifEvents, nextPageToken, err := s.client.ListSavedSearchNotificationEvents(
 		ctx,
 		savedSearchID,
@@ -220,11 +243,11 @@ func (s *Backend) ListSavedSearchNotificationEvents(
 	events := make([]backendtypes.SavedSearchNotificationEvent, 0, len(notifEvents))
 	for _, e := range notifEvents {
 		var summaryBytes []byte
+		var err error
 		if e.Summary.Valid {
-			var err error
-			summaryBytes, err = json.Marshal(e.Summary.Value)
+			summaryBytes, err = extractSummaryBytes(e.Summary, e.ID)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to marshal summary for event %s: %w", e.ID, err)
+				return nil, nil, err
 			}
 		}
 

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -5291,3 +5291,32 @@ func TestExpandSavedSearches_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestListSavedSearchNotificationEvents(t *testing.T) {
+	ctx := context.Background()
+	//nolint:exhaustruct
+	mockClient := &mockBackendSpannerClient{t: t}
+	backendObj := &Backend{client: mockClient}
+
+	// 1. Verify OpenAPI Immediate frequency translates to Spanner snapshot type.
+	mockClient.mockListSavedSearchNotificationEventsCfg = &mockListSavedSearchNotificationEventsConfig{
+		expectedSavedSearchID: "search-id",
+		expectedSnapshotType:  string(gcpspanner.SavedSearchSnapshotTypeImmediate),
+		expectedPageSize:      10,
+		expectedPageToken:     nil,
+		result:                []gcpspanner.SavedSearchNotificationEvent{},
+		outputNextPageToken:   nil,
+		returnedError:         nil,
+	}
+
+	_, _, err := backendObj.ListSavedSearchNotificationEvents(
+		ctx,
+		"search-id",
+		backend.SubscriptionFrequencyImmediate,
+		10,
+		nil,
+	)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}

--- a/lib/workertypes/triggers.go
+++ b/lib/workertypes/triggers.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workertypes
+
+import (
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// ToJobTrigger converts a backend.SubscriptionTriggerWritable to a workertypes.JobTrigger.
+func ToJobTrigger(trigger backend.SubscriptionTriggerWritable) (JobTrigger, bool) {
+	switch trigger {
+	case backend.SubscriptionTriggerFeatureBaselineToNewly:
+		return FeaturePromotedToNewly, true
+	case backend.SubscriptionTriggerFeatureBaselineToWidely:
+		return FeaturePromotedToWidely, true
+	case backend.SubscriptionTriggerFeatureBaselineRegressionToLimited:
+		return FeatureRegressedToLimited, true
+	case backend.SubscriptionTriggerFeatureBrowserImplementationAnyComplete:
+		return BrowserImplementationAnyComplete, true
+	default:
+		return "", false
+	}
+}


### PR DESCRIPTION
This commit fixes the RSS endpoint to properly read from the shared SavedSearchNotificationEvents pool and filter events based on the user's specific subscription triggers.

Specifically, it addresses two critical issues:
1. Updated the unmarshaling struct to expect the root `{"summary": { ... }}` JSON object wrapper, which correctly unwraps the `spanner.NullJSON` column mapping.
2. Implemented `rssShouldNotifyV1` to cross-reference event highlights against the user's `SubscriptionTriggers`, preventing users from receiving untriggered events.