### PR TITLE
chore: fix broken tflint that blocks CI

### DIFF
--- a/infra/.tflint.hcl
+++ b/infra/.tflint.hcl
@@ -15,12 +15,20 @@
 plugin "terraform" {
   enabled = true
   preset  = "all"
-  version = "0.14.1"
+  version = "0.15.0"
   source  = "github.com/terraform-linters/tflint-ruleset-terraform"
+  # Workaround for https://github.com/terraform-linters/tflint/issues/2591
+  # We still want to do some verification even if it is the legacy way.
+  # That is better than the alternatives of 1) not verifying at all or 2) downgrading to an older version.
+  signature = "pgp"
 }
 
 plugin "google" {
   enabled = true
-  version = "0.38.0"
+  version = "0.39.0"
   source  = "github.com/terraform-linters/tflint-ruleset-google"
+  # Workaround for https://github.com/terraform-linters/tflint/issues/2591
+  # We still want to do some verification even if it is the legacy way.
+  # That is better than the alternatives of 1) not verifying at all or 2) downgrading to an older version.
+  signature = "pgp"
 }


### PR DESCRIPTION
CI is currently failing due to failing to verify the signature of the tflint plugins

More details on how this broke yesterday:https://github.com/terraform-linters/tflint/issues/2591

The logs look like this:

```
Installing "terraform" plugin...

Panic: runtime error: invalid memory address or nil pointer dereference
 -> 0: main.main.func1: /main.go(25)
 -> 1: runtime.gopanic: /panic.go(860)
 -> 2: runtime.panicmem: /panic.go(336)
 -> 3: runtime.sigpanic: /signal_unix.go(931)
 -> 4: github.com/sigstore/sigstore-go/pkg/bundle.(*Bundle).TlogEntries: /bundle.go(300)
 -> 5: github.com/sigstore/sigstore-go/pkg/verify.VerifyTlogEntry: /tlog.go(40)
 -> 6: github.com/sigstore/sigstore-go/pkg/verify.(*Verifier).VerifyTransparencyLogInclusion: /signed_entity.go(809)
 -> 7: github.com/sigstore/sigstore-go/pkg/verify.(*Verifier).Verify: /signed_entity.go(606)
 -> 8: github.com/terraform-linters/tflint/plugin.(*SignatureChecker).VerifyAttestations: /signature.go(136)
 -> 9: github.com/terraform-linters/tflint/plugin.(*InstallConfig).Install: /install.go(134)
 -> 10: github.com/terraform-linters/tflint/cmd.(*CLI).init.func1: /init.go(49)
 -> 11: github.com/terraform-linters/tflint/cmd.(*CLI).withinChangedDir: /cli.go(200)
 -> 12: github.com/terraform-linters/tflint/cmd.(*CLI).init: /init.go(23)
 -> 13: github.com/terraform-linters/tflint/cmd.(*CLI).Run: /cli.go(108)
 -> 14: main.main: /main.go(38)
 -> 15: runtime.main: /proc.go(290)
 -> 16: runtime.goexit: /asm_amd64.s(1771)

TFLint crashed... :(
Please attach an output log, describe the situation and version that occurred and post an issue to https://github.com/terraform-linters/tflint/issues
```

I visited the issues link and found that others were having the same issue. There is a workaround documented in the issue that involves setting the verification mode to "pgp".

After the fix, the logs look like this:

```
Installing "terraform" plugin...
The plugin was signed using a legacy PGP signing key. Please update the plugin to the latest version
Installed "terraform" (source: github.com/terraform-linters/tflint-ruleset-terraform, version: 0.15.0)
Installing "google" plugin...
The plugin was signed using a legacy PGP signing key. Please update the plugin to the latest version
Installed "google" (source: github.com/terraform-linters/tflint-ruleset-google, version: 0.39.0)
```

Other work:
- Bumped the plugins for the rules to be their respective latest versions.