### PR TITLE
feat(backend): implement CategorizedSummaryVisitor on RSS visitor with rich sections (#2622)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,10 @@ jsonschema/mdn_browser-compat-data
 jsonschema/web-platform-dx_web-features
 jsonschema/web-platform-dx_web-features-mappings
 docs/schema
+backend/pkg/httpserver/testdata/rss_description.golden.html
+backend/pkg/httpserver/testdata/rss_query_error.golden.html
+backend/pkg/httpserver/testdata/rss_resolved_query_error.golden.html
+backend/pkg/httpserver/testdata/rss_combined_errors_and_features.golden.html
 workers/email/pkg/digest/testdata/digest.golden.html
 workers/email/pkg/digest/testdata/digest_query_error.golden.html
 workers/email/pkg/digest/testdata/digest_resolved_query_error.golden.html

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,11 @@ ADDLICENSE_ARGS := -c "${COPYRIGHT_NAME}" \
 	-ignore '.devcontainer/cache/**' \
 	-ignore 'workers/email/pkg/digest/testdata/digest.golden.html' \
 	-ignore 'workers/email/pkg/digest/testdata/digest_query_error.golden.html' \
-	-ignore 'workers/email/pkg/digest/testdata/digest_resolved_query_error.golden.html'
+	-ignore 'workers/email/pkg/digest/testdata/digest_resolved_query_error.golden.html' \
+	-ignore 'backend/pkg/httpserver/testdata/rss_description.golden.html' \
+	-ignore 'backend/pkg/httpserver/testdata/rss_query_error.golden.html' \
+	-ignore 'backend/pkg/httpserver/testdata/rss_resolved_query_error.golden.html' \
+	-ignore 'backend/pkg/httpserver/testdata/rss_combined_errors_and_features.golden.html'
 
 license-check: go-install-tools
 	go tool addlicense -check $(ADDLICENSE_ARGS) .

--- a/backend/pkg/httpserver/rss_renderer.go
+++ b/backend/pkg/httpserver/rss_renderer.go
@@ -52,10 +52,28 @@ const rssItemTemplate = `
         {{range .Removed}}<li>{{.}}</li>{{end}}
     </ul>
     {{end}}
-    {{if .Other}}
-    <h4>Other Updates</h4>
+    {{if .Changed}}
+    <h4>Features Changed</h4>
     <ul>
-        {{range .Other}}<li>{{.}}</li>{{end}}
+        {{range .Changed}}<li>{{.}}</li>{{end}}
+    </ul>
+    {{end}}
+    {{if .Moved}}
+    <h4>Features Moved/Renamed</h4>
+    <ul>
+        {{range .Moved}}<li>{{.}}</li>{{end}}
+    </ul>
+    {{end}}
+    {{if .Split}}
+    <h4>Features Split</h4>
+    <ul>
+        {{range .Split}}<li>{{.}}</li>{{end}}
+    </ul>
+    {{end}}
+    {{if .Deleted}}
+    <h4>Features Deleted</h4>
+    <ul>
+        {{range .Deleted}}<li>{{.}}</li>{{end}}
     </ul>
     {{end}}
     {{if .Truncated}}
@@ -68,7 +86,10 @@ type RSSItemData struct {
 	SummaryText         string
 	Added               []string
 	Removed             []string
-	Other               []string
+	Changed             []string
+	Moved               []string
+	Split               []string
+	Deleted             []string
 	QueryErrors         []string
 	ResolvedQueryErrors []string
 	Truncated           bool

--- a/backend/pkg/httpserver/rss_renderer.go
+++ b/backend/pkg/httpserver/rss_renderer.go
@@ -19,66 +19,75 @@ import (
 	"html/template"
 )
 
-const rssItemTemplate = `
-<div>
+const rssItemTemplate = `<div>
     <p>{{.SummaryText}}</p>
-    {{if .ResolvedQueryErrors}}
+    {{- if .ResolvedQueryErrors}}
     <h4>Query Recovered</h4>
     <ul>
-        {{range .ResolvedQueryErrors}}
+        {{- range .ResolvedQueryErrors}}
         <li>Tracking resumed cleanly from your baseline. Resolved issue: {{.}}</li>
-        {{end}}
+        {{- end}}
     </ul>
-    {{end}}
-    {{if .QueryErrors}}
+    {{- end}}
+    {{- if .QueryErrors}}
     <h4>Query Errors</h4>
     <ul>
-        {{range .QueryErrors}}
+        {{- range .QueryErrors}}
         <li>{{.}}</li>
-        {{end}}
+        {{- end}}
     </ul>
-    {{end}}
-    {{if .Added}}
+    {{- end}}
+    {{- if .Added}}
     <h4>Features Added</h4>
     <ul>
-        {{range .Added}}
+        {{- range .Added}}
         <li>{{.}}</li>
-        {{end}}
+        {{- end}}
     </ul>
-    {{end}}
-    {{if .Removed}}
+    {{- end}}
+    {{- if .Removed}}
     <h4>Features Removed</h4>
     <ul>
-        {{range .Removed}}<li>{{.}}</li>{{end}}
+        {{- range .Removed}}
+        <li>{{.}}</li>
+        {{- end}}
     </ul>
-    {{end}}
-    {{if .Changed}}
+    {{- end}}
+    {{- if .Changed}}
     <h4>Features Changed</h4>
     <ul>
-        {{range .Changed}}<li>{{.}}</li>{{end}}
+        {{- range .Changed}}
+        <li>{{.}}</li>
+        {{- end}}
     </ul>
-    {{end}}
-    {{if .Moved}}
+    {{- end}}
+    {{- if .Moved}}
     <h4>Features Moved/Renamed</h4>
     <ul>
-        {{range .Moved}}<li>{{.}}</li>{{end}}
+        {{- range .Moved}}
+        <li>{{.}}</li>
+        {{- end}}
     </ul>
-    {{end}}
-    {{if .Split}}
+    {{- end}}
+    {{- if .Split}}
     <h4>Features Split</h4>
     <ul>
-        {{range .Split}}<li>{{.}}</li>{{end}}
+        {{- range .Split}}
+        <li>{{.}}</li>
+        {{- end}}
     </ul>
-    {{end}}
-    {{if .Deleted}}
+    {{- end}}
+    {{- if .Deleted}}
     <h4>Features Deleted</h4>
     <ul>
-        {{range .Deleted}}<li>{{.}}</li>{{end}}
+        {{- range .Deleted}}
+        <li>{{.}}</li>
+        {{- end}}
     </ul>
-    {{end}}
-    {{if .Truncated}}
+    {{- end}}
+    {{- if .Truncated}}
     <p><em>Note: This summary has been truncated. View full details on the site.</em></p>
-    {{end}}
+    {{- end}}
 </div>
 `
 

--- a/backend/pkg/httpserver/rss_renderer_test.go
+++ b/backend/pkg/httpserver/rss_renderer_test.go
@@ -16,8 +16,35 @@ package httpserver
 
 import (
 	"bytes"
+	"flag"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
+
+var updateGolden = flag.Bool("update", false, "update golden files") //nolint:gochecknoglobals // WONTFIX - test flag
+
+func verifyRSSGolden(t *testing.T, filename string, got string) {
+	t.Helper()
+	goldenPath := filepath.Join("testdata", filename)
+	if *updateGolden {
+		err := os.WriteFile(goldenPath, []byte(got), 0600)
+		if err != nil {
+			t.Fatalf("failed to update golden file %s: %v", goldenPath, err)
+		}
+	}
+
+	expected, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("failed to read golden file %s: %v", goldenPath, err)
+	}
+
+	if diff := cmp.Diff(string(expected), got); diff != "" {
+		t.Errorf("RSS description mismatch (-want +got):\n%s", diff)
+	}
+}
 
 func TestNewRSSRenderer(t *testing.T) {
 	renderer := NewRSSRenderer()
@@ -43,7 +70,10 @@ func TestRenderRSSDescription(t *testing.T) {
 				SummaryText:         "1 new feature matched",
 				Added:               []string{"Feature A"},
 				Removed:             nil,
-				Other:               nil,
+				Changed:             nil,
+				Moved:               nil,
+				Split:               nil,
+				Deleted:             nil,
 				QueryErrors:         nil,
 				ResolvedQueryErrors: nil,
 				Truncated:           false,
@@ -59,7 +89,10 @@ func TestRenderRSSDescription(t *testing.T) {
 				SummaryText:         "1 feature removed",
 				Added:               nil,
 				Removed:             []string{"Feature B"},
-				Other:               nil,
+				Changed:             nil,
+				Moved:               nil,
+				Split:               nil,
+				Deleted:             nil,
 				QueryErrors:         nil,
 				ResolvedQueryErrors: nil,
 				Truncated:           false,
@@ -70,19 +103,22 @@ func TestRenderRSSDescription(t *testing.T) {
 			},
 		},
 		{
-			name: "Other Update",
+			name: "Changed Update",
 			data: RSSItemData{
 				SummaryText:         "1 feature updated",
 				Added:               nil,
 				Removed:             nil,
-				Other:               []string{"Feature C (Changed)"},
+				Changed:             []string{"Feature C"},
+				Moved:               nil,
+				Split:               nil,
+				Deleted:             nil,
 				QueryErrors:         nil,
 				ResolvedQueryErrors: nil,
 				Truncated:           false,
 			},
 			expectedContains: []string{
 				"Feature C",
-				"Other Updates",
+				"Features Changed",
 			},
 		},
 		{
@@ -91,7 +127,10 @@ func TestRenderRSSDescription(t *testing.T) {
 				SummaryText:         "HTML escaping test",
 				Added:               []string{"<link rel=\"dns-prefetch\">"},
 				Removed:             nil,
-				Other:               nil,
+				Changed:             nil,
+				Moved:               nil,
+				Split:               nil,
+				Deleted:             nil,
 				QueryErrors:         nil,
 				ResolvedQueryErrors: nil,
 				Truncated:           false,
@@ -107,7 +146,10 @@ func TestRenderRSSDescription(t *testing.T) {
 				SummaryText:         "Summary text",
 				Added:               nil,
 				Removed:             nil,
-				Other:               nil,
+				Changed:             nil,
+				Moved:               nil,
+				Split:               nil,
+				Deleted:             nil,
 				QueryErrors:         nil,
 				ResolvedQueryErrors: nil,
 				Truncated:           true,
@@ -122,7 +164,10 @@ func TestRenderRSSDescription(t *testing.T) {
 				SummaryText:         "Query failure",
 				Added:               nil,
 				Removed:             nil,
-				Other:               nil,
+				Changed:             nil,
+				Moved:               nil,
+				Split:               nil,
+				Deleted:             nil,
 				QueryErrors:         []string{"Invalid query grammar"},
 				ResolvedQueryErrors: nil,
 				Truncated:           false,
@@ -138,7 +183,10 @@ func TestRenderRSSDescription(t *testing.T) {
 				SummaryText:         "Query recovered",
 				Added:               nil,
 				Removed:             nil,
-				Other:               nil,
+				Changed:             nil,
+				Moved:               nil,
+				Split:               nil,
+				Deleted:             nil,
 				QueryErrors:         nil,
 				ResolvedQueryErrors: []string{"Invalid query grammar"},
 				Truncated:           false,
@@ -164,4 +212,109 @@ func TestRenderRSSDescription(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRenderRSSDescription_AllCategories(t *testing.T) {
+	data := RSSItemData{
+		SummaryText:         "Full feature summary",
+		Added:               []string{"Added Feature"},
+		Removed:             []string{"Removed Feature"},
+		Changed:             []string{"Changed Feature"},
+		Moved:               []string{"Moved Feature"},
+		Split:               []string{"Split Feature"},
+		Deleted:             []string{"Deleted Feature"},
+		QueryErrors:         []string{"Saved search not found"},
+		ResolvedQueryErrors: []string{"Invalid query grammar"},
+		Truncated:           true,
+	}
+
+	renderer := NewRSSRenderer()
+	output, err := renderer.RenderRSSDescription(data)
+	if err != nil {
+		t.Fatalf("RenderRSSDescription failed: %v", err)
+	}
+
+	expectedSections := []string{
+		"Query Recovered",
+		"Query Errors",
+		"Features Added",
+		"Features Removed",
+		"Features Changed",
+		"Features Moved/Renamed",
+		"Features Split",
+		"Features Deleted",
+		"Note: This summary has been truncated.",
+	}
+
+	for _, section := range expectedSections {
+		if !bytes.Contains([]byte(output), []byte(section)) {
+			t.Errorf("expected RSS description to contain %q, got: %s", section, output)
+		}
+	}
+
+	verifyRSSGolden(t, "rss_description.golden.html", output)
+}
+
+func TestRenderRSSDescription_GoldenSnapshots(t *testing.T) {
+	renderer := NewRSSRenderer()
+
+	t.Run("Query Error Golden", func(t *testing.T) {
+		data := RSSItemData{
+			SummaryText:         "Query failure",
+			Truncated:           false,
+			QueryErrors:         []string{"Invalid query grammar"},
+			ResolvedQueryErrors: nil,
+			Added:               nil,
+			Removed:             nil,
+			Changed:             nil,
+			Moved:               nil,
+			Split:               nil,
+			Deleted:             nil,
+		}
+		got, err := renderer.RenderRSSDescription(data)
+		if err != nil {
+			t.Fatalf("RenderRSSDescription failed: %v", err)
+		}
+		verifyRSSGolden(t, "rss_query_error.golden.html", got)
+	})
+
+	t.Run("Resolved Query Error Golden", func(t *testing.T) {
+		data := RSSItemData{
+			SummaryText:         "Query recovered",
+			Truncated:           false,
+			QueryErrors:         nil,
+			ResolvedQueryErrors: []string{"Invalid query grammar"},
+			Added:               nil,
+			Removed:             nil,
+			Changed:             nil,
+			Moved:               nil,
+			Split:               nil,
+			Deleted:             nil,
+		}
+		got, err := renderer.RenderRSSDescription(data)
+		if err != nil {
+			t.Fatalf("RenderRSSDescription failed: %v", err)
+		}
+		verifyRSSGolden(t, "rss_resolved_query_error.golden.html", got)
+	})
+
+	t.Run("Combined Errors and Features Golden", func(t *testing.T) {
+		data := RSSItemData{
+			SummaryText:         "Combined summary",
+			Truncated:           false,
+			QueryErrors:         []string{"Saved search not found"},
+			ResolvedQueryErrors: nil,
+			Added:               []string{"Added Feature"},
+			Removed:             nil,
+			Changed:             nil,
+			Moved:               nil,
+			Split:               nil,
+			Deleted:             nil,
+		}
+		got, err := renderer.RenderRSSDescription(data)
+		if err != nil {
+			t.Fatalf("RenderRSSDescription failed: %v", err)
+		}
+		verifyRSSGolden(t, "rss_combined_errors_and_features.golden.html", got)
+	})
 }

--- a/backend/pkg/httpserver/rss_visitor.go
+++ b/backend/pkg/httpserver/rss_visitor.go
@@ -16,9 +16,13 @@ package httpserver
 
 import (
 	"fmt"
+
 	"github.com/GoogleChrome/webstatus.dev/lib/workertypes"
 )
 
+// rssVisitor implements workertypes.CategorizedSummaryVisitor to prepare RSS feed item payloads.
+// It uses double dispatch via BaseSummaryVisitor to populate RSSItemData with pre-filtered,
+// categorized highlights (Added, Removed, Changed, Moved, Split, Deleted) and error banners.
 type rssVisitor struct {
 	triggers []workertypes.JobTrigger
 	data     RSSItemData
@@ -29,7 +33,10 @@ func newEmptyRSSItemData() RSSItemData {
 		SummaryText:         "",
 		Added:               nil,
 		Removed:             nil,
-		Other:               nil,
+		Changed:             nil,
+		Moved:               nil,
+		Split:               nil,
+		Deleted:             nil,
 		QueryErrors:         nil,
 		ResolvedQueryErrors: nil,
 		Truncated:           false,
@@ -43,33 +50,14 @@ func newRSSVisitor(triggers []workertypes.JobTrigger) *rssVisitor {
 	}
 }
 
+// VisitV1 categorizes summary highlights against triggers and populates RSSItemData.
 func (v *rssVisitor) VisitV1(summary workertypes.EventSummary) error {
 	v.data = newEmptyRSSItemData()
 	v.data.SummaryText = summary.Text
 	v.data.Truncated = summary.Truncated
-	for _, qe := range summary.QueryErrors {
-		v.data.QueryErrors = append(v.data.QueryErrors, qe.Code.Message())
-	}
-	for _, qe := range summary.ResolvedQueryErrors {
-		v.data.ResolvedQueryErrors = append(v.data.ResolvedQueryErrors, qe.Code.Message())
-	}
 
-	// 1. Filter highlights against user triggers using shared workertypes helper
-	highlights := workertypes.FilterHighlights(summary.Highlights, v.triggers)
-
-	// 2. Populate current RSS categories
-	for _, h := range highlights {
-		switch h.Type {
-		case workertypes.SummaryHighlightTypeAdded:
-			v.data.Added = append(v.data.Added, h.FeatureName)
-		case workertypes.SummaryHighlightTypeRemoved:
-			v.data.Removed = append(v.data.Removed, h.FeatureName)
-		case workertypes.SummaryHighlightTypeChanged,
-			workertypes.SummaryHighlightTypeMoved,
-			workertypes.SummaryHighlightTypeSplit,
-			workertypes.SummaryHighlightTypeDeleted:
-			v.data.Other = append(v.data.Other, fmt.Sprintf("%s (%s)", h.FeatureName, h.Type))
-		}
+	if err := summary.Accept(v, v.triggers); err != nil {
+		return fmt.Errorf("failed to categorize event summary for RSS: %w", err)
 	}
 
 	return nil
@@ -80,5 +68,72 @@ func (v *rssVisitor) HasContent() bool {
 		len(v.data.ResolvedQueryErrors) > 0 ||
 		len(v.data.Added) > 0 ||
 		len(v.data.Removed) > 0 ||
-		len(v.data.Other) > 0
+		len(v.data.Changed) > 0 ||
+		len(v.data.Moved) > 0 ||
+		len(v.data.Split) > 0 ||
+		len(v.data.Deleted) > 0
+}
+
+func (v *rssVisitor) VisitQueryErrors(errs []workertypes.SummaryQueryError) error {
+	for _, qe := range errs {
+		v.data.QueryErrors = append(v.data.QueryErrors, qe.Code.Message())
+	}
+
+	return nil
+}
+
+func (v *rssVisitor) VisitResolvedQueryErrors(errs []workertypes.SummaryQueryError) error {
+	for _, qe := range errs {
+		v.data.ResolvedQueryErrors = append(v.data.ResolvedQueryErrors, qe.Code.Message())
+	}
+
+	return nil
+}
+
+func (v *rssVisitor) VisitAddedFeatures(features []workertypes.SummaryHighlight) error {
+	for _, h := range features {
+		v.data.Added = append(v.data.Added, h.FeatureName)
+	}
+
+	return nil
+}
+
+func (v *rssVisitor) VisitRemovedFeatures(features []workertypes.SummaryHighlight) error {
+	for _, h := range features {
+		v.data.Removed = append(v.data.Removed, h.FeatureName)
+	}
+
+	return nil
+}
+
+func (v *rssVisitor) VisitChangedFeatures(features []workertypes.SummaryHighlight) error {
+	for _, h := range features {
+		v.data.Changed = append(v.data.Changed, h.FeatureName)
+	}
+
+	return nil
+}
+
+func (v *rssVisitor) VisitMovedFeatures(features []workertypes.SummaryHighlight) error {
+	for _, h := range features {
+		v.data.Moved = append(v.data.Moved, h.FeatureName)
+	}
+
+	return nil
+}
+
+func (v *rssVisitor) VisitSplitFeatures(features []workertypes.SummaryHighlight) error {
+	for _, h := range features {
+		v.data.Split = append(v.data.Split, h.FeatureName)
+	}
+
+	return nil
+}
+
+func (v *rssVisitor) VisitDeletedFeatures(features []workertypes.SummaryHighlight) error {
+	for _, h := range features {
+		v.data.Deleted = append(v.data.Deleted, h.FeatureName)
+	}
+
+	return nil
 }

--- a/backend/pkg/httpserver/rss_visitor_test.go
+++ b/backend/pkg/httpserver/rss_visitor_test.go
@@ -21,29 +21,12 @@ import (
 )
 
 func newTestSummaryWithErrors(errCode workertypes.SummaryQueryErrorCode) workertypes.EventSummary {
-	return workertypes.EventSummary{
-		SchemaVersion:  workertypes.VersionEventSummaryV1,
-		SnapshotOrigin: workertypes.OriginLive,
-		Truncated:      false,
-		Highlights:     nil,
-		Text:           "Query grammar failure",
-		QueryErrors: []workertypes.SummaryQueryError{
-			{Code: errCode},
-		},
-		ResolvedQueryErrors: nil,
-		Categories: workertypes.SummaryCategories{
-			Updated:         0,
-			Added:           0,
-			Removed:         0,
-			Moved:           0,
-			Split:           0,
-			Deleted:         0,
-			UpdatedBaseline: 0,
-			QueryChanged:    0,
-			UpdatedImpl:     0,
-			UpdatedRename:   0,
-		},
-	}
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SnapshotOrigin = workertypes.OriginLive
+	summary.Text = "Query grammar failure"
+	summary.SetQueryErrors([]workertypes.SummaryQueryError{{Code: errCode}})
+
+	return summary
 }
 
 func TestRSSVisitor_QueryErrors(t *testing.T) {
@@ -70,22 +53,22 @@ func TestRSSVisitor_QueryErrors_RenderMessage(t *testing.T) {
 		wantMessage string
 	}{
 		{
-			name:        "QueryGrammar error renders human-readable message",
+			name:        "QueryGrammar error",
 			errorCode:   workertypes.SummaryQueryErrorCodeQueryGrammar,
 			wantMessage: "Invalid query grammar",
 		},
 		{
-			name:        "SavedSearchNotFound error renders human-readable message",
+			name:        "SavedSearchNotFound error",
 			errorCode:   workertypes.SummaryQueryErrorCodeSavedSearchNotFound,
 			wantMessage: "Saved search not found",
 		},
 		{
-			name:        "MaxDepthExceeded error renders human-readable message",
+			name:        "MaxDepthExceeded error",
 			errorCode:   workertypes.SummaryQueryErrorCodeMaxDepthExceeded,
 			wantMessage: "Saved search max depth exceeded",
 		},
 		{
-			name:        "InvalidQuery error renders human-readable message",
+			name:        "InvalidQuery error",
 			errorCode:   workertypes.SummaryQueryErrorCodeInvalidQuery,
 			wantMessage: "Invalid query",
 		},
@@ -117,18 +100,10 @@ func TestRSSVisitor_QueryErrors_RenderMessage(t *testing.T) {
 
 func TestRSSVisitor_ResolvedQueryErrors(t *testing.T) {
 	visitor := newRSSVisitor([]workertypes.JobTrigger{workertypes.FeaturePromotedToNewly})
-	summary := workertypes.EventSummary{
-		SchemaVersion:  workertypes.VersionEventSummaryV1,
-		SnapshotOrigin: workertypes.OriginLive,
-		Truncated:      false,
-		Highlights:     nil,
-		Text:           "Search query recovered",
-		QueryErrors:    nil,
-		ResolvedQueryErrors: []workertypes.SummaryQueryError{
-			{Code: workertypes.SummaryQueryErrorCodeQueryGrammar},
-		},
-		Categories: workertypes.NewEmptySummaryCategories(),
-	}
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SnapshotOrigin = workertypes.OriginLive
+	summary.Text = "Search query recovered"
+	summary.SetResolvedQueryErrors([]workertypes.SummaryQueryError{{Code: workertypes.SummaryQueryErrorCodeQueryGrammar}})
 
 	if err := visitor.VisitV1(summary); err != nil {
 		t.Fatalf("VisitV1 unexpected error: %v", err)
@@ -140,5 +115,186 @@ func TestRSSVisitor_ResolvedQueryErrors(t *testing.T) {
 		visitor.data.ResolvedQueryErrors[0] != workertypes.SummaryQueryErrorCodeQueryGrammar.Message() {
 		t.Errorf("data.ResolvedQueryErrors = %v, want [%s]",
 			visitor.data.ResolvedQueryErrors, workertypes.SummaryQueryErrorCodeQueryGrammar.Message())
+	}
+}
+
+func newTestHighlight(typ workertypes.SummaryHighlightType, id, name string) workertypes.SummaryHighlight {
+	return workertypes.SummaryHighlight{
+		Type:           typ,
+		FeatureID:      id,
+		FeatureName:    name,
+		Docs:           nil,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+		Moved:          nil,
+		Split:          nil,
+	}
+}
+
+func TestRSSVisitor_FeatureCategories(t *testing.T) {
+	testCases := []struct {
+		name      string
+		highlight workertypes.SummaryHighlight
+		checkFunc func(*testing.T, *rssVisitor)
+	}{
+		{
+			name:      "Added feature",
+			highlight: newTestHighlight(workertypes.SummaryHighlightTypeAdded, "f-added", "Added Feature"),
+			checkFunc: func(t *testing.T, v *rssVisitor) {
+				if len(v.data.Added) != 1 || v.data.Added[0] != "Added Feature" {
+					t.Errorf("v.data.Added = %v, want ['Added Feature']", v.data.Added)
+				}
+			},
+		},
+		{
+			name:      "Removed feature",
+			highlight: newTestHighlight(workertypes.SummaryHighlightTypeRemoved, "f-removed", "Removed Feature"),
+			checkFunc: func(t *testing.T, v *rssVisitor) {
+				if len(v.data.Removed) != 1 || v.data.Removed[0] != "Removed Feature" {
+					t.Errorf("v.data.Removed = %v, want ['Removed Feature']", v.data.Removed)
+				}
+			},
+		},
+		{
+			name:      "Changed feature",
+			highlight: newTestHighlight(workertypes.SummaryHighlightTypeChanged, "f-changed", "Changed Feature"),
+			checkFunc: func(t *testing.T, v *rssVisitor) {
+				if len(v.data.Changed) != 1 || v.data.Changed[0] != "Changed Feature" {
+					t.Errorf("v.data.Changed = %v, want ['Changed Feature']", v.data.Changed)
+				}
+			},
+		},
+		{
+			name:      "Moved feature",
+			highlight: newTestHighlight(workertypes.SummaryHighlightTypeMoved, "f-moved", "Moved Feature"),
+			checkFunc: func(t *testing.T, v *rssVisitor) {
+				if len(v.data.Moved) != 1 || v.data.Moved[0] != "Moved Feature" {
+					t.Errorf("v.data.Moved = %v, want ['Moved Feature']", v.data.Moved)
+				}
+			},
+		},
+		{
+			name:      "Split feature",
+			highlight: newTestHighlight(workertypes.SummaryHighlightTypeSplit, "f-split", "Split Feature"),
+			checkFunc: func(t *testing.T, v *rssVisitor) {
+				if len(v.data.Split) != 1 || v.data.Split[0] != "Split Feature" {
+					t.Errorf("v.data.Split = %v, want ['Split Feature']", v.data.Split)
+				}
+			},
+		},
+		{
+			name:      "Deleted feature",
+			highlight: newTestHighlight(workertypes.SummaryHighlightTypeDeleted, "f-deleted", "Deleted Feature"),
+			checkFunc: func(t *testing.T, v *rssVisitor) {
+				if len(v.data.Deleted) != 1 || v.data.Deleted[0] != "Deleted Feature" {
+					t.Errorf("v.data.Deleted = %v, want ['Deleted Feature']", v.data.Deleted)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			visitor := newRSSVisitor(nil)
+			summary := workertypes.NewEmptyEventSummary()
+			summary.AddHighlight(tc.highlight)
+
+			if err := visitor.VisitV1(summary); err != nil {
+				t.Fatalf("VisitV1 unexpected error: %v", err)
+			}
+			if !visitor.HasContent() {
+				t.Error("expected HasContent() to be true")
+			}
+			tc.checkFunc(t, visitor)
+		})
+	}
+}
+
+func TestRSSVisitor_CombinedErrorsAndFeatures(t *testing.T) {
+	visitor := newRSSVisitor(nil)
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SnapshotOrigin = workertypes.OriginLive
+	summary.Text = "Combined errors and features"
+	summary.SetQueryErrors([]workertypes.SummaryQueryError{{Code: workertypes.SummaryQueryErrorCodeSavedSearchNotFound}})
+	summary.SetResolvedQueryErrors([]workertypes.SummaryQueryError{{Code: workertypes.SummaryQueryErrorCodeQueryGrammar}})
+	summary.AddHighlight(newTestHighlight(workertypes.SummaryHighlightTypeAdded, "f-added", "Subgrid"))
+
+	if err := visitor.VisitV1(summary); err != nil {
+		t.Fatalf("VisitV1 unexpected error: %v", err)
+	}
+	if !visitor.HasContent() {
+		t.Error("expected HasContent() to be true")
+	}
+	if len(visitor.data.QueryErrors) != 1 || len(visitor.data.ResolvedQueryErrors) != 1 || len(visitor.data.Added) != 1 {
+		t.Errorf("got QueryErrors=%d, ResolvedQueryErrors=%d, Added=%d; want 1 each",
+			len(visitor.data.QueryErrors), len(visitor.data.ResolvedQueryErrors), len(visitor.data.Added))
+	}
+}
+
+func newTestChangedHighlight(id, name string, status workertypes.BaselineStatus) workertypes.SummaryHighlight {
+	return workertypes.SummaryHighlight{
+		Type:        workertypes.SummaryHighlightTypeChanged,
+		FeatureID:   id,
+		FeatureName: name,
+		Docs:        nil,
+		NameChange:  nil,
+		BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
+			From: workertypes.BaselineValue{
+				Status:   workertypes.BaselineStatusNewly,
+				LowDate:  nil,
+				HighDate: nil,
+			},
+			To: workertypes.BaselineValue{
+				Status:   status,
+				LowDate:  nil,
+				HighDate: nil,
+			},
+		},
+		BrowserChanges: nil,
+		Moved:          nil,
+		Split:          nil,
+	}
+}
+
+func TestRSSVisitor_TriggerFiltering(t *testing.T) {
+	// Subscription only wants FeaturePromotedToNewly
+	visitor := newRSSVisitor([]workertypes.JobTrigger{workertypes.FeaturePromotedToNewly})
+	summary := workertypes.NewEmptyEventSummary()
+	summary.AddHighlight(newTestChangedHighlight("f-widely", "Widely Available Feature", workertypes.BaselineStatusWidely))
+
+	if err := visitor.VisitV1(summary); err != nil {
+		t.Fatalf("VisitV1 unexpected error: %v", err)
+	}
+	if visitor.HasContent() {
+		t.Error("expected HasContent() to be false when highlight is filtered out by triggers")
+	}
+}
+
+func TestRSSVisitor_NilPointerGuards(t *testing.T) {
+	visitor := newRSSVisitor(nil)
+	summary := workertypes.NewEmptyEventSummary()
+	summary.AddHighlight(newTestHighlight(
+		workertypes.SummaryHighlightTypeMoved,
+		"f-moved-nil",
+		"Moved Feature With Nil Struct",
+	))
+	summary.AddHighlight(newTestHighlight(
+		workertypes.SummaryHighlightTypeSplit,
+		"f-split-nil",
+		"Split Feature With Nil Struct",
+	))
+
+	if err := visitor.VisitV1(summary); err != nil {
+		t.Fatalf("VisitV1 unexpected error on nil pointer highlights: %v", err)
+	}
+	if !visitor.HasContent() {
+		t.Error("expected HasContent() to be true")
+	}
+	if len(visitor.data.Moved) != 1 || visitor.data.Moved[0] != "Moved Feature With Nil Struct" {
+		t.Errorf("visitor.data.Moved = %v, want ['Moved Feature With Nil Struct']", visitor.data.Moved)
+	}
+	if len(visitor.data.Split) != 1 || visitor.data.Split[0] != "Split Feature With Nil Struct" {
+		t.Errorf("visitor.data.Split = %v, want ['Split Feature With Nil Struct']", visitor.data.Split)
 	}
 }

--- a/backend/pkg/httpserver/testdata/rss_combined_errors_and_features.golden.html
+++ b/backend/pkg/httpserver/testdata/rss_combined_errors_and_features.golden.html
@@ -1,0 +1,27 @@
+
+<div>
+    <p>Combined summary</p>
+    
+    
+    <h4>Query Errors</h4>
+    <ul>
+        
+        <li>Saved search not found</li>
+        
+    </ul>
+    
+    
+    <h4>Features Added</h4>
+    <ul>
+        
+        <li>Added Feature</li>
+        
+    </ul>
+    
+    
+    
+    
+    
+    
+    
+</div>

--- a/backend/pkg/httpserver/testdata/rss_combined_errors_and_features.golden.html
+++ b/backend/pkg/httpserver/testdata/rss_combined_errors_and_features.golden.html
@@ -1,27 +1,11 @@
-
 <div>
     <p>Combined summary</p>
-    
-    
     <h4>Query Errors</h4>
     <ul>
-        
         <li>Saved search not found</li>
-        
     </ul>
-    
-    
     <h4>Features Added</h4>
     <ul>
-        
         <li>Added Feature</li>
-        
     </ul>
-    
-    
-    
-    
-    
-    
-    
 </div>

--- a/backend/pkg/httpserver/testdata/rss_description.golden.html
+++ b/backend/pkg/httpserver/testdata/rss_description.golden.html
@@ -1,0 +1,61 @@
+
+<div>
+    <p>Full feature summary</p>
+    
+    <h4>Query Recovered</h4>
+    <ul>
+        
+        <li>Tracking resumed cleanly from your baseline. Resolved issue: Invalid query grammar</li>
+        
+    </ul>
+    
+    
+    <h4>Query Errors</h4>
+    <ul>
+        
+        <li>Saved search not found</li>
+        
+    </ul>
+    
+    
+    <h4>Features Added</h4>
+    <ul>
+        
+        <li>Added Feature</li>
+        
+    </ul>
+    
+    
+    <h4>Features Removed</h4>
+    <ul>
+        <li>Removed Feature</li>
+    </ul>
+    
+    
+    <h4>Features Changed</h4>
+    <ul>
+        <li>Changed Feature</li>
+    </ul>
+    
+    
+    <h4>Features Moved/Renamed</h4>
+    <ul>
+        <li>Moved Feature</li>
+    </ul>
+    
+    
+    <h4>Features Split</h4>
+    <ul>
+        <li>Split Feature</li>
+    </ul>
+    
+    
+    <h4>Features Deleted</h4>
+    <ul>
+        <li>Deleted Feature</li>
+    </ul>
+    
+    
+    <p><em>Note: This summary has been truncated. View full details on the site.</em></p>
+    
+</div>

--- a/backend/pkg/httpserver/testdata/rss_description.golden.html
+++ b/backend/pkg/httpserver/testdata/rss_description.golden.html
@@ -1,61 +1,36 @@
-
 <div>
     <p>Full feature summary</p>
-    
     <h4>Query Recovered</h4>
     <ul>
-        
         <li>Tracking resumed cleanly from your baseline. Resolved issue: Invalid query grammar</li>
-        
     </ul>
-    
-    
     <h4>Query Errors</h4>
     <ul>
-        
         <li>Saved search not found</li>
-        
     </ul>
-    
-    
     <h4>Features Added</h4>
     <ul>
-        
         <li>Added Feature</li>
-        
     </ul>
-    
-    
     <h4>Features Removed</h4>
     <ul>
         <li>Removed Feature</li>
     </ul>
-    
-    
     <h4>Features Changed</h4>
     <ul>
         <li>Changed Feature</li>
     </ul>
-    
-    
     <h4>Features Moved/Renamed</h4>
     <ul>
         <li>Moved Feature</li>
     </ul>
-    
-    
     <h4>Features Split</h4>
     <ul>
         <li>Split Feature</li>
     </ul>
-    
-    
     <h4>Features Deleted</h4>
     <ul>
         <li>Deleted Feature</li>
     </ul>
-    
-    
     <p><em>Note: This summary has been truncated. View full details on the site.</em></p>
-    
 </div>

--- a/backend/pkg/httpserver/testdata/rss_query_error.golden.html
+++ b/backend/pkg/httpserver/testdata/rss_query_error.golden.html
@@ -1,0 +1,20 @@
+
+<div>
+    <p>Query failure</p>
+    
+    
+    <h4>Query Errors</h4>
+    <ul>
+        
+        <li>Invalid query grammar</li>
+        
+    </ul>
+    
+    
+    
+    
+    
+    
+    
+    
+</div>

--- a/backend/pkg/httpserver/testdata/rss_query_error.golden.html
+++ b/backend/pkg/httpserver/testdata/rss_query_error.golden.html
@@ -1,20 +1,7 @@
-
 <div>
     <p>Query failure</p>
-    
-    
     <h4>Query Errors</h4>
     <ul>
-        
         <li>Invalid query grammar</li>
-        
     </ul>
-    
-    
-    
-    
-    
-    
-    
-    
 </div>

--- a/backend/pkg/httpserver/testdata/rss_resolved_query_error.golden.html
+++ b/backend/pkg/httpserver/testdata/rss_resolved_query_error.golden.html
@@ -1,0 +1,20 @@
+
+<div>
+    <p>Query recovered</p>
+    
+    <h4>Query Recovered</h4>
+    <ul>
+        
+        <li>Tracking resumed cleanly from your baseline. Resolved issue: Invalid query grammar</li>
+        
+    </ul>
+    
+    
+    
+    
+    
+    
+    
+    
+    
+</div>

--- a/backend/pkg/httpserver/testdata/rss_resolved_query_error.golden.html
+++ b/backend/pkg/httpserver/testdata/rss_resolved_query_error.golden.html
@@ -1,20 +1,7 @@
-
 <div>
     <p>Query recovered</p>
-    
     <h4>Query Recovered</h4>
     <ul>
-        
         <li>Tracking resumed cleanly from your baseline. Resolved issue: Invalid query grammar</li>
-        
     </ul>
-    
-    
-    
-    
-    
-    
-    
-    
-    
 </div>


### PR DESCRIPTION
Implements CategorizedSummaryVisitor on rssVisitor in backend/pkg/httpserver to handle double dispatch for all feature change categories and error banners.

- Implements CategorizedSummaryVisitor on rssVisitor in backend/pkg/httpserver.
- Updates RSSItemData and HTML templates to render dedicated sections for Changed, Moved/Renamed, Split, and Deleted features alongside Added and Removed.
- Adds 4 disk-backed golden snapshot files in backend/pkg/httpserver/testdata/ (rss_description.golden.html, rss_query_error.golden.html, rss_resolved_query_error.golden.html, rss_combined_errors_and_features.golden.html) and converts rss_renderer_test.go to use cmp.Diff with -update flag support.
- Adds TestRSSVisitor_FeatureCategories, TestRSSVisitor_QueryErrors_RenderMessage, TestRSSVisitor_TriggerFiltering, TestRSSVisitor_NilPointerGuards, and TestRSSVisitor_CombinedErrorsAndFeatures unit tests.

Fixes #2622 (PR 2/5)

CONV=f70d8c59-6f49-4a69-bb74-5643e908f5b1
TAG=agy