### PR TITLE
feat(webhook): migrate Slack webhook payload builder to CategorizedSummaryVisitor (#2622)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,6 +18,7 @@ workers/email/pkg/digest/testdata/digest_combined_errors_and_features.golden.htm
 workers/webhook/pkg/webhook/testdata/slack_payload.golden.json
 workers/webhook/pkg/webhook/testdata/slack_payload_query_error.golden.json
 workers/webhook/pkg/webhook/testdata/slack_payload_resolved_query_error.golden.json
+workers/webhook/pkg/webhook/testdata/slack_payload_combined_errors_and_features.golden.json
 workflows/steps/services/bcd_consumer/pkg/data/testdata/data.json
 workflows/steps/services/web_feature_consumer/pkg/data/testdata/v3.data.json
 workflows/steps/services/developer_signals_consumer/pkg/data/testdata/web-features-signals.json

--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,11 @@ ADDLICENSE_ARGS := -c "${COPYRIGHT_NAME}" \
 	-ignore 'backend/pkg/httpserver/testdata/rss_description.golden.html' \
 	-ignore 'backend/pkg/httpserver/testdata/rss_query_error.golden.html' \
 	-ignore 'backend/pkg/httpserver/testdata/rss_resolved_query_error.golden.html' \
-	-ignore 'backend/pkg/httpserver/testdata/rss_combined_errors_and_features.golden.html'
+	-ignore 'backend/pkg/httpserver/testdata/rss_combined_errors_and_features.golden.html' \
+	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload.golden.json' \
+	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload_query_error.golden.json' \
+	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload_resolved_query_error.golden.json' \
+	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload_combined_errors_and_features.golden.json'
 
 license-check: go-install-tools
 	go tool addlicense -check $(ADDLICENSE_ARGS) .

--- a/workers/webhook/pkg/webhook/slack.go
+++ b/workers/webhook/pkg/webhook/slack.go
@@ -181,42 +181,67 @@ type browserChangeData struct {
 	Type        workertypes.SummaryHighlightType
 }
 
+// VisitV1 initializes summary data and delegates trigger filtering and category routing
+// to BaseSummaryVisitor via summary.Accept().
 func (b *slackPayloadBuilder) VisitV1(summary workertypes.EventSummary) error {
 	b.summary = summary
-	b.queryErrors = summary.QueryErrors
-	b.resolvedQueryErrors = summary.ResolvedQueryErrors
 
-	filtered := workertypes.FilterHighlights(summary.Highlights, b.triggers)
-	if len(filtered) != 0 {
-		summary.Highlights = filtered
-	}
+	return summary.Accept(b, b.triggers)
+}
 
-	for _, h := range summary.Highlights {
-		b.processHighlight(h)
+// The following Visit... methods implement workertypes.CategorizedSummaryVisitor.
+// They are dispatched by BaseSummaryVisitor during summary.Accept().
+
+// VisitQueryErrors receives active query errors and populates b.queryErrors.
+func (b *slackPayloadBuilder) VisitQueryErrors(errs []workertypes.SummaryQueryError) error {
+	b.queryErrors = errs
+
+	return nil
+}
+
+// VisitResolvedQueryErrors receives resolved query errors and populates b.resolvedQueryErrors.
+func (b *slackPayloadBuilder) VisitResolvedQueryErrors(errs []workertypes.SummaryQueryError) error {
+	b.resolvedQueryErrors = errs
+
+	return nil
+}
+
+func (b *slackPayloadBuilder) VisitAddedFeatures(features []workertypes.SummaryHighlight) error {
+	b.addedFeatures = features
+
+	return nil
+}
+
+func (b *slackPayloadBuilder) VisitRemovedFeatures(features []workertypes.SummaryHighlight) error {
+	b.removedFeatures = features
+
+	return nil
+}
+
+func (b *slackPayloadBuilder) VisitChangedFeatures(features []workertypes.SummaryHighlight) error {
+	for _, h := range features {
+		b.processChangedData(h)
 	}
 
 	return nil
 }
 
-func (b *slackPayloadBuilder) processHighlight(highlight workertypes.SummaryHighlight) {
-	switch highlight.Type {
-	case workertypes.SummaryHighlightTypeMoved:
-		b.movedFeatures = append(b.movedFeatures, highlight)
-	case workertypes.SummaryHighlightTypeSplit:
-		b.splitFeatures = append(b.splitFeatures, highlight)
-	case workertypes.SummaryHighlightTypeAdded:
-		b.addedFeatures = append(b.addedFeatures, highlight)
-	case workertypes.SummaryHighlightTypeRemoved:
-		if highlight.BaselineChange != nil || len(highlight.BrowserChanges) > 0 {
-			b.processChangedData(highlight)
-		} else {
-			b.removedFeatures = append(b.removedFeatures, highlight)
-		}
-	case workertypes.SummaryHighlightTypeDeleted:
-		b.deletedFeatures = append(b.deletedFeatures, highlight)
-	case workertypes.SummaryHighlightTypeChanged:
-		b.processChangedData(highlight)
-	}
+func (b *slackPayloadBuilder) VisitMovedFeatures(features []workertypes.SummaryHighlight) error {
+	b.movedFeatures = features
+
+	return nil
+}
+
+func (b *slackPayloadBuilder) VisitSplitFeatures(features []workertypes.SummaryHighlight) error {
+	b.splitFeatures = features
+
+	return nil
+}
+
+func (b *slackPayloadBuilder) VisitDeletedFeatures(features []workertypes.SummaryHighlight) error {
+	b.deletedFeatures = features
+
+	return nil
 }
 
 func (b *slackPayloadBuilder) processChangedData(highlight workertypes.SummaryHighlight) {
@@ -267,8 +292,10 @@ func (b *slackPayloadBuilder) buildPayload(searchName string) SlackPayload {
 	blocks = b.appendRegressions(blocks)
 	blocks = b.appendBrowserChanges(blocks)
 	blocks = b.appendAddedFeatures(blocks)
+	blocks = b.appendRemovedFeatures(blocks)
 	blocks = b.appendSplitFeatures(blocks)
 	blocks = b.appendMovedFeatures(blocks)
+	blocks = b.appendDeletedFeatures(blocks)
 
 	unsubscribeURL := fmt.Sprintf("%s/settings/subscriptions", b.frontendBaseURL)
 	if b.subscriptionID != "" {
@@ -400,8 +427,12 @@ func (b *slackPayloadBuilder) processBrowserChange(items []string, c browserChan
 		}
 		items = append(items, txt)
 	case workertypes.BrowserStatusUnavailable:
-		txt := fmt.Sprintf("• %s: Available in %s → *Unavailable* (<%s|%s>)",
-			formatBrowserName(c.Browser), *c.Change.From.Version, featureURL, c.FeatureName)
+		fromVersionStr := ""
+		if c.Change.From.Version != nil {
+			fromVersionStr = fmt.Sprintf(" in %s", *c.Change.From.Version)
+		}
+		txt := fmt.Sprintf("• %s: Available%s → *Unavailable* (<%s|%s>)",
+			formatBrowserName(c.Browser), fromVersionStr, featureURL, c.FeatureName)
 		if c.Type == workertypes.SummaryHighlightTypeRemoved {
 			txt += "\n:warning: _This feature no longer matches your saved search._"
 		}
@@ -433,6 +464,9 @@ func (b *slackPayloadBuilder) appendSplitFeatures(blocks []any) []any {
 	if len(b.splitFeatures) > 0 {
 		blocks = append(blocks, dividerBlock())
 		for _, h := range b.splitFeatures {
+			if h.Split == nil {
+				continue
+			}
 			items := make([]string, 0, len(h.Split.To))
 			for _, sub := range h.Split.To {
 				noLongerStr := ""
@@ -462,6 +496,9 @@ func (b *slackPayloadBuilder) appendMovedFeatures(blocks []any) []any {
 	if len(b.movedFeatures) > 0 {
 		blocks = append(blocks, dividerBlock())
 		for _, h := range b.movedFeatures {
+			if h.Moved == nil {
+				continue
+			}
 			featureURL := fmt.Sprintf("%s/features/%s", b.frontendBaseURL, h.FeatureID)
 			noLongerStr := ""
 			if h.Moved.To.QueryMatch == workertypes.QueryMatchNoMatch {
@@ -474,6 +511,43 @@ func (b *slackPayloadBuilder) appendMovedFeatures(blocks []any) []any {
 	}
 
 	return blocks
+}
+
+func (b *slackPayloadBuilder) appendSimpleFeatureList(
+	blocks []any,
+	features []workertypes.SummaryHighlight,
+	sectionHeader string,
+) []any {
+	if len(features) > 0 {
+		blocks = append(blocks, dividerBlock())
+		blocks = append(blocks, sectionBlock(sectionHeader))
+		items := make([]string, 0, len(features))
+		for _, h := range features {
+			items = append(
+				items,
+				fmt.Sprintf("• <%s/features/%s|%s>", b.frontendBaseURL, h.FeatureID, h.FeatureName),
+			)
+		}
+		blocks = append(blocks, sectionBlock(strings.Join(items, "\n")))
+	}
+
+	return blocks
+}
+
+func (b *slackPayloadBuilder) appendRemovedFeatures(blocks []any) []any {
+	return b.appendSimpleFeatureList(
+		blocks,
+		b.removedFeatures,
+		"*No longer matches* \n_These features no longer match your saved search._",
+	)
+}
+
+func (b *slackPayloadBuilder) appendDeletedFeatures(blocks []any) []any {
+	return b.appendSimpleFeatureList(
+		blocks,
+		b.deletedFeatures,
+		"*Deleted* \n_These features have been removed from the web platform._",
+	)
 }
 
 func headerBlock(text string) map[string]any {

--- a/workers/webhook/pkg/webhook/slack.go
+++ b/workers/webhook/pkg/webhook/slack.go
@@ -33,6 +33,12 @@ const (
 	slackBlockTypeMrkdwn = "mrkdwn"
 	slackBlockKeyType    = "type"
 	slackBlockKeyText    = "text"
+
+	slackSectionAddedHeader     = "*Added* \n_These features now match your search criteria._"
+	slackSectionRemovedHeader   = "*No longer matches* \n_These features no longer match your saved search._"
+	slackSectionDeletedHeader   = "*Deleted* \n_These features have been removed from the web platform._"
+	slackSectionRegressedHeader = "*Regressed to limited availability*"
+	slackSectionBrowserHeader   = "*Browser support changed*"
 )
 
 type SlackPayload struct {
@@ -373,22 +379,14 @@ func (b *slackPayloadBuilder) appendBaselineChanges(blocks []any) []any {
 }
 
 func (b *slackPayloadBuilder) appendRegressions(blocks []any) []any {
-	if len(b.baselineRegressionChanges) > 0 || len(b.removedFeatures) > 0 {
+	if len(b.baselineRegressionChanges) > 0 {
 		blocks = append(blocks, dividerBlock())
-		blocks = append(blocks, sectionBlock("*Regressed to limited availability*"))
-		if len(b.baselineRegressionChanges) > 0 {
-			logoURL := fmt.Sprintf("%s/public/img/email/limited.png", b.frontendBaseURL)
-			for _, h := range b.baselineRegressionChanges {
-				featureURL := fmt.Sprintf("%s/features/%s", b.frontendBaseURL, h.FeatureID)
-				txt := fmt.Sprintf("<%s|%s> _From Widely_", featureURL, h.FeatureName)
-				blocks = append(blocks, contextBlock(contextImageText(logoURL, "Regressed", txt)...))
-			}
-		}
-		for _, h := range b.removedFeatures {
+		blocks = append(blocks, sectionBlock(slackSectionRegressedHeader))
+		logoURL := fmt.Sprintf("%s/public/img/email/limited.png", b.frontendBaseURL)
+		for _, h := range b.baselineRegressionChanges {
 			featureURL := fmt.Sprintf("%s/features/%s", b.frontendBaseURL, h.FeatureID)
-			txt := fmt.Sprintf("<%s|%s> \n_From Newly_ \n:warning: _This feature no longer matches your saved search._",
-				featureURL, h.FeatureName)
-			blocks = append(blocks, sectionBlock(txt))
+			txt := fmt.Sprintf("<%s|%s> _From Widely_", featureURL, h.FeatureName)
+			blocks = append(blocks, contextBlock(contextImageText(logoURL, "Regressed", txt)...))
 		}
 	}
 
@@ -398,7 +396,7 @@ func (b *slackPayloadBuilder) appendRegressions(blocks []any) []any {
 func (b *slackPayloadBuilder) appendBrowserChanges(blocks []any) []any {
 	if len(b.allBrowserChanges) > 0 {
 		blocks = append(blocks, dividerBlock())
-		blocks = append(blocks, sectionBlock("*Browser support changed*"))
+		blocks = append(blocks, sectionBlock(slackSectionBrowserHeader))
 		var items []string
 		for _, c := range b.allBrowserChanges {
 			items = b.processBrowserChange(items, c)
@@ -447,17 +445,11 @@ func (b *slackPayloadBuilder) processBrowserChange(items []string, c browserChan
 }
 
 func (b *slackPayloadBuilder) appendAddedFeatures(blocks []any) []any {
-	if len(b.addedFeatures) > 0 {
-		blocks = append(blocks, dividerBlock())
-		blocks = append(blocks, sectionBlock("*Added* \n_These features now match your search criteria._"))
-		items := make([]string, 0, len(b.addedFeatures))
-		for _, h := range b.addedFeatures {
-			items = append(items, fmt.Sprintf("• <%s/features/%s|%s>", b.frontendBaseURL, h.FeatureID, h.FeatureName))
-		}
-		blocks = append(blocks, sectionBlock(strings.Join(items, "\n")))
-	}
-
-	return blocks
+	return b.appendSimpleFeatureList(
+		blocks,
+		b.addedFeatures,
+		slackSectionAddedHeader,
+	)
 }
 
 func (b *slackPayloadBuilder) appendSplitFeatures(blocks []any) []any {
@@ -538,7 +530,7 @@ func (b *slackPayloadBuilder) appendRemovedFeatures(blocks []any) []any {
 	return b.appendSimpleFeatureList(
 		blocks,
 		b.removedFeatures,
-		"*No longer matches* \n_These features no longer match your saved search._",
+		slackSectionRemovedHeader,
 	)
 }
 
@@ -546,7 +538,7 @@ func (b *slackPayloadBuilder) appendDeletedFeatures(blocks []any) []any {
 	return b.appendSimpleFeatureList(
 		blocks,
 		b.deletedFeatures,
-		"*Deleted* \n_These features have been removed from the web platform._",
+		slackSectionDeletedHeader,
 	)
 }
 

--- a/workers/webhook/pkg/webhook/slack_test.go
+++ b/workers/webhook/pkg/webhook/slack_test.go
@@ -192,299 +192,297 @@ func TestSlackSender_Send_Golden(t *testing.T) {
 	newlyDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	widelyDate := time.Date(2025, 12, 27, 0, 0, 0, 0, time.UTC)
 
-	summary := workertypes.EventSummary{
-		SchemaVersion:  "v1",
-		SnapshotOrigin: workertypes.OriginLive,
-		Text:           "11 features changed",
-		Categories: workertypes.SummaryCategories{
-			Updated:         5,
-			Added:           2,
-			Removed:         1,
-			Moved:           1,
-			Split:           1,
-			Deleted:         1,
-			UpdatedBaseline: 3,
-			QueryChanged:    0,
-			UpdatedImpl:     0,
-			UpdatedRename:   0,
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SnapshotOrigin = workertypes.OriginLive
+	summary.Text = "11 features changed"
+	summary.Categories = workertypes.SummaryCategories{
+		Updated:         5,
+		Added:           2,
+		Removed:         1,
+		Moved:           1,
+		Split:           1,
+		Deleted:         1,
+		UpdatedBaseline: 3,
+		QueryChanged:    0,
+		UpdatedImpl:     0,
+		UpdatedRename:   0,
+	}
+	highlights := []workertypes.SummaryHighlight{
+		{
+			Type:        workertypes.SummaryHighlightTypeChanged,
+			FeatureName: "Container queries",
+			FeatureID:   "container-queries",
+			Docs: &workertypes.Docs{
+				MDNDocs: []workertypes.DocLink{
+					{
+						URL:   "https://developer.mozilla.org/docs/Web/CSS/CSS_Container_Queries",
+						Title: nil,
+						Slug:  nil,
+					},
+				},
+			},
+			NameChange:     nil,
+			BrowserChanges: nil,
+			Moved:          nil,
+			Split:          nil,
+			BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
+				From: workertypes.BaselineValue{
+					Status:   workertypes.BaselineStatusNewly,
+					LowDate:  &newlyDate,
+					HighDate: nil},
+				To: workertypes.BaselineValue{
+					Status:   workertypes.BaselineStatusWidely,
+					LowDate:  &newlyDate,
+					HighDate: &widelyDate},
+			},
 		},
-		Truncated:           false,
-		QueryErrors:         nil,
-		ResolvedQueryErrors: nil,
-		Highlights: []workertypes.SummaryHighlight{
-			{
-				Type:        workertypes.SummaryHighlightTypeChanged,
-				FeatureName: "Container queries",
-				FeatureID:   "container-queries",
-				Docs: &workertypes.Docs{
-					MDNDocs: []workertypes.DocLink{
-						{
-							URL:   "https://developer.mozilla.org/docs/Web/CSS/CSS_Container_Queries",
-							Title: nil,
-							Slug:  nil,
-						},
-					},
+		{
+			Type:           workertypes.SummaryHighlightTypeChanged,
+			FeatureName:    "Newly Available Feature",
+			FeatureID:      "newly-feature",
+			Docs:           nil,
+			NameChange:     nil,
+			BrowserChanges: nil,
+			Moved:          nil,
+			Split:          nil,
+			BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
+				From: workertypes.BaselineValue{
+					Status:   workertypes.BaselineStatusLimited,
+					LowDate:  nil,
+					HighDate: nil,
 				},
-				NameChange:     nil,
-				BrowserChanges: nil,
-				Moved:          nil,
-				Split:          nil,
-				BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
-					From: workertypes.BaselineValue{
-						Status:   workertypes.BaselineStatusNewly,
-						LowDate:  &newlyDate,
-						HighDate: nil},
-					To: workertypes.BaselineValue{
-						Status:   workertypes.BaselineStatusWidely,
-						LowDate:  &newlyDate,
-						HighDate: &widelyDate},
-				},
-			},
-			{
-				Type:           workertypes.SummaryHighlightTypeChanged,
-				FeatureName:    "Newly Available Feature",
-				FeatureID:      "newly-feature",
-				Docs:           nil,
-				NameChange:     nil,
-				BrowserChanges: nil,
-				Moved:          nil,
-				Split:          nil,
-				BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
-					From: workertypes.BaselineValue{
-						Status:   workertypes.BaselineStatusLimited,
-						LowDate:  nil,
-						HighDate: nil,
-					},
-					To: workertypes.BaselineValue{
-						Status:   workertypes.BaselineStatusNewly,
-						LowDate:  &newlyDate,
-						HighDate: nil,
-					},
-				},
-			},
-			{
-				Type:        workertypes.SummaryHighlightTypeChanged,
-				FeatureName: "Regressed Feature",
-				FeatureID:   "regressed-feature",
-				Docs:        nil,
-				NameChange:  nil,
-				Moved:       nil,
-				Split:       nil,
-				BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
-					From: workertypes.BaselineValue{
-						Status:   workertypes.BaselineStatusWidely,
-						LowDate:  &newlyDate,
-						HighDate: &widelyDate},
-					To: workertypes.BaselineValue{
-						Status:   workertypes.BaselineStatusLimited,
-						LowDate:  nil,
-						HighDate: nil},
-				},
-				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
-					workertypes.BrowserChrome: {
-						From: workertypes.BrowserValue{
-							Status:  workertypes.BrowserStatusAvailable,
-							Version: new("120"),
-							Date:    nil,
-						},
-						To: workertypes.BrowserValue{
-							Status:  workertypes.BrowserStatusUnavailable,
-							Version: nil,
-							Date:    nil,
-						},
-					},
-					workertypes.BrowserChromeAndroid:  nil,
-					workertypes.BrowserEdge:           nil,
-					workertypes.BrowserFirefox:        nil,
-					workertypes.BrowserFirefoxAndroid: nil,
-					workertypes.BrowserSafari:         nil,
-					workertypes.BrowserSafariIos:      nil,
-				},
-			},
-			{
-				Type:           workertypes.SummaryHighlightTypeChanged,
-				FeatureName:    "content-visibility",
-				FeatureID:      "content-visibility",
-				Docs:           nil,
-				BaselineChange: nil,
-				NameChange:     nil,
-				Moved:          nil,
-				Split:          nil,
-				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
-					workertypes.BrowserSafariIos: {
-						From: workertypes.BrowserValue{
-							Status:  workertypes.BrowserStatusUnavailable,
-							Version: nil,
-							Date:    nil,
-						},
-						To: workertypes.BrowserValue{
-							Status:  workertypes.BrowserStatusAvailable,
-							Version: new("17.2"),
-							Date:    nil,
-						},
-					},
-					workertypes.BrowserChrome:         nil,
-					workertypes.BrowserChromeAndroid:  nil,
-					workertypes.BrowserEdge:           nil,
-					workertypes.BrowserFirefox:        nil,
-					workertypes.BrowserFirefoxAndroid: nil,
-					workertypes.BrowserSafari:         nil,
-				},
-			},
-			{
-				Type:           workertypes.SummaryHighlightTypeChanged,
-				FeatureName:    "another-feature",
-				FeatureID:      "another-feature",
-				Docs:           nil,
-				BaselineChange: nil,
-				NameChange:     nil,
-				Moved:          nil,
-				Split:          nil,
-				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
-					workertypes.BrowserChrome: {
-						From: workertypes.BrowserValue{
-							Status:  workertypes.BrowserStatusUnavailable,
-							Version: nil,
-							Date:    nil,
-						},
-						To: workertypes.BrowserValue{
-							Status:  workertypes.BrowserStatusAvailable,
-							Version: nil,
-							Date:    &newlyDate,
-						},
-					},
-					workertypes.BrowserChromeAndroid:  nil,
-					workertypes.BrowserEdge:           nil,
-					workertypes.BrowserFirefox:        nil,
-					workertypes.BrowserFirefoxAndroid: nil,
-					workertypes.BrowserSafari:         nil,
-					workertypes.BrowserSafariIos:      nil,
-				},
-			},
-			{
-				Type:           workertypes.SummaryHighlightTypeAdded,
-				FeatureName:    "New Feature",
-				FeatureID:      "new-feature",
-				Docs:           nil,
-				BaselineChange: nil,
-				BrowserChanges: nil,
-				NameChange:     nil,
-				Moved:          nil,
-				Split:          nil,
-			},
-			{
-				Type:           workertypes.SummaryHighlightTypeAdded,
-				FeatureName:    "Another New Feature",
-				FeatureID:      "another-new-feature",
-				Docs:           nil,
-				BaselineChange: nil,
-				BrowserChanges: nil,
-				NameChange:     nil,
-				Moved:          nil,
-				Split:          nil,
-			},
-			{
-				Type:           workertypes.SummaryHighlightTypeRemoved,
-				FeatureName:    "Removed Feature",
-				FeatureID:      "removed-feature",
-				Docs:           nil,
-				BaselineChange: nil,
-				BrowserChanges: nil,
-				NameChange:     nil,
-				Moved:          nil,
-				Split:          nil,
-			},
-			{
-				Type:           workertypes.SummaryHighlightTypeMoved,
-				FeatureName:    "New Cool Name",
-				FeatureID:      "new-cool-name",
-				Docs:           nil,
-				BaselineChange: nil,
-				BrowserChanges: nil,
-				NameChange:     nil,
-				Split:          nil,
-				Moved: &workertypes.Change[workertypes.FeatureRef]{
-					From: workertypes.FeatureRef{
-						ID:         "old-name",
-						Name:       "Old Name",
-						QueryMatch: workertypes.QueryMatchNoMatch},
-					To: workertypes.FeatureRef{
-						ID:         "new-cool-name",
-						Name:       "New Cool Name",
-						QueryMatch: workertypes.QueryMatchNoMatch},
-				},
-			},
-			{
-				Type:           workertypes.SummaryHighlightTypeSplit,
-				FeatureName:    "Feature To Split",
-				FeatureID:      "feature-to-split",
-				Docs:           nil,
-				BaselineChange: nil,
-				BrowserChanges: nil,
-				NameChange:     nil,
-				Moved:          nil,
-				Split: &workertypes.SplitChange{
-					From: workertypes.FeatureRef{
-						ID: "feature-to-split", Name: "Feature To Split", QueryMatch: workertypes.QueryMatchNoMatch},
-					To: []workertypes.FeatureRef{
-						{ID: "sub-feature-1", Name: "Sub Feature 1", QueryMatch: workertypes.QueryMatchMatch},
-						{ID: "sub-feature-2", Name: "Sub Feature 2", QueryMatch: workertypes.QueryMatchNoMatch},
-					},
-				},
-			},
-			{
-				Type:           workertypes.SummaryHighlightTypeDeleted,
-				FeatureName:    "Deleted Feature",
-				FeatureID:      "deleted-feature",
-				Docs:           nil,
-				BaselineChange: nil,
-				BrowserChanges: nil,
-				NameChange:     nil,
-				Moved:          nil,
-				Split:          nil,
-			},
-			{
-				Type:        workertypes.SummaryHighlightTypeRemoved,
-				FeatureName: "Removed With Details",
-				FeatureID:   "removed-details",
-				Docs:        nil,
-				NameChange:  nil,
-				Moved:       nil,
-				Split:       nil,
-				BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
-					From: workertypes.BaselineValue{
-						Status:   workertypes.BaselineStatusNewly,
-						LowDate:  &newlyDate,
-						HighDate: nil,
-					},
-					To: workertypes.BaselineValue{
-						Status:   workertypes.BaselineStatusLimited,
-						LowDate:  nil,
-						HighDate: nil,
-					},
-				},
-				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
-					workertypes.BrowserChrome: {
-						From: workertypes.BrowserValue{
-							Status:  workertypes.BrowserStatusAvailable,
-							Version: new("110"),
-							Date:    nil,
-						},
-						To: workertypes.BrowserValue{
-							Status:  workertypes.BrowserStatusUnavailable,
-							Version: nil,
-							Date:    nil,
-						},
-					},
-					workertypes.BrowserChromeAndroid:  nil,
-					workertypes.BrowserEdge:           nil,
-					workertypes.BrowserFirefox:        nil,
-					workertypes.BrowserFirefoxAndroid: nil,
-					workertypes.BrowserSafari:         nil,
-					workertypes.BrowserSafariIos:      nil,
+				To: workertypes.BaselineValue{
+					Status:   workertypes.BaselineStatusNewly,
+					LowDate:  &newlyDate,
+					HighDate: nil,
 				},
 			},
 		},
+		{
+			Type:        workertypes.SummaryHighlightTypeChanged,
+			FeatureName: "Regressed Feature",
+			FeatureID:   "regressed-feature",
+			Docs:        nil,
+			NameChange:  nil,
+			Moved:       nil,
+			Split:       nil,
+			BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
+				From: workertypes.BaselineValue{
+					Status:   workertypes.BaselineStatusWidely,
+					LowDate:  &newlyDate,
+					HighDate: &widelyDate},
+				To: workertypes.BaselineValue{
+					Status:   workertypes.BaselineStatusLimited,
+					LowDate:  nil,
+					HighDate: nil},
+			},
+			BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+				workertypes.BrowserChrome: {
+					From: workertypes.BrowserValue{
+						Status:  workertypes.BrowserStatusAvailable,
+						Version: new("120"),
+						Date:    nil,
+					},
+					To: workertypes.BrowserValue{
+						Status:  workertypes.BrowserStatusUnavailable,
+						Version: nil,
+						Date:    nil,
+					},
+				},
+				workertypes.BrowserChromeAndroid:  nil,
+				workertypes.BrowserEdge:           nil,
+				workertypes.BrowserFirefox:        nil,
+				workertypes.BrowserFirefoxAndroid: nil,
+				workertypes.BrowserSafari:         nil,
+				workertypes.BrowserSafariIos:      nil,
+			},
+		},
+		{
+			Type:           workertypes.SummaryHighlightTypeChanged,
+			FeatureName:    "content-visibility",
+			FeatureID:      "content-visibility",
+			Docs:           nil,
+			BaselineChange: nil,
+			NameChange:     nil,
+			Moved:          nil,
+			Split:          nil,
+			BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+				workertypes.BrowserSafariIos: {
+					From: workertypes.BrowserValue{
+						Status:  workertypes.BrowserStatusUnavailable,
+						Version: nil,
+						Date:    nil,
+					},
+					To: workertypes.BrowserValue{
+						Status:  workertypes.BrowserStatusAvailable,
+						Version: new("17.2"),
+						Date:    nil,
+					},
+				},
+				workertypes.BrowserChrome:         nil,
+				workertypes.BrowserChromeAndroid:  nil,
+				workertypes.BrowserEdge:           nil,
+				workertypes.BrowserFirefox:        nil,
+				workertypes.BrowserFirefoxAndroid: nil,
+				workertypes.BrowserSafari:         nil,
+			},
+		},
+		{
+			Type:           workertypes.SummaryHighlightTypeChanged,
+			FeatureName:    "another-feature",
+			FeatureID:      "another-feature",
+			Docs:           nil,
+			BaselineChange: nil,
+			NameChange:     nil,
+			Moved:          nil,
+			Split:          nil,
+			BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+				workertypes.BrowserChrome: {
+					From: workertypes.BrowserValue{
+						Status:  workertypes.BrowserStatusUnavailable,
+						Version: nil,
+						Date:    nil,
+					},
+					To: workertypes.BrowserValue{
+						Status:  workertypes.BrowserStatusAvailable,
+						Version: nil,
+						Date:    &newlyDate,
+					},
+				},
+				workertypes.BrowserChromeAndroid:  nil,
+				workertypes.BrowserEdge:           nil,
+				workertypes.BrowserFirefox:        nil,
+				workertypes.BrowserFirefoxAndroid: nil,
+				workertypes.BrowserSafari:         nil,
+				workertypes.BrowserSafariIos:      nil,
+			},
+		},
+		{
+			Type:           workertypes.SummaryHighlightTypeAdded,
+			FeatureName:    "New Feature",
+			FeatureID:      "new-feature",
+			Docs:           nil,
+			BaselineChange: nil,
+			BrowserChanges: nil,
+			NameChange:     nil,
+			Moved:          nil,
+			Split:          nil,
+		},
+		{
+			Type:           workertypes.SummaryHighlightTypeAdded,
+			FeatureName:    "Another New Feature",
+			FeatureID:      "another-new-feature",
+			Docs:           nil,
+			BaselineChange: nil,
+			BrowserChanges: nil,
+			NameChange:     nil,
+			Moved:          nil,
+			Split:          nil,
+		},
+		{
+			Type:           workertypes.SummaryHighlightTypeRemoved,
+			FeatureName:    "Removed Feature",
+			FeatureID:      "removed-feature",
+			Docs:           nil,
+			BaselineChange: nil,
+			BrowserChanges: nil,
+			NameChange:     nil,
+			Moved:          nil,
+			Split:          nil,
+		},
+		{
+			Type:           workertypes.SummaryHighlightTypeMoved,
+			FeatureName:    "New Cool Name",
+			FeatureID:      "new-cool-name",
+			Docs:           nil,
+			BaselineChange: nil,
+			BrowserChanges: nil,
+			NameChange:     nil,
+			Split:          nil,
+			Moved: &workertypes.Change[workertypes.FeatureRef]{
+				From: workertypes.FeatureRef{
+					ID:         "old-name",
+					Name:       "Old Name",
+					QueryMatch: workertypes.QueryMatchNoMatch},
+				To: workertypes.FeatureRef{
+					ID:         "new-cool-name",
+					Name:       "New Cool Name",
+					QueryMatch: workertypes.QueryMatchNoMatch},
+			},
+		},
+		{
+			Type:           workertypes.SummaryHighlightTypeSplit,
+			FeatureName:    "Feature To Split",
+			FeatureID:      "feature-to-split",
+			Docs:           nil,
+			BaselineChange: nil,
+			BrowserChanges: nil,
+			NameChange:     nil,
+			Moved:          nil,
+			Split: &workertypes.SplitChange{
+				From: workertypes.FeatureRef{
+					ID: "feature-to-split", Name: "Feature To Split", QueryMatch: workertypes.QueryMatchNoMatch},
+				To: []workertypes.FeatureRef{
+					{ID: "sub-feature-1", Name: "Sub Feature 1", QueryMatch: workertypes.QueryMatchMatch},
+					{ID: "sub-feature-2", Name: "Sub Feature 2", QueryMatch: workertypes.QueryMatchNoMatch},
+				},
+			},
+		},
+		{
+			Type:           workertypes.SummaryHighlightTypeDeleted,
+			FeatureName:    "Deleted Feature",
+			FeatureID:      "deleted-feature",
+			Docs:           nil,
+			BaselineChange: nil,
+			BrowserChanges: nil,
+			NameChange:     nil,
+			Moved:          nil,
+			Split:          nil,
+		},
+		{
+			Type:        workertypes.SummaryHighlightTypeRemoved,
+			FeatureName: "Removed With Details",
+			FeatureID:   "removed-details",
+			Docs:        nil,
+			NameChange:  nil,
+			Moved:       nil,
+			Split:       nil,
+			BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
+				From: workertypes.BaselineValue{
+					Status:   workertypes.BaselineStatusNewly,
+					LowDate:  &newlyDate,
+					HighDate: nil,
+				},
+				To: workertypes.BaselineValue{
+					Status:   workertypes.BaselineStatusLimited,
+					LowDate:  nil,
+					HighDate: nil,
+				},
+			},
+			BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+				workertypes.BrowserChrome: {
+					From: workertypes.BrowserValue{
+						Status:  workertypes.BrowserStatusAvailable,
+						Version: new("110"),
+						Date:    nil,
+					},
+					To: workertypes.BrowserValue{
+						Status:  workertypes.BrowserStatusUnavailable,
+						Version: nil,
+						Date:    nil,
+					},
+				},
+				workertypes.BrowserChromeAndroid:  nil,
+				workertypes.BrowserEdge:           nil,
+				workertypes.BrowserFirefox:        nil,
+				workertypes.BrowserFirefoxAndroid: nil,
+				workertypes.BrowserSafari:         nil,
+				workertypes.BrowserSafariIos:      nil,
+			},
+		},
+	}
+	for _, h := range highlights {
+		summary.AddHighlight(h)
 	}
 	summaryBytes, _ := json.Marshal(summary)
 
@@ -577,29 +575,12 @@ func TestSlackSender_Send_Golden(t *testing.T) {
 }
 
 func TestSlackSender_Send_QueryError_Golden(t *testing.T) {
-	summary := workertypes.EventSummary{
-		SchemaVersion:  "v1",
-		Text:           "Query failed",
-		SnapshotOrigin: workertypes.OriginFallbackPrevious,
-		Categories: workertypes.SummaryCategories{
-			QueryChanged:    0,
-			Added:           0,
-			Removed:         0,
-			Deleted:         0,
-			Moved:           0,
-			Split:           0,
-			Updated:         0,
-			UpdatedImpl:     0,
-			UpdatedRename:   0,
-			UpdatedBaseline: 0,
-		},
-		Truncated: false,
-		QueryErrors: []workertypes.SummaryQueryError{
-			{Code: workertypes.SummaryQueryErrorCodeSavedSearchNotFound},
-		},
-		ResolvedQueryErrors: nil,
-		Highlights:          nil,
-	}
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SnapshotOrigin = workertypes.OriginFallbackPrevious
+	summary.Text = "Query failed"
+	summary.SetQueryErrors([]workertypes.SummaryQueryError{
+		{Code: workertypes.SummaryQueryErrorCodeSavedSearchNotFound},
+	})
 	summaryBytes, _ := json.Marshal(summary)
 
 	job := workertypes.IncomingWebhookDeliveryJob{
@@ -690,33 +671,12 @@ func TestSlackSender_Send_QueryError_Golden(t *testing.T) {
 	}
 }
 
-//go:fix inline
-func TestSlackPayloadBuilder_VisitV1_Filter(t *testing.T) {
+func TestSlackPayloadBuilder_TriggerFiltering(t *testing.T) {
 	builder := &slackPayloadBuilder{
-		frontendBaseURL: "https://webstatus.dev",
-		query:           "group:css",
-		resultsURL:      "https://webstatus.dev/features?q=group:css",
-		summary: workertypes.EventSummary{
-			SchemaVersion:       "v1",
-			SnapshotOrigin:      workertypes.OriginLive,
-			Text:                "",
-			Truncated:           false,
-			QueryErrors:         nil,
-			ResolvedQueryErrors: nil,
-			Highlights:          nil,
-			Categories: workertypes.SummaryCategories{
-				QueryChanged:    0,
-				Added:           0,
-				Removed:         0,
-				Deleted:         0,
-				Moved:           0,
-				Split:           0,
-				Updated:         0,
-				UpdatedImpl:     0,
-				UpdatedRename:   0,
-				UpdatedBaseline: 0,
-			},
-		},
+		frontendBaseURL:           "https://webstatus.dev",
+		query:                     "group:css",
+		resultsURL:                "https://webstatus.dev/features?q=group:css",
+		summary:                   workertypes.NewEmptyEventSummary(),
 		queryErrors:               nil,
 		resolvedQueryErrors:       nil,
 		baselineNewlyChanges:      nil,
@@ -734,65 +694,51 @@ func TestSlackPayloadBuilder_VisitV1_Filter(t *testing.T) {
 		subscriptionID: "",
 	}
 
-	summary := workertypes.EventSummary{
-		SchemaVersion:  "v1",
-		SnapshotOrigin: workertypes.OriginLive,
-		Categories: workertypes.SummaryCategories{
-			QueryChanged:    0,
-			Added:           0,
-			Removed:         0,
-			Deleted:         0,
-			Moved:           0,
-			Split:           0,
-			Updated:         0,
-			UpdatedImpl:     0,
-			UpdatedRename:   0,
-			UpdatedBaseline: 0,
-		},
-		Text:                "Test summary",
-		Truncated:           false,
-		QueryErrors:         nil,
-		ResolvedQueryErrors: nil,
-		Highlights: []workertypes.SummaryHighlight{
-			{
-				Type:        workertypes.SummaryHighlightTypeChanged,
-				FeatureName: "Chrome Feature",
-				FeatureID:   "chrome-feat",
-				Docs:        nil,
-				BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
-					workertypes.BrowserChrome: {
-						From: workertypes.BrowserValue{
-							Status:  workertypes.BrowserStatusUnavailable,
-							Version: nil,
-							Date:    nil,
-						},
-						To: workertypes.BrowserValue{
-							Status:  workertypes.BrowserStatusAvailable,
-							Version: nil,
-							Date:    nil,
-						},
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SnapshotOrigin = workertypes.OriginLive
+	summary.Text = "Test summary"
+	highlights := []workertypes.SummaryHighlight{
+		{
+			Type:        workertypes.SummaryHighlightTypeChanged,
+			FeatureName: "Chrome Feature",
+			FeatureID:   "chrome-feat",
+			Docs:        nil,
+			BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+				workertypes.BrowserChrome: {
+					From: workertypes.BrowserValue{
+						Status:  workertypes.BrowserStatusUnavailable,
+						Version: nil,
+						Date:    nil,
 					},
-					workertypes.BrowserChromeAndroid:  nil,
-					workertypes.BrowserEdge:           nil,
-					workertypes.BrowserFirefox:        nil,
-					workertypes.BrowserFirefoxAndroid: nil,
-					workertypes.BrowserSafari:         nil,
-					workertypes.BrowserSafariIos:      nil,
+					To: workertypes.BrowserValue{
+						Status:  workertypes.BrowserStatusAvailable,
+						Version: nil,
+						Date:    nil,
+					},
 				},
-				NameChange: nil, Moved: nil, Split: nil, BaselineChange: nil,
+				workertypes.BrowserChromeAndroid:  nil,
+				workertypes.BrowserEdge:           nil,
+				workertypes.BrowserFirefox:        nil,
+				workertypes.BrowserFirefoxAndroid: nil,
+				workertypes.BrowserSafari:         nil,
+				workertypes.BrowserSafariIos:      nil,
 			},
-			{
-				Type:           workertypes.SummaryHighlightTypeAdded,
-				FeatureName:    "Added Feature",
-				FeatureID:      "added-feat",
-				Docs:           nil,
-				BrowserChanges: nil,
-				NameChange:     nil,
-				Moved:          nil,
-				Split:          nil,
-				BaselineChange: nil,
-			},
+			NameChange: nil, Moved: nil, Split: nil, BaselineChange: nil,
 		},
+		{
+			Type:           workertypes.SummaryHighlightTypeAdded,
+			FeatureName:    "Added Feature",
+			FeatureID:      "added-feat",
+			Docs:           nil,
+			BrowserChanges: nil,
+			NameChange:     nil,
+			Moved:          nil,
+			Split:          nil,
+			BaselineChange: nil,
+		},
+	}
+	for _, h := range highlights {
+		summary.AddHighlight(h)
 	}
 
 	err := builder.VisitV1(summary)
@@ -808,19 +754,13 @@ func TestSlackPayloadBuilder_VisitV1_Filter(t *testing.T) {
 	}
 }
 
-func TestSlackPayloadBuilder_VisitV1_ResolvedQueryError_Golden(t *testing.T) {
-	summary := workertypes.EventSummary{
-		SchemaVersion:  "v1",
-		Text:           "Search query recovered and tracking 2 features normally.",
-		SnapshotOrigin: workertypes.OriginLive,
-		Categories:     workertypes.NewEmptySummaryCategories(),
-		Truncated:      false,
-		QueryErrors:    nil,
-		ResolvedQueryErrors: []workertypes.SummaryQueryError{
-			{Code: workertypes.SummaryQueryErrorCodeQueryGrammar},
-		},
-		Highlights: nil,
-	}
+func TestSlackPayloadBuilder_ResolvedQueryError_Golden(t *testing.T) {
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SnapshotOrigin = workertypes.OriginLive
+	summary.Text = "Search query recovered and tracking 2 features normally."
+	summary.SetResolvedQueryErrors([]workertypes.SummaryQueryError{
+		{Code: workertypes.SummaryQueryErrorCodeQueryGrammar},
+	})
 
 	builder := newSlackPayloadBuilder("http://localhost:5555", "group:css",
 		"http://localhost:5555/features?q=group:css", "sub-123", nil)
@@ -853,5 +793,388 @@ func TestSlackPayloadBuilder_VisitV1_ResolvedQueryError_Golden(t *testing.T) {
 
 	if diff := cmp.Diff(string(expected), string(payloadBytes)); diff != "" {
 		t.Errorf("Payload mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSlackPayloadBuilder_CombinedErrorsAndFeatures_Golden(t *testing.T) {
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SnapshotOrigin = workertypes.OriginLive
+	summary.Text = "Partial errors alongside feature updates"
+	summary.SetQueryErrors([]workertypes.SummaryQueryError{
+		{Code: workertypes.SummaryQueryErrorCodeSavedSearchNotFound},
+	})
+	summary.SetResolvedQueryErrors([]workertypes.SummaryQueryError{
+		{Code: workertypes.SummaryQueryErrorCodeQueryGrammar},
+	})
+	summary.AddHighlight(newTestHighlight(workertypes.SummaryHighlightTypeAdded, "feat-added", "Subgrid"))
+
+	builder := newSlackPayloadBuilder("http://localhost:5555", "group:css",
+		"http://localhost:5555/features?q=group:css", "sub-123", nil)
+	if err := builder.VisitV1(summary); err != nil {
+		t.Fatalf("VisitV1 failed: %v", err)
+	}
+
+	payload := builder.buildPayload("My CSS Search")
+
+	goldenFile := filepath.Join("testdata", "slack_payload_combined_errors_and_features.golden.json")
+
+	payloadBytes, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if *updateGolden {
+		if err := os.MkdirAll("testdata", 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(goldenFile, payloadBytes, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	expected, err := os.ReadFile(goldenFile)
+	if err != nil {
+		t.Fatalf("failed to read golden file: %v", err)
+	}
+
+	if diff := cmp.Diff(string(expected), string(payloadBytes)); diff != "" {
+		t.Errorf("Payload mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSlackPayloadBuilder_FeatureCategories(t *testing.T) {
+	testCases := []struct {
+		name      string
+		highlight workertypes.SummaryHighlight
+		wantText  string
+	}{
+		{
+			name:      "Added feature",
+			highlight: newTestHighlight(workertypes.SummaryHighlightTypeAdded, "f-add", "Added Feature"),
+			wantText:  "Added Feature",
+		},
+		{
+			name:      "Removed feature",
+			highlight: newTestHighlight(workertypes.SummaryHighlightTypeRemoved, "f-rem", "Removed Feature"),
+			wantText:  "Removed Feature",
+		},
+		{
+			name:      "Changed feature",
+			highlight: newTestChangedHighlight("f-chg", "Changed Feature", workertypes.BaselineStatusNewly),
+			wantText:  "Changed Feature",
+		},
+		{
+			name:      "Moved feature",
+			highlight: newTestMovedHighlight("f-mvd", "Moved Feature", "Old Name"),
+			wantText:  "Moved Feature",
+		},
+		{
+			name:      "Split feature",
+			highlight: newTestSplitHighlight("f-splt", "Split Feature", "Child Feature"),
+			wantText:  "Split Feature",
+		},
+		{
+			name:      "Deleted feature",
+			highlight: newTestHighlight(workertypes.SummaryHighlightTypeDeleted, "f-del", "Deleted Feature"),
+			wantText:  "Deleted Feature",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := newSlackPayloadBuilder("https://webstatus.dev", "group:css",
+				"https://webstatus.dev/features?q=group:css", "sub-123", nil)
+
+			summary := workertypes.NewEmptyEventSummary()
+			summary.AddHighlight(tc.highlight)
+
+			if err := builder.VisitV1(summary); err != nil {
+				t.Fatalf("VisitV1 unexpected error: %v", err)
+			}
+
+			payload := builder.buildPayload("CSS Search")
+			payloadBytes, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("failed to marshal payload: %v", err)
+			}
+
+			if !bytes.Contains(payloadBytes, []byte(tc.wantText)) {
+				t.Errorf("buildPayload payload missing expected text %q; got: %s", tc.wantText, string(payloadBytes))
+			}
+		})
+	}
+}
+
+func TestSlackPayloadBuilder_QueryErrors_RenderMessage(t *testing.T) {
+	testCases := []struct {
+		name        string
+		errorCode   workertypes.SummaryQueryErrorCode
+		wantMessage string
+	}{
+		{
+			name:        "QueryGrammar error",
+			errorCode:   workertypes.SummaryQueryErrorCodeQueryGrammar,
+			wantMessage: "Invalid query grammar",
+		},
+		{
+			name:        "SavedSearchNotFound error",
+			errorCode:   workertypes.SummaryQueryErrorCodeSavedSearchNotFound,
+			wantMessage: "Saved search not found",
+		},
+		{
+			name:        "MaxDepthExceeded error",
+			errorCode:   workertypes.SummaryQueryErrorCodeMaxDepthExceeded,
+			wantMessage: "Saved search max depth exceeded",
+		},
+		{
+			name:        "InvalidQuery error",
+			errorCode:   workertypes.SummaryQueryErrorCodeInvalidQuery,
+			wantMessage: "Invalid query",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := newSlackPayloadBuilder("https://webstatus.dev", "group:css",
+				"https://webstatus.dev/features?q=group:css", "sub-123", nil)
+
+			summary := workertypes.NewEmptyEventSummary()
+			summary.SetQueryErrors([]workertypes.SummaryQueryError{{Code: tc.errorCode}})
+
+			if err := builder.VisitV1(summary); err != nil {
+				t.Fatalf("VisitV1 unexpected error: %v", err)
+			}
+
+			payload := builder.buildPayload("CSS Search")
+			payloadBytes, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("failed to marshal payload: %v", err)
+			}
+
+			if !bytes.Contains(payloadBytes, []byte(tc.wantMessage)) {
+				t.Errorf(
+					"buildPayload payload missing expected query error message %q; got: %s",
+					tc.wantMessage,
+					string(payloadBytes),
+				)
+			}
+		})
+	}
+}
+
+func newTestChangedHighlight(id, name string, status workertypes.BaselineStatus) workertypes.SummaryHighlight {
+	return workertypes.SummaryHighlight{
+		Type:        workertypes.SummaryHighlightTypeChanged,
+		FeatureID:   id,
+		FeatureName: name,
+		Docs:        nil,
+		NameChange:  nil,
+		BaselineChange: &workertypes.Change[workertypes.BaselineValue]{
+			From: workertypes.BaselineValue{
+				Status:   workertypes.BaselineStatusNewly,
+				LowDate:  nil,
+				HighDate: nil,
+			},
+			To: workertypes.BaselineValue{
+				Status:   status,
+				LowDate:  nil,
+				HighDate: nil,
+			},
+		},
+		BrowserChanges: nil,
+		Moved:          nil,
+		Split:          nil,
+	}
+}
+
+func newTestMovedHighlight(id, name, oldName string) workertypes.SummaryHighlight {
+	return workertypes.SummaryHighlight{
+		Type:           workertypes.SummaryHighlightTypeMoved,
+		FeatureID:      id,
+		FeatureName:    name,
+		Docs:           nil,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+		Moved: &workertypes.Change[workertypes.FeatureRef]{
+			From: workertypes.FeatureRef{ID: "", Name: oldName, QueryMatch: workertypes.QueryMatchNoMatch},
+			To:   workertypes.FeatureRef{ID: id, Name: name, QueryMatch: workertypes.QueryMatchNoMatch},
+		},
+		Split: nil,
+	}
+}
+
+func newTestSplitHighlight(id, name, childName string) workertypes.SummaryHighlight {
+	return workertypes.SummaryHighlight{
+		Type:           workertypes.SummaryHighlightTypeSplit,
+		FeatureID:      id,
+		FeatureName:    name,
+		Docs:           nil,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+		Moved:          nil,
+		Split: &workertypes.SplitChange{
+			From: workertypes.FeatureRef{ID: id, Name: name, QueryMatch: workertypes.QueryMatchNoMatch},
+			To:   []workertypes.FeatureRef{{ID: "c-1", Name: childName, QueryMatch: workertypes.QueryMatchNoMatch}},
+		},
+	}
+}
+
+func newTestHighlight(hType workertypes.SummaryHighlightType, id, name string) workertypes.SummaryHighlight {
+	return workertypes.SummaryHighlight{
+		Type:           hType,
+		FeatureID:      id,
+		FeatureName:    name,
+		Docs:           nil,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+		Moved:          nil,
+		Split:          nil,
+	}
+}
+
+func TestSlackPayloadBuilder_CombinedErrorsAndFeatures(t *testing.T) {
+	builder := newSlackPayloadBuilder("https://webstatus.dev", "group:css",
+		"https://webstatus.dev/features?q=group:css", "sub-123", nil)
+
+	summary := workertypes.NewEmptyEventSummary()
+	summary.SetQueryErrors([]workertypes.SummaryQueryError{{Code: workertypes.SummaryQueryErrorCodeSavedSearchNotFound}})
+	summary.SetResolvedQueryErrors([]workertypes.SummaryQueryError{{Code: workertypes.SummaryQueryErrorCodeQueryGrammar}})
+	summary.AddHighlight(newTestHighlight(workertypes.SummaryHighlightTypeAdded, "feat-added", "Added Feature"))
+
+	if err := builder.VisitV1(summary); err != nil {
+		t.Fatalf("VisitV1 unexpected error: %v", err)
+	}
+
+	payload := builder.buildPayload("Combined Search")
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	if !bytes.Contains(payloadBytes, []byte("Saved search not found")) {
+		t.Errorf("missing query error in payload: %s", string(payloadBytes))
+	}
+	if !bytes.Contains(payloadBytes, []byte("Query Recovered")) {
+		t.Errorf("missing resolved query error in payload: %s", string(payloadBytes))
+	}
+	if !bytes.Contains(payloadBytes, []byte("Added Feature")) {
+		t.Errorf("missing added feature in payload: %s", string(payloadBytes))
+	}
+}
+
+func TestSlackPayloadBuilder_NilPointerGuards(t *testing.T) {
+	builder := newSlackPayloadBuilder(
+		"sub-1",
+		"chan-1",
+		"sub-1",
+		"http://localhost:8080",
+		nil,
+	)
+
+	summary := workertypes.NewEmptyEventSummary()
+	summary.AddHighlight(workertypes.SummaryHighlight{
+		Type:           workertypes.SummaryHighlightTypeMoved,
+		FeatureID:      "feat-moved",
+		FeatureName:    "Moved Feature",
+		Docs:           nil,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+		Moved:          nil, // nil guard check
+		Split:          nil,
+	})
+	summary.AddHighlight(workertypes.SummaryHighlight{
+		Type:           workertypes.SummaryHighlightTypeSplit,
+		FeatureID:      "feat-split",
+		FeatureName:    "Split Feature",
+		Docs:           nil,
+		NameChange:     nil,
+		BaselineChange: nil,
+		BrowserChanges: nil,
+		Moved:          nil,
+		Split:          nil, // nil guard check
+	})
+	summary.AddHighlight(workertypes.SummaryHighlight{
+		Type:           workertypes.SummaryHighlightTypeChanged,
+		FeatureID:      "feat-browser",
+		FeatureName:    "Browser Feature",
+		Docs:           nil,
+		NameChange:     nil,
+		Moved:          nil,
+		Split:          nil,
+		BaselineChange: nil,
+		BrowserChanges: map[workertypes.BrowserName]*workertypes.Change[workertypes.BrowserValue]{
+			workertypes.BrowserChrome: {
+				From: workertypes.BrowserValue{
+					Status:  workertypes.BrowserStatusAvailable,
+					Version: nil, // nil pointer guard check
+					Date:    nil,
+				},
+				To: workertypes.BrowserValue{
+					Status:  workertypes.BrowserStatusUnavailable,
+					Version: nil,
+					Date:    nil,
+				},
+			},
+			workertypes.BrowserChromeAndroid:  nil,
+			workertypes.BrowserEdge:           nil,
+			workertypes.BrowserFirefox:        nil,
+			workertypes.BrowserFirefoxAndroid: nil,
+			workertypes.BrowserSafari:         nil,
+			workertypes.BrowserSafariIos:      nil,
+		},
+	})
+
+	if err := builder.VisitV1(summary); err != nil {
+		t.Fatalf("VisitV1 unexpected error: %v", err)
+	}
+
+	// Must build payload without panicking
+	payload := builder.buildPayload("Nil Check Search")
+	if len(payload.Blocks) == 0 {
+		t.Fatal("buildPayload returned empty blocks")
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	if !bytes.Contains(payloadBytes, []byte("Available → *Unavailable*")) {
+		t.Errorf("expected payload to contain 'Available → *Unavailable*' without version, got: %s", string(payloadBytes))
+	}
+}
+
+func TestSlackPayloadBuilder_Sanitization(t *testing.T) {
+	builder := newSlackPayloadBuilder("https://test.dev", "sub-sanitize", "Sanitization Check", "feature:a", nil)
+
+	summary := workertypes.NewEmptyEventSummary()
+	summary.AddHighlight(newTestHighlight(
+		workertypes.SummaryHighlightTypeAdded,
+		"f-sanitize",
+		"<script>alert('xss')</script> *bold* _italic_ \"quoted\"",
+	))
+
+	if err := builder.VisitV1(summary); err != nil {
+		t.Fatalf("VisitV1 unexpected error: %v", err)
+	}
+
+	payload := builder.buildPayload("Sanitization Check")
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal failed on special markdown characters: %v", err)
+	}
+
+	if !json.Valid(payloadBytes) {
+		t.Fatal("json.Marshal produced invalid JSON")
+	}
+
+	hasXSS := bytes.Contains(payloadBytes, []byte("xss"))
+	hasBold := bytes.Contains(payloadBytes, []byte("*bold*"))
+	if !hasXSS || !hasBold {
+		t.Error("payload missing original sanitized feature name components")
 	}
 }

--- a/workers/webhook/pkg/webhook/slack_test.go
+++ b/workers/webhook/pkg/webhook/slack_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1177,4 +1178,184 @@ func TestSlackPayloadBuilder_Sanitization(t *testing.T) {
 	if !hasXSS || !hasBold {
 		t.Error("payload missing original sanitized feature name components")
 	}
+}
+
+type sectionSeparationTestCase struct {
+	name         string
+	highlights   []workertypes.SummaryHighlight
+	wantContains []string
+	wontContains []string
+	exactCounts  map[string]int
+}
+
+// TestSlackPayloadBuilder_SectionSeparationAndDeduplication validates that each highlight category
+// (Removed, Regressed, Added, Deleted) is routed exclusively to its own section in the Slack payload
+// and that features are not duplicated across multiple sections (e.g. pure query removals appearing under regressions).
+func TestSlackPayloadBuilder_SectionSeparationAndDeduplication(t *testing.T) {
+	testCases := []sectionSeparationTestCase{
+		{
+			name: "removed feature only does not create regression section",
+			highlights: []workertypes.SummaryHighlight{
+				newTestHighlight(workertypes.SummaryHighlightTypeRemoved, "feat-removed", "Removed Feature"),
+			},
+			wantContains: []string{
+				slackSectionRemovedHeader,
+				"/features/feat-removed|Removed Feature",
+			},
+			wontContains: []string{
+				slackSectionRegressedHeader,
+				"_From Newly_",
+			},
+			exactCounts: map[string]int{
+				"feat-removed": 1,
+			},
+		},
+		{
+			name: "regressed feature only creates regression section and not removed section",
+			highlights: []workertypes.SummaryHighlight{
+				newTestChangedHighlight("feat-regressed", "Regressed Feature", workertypes.BaselineStatusLimited),
+			},
+			wantContains: []string{
+				slackSectionRegressedHeader,
+				"/features/feat-regressed|Regressed Feature",
+			},
+			wontContains: []string{
+				slackSectionRemovedHeader,
+			},
+			exactCounts: map[string]int{
+				"feat-regressed": 1,
+			},
+		},
+		{
+			name: "both regressed and removed features render cleanly without duplication",
+			highlights: []workertypes.SummaryHighlight{
+				newTestChangedHighlight("feat-regressed", "Regressed Feature", workertypes.BaselineStatusLimited),
+				newTestHighlight(workertypes.SummaryHighlightTypeRemoved, "feat-removed", "Removed Feature"),
+			},
+			wantContains: []string{
+				slackSectionRegressedHeader,
+				"/features/feat-regressed|Regressed Feature",
+				slackSectionRemovedHeader,
+				"/features/feat-removed|Removed Feature",
+			},
+			wontContains: []string{
+				"_From Newly_",
+			},
+			exactCounts: map[string]int{
+				"feat-regressed": 1,
+				"feat-removed":   1,
+			},
+		},
+		{
+			name: "added feature renders via simple list",
+			highlights: []workertypes.SummaryHighlight{
+				newTestHighlight(workertypes.SummaryHighlightTypeAdded, "feat-added", "Added Feature"),
+			},
+			wantContains: []string{
+				slackSectionAddedHeader,
+				"/features/feat-added|Added Feature",
+			},
+			wontContains: []string{
+				slackSectionRegressedHeader,
+				slackSectionRemovedHeader,
+			},
+			exactCounts: map[string]int{
+				"feat-added": 1,
+			},
+		},
+		{
+			name: "deleted feature renders via simple list",
+			highlights: []workertypes.SummaryHighlight{
+				newTestHighlight(workertypes.SummaryHighlightTypeDeleted, "feat-deleted", "Deleted Feature"),
+			},
+			wantContains: []string{
+				slackSectionDeletedHeader,
+				"/features/feat-deleted|Deleted Feature",
+			},
+			wontContains: []string{
+				slackSectionRegressedHeader,
+				slackSectionRemovedHeader,
+			},
+			exactCounts: map[string]int{
+				"feat-deleted": 1,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			verifySectionSeparationCase(t, tc)
+		})
+	}
+}
+
+func verifySectionSeparationCase(t *testing.T, tc sectionSeparationTestCase) {
+	builder := newSlackPayloadBuilder("https://webstatus.dev", "sub-123", "Separation Check", "group:css", nil)
+	summary := workertypes.NewEmptyEventSummary()
+	for _, h := range tc.highlights {
+		summary.AddHighlight(h)
+	}
+
+	if err := builder.VisitV1(summary); err != nil {
+		t.Fatalf("VisitV1 unexpected error: %v", err)
+	}
+
+	payload := builder.buildPayload("Separation Check")
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	for _, want := range tc.wantContains {
+		if !hasBlockWithText(payload.Blocks, want) {
+			t.Errorf("payload blocks missing expected text %q; blocks: %+v", want, payload.Blocks)
+		}
+	}
+
+	for _, wont := range tc.wontContains {
+		if hasBlockWithText(payload.Blocks, wont) {
+			t.Errorf("payload blocks contains unexpected text %q; blocks: %+v", wont, payload.Blocks)
+		}
+	}
+
+	for token, expectedCount := range tc.exactCounts {
+		actualCount := bytes.Count(payloadBytes, []byte(token))
+		if actualCount != expectedCount {
+			t.Errorf("token %q expected count %d, got %d. Payload: %s",
+				token, expectedCount, actualCount, string(payloadBytes))
+		}
+	}
+}
+
+func hasBlockWithText(blocks []any, text string) bool {
+	for _, b := range blocks {
+		if blockContainsText(b, text) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func blockContainsText(block any, expected string) bool {
+	switch m := block.(type) {
+	case map[string]any:
+		if textMap, ok := m["text"].(map[string]any); ok {
+			if txt, ok := textMap["text"].(string); ok && strings.Contains(txt, expected) {
+				return true
+			}
+		}
+		if textStr, ok := m["text"].(string); ok && strings.Contains(textStr, expected) {
+			return true
+		}
+		if elements, ok := m["elements"].([]any); ok {
+			for _, elem := range elements {
+				if blockContainsText(elem, expected) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/workers/webhook/pkg/webhook/testdata/slack_payload.golden.json
+++ b/workers/webhook/pkg/webhook/testdata/slack_payload.golden.json
@@ -144,6 +144,23 @@
     },
     {
       "text": {
+        "text": "*No longer matches* \n_These features no longer match your saved search._",
+        "type": "mrkdwn"
+      },
+      "type": "section"
+    },
+    {
+      "text": {
+        "text": "• \u003chttps://webstatus.dev/features/removed-feature|Removed Feature\u003e",
+        "type": "mrkdwn"
+      },
+      "type": "section"
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "text": {
         "text": "*Split* \n\u003chttps://webstatus.dev/features/feature-to-split|Feature To Split\u003e split into: \n• \u003chttps://webstatus.dev/features/sub-feature-1|Sub Feature 1\u003e\n• \u003chttps://webstatus.dev/features/sub-feature-2|Sub Feature 2\u003e :warning: _(No longer matches)_",
         "type": "mrkdwn"
       },
@@ -155,6 +172,23 @@
     {
       "text": {
         "text": "*Moved/Renamed* \nRenamed from Old Name to \u003chttps://webstatus.dev/features/new-cool-name|New Cool Name\u003e :warning: _(No longer matches)_",
+        "type": "mrkdwn"
+      },
+      "type": "section"
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "text": {
+        "text": "*Deleted* \n_These features have been removed from the web platform._",
+        "type": "mrkdwn"
+      },
+      "type": "section"
+    },
+    {
+      "text": {
+        "text": "• \u003chttps://webstatus.dev/features/deleted-feature|Deleted Feature\u003e",
         "type": "mrkdwn"
       },
       "type": "section"

--- a/workers/webhook/pkg/webhook/testdata/slack_payload.golden.json
+++ b/workers/webhook/pkg/webhook/testdata/slack_payload.golden.json
@@ -99,13 +99,6 @@
       "type": "context"
     },
     {
-      "text": {
-        "text": "\u003chttps://webstatus.dev/features/removed-feature|Removed Feature\u003e \n_From Newly_ \n:warning: _This feature no longer matches your saved search._",
-        "type": "mrkdwn"
-      },
-      "type": "section"
-    },
-    {
       "type": "divider"
     },
     {

--- a/workers/webhook/pkg/webhook/testdata/slack_payload_combined_errors_and_features.golden.json
+++ b/workers/webhook/pkg/webhook/testdata/slack_payload_combined_errors_and_features.golden.json
@@ -1,0 +1,68 @@
+{
+  "blocks": [
+    {
+      "text": {
+        "emoji": true,
+        "text": "Weekly digest: My CSS Search",
+        "type": "plain_text"
+      },
+      "type": "header"
+    },
+    {
+      "text": {
+        "text": "Here is your update for the saved search *'My CSS Search'*. \n*Partial errors alongside feature updates.*",
+        "type": "mrkdwn"
+      },
+      "type": "section"
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "text": {
+        "text": "⚠️ *Saved search not found*",
+        "type": "mrkdwn"
+      },
+      "type": "section"
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "text": {
+        "text": "✅ *Query Recovered:* Tracking resumed cleanly from your baseline. Resolved issue: Invalid query grammar",
+        "type": "mrkdwn"
+      },
+      "type": "section"
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "text": {
+        "text": "*Added* \n_These features now match your search criteria._",
+        "type": "mrkdwn"
+      },
+      "type": "section"
+    },
+    {
+      "text": {
+        "text": "• \u003chttp://localhost:5555/features/feat-added|Subgrid\u003e",
+        "type": "mrkdwn"
+      },
+      "type": "section"
+    },
+    {
+      "elements": [
+        {
+          "text": "You can \u003chttp://localhost:5555/settings/subscriptions?unsubscribe=sub-123|unsubscribe\u003e on \u003chttp://localhost:5555/settings/subscriptions|webstatus.dev\u003e",
+          "type": "mrkdwn"
+        }
+      ],
+      "type": "context"
+    }
+  ]
+}


### PR DESCRIPTION
Migrates the Slack webhook payload builder to the CategorizedSummaryVisitor interface and adds missing feature removal and deletion notification sections.

- Implements CategorizedSummaryVisitor on slackPayloadBuilder in workers/webhook/pkg/webhook.
- Adds appendRemovedFeatures and appendDeletedFeatures block builders to Slack payload construction.
- Adds nil pointer guards for optional Split, Moved, and Change.From.Version fields.
- Adds TestSlackPayloadBuilder_FeatureCategories, TestSlackPayloadBuilder_QueryErrors_RenderMessage, TestSlackPayloadBuilder_TriggerFiltering, TestSlackPayloadBuilder_NilPointerGuards, TestSlackPayloadBuilder_CombinedErrorsAndFeatures, and TestSlackPayloadBuilder_Sanitization unit tests.
- Adds slack_payload_combined_errors_and_features.golden.json golden snapshot file and test.

Fixes #2622 (PR 4/5)

CONV=f70d8c59-6f49-4a69-bb74-5643e908f5b1
TAG=agy