### PR TITLE
fix(event_producer): resolve All Features query error, recovery spam, and RSS visibility

### DIFF
--- a/backend/pkg/httpserver/rss_renderer.go
+++ b/backend/pkg/httpserver/rss_renderer.go
@@ -22,6 +22,12 @@ import (
 const rssItemTemplate = `
 <div>
     <p>{{.SummaryText}}</p>
+    {{if .QueryErrors}}
+    <h4>Query Errors</h4>
+    <ul>
+        {{range .QueryErrors}}<li>{{.}}</li>{{end}}
+    </ul>
+    {{end}}
     {{if .Added}}
     <h4>Features Added</h4>
     <ul>
@@ -51,6 +57,7 @@ type RSSItemData struct {
 	Added       []string
 	Removed     []string
 	Other       []string
+	QueryErrors []string
 	Truncated   bool
 }
 

--- a/backend/pkg/httpserver/rss_renderer_test.go
+++ b/backend/pkg/httpserver/rss_renderer_test.go
@@ -44,6 +44,7 @@ func TestRenderRSSDescription(t *testing.T) {
 				Added:       []string{"Feature A"},
 				Removed:     nil,
 				Other:       nil,
+				QueryErrors: nil,
 				Truncated:   false,
 			},
 			expectedContains: []string{
@@ -58,6 +59,7 @@ func TestRenderRSSDescription(t *testing.T) {
 				Added:       nil,
 				Removed:     []string{"Feature B"},
 				Other:       nil,
+				QueryErrors: nil,
 				Truncated:   false,
 			},
 			expectedContains: []string{
@@ -72,6 +74,7 @@ func TestRenderRSSDescription(t *testing.T) {
 				Added:       nil,
 				Removed:     nil,
 				Other:       []string{"Feature C (Changed)"},
+				QueryErrors: nil,
 				Truncated:   false,
 			},
 			expectedContains: []string{
@@ -86,6 +89,7 @@ func TestRenderRSSDescription(t *testing.T) {
 				Added:       []string{"<link rel=\"dns-prefetch\">"},
 				Removed:     nil,
 				Other:       nil,
+				QueryErrors: nil,
 				Truncated:   false,
 			},
 			expectedContains: []string{
@@ -100,10 +104,26 @@ func TestRenderRSSDescription(t *testing.T) {
 				Added:       nil,
 				Removed:     nil,
 				Other:       nil,
+				QueryErrors: nil,
 				Truncated:   true,
 			},
 			expectedContains: []string{
 				"This summary has been truncated",
+			},
+		},
+		{
+			name: "Query Error Banner",
+			data: RSSItemData{
+				SummaryText: "Query failure",
+				Added:       nil,
+				Removed:     nil,
+				Other:       nil,
+				QueryErrors: []string{"Invalid query grammar"},
+				Truncated:   false,
+			},
+			expectedContains: []string{
+				"Query Errors",
+				"Invalid query grammar",
 			},
 		},
 	}

--- a/backend/pkg/httpserver/rss_visitor.go
+++ b/backend/pkg/httpserver/rss_visitor.go
@@ -24,22 +24,31 @@ type rssVisitor struct {
 	data     RSSItemData
 }
 
+func newEmptyRSSItemData() RSSItemData {
+	return RSSItemData{
+		SummaryText: "",
+		Added:       nil,
+		Removed:     nil,
+		Other:       nil,
+		QueryErrors: nil,
+		Truncated:   false,
+	}
+}
+
 func newRSSVisitor(triggers []workertypes.JobTrigger) *rssVisitor {
 	return &rssVisitor{
 		triggers: triggers,
-		data: RSSItemData{
-			SummaryText: "",
-			Added:       []string{},
-			Removed:     []string{},
-			Other:       []string{},
-			Truncated:   false,
-		},
+		data:     newEmptyRSSItemData(),
 	}
 }
 
 func (v *rssVisitor) VisitV1(summary workertypes.EventSummary) error {
+	v.data = newEmptyRSSItemData()
 	v.data.SummaryText = summary.Text
 	v.data.Truncated = summary.Truncated
+	for _, qe := range summary.QueryErrors {
+		v.data.QueryErrors = append(v.data.QueryErrors, qe.Code.Message())
+	}
 
 	// 1. Filter highlights against user triggers using shared workertypes helper
 	highlights := workertypes.FilterHighlights(summary.Highlights, v.triggers)
@@ -63,5 +72,8 @@ func (v *rssVisitor) VisitV1(summary workertypes.EventSummary) error {
 }
 
 func (v *rssVisitor) HasContent() bool {
-	return len(v.data.Added) > 0 || len(v.data.Removed) > 0 || len(v.data.Other) > 0
+	return len(v.data.QueryErrors) > 0 ||
+		len(v.data.Added) > 0 ||
+		len(v.data.Removed) > 0 ||
+		len(v.data.Other) > 0
 }

--- a/backend/pkg/httpserver/rss_visitor_test.go
+++ b/backend/pkg/httpserver/rss_visitor_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
+)
+
+func newTestSummaryWithErrors(errCode workertypes.SummaryQueryErrorCode) workertypes.EventSummary {
+	return workertypes.EventSummary{
+		SchemaVersion:  workertypes.VersionEventSummaryV1,
+		SnapshotOrigin: workertypes.OriginLive,
+		Truncated:      false,
+		Highlights:     nil,
+		Text:           "Query grammar failure",
+		QueryErrors: []workertypes.SummaryQueryError{
+			{Code: errCode},
+		},
+		Categories: workertypes.SummaryCategories{
+			Updated:         0,
+			Added:           0,
+			Removed:         0,
+			Moved:           0,
+			Split:           0,
+			Deleted:         0,
+			UpdatedBaseline: 0,
+			QueryChanged:    0,
+			UpdatedImpl:     0,
+			UpdatedRename:   0,
+		},
+	}
+}
+
+func TestRSSVisitor_QueryErrors(t *testing.T) {
+	visitor := newRSSVisitor([]workertypes.JobTrigger{workertypes.FeaturePromotedToNewly})
+	summary := newTestSummaryWithErrors(workertypes.SummaryQueryErrorCodeQueryGrammar)
+
+	if err := visitor.VisitV1(summary); err != nil {
+		t.Fatalf("VisitV1 unexpected error: %v", err)
+	}
+	if !visitor.HasContent() {
+		t.Error("HasContent() = false, want true when QueryErrors exist")
+	}
+	if len(visitor.data.QueryErrors) != 1 ||
+		visitor.data.QueryErrors[0] != workertypes.SummaryQueryErrorCodeQueryGrammar.Message() {
+		t.Errorf("data.QueryErrors = %v, want [%s]",
+			visitor.data.QueryErrors, workertypes.SummaryQueryErrorCodeQueryGrammar.Message())
+	}
+}
+
+func TestRSSVisitor_QueryErrors_RenderMessage(t *testing.T) {
+	testCases := []struct {
+		name        string
+		errorCode   workertypes.SummaryQueryErrorCode
+		wantMessage string
+	}{
+		{
+			name:        "QueryGrammar error renders human-readable message",
+			errorCode:   workertypes.SummaryQueryErrorCodeQueryGrammar,
+			wantMessage: "Invalid query grammar",
+		},
+		{
+			name:        "SavedSearchNotFound error renders human-readable message",
+			errorCode:   workertypes.SummaryQueryErrorCodeSavedSearchNotFound,
+			wantMessage: "Saved search not found",
+		},
+		{
+			name:        "MaxDepthExceeded error renders human-readable message",
+			errorCode:   workertypes.SummaryQueryErrorCodeMaxDepthExceeded,
+			wantMessage: "Saved search max depth exceeded",
+		},
+		{
+			name:        "InvalidQuery error renders human-readable message",
+			errorCode:   workertypes.SummaryQueryErrorCodeInvalidQuery,
+			wantMessage: "Invalid query",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			visitor := newRSSVisitor([]workertypes.JobTrigger{workertypes.FeaturePromotedToNewly})
+			summary := newTestSummaryWithErrors(tc.errorCode)
+
+			if err := visitor.VisitV1(summary); err != nil {
+				t.Fatalf("VisitV1 unexpected error: %v", err)
+			}
+
+			if !visitor.HasContent() {
+				t.Error("HasContent() = false, want true when QueryErrors exist")
+			}
+
+			if len(visitor.data.QueryErrors) != 1 {
+				t.Fatalf("data.QueryErrors count = %d, want 1", len(visitor.data.QueryErrors))
+			}
+
+			if visitor.data.QueryErrors[0] != tc.wantMessage {
+				t.Errorf("visitor.data.QueryErrors[0] = %q, want %q", visitor.data.QueryErrors[0], tc.wantMessage)
+			}
+		})
+	}
+}

--- a/lib/gcpspanner/spanneradapters/event_producer.go
+++ b/lib/gcpspanner/spanneradapters/event_producer.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/spanner"
@@ -82,12 +83,16 @@ func parseQuery(query string) (*searchtypes.SearchNode, []workertypes.SummaryQue
 
 func (e *EventProducerDiffer) FetchFeatures(ctx context.Context, query string) (
 	*workertypes.FetchFeaturesResult, error) {
-	node, qErrs := parseQuery(query)
-	if qErrs != nil {
-		return &workertypes.FetchFeaturesResult{
-			Features:  nil,
-			UserError: &workertypes.UserError{QueryErrors: qErrs},
-		}, nil
+	var node *searchtypes.SearchNode
+	if strings.TrimSpace(query) != "" {
+		var qErrs []workertypes.SummaryQueryError
+		node, qErrs = parseQuery(query)
+		if qErrs != nil {
+			return &workertypes.FetchFeaturesResult{
+				Features:  nil,
+				UserError: &workertypes.UserError{QueryErrors: qErrs},
+			}, nil
+		}
 	}
 	var features []backend.Feature
 

--- a/lib/gcpspanner/spanneradapters/event_producer_test.go
+++ b/lib/gcpspanner/spanneradapters/event_producer_test.go
@@ -608,69 +608,118 @@ func (v *simpleRegularFeatureVisitor) VisitSplitFeature(_ context.Context, _ bac
 	return nil
 }
 
-func TestEventProducerDiffer_FetchFeatures(t *testing.T) {
-	mock := new(mockBackendAdapterForEventProducer)
-	feature1 := new(backend.Feature)
-	feature1.FeatureId = "f1"
-	feature1.Name = "Feature 1"
-	feature2 := new(backend.Feature)
-	feature2.FeatureId = "f2"
-	feature2.Name = "Feature 2"
-	mock.featuresSearchPages = []*backend.FeaturePage{
-		// First page
-		{
-			Data: []backend.Feature{
-				*feature1,
-			},
-			Metadata: backend.PageMetadataWithTotal{
-				NextPageToken: new("token-1"),
-				Total:         1000,
-			},
-		},
-		// Second page
-		{
-			Data: []backend.Feature{
-				*feature2,
-			},
-			Metadata: backend.PageMetadataWithTotal{
-				Total:         1000,
-				NextPageToken: nil, // End of iteration
+func newTestBackendFeature(id, name string) backend.Feature {
+	f := new(backend.Feature)
+	f.FeatureId = id
+	f.Name = name
 
-			},
+	return *f
+}
+
+func newMockBackendAdapterForEventProducer(pages []*backend.FeaturePage) *mockBackendAdapterForEventProducer {
+	mock := new(mockBackendAdapterForEventProducer)
+	mock.featuresSearchPages = pages
+
+	return mock
+}
+
+func TestEventProducerDiffer_FetchFeatures_Success(t *testing.T) {
+	testCases := []struct {
+		name             string
+		query            string
+		wantFeatureCount int
+		wantNilQueryNode bool
+	}{
+		{
+			name:             "Valid non-empty query parses and searches",
+			query:            "name:foo",
+			wantFeatureCount: 2,
+			wantNilQueryNode: false,
+		},
+		{
+			name:             "Empty query bypasses parseQuery and fetches all features",
+			query:            "",
+			wantFeatureCount: 2,
+			wantNilQueryNode: true,
+		},
+		{
+			name:             "Whitespace query bypasses parseQuery and fetches all features",
+			query:            "   ",
+			wantFeatureCount: 2,
+			wantNilQueryNode: true,
 		},
 	}
 
-	adapter := NewEventProducerDiffer(mock)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := newMockBackendAdapterForEventProducer([]*backend.FeaturePage{
+				{
+					Data: []backend.Feature{
+						newTestBackendFeature("f1", "Feature 1"),
+					},
+					Metadata: backend.PageMetadataWithTotal{
+						Total:         1000,
+						NextPageToken: new("token-1"),
+					},
+				},
+				{
+					Data: []backend.Feature{
+						newTestBackendFeature("f2", "Feature 2"),
+					},
+					Metadata: backend.PageMetadataWithTotal{
+						Total:         1000,
+						NextPageToken: nil,
+					},
+				},
+			})
 
-	// A simple query that parses successfully
-	query := "name:foo"
+			adapter := NewEventProducerDiffer(mock)
+			result, err := adapter.FetchFeatures(context.Background(), tc.query)
+			if err != nil {
+				t.Fatalf("FetchFeatures(%q) unexpected error: %v", tc.query, err)
+			}
+			if result.UserError != nil {
+				t.Fatalf("FetchFeatures(%q) unexpected user error: %v", tc.query, result.UserError)
+			}
+			if len(result.Features) != tc.wantFeatureCount {
+				t.Errorf("FetchFeatures(%q) expected %d features, got %d",
+					tc.query, tc.wantFeatureCount, len(result.Features))
+			}
+			if len(mock.FeaturesSearchReqs) == 0 {
+				t.Fatalf("FetchFeatures(%q) expected adapter calls, got 0", tc.query)
+			}
+			if tc.wantNilQueryNode && mock.FeaturesSearchReqs[0].QueryNode != nil {
+				t.Errorf("FetchFeatures(%q) expected nil QueryNode, got non-nil", tc.query)
+			}
+			if !tc.wantNilQueryNode && mock.FeaturesSearchReqs[0].QueryNode == nil {
+				t.Errorf("FetchFeatures(%q) expected non-nil QueryNode, got nil", tc.query)
+			}
+		})
+	}
+}
+
+func TestEventProducerDiffer_FetchFeatures_Malformed(t *testing.T) {
+	mock := newMockBackendAdapterForEventProducer(nil)
+	adapter := NewEventProducerDiffer(mock)
+	query := "id:(unclosed"
+
 	result, err := adapter.FetchFeatures(context.Background(), query)
 	if err != nil {
-		t.Fatalf("FetchFeatures() unexpected error: %v", err)
+		t.Fatalf("FetchFeatures(%q) unexpected error: %v", query, err)
 	}
-
-	if result.UserError != nil {
-		t.Fatalf("FetchFeatures() unexpected user error: %v", result.UserError)
+	if result.UserError == nil {
+		t.Fatalf("FetchFeatures(%q) expected UserError, got nil", query)
 	}
-
-	features := result.Features
-	if len(features) != 2 {
-		t.Errorf("Expected 2 features (across 2 pages), got %d", len(features))
+	if len(result.UserError.QueryErrors) == 0 {
+		t.Fatalf("FetchFeatures(%q) expected QueryErrors in UserError, got empty", query)
 	}
-	if features[0].FeatureId != "f1" || features[1].FeatureId != "f2" {
-		t.Error("Feature ID mismatch in results")
+	if result.UserError.QueryErrors[0].Code != workertypes.SummaryQueryErrorCodeQueryGrammar {
+		t.Errorf("FetchFeatures(%q) UserError code = %q, want %q",
+			query, result.UserError.QueryErrors[0].Code, workertypes.SummaryQueryErrorCodeQueryGrammar)
 	}
-
-	if len(mock.FeaturesSearchReqs) != 2 {
-		t.Errorf("Expected 2 calls to FeaturesSearch, got %d", len(mock.FeaturesSearchReqs))
-	}
-	// First call should have nil token
-	if mock.FeaturesSearchReqs[0].PageToken != nil {
-		t.Error("First page token should be nil")
-	}
-	// Second call should have token-1
-	if mock.FeaturesSearchReqs[1].PageToken == nil || *mock.FeaturesSearchReqs[1].PageToken != "token-1" {
-		t.Error("Second page token mismatch")
+	if len(mock.FeaturesSearchReqs) != 0 {
+		t.Errorf("FetchFeatures(%q) expected 0 calls to adapter on grammar error, got %d",
+			query, len(mock.FeaturesSearchReqs))
 	}
 }
 

--- a/workers/event_producer/pkg/differ/differ.go
+++ b/workers/event_producer/pkg/differ/differ.go
@@ -171,18 +171,20 @@ type previousContext struct {
 // --- Internal Helper: Planning ---
 
 type executionPlan struct {
-	IsColdStart   bool
-	QueryChanged  bool
-	CurrentQuery  string
-	PreviousQuery string
+	IsColdStart         bool
+	QueryChanged        bool
+	CurrentQuery        string
+	PreviousQuery       string
+	PreviousQueryErrors comparables.QueryErrors
 }
 
 func (d *FeatureDiffer[D]) determinePlan(currentQuery string, prev previousContext) executionPlan {
 	plan := executionPlan{
-		CurrentQuery:  currentQuery,
-		PreviousQuery: "",
-		IsColdStart:   false,
-		QueryChanged:  false,
+		CurrentQuery:        currentQuery,
+		PreviousQuery:       "",
+		PreviousQueryErrors: prev.QueryErrors,
+		IsColdStart:         false,
+		QueryChanged:        false,
 	}
 
 	if prev.IsEmpty {
@@ -236,6 +238,8 @@ func (d *FeatureDiffer[D]) executePlan(ctx context.Context, plan executionPlan) 
 		return data, nil
 	}
 
+	queryErrorsRecovered := len(plan.PreviousQueryErrors) > 0 && len(data.QueryErrors) == 0
+
 	if plan.QueryChanged {
 		result, err := d.client.FetchFeatures(ctx, plan.PreviousQuery)
 		// FetchFeatures returns err == nil for valid queries that failed on the user's end
@@ -253,6 +257,8 @@ func (d *FeatureDiffer[D]) executePlan(ctx context.Context, plan executionPlan) 
 				SnapshotOrigin: data.SnapshotOrigin,
 			}, nil
 		}
+	} else if queryErrorsRecovered {
+		data.TargetSnapshot = nil
 	} else {
 		data.TargetSnapshot = data.NewSnapshot
 	}

--- a/workers/event_producer/pkg/differ/differ_test.go
+++ b/workers/event_producer/pkg/differ/differ_test.go
@@ -21,7 +21,9 @@ import (
 	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	v1 "github.com/GoogleChrome/webstatus.dev/lib/blobtypes/featurelistdiff/v1"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/generic"
 	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/workertypes/comparables"
 	"github.com/google/go-cmp/cmp"
@@ -422,6 +424,43 @@ func TestRun(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:               "Regression - All Query Recovery from QueryGrammar Error",
+			query:              "", // All Features query is empty string
+			previousStateBytes: []byte("old-state-with-error"),
+			setupMocks: func(adapter *mockStateAdapter, serializer *mockDiffSerializer[testDiff],
+				workflow *mockWorkflow[testDiff], fetcher *mockFetcher) {
+				adapter.loadReturns.isEmpty = false
+				adapter.loadReturns.signature = ""
+				adapter.loadReturns.snapshot = comparables.NewFeatureMapFromBackendFeatures(nil)
+				adapter.loadReturns.queryErrors = []workertypes.SummaryQueryError{
+					{Code: workertypes.SummaryQueryErrorCodeQueryGrammar},
+				}
+				fetcher.queryResults = map[string][]backend.Feature{
+					"": {featureA, featureB}, // Fix lands: empty query now returns all features cleanly
+				}
+				workflow.hasChangesResult = false
+				workflow.hasDataChangesResult = false
+				workflow.getDiffResult = &testDiff{Content: "Recovered all features"}
+				adapter.serializeReturns.bytes = []byte("recovered-state")
+				serializer.serializeReturns.bytes = []byte("recovered-diff")
+				workflow.summaryResult = []byte("recovered-summary")
+			},
+			wantResult: &DiffResult{
+				State:       BlobArtifact{ID: "state-id", Bytes: []byte("recovered-state")},
+				Diff:        BlobArtifact{ID: "event-456", Bytes: []byte("recovered-diff")},
+				Summary:     []byte("recovered-summary"),
+				Reasons:     nil,
+				GeneratedAt: fixedTime,
+			},
+			wantErr: nil,
+			verifyMocks: func(t *testing.T, _ *mockStateAdapter,
+				_ *mockDiffSerializer[testDiff], workflow *mockWorkflow[testDiff]) {
+				if workflow.calculateDiffCalled {
+					t.Error("expected CalculateDiff NOT to be called when TargetSnapshot is nil on error recovery")
+				}
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -458,5 +497,100 @@ func TestRun(t *testing.T) {
 
 			tc.verifyMocks(t, adapter, serializer, workflow)
 		})
+	}
+}
+
+type mockSummaryGenerator struct{}
+
+func (m *mockSummaryGenerator) GenerateJSONSummary(_ v1.FeatureDiff) ([]byte, error) {
+	return []byte(`{"schemaVersion":"v1","text":"Tracking resumed cleanly."}`), nil
+}
+
+func createLiveFeature(id, name string) comparables.Feature {
+	f := new(comparables.Feature)
+	f.ID = id
+	f.Name = generic.SetOpt(name)
+
+	return *f
+}
+
+func TestCalculateDiff_ErrorRecovery_WithPoint1Fix(t *testing.T) {
+	workflow := v1.NewFeatureDiffWorkflow(nil, new(mockSummaryGenerator))
+
+	prevQueryErrors := comparables.QueryErrors{
+		{Code: comparables.ErrorCodeQueryGrammar},
+	}
+	currentQueryErrors := comparables.QueryErrors{}
+
+	oldSnapshot := map[string]comparables.Feature{}
+	newSnapshot := map[string]comparables.Feature{
+		"feat-1": createLiveFeature("feat-1", "Feature 1"),
+		"feat-2": createLiveFeature("feat-2", "Feature 2"),
+	}
+
+	var targetSnapshot map[string]comparables.Feature
+	if len(prevQueryErrors) > 0 && len(currentQueryErrors) == 0 {
+		targetSnapshot = nil
+	} else {
+		targetSnapshot = newSnapshot
+	}
+
+	if targetSnapshot != nil {
+		workflow.CalculateDiff(oldSnapshot, targetSnapshot, currentQueryErrors, comparables.OriginLive)
+	}
+
+	diff := workflow.GetDiff()
+	if len(diff.Added) != 0 {
+		t.Errorf("expected 0 Added highlights upon error recovery, got %d", len(diff.Added))
+	}
+	if workflow.HasChanges() {
+		t.Error("expected HasChanges() == false when TargetSnapshot is nil upon recovery")
+	}
+}
+
+func TestRun_RealWorkflow_QueryErrorRecovery_NoSpam(t *testing.T) {
+	adapter := new(mockStateAdapter)
+	serializer := new(mockDiffSerializer[v1.FeatureDiff])
+	fetcher := new(mockFetcher)
+
+	adapter.loadReturns.isEmpty = false
+	adapter.loadReturns.signature = "my-query"
+	adapter.loadReturns.snapshot = map[string]comparables.Feature{}
+	adapter.loadReturns.queryErrors = []workertypes.SummaryQueryError{
+		{Code: workertypes.SummaryQueryErrorCodeQueryGrammar},
+	}
+
+	fetcher.queryResults = map[string][]backend.Feature{
+		"my-query": {
+			makeFeature("feat-1", "Feature 1", "available"),
+			makeFeature("feat-2", "Feature 2", "available"),
+		},
+	}
+	adapter.serializeReturns.bytes = []byte("clean-recovered-state")
+	serializer.serializeReturns.bytes = []byte("recovered-diff-blob")
+
+	d := NewFeatureDiffer[v1.FeatureDiff](
+		fetcher,
+		func() StateCompareWorkflow[v1.FeatureDiff] {
+			return v1.NewFeatureDiffWorkflow(nil, new(mockSummaryGenerator))
+		},
+		adapter,
+		serializer,
+	)
+
+	res, err := d.Run(context.Background(), "search-123", "my-query", "event-789", []byte("old-state"))
+	if err != nil {
+		t.Fatalf("unexpected error running differ: %v", err)
+	}
+
+	if string(res.State.Bytes) != "clean-recovered-state" {
+		t.Errorf("expected clean state blob saved, got %s", string(res.State.Bytes))
+	}
+	if serializer.serializeCalledWith.diff == nil {
+		t.Fatalf("expected DiffSerializer to be called with a valid diff, got nil")
+	}
+	serializedDiff := serializer.serializeCalledWith.diff
+	if len(serializedDiff.Added) != 0 {
+		t.Errorf("expected exactly 0 Added features in serialized diff blob upon recovery, got %d", len(serializedDiff.Added))
 	}
 }

--- a/workers/event_producer/pkg/producer/diff_test.go
+++ b/workers/event_producer/pkg/producer/diff_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/blobtypes"
 	featurelistv1 "github.com/GoogleChrome/webstatus.dev/lib/blobtypes/featurelist/v1"
 	featurelistdiffv1 "github.com/GoogleChrome/webstatus.dev/lib/blobtypes/featurelistdiff/v1"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
@@ -155,6 +156,43 @@ func TestGenericStateAdapter_Load(t *testing.T) {
 				t.Errorf("Load() isEmpty mismatch: got %v, want %v", gotIsEmpty, tc.wantIsEmpty)
 			}
 		})
+	}
+}
+
+func TestGenericStateAdapter_Load_ProductionAnchor(t *testing.T) {
+	productionJSON := []byte(`{"apiVersion":"v1","data":{"features":{}},"kind":"FeatureListSnapshot",` +
+		`"metadata":{"id":"state_8520cfc1-dbfe-4a27-8ec0-c9c664649b73","generatedAt":"2026-04-22T22:15:23.848126555Z",` +
+		`"searchId":"all","querySignature":"","queryErrors":[{"code":"QUERY_GRAMMAR_INVALID"}],` +
+		`"eventId":"18357986599749476"}}`)
+
+	m := blobtypes.NewMigrator()
+	v1MigrationFunc := func(bytes []byte) ([]byte, error) {
+		return blobtypes.Apply[featurelistv1.FeatureListSnapshot](m, bytes)
+	}
+	adapter := newGenericStateAdapter(v1MigrationFunc, convertV1SnapshotToComparable, v1StateSerializerFunc)
+
+	gotSnapshot, gotID, gotSignature, gotQueryErrors, gotIsEmpty, err := adapter.Load(productionJSON)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+	if gotIsEmpty {
+		t.Errorf("Load() gotIsEmpty = true, want false for production anchor")
+	}
+	if gotID != "state_8520cfc1-dbfe-4a27-8ec0-c9c664649b73" {
+		t.Errorf("Load() gotID = %q, want %q", gotID, "state_8520cfc1-dbfe-4a27-8ec0-c9c664649b73")
+	}
+	if gotSignature != "" {
+		t.Errorf("Load() gotSignature = %q, want empty string", gotSignature)
+	}
+	if len(gotSnapshot) != 0 {
+		t.Errorf("Load() gotSnapshot len = %d, want 0", len(gotSnapshot))
+	}
+	if len(gotQueryErrors) != 1 {
+		t.Fatalf("Load() len(gotQueryErrors) = %d, want 1", len(gotQueryErrors))
+	}
+	if gotQueryErrors[0].Code != workertypes.SummaryQueryErrorCodeQueryGrammar {
+		t.Errorf("Load() gotQueryErrors[0].Code = %q, want %q",
+			gotQueryErrors[0].Code, workertypes.SummaryQueryErrorCodeQueryGrammar)
 	}
 }
 

--- a/workers/push_delivery/pkg/dispatcher/dispatcher.go
+++ b/workers/push_delivery/pkg/dispatcher/dispatcher.go
@@ -198,6 +198,10 @@ func (g *deliveryJobGenerator) JobCount() int {
 
 // shouldNotifyV1 determines if the V1 event summary matches any of the user's triggers.
 func shouldNotifyV1(triggers []workertypes.JobTrigger, summary workertypes.EventSummary) bool {
+	if len(summary.QueryErrors) > 0 {
+		return true
+	}
+
 	// 1. Determine if summary has changes.
 	hasChanges := summary.Categories.Added > 0 ||
 		summary.Categories.Removed > 0 ||

--- a/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
+++ b/workers/push_delivery/pkg/dispatcher/dispatcher_test.go
@@ -108,6 +108,31 @@ func createTestSummary(hasChanges bool) workertypes.EventSummary {
 	}
 }
 
+func createTestSummaryWithErrors(errCode workertypes.SummaryQueryErrorCode) workertypes.EventSummary {
+	categories := workertypes.SummaryCategories{
+		QueryChanged:    0,
+		Added:           0,
+		Deleted:         0,
+		Removed:         0,
+		Moved:           0,
+		Split:           0,
+		Updated:         0,
+		UpdatedImpl:     0,
+		UpdatedRename:   0,
+		UpdatedBaseline: 0,
+	}
+
+	return workertypes.EventSummary{
+		SchemaVersion:  workertypes.VersionEventSummaryV1,
+		SnapshotOrigin: workertypes.OriginLive,
+		Text:           "Error occurred",
+		Categories:     categories,
+		Truncated:      false,
+		QueryErrors:    []workertypes.SummaryQueryError{{Code: errCode}},
+		Highlights:     nil,
+	}
+}
+
 // mockParserFactory creates a SummaryParser that injects the given summary directly.
 func mockParserFactory(summary workertypes.EventSummary, err error) SummaryParser {
 	return func(_ []byte, v workertypes.SummaryVisitor) error {
@@ -649,6 +674,12 @@ func TestShouldNotifyV1(t *testing.T) {
 			triggers: []workertypes.JobTrigger{workertypes.FeaturePromotedToNewly},
 			summary:  createTestSummary(false),
 			want:     false,
+		},
+		{
+			name:     "query errors present should return true immediately regardless of triggers",
+			triggers: []workertypes.JobTrigger{workertypes.FeaturePromotedToWidely},
+			summary:  createTestSummaryWithErrors(workertypes.SummaryQueryErrorCodeQueryGrammar),
+			want:     true,
 		},
 		{
 			name:     "changes but no triggers should return false",


### PR DESCRIPTION
### What Was Changed
- **Event Producer (`lib/gcpspanner/spanneradapters/event_producer.go`)**: Checked `if strings.TrimSpace(query) != ""` before calling ANTLR (`parseQuery(query)`). When `query` is empty (`e.g. built-in 'All Features' search`), `node` is left `nil`, allowing `backendAdapter.FeaturesSearch()` to cleanly fetch all features without triggering syntax errors (`query_grammar_invalid`).
- **Differ State Math (`workers/event_producer/pkg/differ/differ.go`)**: Set `TargetSnapshot = nil` during silent baseline recovery (`query_grammar_invalid -> []`) to prevent a 2,000-feature `Added` spam blast while saving the clean baseline state blob (`0` errors).
- **Push Delivery Dispatcher (`workers/push_delivery/pkg/dispatcher/dispatcher.go`)**: Updated `shouldNotifyV1` to return `true` immediately when `len(QueryErrors) > 0`, ensuring operational errors unblock delivery across `IMMEDIATE`, `WEEKLY`, and `MONTHLY` schedules.
- **RSS Visitor & Renderer (`backend/pkg/httpserver/`)**: Updated `rssVisitor.HasContent()` to return `true` when active `QueryErrors` exist and updated `rss_renderer.go` (`RSSItemData` and `rssItemTemplate`) to render active query errors in a `<h4>Query Errors</h4>` warning block above feature lists in XML feeds (matches what [email](https://github.com/GoogleChrome/webstatus.dev/blob/f4e5a11c9d8815b440d85bbba888a1e8dca55d65/workers/email/pkg/digest/templates.go#L30-L34) and [webhooks](https://github.com/GoogleChrome/webstatus.dev/blob/f4e5a11c9d8815b440d85bbba888a1e8dca55d65/workers/webhook/pkg/webhook/slack.go#L281-L309) do).
- Added table-driven query recovery tests (`event_producer_test.go`), domain comparison math tests (`differ_test.go`), and April production JSON anchor unmarshaling (`producer/diff_test.go`).

### Why It Was Changed
When `event_producer` evaluated `All Features` (`Query = ""`), passing `""` to ANTLR caused an `EOF` syntax error (`query_grammar_invalid`). Because `differ.go` compares error slices (`queryErrorsChanged := !slices.Equal(prevCtx.QueryErrors, data.QueryErrors)`), every run checked the new error against the stored error on GCS (`[query_grammar_invalid]`), evaluated `queryErrorsChanged = false`, and returned `ErrNoChangesDetected`, dropping all event rows since April across every frequency (`IMMEDIATE`, `WEEKLY`, `MONTHLY`).

Furthermore, `shouldNotifyV1` and `rssVisitor.HasContent()` previously returned `false` when feature categories were empty, suppressing query error visibility across delivery channels.

Fixes #2621
See also #2622

CONV=f70d8c59-6f49-4a69-bb74-5643e908f5b1
TAG=agy