### PR TITLE
feat(email): migrate email digest renderer to CategorizedSummaryVisitor (#2622)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,7 @@ backend/pkg/httpserver/testdata/rss_combined_errors_and_features.golden.html
 workers/email/pkg/digest/testdata/digest.golden.html
 workers/email/pkg/digest/testdata/digest_query_error.golden.html
 workers/email/pkg/digest/testdata/digest_resolved_query_error.golden.html
+workers/email/pkg/digest/testdata/digest_combined_errors_and_features.golden.html
 workers/webhook/pkg/webhook/testdata/slack_payload.golden.json
 workers/webhook/pkg/webhook/testdata/slack_payload_query_error.golden.json
 workers/webhook/pkg/webhook/testdata/slack_payload_resolved_query_error.golden.json

--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,7 @@ ADDLICENSE_ARGS := -c "${COPYRIGHT_NAME}" \
 	-ignore 'workers/email/pkg/digest/testdata/digest.golden.html' \
 	-ignore 'workers/email/pkg/digest/testdata/digest_query_error.golden.html' \
 	-ignore 'workers/email/pkg/digest/testdata/digest_resolved_query_error.golden.html' \
+	-ignore 'workers/email/pkg/digest/testdata/digest_combined_errors_and_features.golden.html' \
 	-ignore 'backend/pkg/httpserver/testdata/rss_description.golden.html' \
 	-ignore 'backend/pkg/httpserver/testdata/rss_query_error.golden.html' \
 	-ignore 'backend/pkg/httpserver/testdata/rss_resolved_query_error.golden.html' \

--- a/workers/email/pkg/digest/renderer.go
+++ b/workers/email/pkg/digest/renderer.go
@@ -268,7 +268,8 @@ func (r *HTMLRenderer) RenderDigest(job workertypes.IncomingEmailDeliveryJob) (s
 	return subject, body.String(), nil
 }
 
-// templateDataGenerator implements workertypes.SummaryVisitor to prepare the data for the template.
+// templateDataGenerator implements workertypes.CategorizedSummaryVisitor to prepare email digest template data.
+// It receives pre-filtered categories and errors from EventSummary.Accept() via double dispatch.
 type templateDataGenerator struct {
 	job         workertypes.IncomingEmailDeliveryJob
 	subject     string
@@ -277,7 +278,7 @@ type templateDataGenerator struct {
 	data        templateData
 }
 
-// VisitV1 is called when a V1 summary is parsed.
+// VisitV1 initializes template metadata and triggers double dispatch categorization via summary.Accept().
 func (g *templateDataGenerator) VisitV1(summary workertypes.EventSummary) error {
 	g.data = newEmptyTemplateData()
 	g.data.Subject = g.subject
@@ -285,59 +286,81 @@ func (g *templateDataGenerator) VisitV1(summary workertypes.EventSummary) error 
 	g.data.SearchName = g.job.Metadata.SearchName
 	g.data.Query = g.job.Metadata.Query
 	g.data.SummaryText = summary.Text
-	g.data.QueryErrors = summary.QueryErrors
-	g.data.ResolvedQueryErrors = summary.ResolvedQueryErrors
 	g.data.Truncated = summary.Truncated
 	g.data.BaseURL = g.baseURL
 	g.data.UnsubscribeURL = fmt.Sprintf("%s/settings/subscriptions?unsubscribe=%s",
 		g.baseURL, g.job.SubscriptionID)
-	// 2. Filter Content (Content Filtering)
-	// We only show highlights that match the user's specific triggers.
-	filteredHighlights := workertypes.FilterHighlights(summary.Highlights, g.job.Triggers)
-	if len(filteredHighlights) != 0 {
-		// As long as we have some filtered highlights, override it.
-		// This should be the common case unless there's some logic error.
-		summary.Highlights = filteredHighlights
-	}
 
-	g.categorizeHighlights(summary.Highlights)
+	return summary.Accept(g, g.job.Triggers)
+}
+
+// The following Visit... methods are called by BaseSummaryVisitor during summary.Accept() double dispatch.
+
+// VisitQueryErrors receives active query errors and populates g.data.QueryErrors.
+func (g *templateDataGenerator) VisitQueryErrors(errs []workertypes.SummaryQueryError) error {
+	g.data.QueryErrors = errs
 
 	return nil
 }
 
-func (g *templateDataGenerator) categorizeHighlights(highlights []workertypes.SummaryHighlight) {
-	for _, highlight := range highlights {
-		g.processHighlight(highlight)
+// VisitResolvedQueryErrors receives resolved query errors and populates g.data.ResolvedQueryErrors.
+func (g *templateDataGenerator) VisitResolvedQueryErrors(errs []workertypes.SummaryQueryError) error {
+	g.data.ResolvedQueryErrors = errs
+
+	return nil
+}
+
+// VisitAddedFeatures receives newly added feature highlights.
+func (g *templateDataGenerator) VisitAddedFeatures(features []workertypes.SummaryHighlight) error {
+	g.data.AddedFeatures = features
+
+	return nil
+}
+
+// VisitRemovedFeatures receives feature highlights removed from query results.
+func (g *templateDataGenerator) VisitRemovedFeatures(features []workertypes.SummaryHighlight) error {
+	g.data.RemovedFeatures = features
+
+	return nil
+}
+
+// VisitChangedFeatures receives feature highlights with baseline status or browser availability changes.
+func (g *templateDataGenerator) VisitChangedFeatures(features []workertypes.SummaryHighlight) error {
+	for _, h := range features {
+		g.processChangedData(h)
 	}
+
+	return nil
 }
 
-func (g *templateDataGenerator) processHighlight(highlight workertypes.SummaryHighlight) {
-	g.routeHighlightToCategory(highlight)
-}
-
-func (g *templateDataGenerator) routeHighlightToCategory(highlight workertypes.SummaryHighlight) {
-	switch highlight.Type {
-	case workertypes.SummaryHighlightTypeMoved:
-		g.data.MovedFeatures = append(g.data.MovedFeatures, highlight)
-	case workertypes.SummaryHighlightTypeSplit:
-		g.data.SplitFeatures = append(g.data.SplitFeatures, highlight)
-	case workertypes.SummaryHighlightTypeAdded:
-		g.data.AddedFeatures = append(g.data.AddedFeatures, highlight)
-	case workertypes.SummaryHighlightTypeRemoved:
-		// Promotion Strategy:
-		// If a removed feature has significant changes (Baseline or Browser),
-		// we treat it as a "Change" so it appears in the specific sections (e.g. Baseline Newly)
-		// rather than the generic "Removed" list.
-		if highlight.BaselineChange != nil || len(highlight.BrowserChanges) > 0 {
-			g.processChangedData(highlight)
-		} else {
-			g.data.RemovedFeatures = append(g.data.RemovedFeatures, highlight)
+func (g *templateDataGenerator) VisitMovedFeatures(features []workertypes.SummaryHighlight) error {
+	valid := make([]workertypes.SummaryHighlight, 0, len(features))
+	for _, f := range features {
+		if f.Moved != nil {
+			valid = append(valid, f)
 		}
-	case workertypes.SummaryHighlightTypeDeleted:
-		g.data.DeletedFeatures = append(g.data.DeletedFeatures, highlight)
-	case workertypes.SummaryHighlightTypeChanged:
-		g.processChangedData(highlight)
 	}
+	g.data.MovedFeatures = valid
+
+	return nil
+}
+
+func (g *templateDataGenerator) VisitSplitFeatures(features []workertypes.SummaryHighlight) error {
+	valid := make([]workertypes.SummaryHighlight, 0, len(features))
+	for _, f := range features {
+		if f.Split != nil {
+			valid = append(valid, f)
+		}
+	}
+	g.data.SplitFeatures = valid
+
+	return nil
+}
+
+func (g *templateDataGenerator) VisitDeletedFeatures(features []workertypes.SummaryHighlight) error {
+	g.data.DeletedFeatures = features
+
+	return nil
 }
 
 func (g *templateDataGenerator) processChangedData(highlight workertypes.SummaryHighlight) {

--- a/workers/email/pkg/digest/renderer_test.go
+++ b/workers/email/pkg/digest/renderer_test.go
@@ -15,6 +15,7 @@
 package digest
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"os"
@@ -34,364 +35,362 @@ func TestRenderDigest_Golden(t *testing.T) {
 	widelyDate := time.Date(2025, 12, 27, 0, 0, 0, 0, time.UTC)
 
 	// Setup complex test data to exercise all templates
-	summary := workertypes.EventSummary{
-		SchemaVersion:  "v1",
-		SnapshotOrigin: workertypes.OriginLive,
-		Text:           "11 features changed",
-		Categories: workertypes.SummaryCategories{
-			Updated:         5,
-			Added:           2,
-			Removed:         1,
-			Moved:           1,
-			Split:           1,
-			Deleted:         1,
-			QueryChanged:    0,
-			UpdatedImpl:     0,
-			UpdatedRename:   0,
-			UpdatedBaseline: 3,
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SnapshotOrigin = workertypes.OriginLive
+	summary.Text = "11 features changed"
+	summary.Categories = workertypes.SummaryCategories{
+		Updated:         5,
+		Added:           2,
+		Removed:         1,
+		Moved:           1,
+		Split:           1,
+		Deleted:         1,
+		QueryChanged:    0,
+		UpdatedImpl:     0,
+		UpdatedRename:   0,
+		UpdatedBaseline: 3,
+	}
+	highlights := []workertypes.SummaryHighlight{
+		{
+			// Case 1: Baseline Widely (with multiple docs)
+			Type:        workertypes.SummaryHighlightTypeChanged,
+			FeatureName: "Container queries",
+			FeatureID:   "container-queries",
+			Docs: &workertypes.Docs{
+				MDNDocs: []workertypes.DocLink{
+					{
+						URL:   "https://developer.mozilla.org/docs/Web/CSS/CSS_Container_Queries",
+						Title: nil,
+						Slug:  nil,
+					},
+					{URL: "https://developer.mozilla.org/docs/Web/CSS/container-queries", Title: nil, Slug: nil},
+				},
+			},
+			BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
+				From: workertypes.BaselineValue{Status: workertypes.BaselineStatusNewly, LowDate: &newlyDate,
+					HighDate: nil},
+				To: workertypes.BaselineValue{Status: workertypes.BaselineStatusWidely, LowDate: &newlyDate,
+					HighDate: &widelyDate},
+			},
+			NameChange:     nil,
+			BrowserChanges: nil,
+			Moved:          nil,
+			Split:          nil,
 		},
-		Truncated:           false,
-		QueryErrors:         nil,
-		ResolvedQueryErrors: nil,
-		Highlights: []workertypes.SummaryHighlight{
-			{
-				// Case 1: Baseline Widely (with multiple docs)
-				Type:        workertypes.SummaryHighlightTypeChanged,
-				FeatureName: "Container queries",
-				FeatureID:   "container-queries",
-				Docs: &workertypes.Docs{
-					MDNDocs: []workertypes.DocLink{
-						{
-							URL:   "https://developer.mozilla.org/docs/Web/CSS/CSS_Container_Queries",
-							Title: nil,
-							Slug:  nil,
-						},
-						{URL: "https://developer.mozilla.org/docs/Web/CSS/container-queries", Title: nil, Slug: nil},
-					},
-				},
-				BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
-					From: workertypes.BaselineValue{Status: workertypes.BaselineStatusNewly, LowDate: &newlyDate,
-						HighDate: nil},
-					To: workertypes.BaselineValue{Status: workertypes.BaselineStatusWidely, LowDate: &newlyDate,
-						HighDate: &widelyDate},
-				},
-				NameChange:     nil,
-				BrowserChanges: nil,
-				Moved:          nil,
-				Split:          nil,
+		{
+			// Case 2: Baseline Newly
+			Type:        workertypes.SummaryHighlightTypeChanged,
+			FeatureName: "Newly Available Feature",
+			FeatureID:   "newly-feature",
+			BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
+				From: workertypes.BaselineValue{Status: workertypes.BaselineStatusLimited, LowDate: nil,
+					HighDate: nil},
+				To: workertypes.BaselineValue{Status: workertypes.BaselineStatusNewly, LowDate: &newlyDate,
+					HighDate: nil},
 			},
-			{
-				// Case 2: Baseline Newly
-				Type:        workertypes.SummaryHighlightTypeChanged,
-				FeatureName: "Newly Available Feature",
-				FeatureID:   "newly-feature",
-				BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
-					From: workertypes.BaselineValue{Status: workertypes.BaselineStatusLimited, LowDate: nil,
-						HighDate: nil},
-					To: workertypes.BaselineValue{Status: workertypes.BaselineStatusNewly, LowDate: &newlyDate,
-						HighDate: nil},
-				},
-				Docs:           nil,
-				NameChange:     nil,
-				BrowserChanges: nil,
-				Moved:          nil,
-				Split:          nil,
-			},
-			{
-				// Case 3: Baseline Regression
-				Type:        workertypes.SummaryHighlightTypeChanged,
-				FeatureName: "Regressed Feature",
-				FeatureID:   "regressed-feature",
-				BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
-					From: workertypes.BaselineValue{Status: workertypes.BaselineStatusWidely,
-						LowDate: &newlyDate, HighDate: &widelyDate},
-					To: workertypes.BaselineValue{Status: workertypes.BaselineStatusLimited,
-						LowDate: nil, HighDate: nil},
-				},
-				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
-					workertypes.BrowserChrome: {
-						From: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
-							Version: new("120"), Date: nil},
-						To: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnavailable, Version: nil,
-							Date: nil},
-					},
-					workertypes.BrowserFirefox:        nil,
-					workertypes.BrowserChromeAndroid:  nil,
-					workertypes.BrowserEdge:           nil,
-					workertypes.BrowserFirefoxAndroid: nil,
-					workertypes.BrowserSafari:         nil,
-					workertypes.BrowserSafariIos:      nil,
-				},
-				Docs:       nil,
-				NameChange: nil,
-				Moved:      nil,
-				Split:      nil,
-			},
-			{
-				// Case 4: Browser Implementation with version
-				Type:        workertypes.SummaryHighlightTypeChanged,
-				FeatureName: "content-visibility",
-				FeatureID:   "content-visibility",
-				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
-					workertypes.BrowserSafariIos: {
-						From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnavailable, Version: nil,
-							Date: nil},
-						To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
-							Version: new("17.2"),
-							// Purposefully set to nil to test that it doesn't crash.
-							Date: nil},
-					},
-					workertypes.BrowserChrome:         nil,
-					workertypes.BrowserChromeAndroid:  nil,
-					workertypes.BrowserEdge:           nil,
-					workertypes.BrowserFirefoxAndroid: nil,
-					workertypes.BrowserSafari:         nil,
-					workertypes.BrowserFirefox:        nil,
-				},
-				Docs:           nil,
-				NameChange:     nil,
-				BaselineChange: nil,
-				Moved:          nil,
-				Split:          nil,
-			},
-			{
-				// Case 5: Browser Implementation with date
-				Type:        workertypes.SummaryHighlightTypeChanged,
-				FeatureName: "another-feature",
-				FeatureID:   "another-feature",
-				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
-					workertypes.BrowserChrome: {
-						From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnavailable,
-							Date: nil, Version: nil},
-						To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable, Date: &newlyDate,
-							// Purposefully set to nil so that we can see that it doesn't crash.
-							Version: nil},
-					},
-					workertypes.BrowserFirefox:        nil,
-					workertypes.BrowserChromeAndroid:  nil,
-					workertypes.BrowserEdge:           nil,
-					workertypes.BrowserFirefoxAndroid: nil,
-					workertypes.BrowserSafari:         nil,
-					workertypes.BrowserSafariIos:      nil,
-				},
-				Docs:           nil,
-				NameChange:     nil,
-				BaselineChange: nil,
-				Moved:          nil,
-				Split:          nil,
-			},
-			{
-				// Case 6: Added
-				Type:           workertypes.SummaryHighlightTypeAdded,
-				FeatureName:    "New Feature",
-				FeatureID:      "new-feature",
-				Docs:           nil,
-				NameChange:     nil,
-				BaselineChange: nil,
-				BrowserChanges: nil,
-				Moved:          nil,
-				Split:          nil,
-			},
-			{
-				// Case 6b: Another Added
-				Type:           workertypes.SummaryHighlightTypeAdded,
-				FeatureName:    "Another New Feature",
-				FeatureID:      "another-new-feature",
-				Docs:           nil,
-				NameChange:     nil,
-				BaselineChange: nil,
-				BrowserChanges: nil,
-				Moved:          nil,
-				Split:          nil,
-			},
-			{
-				// Case 7: Removed
-				Type:           workertypes.SummaryHighlightTypeRemoved,
-				FeatureName:    "Removed Feature",
-				FeatureID:      "removed-feature",
-				Docs:           nil,
-				NameChange:     nil,
-				BaselineChange: nil,
-				BrowserChanges: nil,
-				Moved:          nil,
-				Split:          nil,
-			},
-			{
-				// Case 8: Moved - No Match
-				Type:        workertypes.SummaryHighlightTypeMoved,
-				FeatureName: "New Cool Name",
-				FeatureID:   "new-cool-name",
-				Moved: &workertypes.Change[workertypes.FeatureRef]{
-					From: workertypes.FeatureRef{ID: "old-name", Name: "Old Name", QueryMatch: ""},
-					To: workertypes.FeatureRef{
-						ID:         "new-cool-name",
-						Name:       "New Cool Name",
-						QueryMatch: workertypes.QueryMatchNoMatch,
-					},
-				},
-				Docs:           nil,
-				NameChange:     nil,
-				BaselineChange: nil,
-				BrowserChanges: nil,
-				Split:          nil,
-			},
-			{
-				// Case 9: Split - Partial Match
-				Type:        workertypes.SummaryHighlightTypeSplit,
-				FeatureName: "Feature To Split",
-				FeatureID:   "feature-to-split",
-				Split: &workertypes.SplitChange{
-					From: workertypes.FeatureRef{ID: "feature-to-split", Name: "Feature To Split", QueryMatch: ""},
-					To: []workertypes.FeatureRef{
-						{ID: "sub-feature-1", Name: "Sub Feature 1", QueryMatch: workertypes.QueryMatchMatch},
-						{ID: "sub-feature-2", Name: "Sub Feature 2", QueryMatch: workertypes.QueryMatchNoMatch},
-					},
-				},
-				Docs:           nil,
-				NameChange:     nil,
-				BaselineChange: nil,
-				BrowserChanges: nil,
-				Moved:          nil,
-			},
-			{
-				// Case 10: Browser Implementation with version and date
-				Type:        workertypes.SummaryHighlightTypeChanged,
-				FeatureName: "new-browser-feature",
-				FeatureID:   "new-browser-feature",
-				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
-					workertypes.BrowserFirefox: {
-						From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnavailable,
-							Version: nil, Date: nil},
-						To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
-							Version: new("123"), Date: &newlyDate},
-					},
-					workertypes.BrowserChrome:         nil,
-					workertypes.BrowserChromeAndroid:  nil,
-					workertypes.BrowserEdge:           nil,
-					workertypes.BrowserFirefoxAndroid: nil,
-					workertypes.BrowserSafari:         nil,
-					workertypes.BrowserSafariIos:      nil,
-				},
-				NameChange:     nil,
-				BaselineChange: nil,
-				Moved:          nil,
-				Split:          nil,
-				Docs:           nil,
-			},
-			{
-				// Case 11: Deleted
-				Type:           workertypes.SummaryHighlightTypeDeleted,
-				FeatureName:    "Deleted Feature",
-				FeatureID:      "deleted-feature",
-				Docs:           nil,
-				NameChange:     nil,
-				BaselineChange: nil,
-				BrowserChanges: nil,
-				Moved:          nil,
-				Split:          nil,
-			},
-			{
-				// Case 12: Removed with details (Baseline + Browser changes)
-				Type:        workertypes.SummaryHighlightTypeRemoved,
-				FeatureName: "Removed With Details",
-				FeatureID:   "removed-details",
-				Docs:        nil,
-				BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
-					From: workertypes.BaselineValue{
-						Status:  workertypes.BaselineStatusNewly,
-						LowDate: &newlyDate, HighDate: nil,
-					},
-					To: workertypes.BaselineValue{
-						Status:   workertypes.BaselineStatusLimited,
-						LowDate:  nil,
-						HighDate: nil,
-					},
-				},
-				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
-					workertypes.BrowserChrome: {
-						From: workertypes.BrowserValue{
-							Status:  workertypes.BrowserStatusAvailable,
-							Version: new("110"),
-							Date:    nil,
-						},
-						To: workertypes.BrowserValue{
-							Status:  workertypes.BrowserStatusUnavailable,
-							Version: nil,
-							Date:    nil,
-						},
-					},
-					workertypes.BrowserEdge:           nil,
-					workertypes.BrowserFirefox:        nil,
-					workertypes.BrowserSafari:         nil,
-					workertypes.BrowserChromeAndroid:  nil,
-					workertypes.BrowserFirefoxAndroid: nil,
-					workertypes.BrowserSafariIos:      nil,
-				},
-				NameChange: nil,
-				Moved:      nil,
-				Split:      nil,
-			},
-			{
-				// Case 13: Browser implementation grouping (Desktop & Mobile)
-				Type:        workertypes.SummaryHighlightTypeChanged,
-				FeatureName: "grouped-browser-feature",
-				FeatureID:   "grouped-browser-feature",
-				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
-					workertypes.BrowserChrome: {
-						From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnknown,
-							Version: nil, Date: nil},
-						To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
-							Version: new("148"), Date: &newlyDate},
-					},
-					workertypes.BrowserChromeAndroid: {
-						From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnknown,
-							Version: nil, Date: nil},
-						To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
-							Version: new("148"), Date: &newlyDate},
-					},
-					workertypes.BrowserEdge:           nil,
-					workertypes.BrowserFirefox:        nil,
-					workertypes.BrowserFirefoxAndroid: nil,
-					workertypes.BrowserSafari:         nil,
-					workertypes.BrowserSafariIos:      nil,
-				},
-				NameChange:     nil,
-				BaselineChange: nil,
-				Moved:          nil,
-				Split:          nil,
-				Docs:           nil,
-			},
-			{
-				// Case 14: Browser implementation NOT grouping (Different Versions)
-				Type:        workertypes.SummaryHighlightTypeChanged,
-				FeatureName: "ungrouped-browser-feature",
-				FeatureID:   "ungrouped-browser-feature",
-				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
-					workertypes.BrowserChrome:         nil,
-					workertypes.BrowserChromeAndroid:  nil,
-					workertypes.BrowserEdge:           nil,
-					workertypes.BrowserFirefox:        nil,
-					workertypes.BrowserFirefoxAndroid: nil,
-					workertypes.BrowserSafari: {
-						From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnknown,
-							Version: nil, Date: nil},
-						To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
-							Version: new("17.0"), Date: &newlyDate},
-					},
-					workertypes.BrowserSafariIos: {
-						From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnknown,
-							Version: nil, Date: nil},
-						To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
-							Version: new("17.2"), Date: &newlyDate},
-					},
-				},
-				NameChange:     nil,
-				BaselineChange: nil,
-				Moved:          nil,
-				Split:          nil,
-				Docs:           nil,
-			},
+			Docs:           nil,
+			NameChange:     nil,
+			BrowserChanges: nil,
+			Moved:          nil,
+			Split:          nil,
 		},
+		{
+			// Case 3: Baseline Regression
+			Type:        workertypes.SummaryHighlightTypeChanged,
+			FeatureName: "Regressed Feature",
+			FeatureID:   "regressed-feature",
+			BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
+				From: workertypes.BaselineValue{Status: workertypes.BaselineStatusWidely,
+					LowDate: &newlyDate, HighDate: &widelyDate},
+				To: workertypes.BaselineValue{Status: workertypes.BaselineStatusLimited,
+					LowDate: nil, HighDate: nil},
+			},
+			BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+				workertypes.BrowserChrome: {
+					From: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
+						Version: new("120"), Date: nil},
+					To: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnavailable, Version: nil,
+						Date: nil},
+				},
+				workertypes.BrowserFirefox:        nil,
+				workertypes.BrowserChromeAndroid:  nil,
+				workertypes.BrowserEdge:           nil,
+				workertypes.BrowserFirefoxAndroid: nil,
+				workertypes.BrowserSafari:         nil,
+				workertypes.BrowserSafariIos:      nil,
+			},
+			Docs:       nil,
+			NameChange: nil,
+			Moved:      nil,
+			Split:      nil,
+		},
+		{
+			// Case 4: Browser Implementation with version
+			Type:        workertypes.SummaryHighlightTypeChanged,
+			FeatureName: "content-visibility",
+			FeatureID:   "content-visibility",
+			BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+				workertypes.BrowserSafariIos: {
+					From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnavailable, Version: nil,
+						Date: nil},
+					To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
+						Version: new("17.2"),
+						// Purposefully set to nil to test that it doesn't crash.
+						Date: nil},
+				},
+				workertypes.BrowserChrome:         nil,
+				workertypes.BrowserChromeAndroid:  nil,
+				workertypes.BrowserEdge:           nil,
+				workertypes.BrowserFirefoxAndroid: nil,
+				workertypes.BrowserSafari:         nil,
+				workertypes.BrowserFirefox:        nil,
+			},
+			Docs:           nil,
+			NameChange:     nil,
+			BaselineChange: nil,
+			Moved:          nil,
+			Split:          nil,
+		},
+		{
+			// Case 5: Browser Implementation with date
+			Type:        workertypes.SummaryHighlightTypeChanged,
+			FeatureName: "another-feature",
+			FeatureID:   "another-feature",
+			BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+				workertypes.BrowserChrome: {
+					From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnavailable,
+						Date: nil, Version: nil},
+					To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable, Date: &newlyDate,
+						// Purposefully set to nil so that we can see that it doesn't crash.
+						Version: nil},
+				},
+				workertypes.BrowserFirefox:        nil,
+				workertypes.BrowserChromeAndroid:  nil,
+				workertypes.BrowserEdge:           nil,
+				workertypes.BrowserFirefoxAndroid: nil,
+				workertypes.BrowserSafari:         nil,
+				workertypes.BrowserSafariIos:      nil,
+			},
+			Docs:           nil,
+			NameChange:     nil,
+			BaselineChange: nil,
+			Moved:          nil,
+			Split:          nil,
+		},
+		{
+			// Case 6: Added
+			Type:           workertypes.SummaryHighlightTypeAdded,
+			FeatureName:    "New Feature",
+			FeatureID:      "new-feature",
+			Docs:           nil,
+			NameChange:     nil,
+			BaselineChange: nil,
+			BrowserChanges: nil,
+			Moved:          nil,
+			Split:          nil,
+		},
+		{
+			// Case 6b: Another Added
+			Type:           workertypes.SummaryHighlightTypeAdded,
+			FeatureName:    "Another New Feature",
+			FeatureID:      "another-new-feature",
+			Docs:           nil,
+			NameChange:     nil,
+			BaselineChange: nil,
+			BrowserChanges: nil,
+			Moved:          nil,
+			Split:          nil,
+		},
+		{
+			// Case 7: Removed
+			Type:           workertypes.SummaryHighlightTypeRemoved,
+			FeatureName:    "Removed Feature",
+			FeatureID:      "removed-feature",
+			Docs:           nil,
+			NameChange:     nil,
+			BaselineChange: nil,
+			BrowserChanges: nil,
+			Moved:          nil,
+			Split:          nil,
+		},
+		{
+			// Case 8: Moved - No Match
+			Type:        workertypes.SummaryHighlightTypeMoved,
+			FeatureName: "New Cool Name",
+			FeatureID:   "new-cool-name",
+			Moved: &workertypes.Change[workertypes.FeatureRef]{
+				From: workertypes.FeatureRef{ID: "old-name", Name: "Old Name", QueryMatch: ""},
+				To: workertypes.FeatureRef{
+					ID:         "new-cool-name",
+					Name:       "New Cool Name",
+					QueryMatch: workertypes.QueryMatchNoMatch,
+				},
+			},
+			Docs:           nil,
+			NameChange:     nil,
+			BaselineChange: nil,
+			BrowserChanges: nil,
+			Split:          nil,
+		},
+		{
+			// Case 9: Split - Partial Match
+			Type:        workertypes.SummaryHighlightTypeSplit,
+			FeatureName: "Feature To Split",
+			FeatureID:   "feature-to-split",
+			Split: &workertypes.SplitChange{
+				From: workertypes.FeatureRef{ID: "feature-to-split", Name: "Feature To Split", QueryMatch: ""},
+				To: []workertypes.FeatureRef{
+					{ID: "sub-feature-1", Name: "Sub Feature 1", QueryMatch: workertypes.QueryMatchMatch},
+					{ID: "sub-feature-2", Name: "Sub Feature 2", QueryMatch: workertypes.QueryMatchNoMatch},
+				},
+			},
+			Docs:           nil,
+			NameChange:     nil,
+			BaselineChange: nil,
+			BrowserChanges: nil,
+			Moved:          nil,
+		},
+		{
+			// Case 10: Browser Implementation with version and date
+			Type:        workertypes.SummaryHighlightTypeChanged,
+			FeatureName: "new-browser-feature",
+			FeatureID:   "new-browser-feature",
+			BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+				workertypes.BrowserFirefox: {
+					From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnavailable,
+						Version: nil, Date: nil},
+					To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
+						Version: new("123"), Date: &newlyDate},
+				},
+				workertypes.BrowserChrome:         nil,
+				workertypes.BrowserChromeAndroid:  nil,
+				workertypes.BrowserEdge:           nil,
+				workertypes.BrowserFirefoxAndroid: nil,
+				workertypes.BrowserSafari:         nil,
+				workertypes.BrowserSafariIos:      nil,
+			},
+			NameChange:     nil,
+			BaselineChange: nil,
+			Moved:          nil,
+			Split:          nil,
+			Docs:           nil,
+		},
+		{
+			// Case 11: Deleted
+			Type:           workertypes.SummaryHighlightTypeDeleted,
+			FeatureName:    "Deleted Feature",
+			FeatureID:      "deleted-feature",
+			Docs:           nil,
+			NameChange:     nil,
+			BaselineChange: nil,
+			BrowserChanges: nil,
+			Moved:          nil,
+			Split:          nil,
+		},
+		{
+			// Case 12: Removed with details (Baseline + Browser changes)
+			Type:        workertypes.SummaryHighlightTypeRemoved,
+			FeatureName: "Removed With Details",
+			FeatureID:   "removed-details",
+			Docs:        nil,
+			BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
+				From: workertypes.BaselineValue{
+					Status:  workertypes.BaselineStatusNewly,
+					LowDate: &newlyDate, HighDate: nil,
+				},
+				To: workertypes.BaselineValue{
+					Status:   workertypes.BaselineStatusLimited,
+					LowDate:  nil,
+					HighDate: nil,
+				},
+			},
+			BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+				workertypes.BrowserChrome: {
+					From: workertypes.BrowserValue{
+						Status:  workertypes.BrowserStatusAvailable,
+						Version: new("110"),
+						Date:    nil,
+					},
+					To: workertypes.BrowserValue{
+						Status:  workertypes.BrowserStatusUnavailable,
+						Version: nil,
+						Date:    nil,
+					},
+				},
+				workertypes.BrowserEdge:           nil,
+				workertypes.BrowserFirefox:        nil,
+				workertypes.BrowserSafari:         nil,
+				workertypes.BrowserChromeAndroid:  nil,
+				workertypes.BrowserFirefoxAndroid: nil,
+				workertypes.BrowserSafariIos:      nil,
+			},
+			NameChange: nil,
+			Moved:      nil,
+			Split:      nil,
+		},
+		{
+			// Case 13: Browser implementation grouping (Desktop & Mobile)
+			Type:        workertypes.SummaryHighlightTypeChanged,
+			FeatureName: "grouped-browser-feature",
+			FeatureID:   "grouped-browser-feature",
+			BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+				workertypes.BrowserChrome: {
+					From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnknown,
+						Version: nil, Date: nil},
+					To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
+						Version: new("148"), Date: &newlyDate},
+				},
+				workertypes.BrowserChromeAndroid: {
+					From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnknown,
+						Version: nil, Date: nil},
+					To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
+						Version: new("148"), Date: &newlyDate},
+				},
+				workertypes.BrowserEdge:           nil,
+				workertypes.BrowserFirefox:        nil,
+				workertypes.BrowserFirefoxAndroid: nil,
+				workertypes.BrowserSafari:         nil,
+				workertypes.BrowserSafariIos:      nil,
+			},
+			NameChange:     nil,
+			BaselineChange: nil,
+			Moved:          nil,
+			Split:          nil,
+			Docs:           nil,
+		},
+		{
+			// Case 14: Browser implementation NOT grouping (Different Versions)
+			Type:        workertypes.SummaryHighlightTypeChanged,
+			FeatureName: "ungrouped-browser-feature",
+			FeatureID:   "ungrouped-browser-feature",
+			BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+				workertypes.BrowserChrome:         nil,
+				workertypes.BrowserChromeAndroid:  nil,
+				workertypes.BrowserEdge:           nil,
+				workertypes.BrowserFirefox:        nil,
+				workertypes.BrowserFirefoxAndroid: nil,
+				workertypes.BrowserSafari: {
+					From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnknown,
+						Version: nil, Date: nil},
+					To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
+						Version: new("17.0"), Date: &newlyDate},
+				},
+				workertypes.BrowserSafariIos: {
+					From: workertypes.BrowserValue{Status: workertypes.BrowserStatusUnknown,
+						Version: nil, Date: nil},
+					To: workertypes.BrowserValue{Status: workertypes.BrowserStatusAvailable,
+						Version: new("17.2"), Date: &newlyDate},
+				},
+			},
+			NameChange:     nil,
+			BaselineChange: nil,
+			Moved:          nil,
+			Split:          nil,
+			Docs:           nil,
+		},
+	}
+	for _, h := range highlights {
+		summary.AddHighlight(h)
 	}
 	summaryBytes, _ := json.Marshal(summary)
 
@@ -447,30 +446,15 @@ func TestRenderDigest_Golden(t *testing.T) {
 	}
 }
 
-func TestRenderDigest_QueryError_Golden(t *testing.T) {
-	summary := workertypes.EventSummary{
-		SchemaVersion:  "v1",
-		Text:           "Query failed",
-		SnapshotOrigin: workertypes.OriginFallbackPrevious,
-		Categories: workertypes.SummaryCategories{
-			QueryChanged:    0,
-			Added:           0,
-			Removed:         0,
-			Deleted:         0,
-			Moved:           0,
-			Split:           0,
-			Updated:         0,
-			UpdatedImpl:     0,
-			UpdatedRename:   0,
-			UpdatedBaseline: 0,
-		},
-		Truncated: false,
-		QueryErrors: []workertypes.SummaryQueryError{
-			{Code: workertypes.SummaryQueryErrorCodeSavedSearchNotFound},
-		},
-		ResolvedQueryErrors: nil,
-		Highlights:          nil,
-	}
+func renderAndVerifyDigestGolden(
+	t *testing.T,
+	summary workertypes.EventSummary,
+	freq workertypes.JobFrequency,
+	eventID string,
+	goldenFilename string,
+) {
+	t.Helper()
+
 	summaryRaw, err := json.Marshal(summary)
 	if err != nil {
 		t.Fatal(err)
@@ -485,8 +469,8 @@ func TestRenderDigest_QueryError_Golden(t *testing.T) {
 			Metadata: workertypes.DeliveryMetadata{
 				SearchName:  "My CSS Search",
 				Query:       "group:css",
-				Frequency:   workertypes.FrequencyWeekly,
-				EventID:     "evt-123",
+				Frequency:   freq,
+				EventID:     eventID,
 				SearchID:    "s-1",
 				GeneratedAt: time.Now(),
 			},
@@ -505,7 +489,7 @@ func TestRenderDigest_QueryError_Golden(t *testing.T) {
 		t.Fatalf("RenderDigest failed: %v", err)
 	}
 
-	goldenFile := filepath.Join("testdata", "digest_query_error.golden.html")
+	goldenFile := filepath.Join("testdata", goldenFilename)
 
 	if *updateGolden {
 		if err := os.MkdirAll("testdata", 0755); err != nil {
@@ -524,6 +508,17 @@ func TestRenderDigest_QueryError_Golden(t *testing.T) {
 	if diff := cmp.Diff(string(expected), body); diff != "" {
 		t.Errorf("HTML mismatch (-want +got):\n%s", diff)
 	}
+}
+
+func TestRenderDigest_QueryError_Golden(t *testing.T) {
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SnapshotOrigin = workertypes.OriginFallbackPrevious
+	summary.Text = "Query failed"
+	summary.SetQueryErrors([]workertypes.SummaryQueryError{
+		{Code: workertypes.SummaryQueryErrorCodeSavedSearchNotFound},
+	})
+
+	renderAndVerifyDigestGolden(t, summary, workertypes.FrequencyWeekly, "evt-123", "digest_query_error.golden.html")
 }
 
 func TestRenderDigest_InvalidJSON(t *testing.T) {
@@ -550,69 +545,434 @@ func TestRenderDigest_InvalidJSON(t *testing.T) {
 }
 
 func TestRenderDigest_ResolvedQueryError_Golden(t *testing.T) {
-	summary := workertypes.EventSummary{
-		SchemaVersion:  "v1",
-		Text:           "Search query recovered and tracking 2 features normally.",
-		SnapshotOrigin: workertypes.OriginLive,
-		Categories:     workertypes.NewEmptySummaryCategories(),
-		Truncated:      false,
-		QueryErrors:    nil,
-		ResolvedQueryErrors: []workertypes.SummaryQueryError{
-			{Code: workertypes.SummaryQueryErrorCodeQueryGrammar},
-		},
-		Highlights: nil,
-	}
-	summaryRaw, err := json.Marshal(summary)
-	if err != nil {
-		t.Fatal(err)
-	}
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SnapshotOrigin = workertypes.OriginLive
+	summary.Text = "Search query recovered and tracking 2 features normally."
+	summary.SetResolvedQueryErrors([]workertypes.SummaryQueryError{
+		{Code: workertypes.SummaryQueryErrorCodeQueryGrammar},
+	})
 
-	job := workertypes.IncomingEmailDeliveryJob{
-		EmailDeliveryJob: workertypes.EmailDeliveryJob{
-			SummaryRaw:     summaryRaw,
-			RecipientEmail: "user@example.com",
-			SubscriptionID: "sub-123",
-			ChannelID:      "chan-1",
-			Metadata: workertypes.DeliveryMetadata{
-				SearchName:  "My CSS Search",
-				Query:       "group:css",
-				Frequency:   workertypes.FrequencyImmediate,
-				EventID:     "evt-recovery",
-				SearchID:    "s-1",
-				GeneratedAt: time.Now(),
+	renderAndVerifyDigestGolden(
+		t,
+		summary,
+		workertypes.FrequencyImmediate,
+		"evt-recovery",
+		"digest_resolved_query_error.golden.html",
+	)
+}
+
+func newTestAddedHighlight(id, name string) workertypes.SummaryHighlight {
+	return workertypes.SummaryHighlight{
+		Type:           workertypes.SummaryHighlightTypeAdded,
+		FeatureID:      id,
+		FeatureName:    name,
+		Docs:           nil,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+		Moved:          nil,
+		Split:          nil,
+	}
+}
+
+func newTestRemovedHighlight(id, name string) workertypes.SummaryHighlight {
+	return workertypes.SummaryHighlight{
+		Type:           workertypes.SummaryHighlightTypeRemoved,
+		FeatureID:      id,
+		FeatureName:    name,
+		Docs:           nil,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+		Moved:          nil,
+		Split:          nil,
+	}
+}
+
+func newTestChangedHighlight(id, name string, status workertypes.BaselineStatus) workertypes.SummaryHighlight {
+	return workertypes.SummaryHighlight{
+		Type:        workertypes.SummaryHighlightTypeChanged,
+		FeatureID:   id,
+		FeatureName: name,
+		Docs:        nil,
+		NameChange:  nil,
+		BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
+			From: workertypes.BaselineValue{
+				Status:   workertypes.BaselineStatusNewly,
+				LowDate:  nil,
+				HighDate: nil,
 			},
-			Triggers: nil,
+			To: workertypes.BaselineValue{
+				Status:   status,
+				LowDate:  nil,
+				HighDate: nil,
+			},
 		},
-		EmailEventID: "email-event-id",
+		BrowserChanges: nil,
+		Moved:          nil,
+		Split:          nil,
+	}
+}
+
+func newTestMovedHighlight(id, name, oldName string) workertypes.SummaryHighlight {
+	return workertypes.SummaryHighlight{
+		Type:           workertypes.SummaryHighlightTypeMoved,
+		FeatureID:      id,
+		FeatureName:    name,
+		Docs:           nil,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+		Moved: &workertypes.Change[workertypes.FeatureRef]{
+			From: workertypes.FeatureRef{ID: "", Name: oldName, QueryMatch: workertypes.QueryMatchNoMatch},
+			To:   workertypes.FeatureRef{ID: id, Name: name, QueryMatch: workertypes.QueryMatchNoMatch},
+		},
+		Split: nil,
+	}
+}
+
+func newTestSplitHighlight(id, name, childName string) workertypes.SummaryHighlight {
+	return workertypes.SummaryHighlight{
+		Type:           workertypes.SummaryHighlightTypeSplit,
+		FeatureID:      id,
+		FeatureName:    name,
+		Docs:           nil,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+		Moved:          nil,
+		Split: &workertypes.SplitChange{
+			From: workertypes.FeatureRef{ID: id, Name: name, QueryMatch: workertypes.QueryMatchNoMatch},
+			To:   []workertypes.FeatureRef{{ID: "c-1", Name: childName, QueryMatch: workertypes.QueryMatchNoMatch}},
+		},
+	}
+}
+
+func newTestDeletedHighlight(id, name string) workertypes.SummaryHighlight {
+	return workertypes.SummaryHighlight{
+		Type:           workertypes.SummaryHighlightTypeDeleted,
+		FeatureID:      id,
+		FeatureName:    name,
+		Docs:           nil,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+		Moved:          nil,
+		Split:          nil,
+	}
+}
+
+// TestRenderDigest_CombinedErrorsAndFeatures verifies the golden HTML layout for the edge case
+// where an event summary contains both query error banners (active/resolved) AND feature change
+// sections simultaneously in the same email notification digest.
+func TestRenderDigest_CombinedErrorsAndFeatures(t *testing.T) {
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SnapshotOrigin = workertypes.OriginLive
+	summary.Text = "Partial errors alongside feature updates"
+	summary.SetQueryErrors([]workertypes.SummaryQueryError{
+		{Code: workertypes.SummaryQueryErrorCodeSavedSearchNotFound},
+	})
+	summary.SetResolvedQueryErrors([]workertypes.SummaryQueryError{
+		{Code: workertypes.SummaryQueryErrorCodeQueryGrammar},
+	})
+	summary.AddHighlight(newTestAddedHighlight("f-added", "Subgrid"))
+
+	renderAndVerifyDigestGolden(
+		t,
+		summary,
+		workertypes.FrequencyWeekly,
+		"evt-combined",
+		"digest_combined_errors_and_features.golden.html",
+	)
+}
+
+func createTestIncomingJob(
+	t *testing.T,
+	summary workertypes.EventSummary,
+	triggers []workertypes.JobTrigger,
+	eventID string,
+) workertypes.IncomingEmailDeliveryJob {
+	raw, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("failed to marshal summary: %v", err)
 	}
 
-	renderer, err := NewHTMLRenderer("http://localhost:5555")
-	if err != nil {
-		t.Fatalf("NewHTMLRenderer failed: %v", err)
+	return workertypes.IncomingEmailDeliveryJob{
+		EmailDeliveryJob: workertypes.EmailDeliveryJob{
+			SubscriptionID: "sub-1",
+			RecipientEmail: "user@example.com",
+			ChannelID:      "chan-1",
+			Triggers:       triggers,
+			SummaryRaw:     raw,
+			Metadata: workertypes.DeliveryMetadata{
+				EventID:     eventID,
+				SearchID:    "search-1",
+				Query:       "feature:a",
+				GeneratedAt: time.Time{},
+				Frequency:   workertypes.FrequencyWeekly,
+				SearchName:  "Search A",
+			},
+		},
+		EmailEventID: eventID,
 	}
+}
+
+func TestEmailVisitor_FeatureCategories(t *testing.T) {
+	renderer, err := NewHTMLRenderer("https://test.dev")
+	if err != nil {
+		t.Fatalf("NewHTMLRenderer unexpected error: %v", err)
+	}
+
+	testCases := []struct {
+		name      string
+		highlight workertypes.SummaryHighlight
+		wantText  string
+	}{
+		{
+			name:      "Added feature",
+			highlight: newTestAddedHighlight("f-add", "Added Feature"),
+			wantText:  "Added Feature",
+		},
+		{
+			name:      "Removed feature",
+			highlight: newTestRemovedHighlight("f-rem", "Removed Feature"),
+			wantText:  "Removed Feature",
+		},
+		{
+			name:      "Changed feature",
+			highlight: newTestChangedHighlight("f-chg", "Changed Feature", workertypes.BaselineStatusNewly),
+			wantText:  "Changed Feature",
+		},
+		{
+			name:      "Moved feature",
+			highlight: newTestMovedHighlight("f-mvd", "Moved Feature", "Old Name"),
+			wantText:  "Moved Feature",
+		},
+		{
+			name:      "Split feature",
+			highlight: newTestSplitHighlight("f-splt", "Split Feature", "Child Feature"),
+			wantText:  "Split Feature",
+		},
+		{
+			name:      "Deleted feature",
+			highlight: newTestDeletedHighlight("f-del", "Deleted Feature"),
+			wantText:  "Deleted Feature",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			summary := workertypes.NewEmptyEventSummary()
+			summary.SnapshotOrigin = workertypes.OriginLive
+			summary.Text = "Digest Summary"
+			summary.AddHighlight(tc.highlight)
+
+			job := createTestIncomingJob(t, summary, nil, "evt-1")
+
+			_, body, err := renderer.RenderDigest(job)
+			if err != nil {
+				t.Fatalf("RenderDigest unexpected error: %v", err)
+			}
+
+			if !bytes.Contains([]byte(body), []byte(tc.wantText)) {
+				t.Errorf("rendered body does not contain expected text %q", tc.wantText)
+			}
+		})
+	}
+}
+
+func TestEmailVisitor_QueryErrors_RenderMessage(t *testing.T) {
+	renderer, err := NewHTMLRenderer("https://test.dev")
+	if err != nil {
+		t.Fatalf("NewHTMLRenderer unexpected error: %v", err)
+	}
+
+	testCases := []struct {
+		name        string
+		errorCode   workertypes.SummaryQueryErrorCode
+		wantMessage string
+	}{
+		{
+			name:        "QueryGrammar error",
+			errorCode:   workertypes.SummaryQueryErrorCodeQueryGrammar,
+			wantMessage: "Invalid query grammar",
+		},
+		{
+			name:        "SavedSearchNotFound error",
+			errorCode:   workertypes.SummaryQueryErrorCodeSavedSearchNotFound,
+			wantMessage: "Saved search not found",
+		},
+		{
+			name:        "MaxDepthExceeded error",
+			errorCode:   workertypes.SummaryQueryErrorCodeMaxDepthExceeded,
+			wantMessage: "Saved search max depth exceeded",
+		},
+		{
+			name:        "InvalidQuery error",
+			errorCode:   workertypes.SummaryQueryErrorCodeInvalidQuery,
+			wantMessage: "Invalid query",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			summary := workertypes.NewEmptyEventSummary()
+			summary.SetQueryErrors([]workertypes.SummaryQueryError{{Code: tc.errorCode}})
+
+			job := createTestIncomingJob(t, summary, nil, "evt-err")
+
+			_, body, err := renderer.RenderDigest(job)
+			if err != nil {
+				t.Fatalf("RenderDigest unexpected error: %v", err)
+			}
+
+			if !bytes.Contains([]byte(body), []byte(tc.wantMessage)) {
+				t.Errorf("rendered body missing translated query error message %q", tc.wantMessage)
+			}
+		})
+	}
+}
+
+func TestEmailVisitor_QueryErrors(t *testing.T) {
+	renderer, err := NewHTMLRenderer("https://test.dev")
+	if err != nil {
+		t.Fatalf("NewHTMLRenderer unexpected error: %v", err)
+	}
+
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SetQueryErrors([]workertypes.SummaryQueryError{
+		{Code: workertypes.SummaryQueryErrorCodeSavedSearchNotFound},
+	})
+
+	job := createTestIncomingJob(t, summary, nil, "evt-err")
 
 	_, body, err := renderer.RenderDigest(job)
 	if err != nil {
-		t.Fatalf("RenderDigest failed: %v", err)
+		t.Fatalf("RenderDigest unexpected error: %v", err)
 	}
 
-	goldenFile := filepath.Join("testdata", "digest_resolved_query_error.golden.html")
-
-	if *updateGolden {
-		if err := os.MkdirAll("testdata", 0755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(goldenFile, []byte(body), 0600); err != nil {
-			t.Fatal(err)
-		}
+	if !bytes.Contains([]byte(body), []byte("Saved search not found")) {
+		t.Error("rendered body missing translated query error message")
 	}
+}
 
-	expected, err := os.ReadFile(goldenFile)
+func TestEmailVisitor_ResolvedQueryErrors(t *testing.T) {
+	renderer, err := NewHTMLRenderer("https://test.dev")
 	if err != nil {
-		t.Fatalf("failed to read golden file: %v", err)
+		t.Fatalf("NewHTMLRenderer unexpected error: %v", err)
 	}
 
-	if diff := cmp.Diff(string(expected), body); diff != "" {
-		t.Errorf("HTML mismatch (-want +got):\n%s", diff)
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SetResolvedQueryErrors([]workertypes.SummaryQueryError{
+		{Code: workertypes.SummaryQueryErrorCodeQueryGrammar},
+	})
+
+	job := createTestIncomingJob(t, summary, nil, "evt-rec")
+
+	_, body, err := renderer.RenderDigest(job)
+	if err != nil {
+		t.Fatalf("RenderDigest unexpected error: %v", err)
+	}
+
+	if !bytes.Contains([]byte(body), []byte("Invalid query grammar")) {
+		t.Error("rendered body missing resolved query recovery message")
+	}
+}
+
+func TestEmailVisitor_TriggerFiltering(t *testing.T) {
+	renderer, err := NewHTMLRenderer("https://test.dev")
+	if err != nil {
+		t.Fatalf("NewHTMLRenderer unexpected error: %v", err)
+	}
+
+	summary := workertypes.NewEmptyEventSummary()
+	summary.AddHighlight(newTestChangedHighlight("f-widely", "Widely Available Feature", workertypes.BaselineStatusWidely))
+
+	// Job triggers only ask for FeaturePromotedToNewly
+	job := createTestIncomingJob(t, summary, []workertypes.JobTrigger{workertypes.FeaturePromotedToNewly}, "evt-filtered")
+
+	_, body, err := renderer.RenderDigest(job)
+	if err != nil {
+		t.Fatalf("RenderDigest unexpected error: %v", err)
+	}
+
+	if bytes.Contains([]byte(body), []byte("Widely Available Feature")) {
+		t.Error("rendered body should not contain feature filtered out by subscriber triggers")
+	}
+}
+
+func TestEmailVisitor_NilPointerGuards(t *testing.T) {
+	renderer, err := NewHTMLRenderer("https://test.dev")
+	if err != nil {
+		t.Fatalf("NewHTMLRenderer unexpected error: %v", err)
+	}
+
+	summary := workertypes.NewEmptyEventSummary()
+	summary.AddHighlight(newTestMovedHighlight("f-mvd-nil", "Nil Moved Feature", ""))
+	summary.AddHighlight(newTestSplitHighlight("f-splt-nil", "Nil Split Feature", ""))
+	summary.AddHighlight(newTestAddedHighlight("f-valid", "Valid Added Feature"))
+
+	job := createTestIncomingJob(t, summary, nil, "evt-nil")
+
+	_, body, err := renderer.RenderDigest(job)
+	if err != nil {
+		t.Fatalf("RenderDigest unexpected error on nil pointer highlights: %v", err)
+	}
+
+	if !bytes.Contains([]byte(body), []byte("Valid Added Feature")) {
+		t.Error("rendered body missing Valid Added Feature")
+	}
+}
+
+func TestEmailVisitor_HTMLEscaping(t *testing.T) {
+	renderer, err := NewHTMLRenderer("https://test.dev")
+	if err != nil {
+		t.Fatalf("NewHTMLRenderer unexpected error: %v", err)
+	}
+
+	summary := workertypes.NewEmptyEventSummary()
+	summary.AddHighlight(newTestAddedHighlight("f-xss", "<script>alert('xss')</script>"))
+
+	job := createTestIncomingJob(t, summary, nil, "evt-xss")
+
+	_, body, err := renderer.RenderDigest(job)
+	if err != nil {
+		t.Fatalf("RenderDigest unexpected error: %v", err)
+	}
+
+	if bytes.Contains([]byte(body), []byte("<script>")) {
+		t.Error("rendered body contains unescaped <script> tag")
+	}
+	if !bytes.Contains([]byte(body), []byte("&lt;script&gt;")) {
+		t.Error("rendered body missing properly HTML-escaped &lt;script&gt;")
+	}
+}
+
+func TestEmailVisitor_TransportPayloadVerification(t *testing.T) {
+	renderer, err := NewHTMLRenderer("https://test.dev")
+	if err != nil {
+		t.Fatalf("NewHTMLRenderer unexpected error: %v", err)
+	}
+
+	summary := workertypes.NewEmptyEventSummary()
+	summary.AddHighlight(newTestAddedHighlight("f-transport-1", "Transport Feature One"))
+	summary.AddHighlight(newTestAddedHighlight("f-transport-2", "Transport Feature Two"))
+
+	job := createTestIncomingJob(t, summary, nil, "evt-transport")
+
+	subject, body, err := renderer.RenderDigest(job)
+	if err != nil {
+		t.Fatalf("RenderDigest unexpected error: %v", err)
+	}
+
+	expectedSubject := "Weekly digest: Search A"
+	if subject != expectedSubject {
+		t.Errorf("subject mismatch: got %q, want %q", subject, expectedSubject)
+	}
+
+	hasOne := bytes.Contains([]byte(body), []byte("Transport Feature One"))
+	hasTwo := bytes.Contains([]byte(body), []byte("Transport Feature Two"))
+	if !hasOne || !hasTwo {
+		t.Error("rendered HTML body missing transport feature names")
 	}
 }

--- a/workers/email/pkg/digest/testdata/digest_combined_errors_and_features.golden.html
+++ b/workers/email/pkg/digest/testdata/digest_combined_errors_and_features.golden.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Weekly digest: My CSS Search</title>
+</head>
+<body style='font-family: SF Pro, system-ui, sans-serif;; line-height: 1.5; color: #333; margin: 0; padding: 0;'>
+    <div style='max-width: 600px; margin: 0 auto; padding: 20px;'><div style='width: auto; padding: 16px; background: #F4F4F5; border-radius: 4px; display: block; margin-bottom: 4px;'>
+    <h2 style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 21px; word-wrap: break-word;; margin-top: 0; margin-bottom: 0; padding-bottom: 8px; font-weight: 700; font-size: 18px;'>Weekly digest: My CSS Search</h2>
+    <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; line-height: 21px; word-wrap: break-word;; margin-top: 0; margin-bottom: 0; align-self: stretch;'>
+        Here is your update for the saved search <strong style='font-weight: bold;'>'My CSS Search'</strong>.
+        Partial errors alongside feature updates.
+    </div>
+</div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;background: #E6F4EA;'>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <tr>
+            <td align="left" valign="middle" style="padding: 12px;">
+                <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>✅ Query Recovered:</span>
+                <span style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'> Tracking resumed cleanly from your baseline. Resolved issue: Invalid query grammar</span>
+            </td>
+        </tr>
+    </table>
+</div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; height: 50px; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;background: #FEF3C7;'>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+        <tr>
+            <td align="left" valign="middle" style="padding: 12px;">
+                <span style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;; font-style: italic; margin-top: 4px; display: block;'>⚠️ Saved search not found</span>
+            </td>
+        </tr>
+    </table>
+</div></div><div style='width: 100%; padding-top: 8px; padding-bottom: 8px; display: block;'><div style='width: auto; padding-top: 12px; padding-bottom: 11px; padding-left: 15px; padding-right: 16px; overflow: hidden; border-top-left-radius: 4px; border-top-right-radius: 4px; display: block; margin-bottom: 0;; background:#E6F4EA;'>
+    <div style='display: block;'>
+        <div style='color: #18181B;; font-size: 14px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 700;; word-wrap: break-word;'>Added</div><div style='color: #52525B;; font-size: 12px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; word-wrap: break-word;'>These features now match your search criteria.</div></div>
+</div><div style='width: auto; padding-top: 12px; padding-bottom: 15px; padding-left: 15px; padding-right: 15px; overflow: hidden; border-bottom-right-radius: 4px; border-bottom-left-radius: 4px; border-left: 1px solid #E4E4E7; border-right: 1px solid #E4E4E7; border-bottom: 1px solid #E4E4E7; display: block; background: #FFFFFF; margin-top: 0;'><table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt;">
+    <tr>
+        <td align="left" valign="top">
+            <a href="http://localhost:5555/features/f-added" style='color: #18181B;; font-size: 16px;font-family: SF Pro, system-ui, sans-serif;;font-weight: 400;; text-decoration: underline; line-height: 30.40px; word-wrap: break-word;'>Subgrid</a></td></tr>
+</table></div></div><div style='width: 100%; padding-top: 16px; display: block;font-family: SF Pro, system-ui, sans-serif;;'>
+    <div style='width: 100%; height: 1px; background: #E4E4E7; margin-bottom: 12px;'></div>
+    <div style='display: block;'>
+        <span style='color: #52525B;; font-size: 11px;font-weight: 400;; word-wrap: break-word;'>You can </span>
+        <a href="http://localhost:5555/settings/subscriptions?unsubscribe=sub-123" style='color: #52525B;; font-size: 11px;font-weight: 400;; text-decoration: underline; word-wrap: break-word;'>unsubscribe</a>
+        <span style='color: #52525B;; font-size: 11px;font-weight: 400;; word-wrap: break-word;'> or change any of your alerts on </span>
+        <a href="http://localhost:5555/settings/subscriptions" style='color: #52525B;; font-size: 11px;font-weight: 400;; text-decoration: underline; word-wrap: break-word;'>webstatus.dev</a>
+    </div>
+</div></div>
+</body>
+</html>


### PR DESCRIPTION
Migrates the email digest template generator to the CategorizedSummaryVisitor interface for double-dispatch rendering.

- Implements CategorizedSummaryVisitor on templateDataGenerator in workers/email/pkg/digest.
- Wires trigger filtering and highlight categorization through EventSummary.Accept().
- Adds TestEmailVisitor_FeatureCategories, TestEmailVisitor_QueryErrors_RenderMessage, TestEmailVisitor_TriggerFiltering, TestEmailVisitor_NilPointerGuards, TestEmailVisitor_HTMLEscaping, and TestEmailVisitor_TransportPayloadVerification unit tests.
- Adds digest_combined_errors_and_features.golden.html golden snapshot file and test.

Fixes #2622 (PR 3/5)

CONV=f70d8c59-6f49-4a69-bb74-5643e908f5b1
TAG=agy