### PR TITLE
fix(backend): expand saved search query length to 2048 and enforce AST node complexity guard (#2604)

### DIFF
--- a/backend/pkg/httpserver/create_saved_search.go
+++ b/backend/pkg/httpserver/create_saved_search.go
@@ -32,8 +32,11 @@ const (
 	savedSearchNameMinLength            = 1
 	savedSearchNameDescriptionMaxLength = 1024
 	savedSearchNameDescriptionMinLength = 1
-	savedSearchQueryMaxLength           = 256
-	savedSearchQueryMinLength           = 1
+	// savedSearchQueryMaxLength allows bookmarking long lists of feature IDs (issue #2604).
+	savedSearchQueryMaxLength = 2048
+	savedSearchQueryMinLength = 1
+	// maxASTNodes caps query structural complexity after deduplication to protect Cloud Spanner parameter limits.
+	maxASTNodes = backendtypes.MaxASTNodes
 )
 
 var (
@@ -69,17 +72,26 @@ func validateSavedSearchQuery(query *string, fieldErrors *fieldValidationErrors)
 		return
 	}
 
+	// 1. Length validation check
 	if len(*query) < savedSearchQueryMinLength || len(*query) > savedSearchQueryMaxLength {
 		fieldErrors.addFieldError("query", errSavedSearchInvalidQueryLength)
 
 		return
 	}
 
-	// Only parse if length is okay
+	// 2. Upstream ANTLR grammar parse check
 	parser := searchtypes.FeaturesSearchQueryParser{}
-	_, err := parser.Parse(*query)
+	node, err := parser.Parse(*query)
 	if err != nil {
 		fieldErrors.addFieldError("query", errQueryDoesNotMatchGrammar)
+
+		return
+	}
+
+	// 3. Upstream AST deduplication and structural complexity validation
+	dedupNode := searchtypes.Deduplicate(node)
+	if searchtypes.CountNodes(dedupNode) > maxASTNodes {
+		fieldErrors.addFieldError("query", backendtypes.ErrQueryComplexityExceeded)
 	}
 
 }
@@ -134,6 +146,8 @@ func sanitizeValidationError(err error) error {
 		return backendtypes.ErrSavedSearchMaxDepthExceeded
 	case errors.Is(err, backendtypes.ErrQueryConsistsEntirelyOfSavedSearch):
 		return backendtypes.ErrQueryConsistsEntirelyOfSavedSearch
+	case errors.Is(err, backendtypes.ErrQueryComplexityExceeded):
+		return backendtypes.ErrQueryComplexityExceeded
 	case errors.Is(err, errQueryDoesNotMatchGrammar):
 		return errQueryDoesNotMatchGrammar
 	default:

--- a/backend/pkg/httpserver/create_saved_search_test.go
+++ b/backend/pkg/httpserver/create_saved_search_test.go
@@ -16,6 +16,7 @@ package httpserver
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -64,7 +65,7 @@ func TestCreateSavedSearch(t *testing.T) {
 					"code":400,
 					"errors":{
 						"name":"name must be between 1 and 32 characters long",
-						"query":"query must be between 1 and 256 characters long"
+						"query":"query must be between 1 and 2048 characters long"
 					},
 					"message":"input validation errors"
 				}`),
@@ -121,26 +122,26 @@ func TestCreateSavedSearch(t *testing.T) {
 				`{
 					"code":400,
 					"errors":{
-						"query":"query must be between 1 and 256 characters long"
+						"query":"query must be between 1 and 2048 characters long"
 					},
 					"message":"input validation errors"
 				}`),
 		},
 		{
-			name:                            "query is 257 characters long",
+			name:                            "query is 2049 characters long",
 			mockCreateUserSavedSearchConfig: nil,
 			mockPublishConfig:               nil,
 			authMiddlewareOption:            withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
 				http.MethodPost,
 				"/v1/saved-searches",
-				strings.NewReader(`{"query": "`+createStringOfNLength(257)+`", "name" : "test name"}`),
+				strings.NewReader(`{"query": "`+createStringOfNLength(2049)+`", "name" : "test name"}`),
 			),
 			expectedResponse: testJSONResponse(400,
 				`{
 					"code":400,
 					"errors":{
-						"query":"query must be between 1 and 256 characters long"
+						"query":"query must be between 1 and 2048 characters long"
 					},
 					"message":"input validation errors"
 				}`),
@@ -185,6 +186,145 @@ func TestCreateSavedSearch(t *testing.T) {
 				}`),
 		},
 		{
+			name: "description is 1024 characters long (ON upper bound)",
+			mockCreateUserSavedSearchConfig: &MockCreateUserSavedSearchConfig{
+				expectedSavedSearch: backend.SavedSearch{
+					Name:        "test name",
+					Query:       `name:"test"`,
+					Description: new(createStringOfNLength(1024)),
+				},
+				expectedUserID: "testID1",
+				output: &backend.SavedSearchResponse{
+					Id:             "searchID1",
+					Name:           "test name",
+					Query:          `name:"test"`,
+					Description:    new(createStringOfNLength(1024)),
+					Permissions:    nil,
+					BookmarkStatus: nil,
+					CreatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+				err: nil,
+			},
+			mockPublishConfig: &MockPublishSearchConfigurationChangedConfig{
+				expectedResp: &backend.SavedSearchResponse{
+					Id:             "searchID1",
+					Name:           "test name",
+					Query:          `name:"test"`,
+					Description:    new(createStringOfNLength(1024)),
+					Permissions:    nil,
+					BookmarkStatus: nil,
+					CreatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+				},
+				expectedUserID:     "testID1",
+				expectedIsCreation: true,
+				err:                nil,
+			},
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodPost,
+				"/v1/saved-searches",
+				strings.NewReader(fmt.Sprintf(
+					`{"query": "name:\"test\"", "name" : "test name", "description": %q}`,
+					createStringOfNLength(1024))),
+			),
+			expectedResponse: testJSONResponse(201,
+				fmt.Sprintf(`{
+					"id":"searchID1",
+					"name":"test name",
+					"query":"name:\"test\"",
+					"description":%q,
+					"created_at":"2000-01-01T00:00:00Z",
+					"updated_at":"2000-01-01T00:00:00Z"
+				}`, createStringOfNLength(1024)),
+			),
+		},
+		{
+			name: "query with >50 raw nodes deduplicates to <=50 nodes and succeeds",
+			mockCreateUserSavedSearchConfig: func() *MockCreateUserSavedSearchConfig {
+				terms := make([]string, 60)
+				for i := range terms {
+					terms[i] = "group:layout"
+				}
+				q := strings.Join(terms, " AND ")
+
+				return &MockCreateUserSavedSearchConfig{
+					expectedSavedSearch: backend.SavedSearch{
+						Name:        "test name",
+						Query:       q,
+						Description: nil,
+					},
+					expectedUserID: "testID1",
+					output: &backend.SavedSearchResponse{
+						Id:             "searchID1",
+						Name:           "test name",
+						Query:          q,
+						Description:    nil,
+						Permissions:    nil,
+						BookmarkStatus: nil,
+						CreatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						UpdatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					},
+					err: nil,
+				}
+			}(),
+			mockPublishConfig: func() *MockPublishSearchConfigurationChangedConfig {
+				terms := make([]string, 60)
+				for i := range terms {
+					terms[i] = "group:layout"
+				}
+				q := strings.Join(terms, " AND ")
+
+				return &MockPublishSearchConfigurationChangedConfig{
+					expectedResp: &backend.SavedSearchResponse{
+						Id:             "searchID1",
+						Name:           "test name",
+						Query:          q,
+						Description:    nil,
+						Permissions:    nil,
+						BookmarkStatus: nil,
+						CreatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						UpdatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					},
+					expectedUserID:     "testID1",
+					expectedIsCreation: true,
+					err:                nil,
+				}
+			}(),
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: func() *http.Request {
+				terms := make([]string, 60)
+				for i := range terms {
+					terms[i] = "group:layout"
+				}
+				q := strings.Join(terms, " AND ")
+
+				return httptest.NewRequestWithContext(t.Context(),
+					http.MethodPost,
+					"/v1/saved-searches",
+					strings.NewReader(fmt.Sprintf(`{"query": %q, "name" : "test name"}`, q)),
+				)
+			}(),
+			expectedResponse: testJSONResponse(201,
+				func() string {
+					terms := make([]string, 60)
+					for i := range terms {
+						terms[i] = "group:layout"
+					}
+					q := strings.Join(terms, " AND ")
+
+					return fmt.Sprintf(`{
+						"id":"searchID1",
+						"name":"test name",
+						"query":%q,
+						"created_at":"2000-01-01T00:00:00Z",
+						"updated_at":"2000-01-01T00:00:00Z"
+					}`, q)
+				}(),
+			),
+		},
+		{
 			name:                            "query has bad syntax",
 			mockCreateUserSavedSearchConfig: nil,
 			mockPublishConfig:               nil,
@@ -204,6 +344,117 @@ func TestCreateSavedSearch(t *testing.T) {
 				}`),
 		},
 		{
+			name:                            "query exceeds max AST complexity",
+			mockCreateUserSavedSearchConfig: nil,
+			mockPublishConfig:               nil,
+			authMiddlewareOption:            withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: func() *http.Request {
+				terms := make([]string, 26)
+				for i := range terms {
+					terms[i] = fmt.Sprintf("id:feat-%d", i)
+				}
+				query := strings.Join(terms, " OR ")
+
+				return httptest.NewRequestWithContext(t.Context(),
+					http.MethodPost,
+					"/v1/saved-searches",
+					strings.NewReader(fmt.Sprintf(`{"query": %q, "name" : "test name"}`, query)),
+				)
+			}(),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"query":"search query complexity limit exceeded"
+					},
+					"message":"input validation errors"
+				}`),
+		},
+		{
+			name: "query with exactly 50 AST nodes (right at limit)",
+			mockCreateUserSavedSearchConfig: func() *MockCreateUserSavedSearchConfig {
+				terms := make([]string, 25)
+				for i := range terms {
+					terms[i] = fmt.Sprintf("id:feat-%d", i)
+				}
+				q := strings.Join(terms, " OR ")
+
+				return &MockCreateUserSavedSearchConfig{
+					expectedSavedSearch: backend.SavedSearch{
+						Name:        "test name",
+						Query:       q,
+						Description: nil,
+					},
+					expectedUserID: "testID1",
+					output: &backend.SavedSearchResponse{
+						Id:             "searchID1",
+						Name:           "test name",
+						Query:          q,
+						Description:    nil,
+						Permissions:    nil,
+						BookmarkStatus: nil,
+						CreatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						UpdatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					},
+					err: nil,
+				}
+			}(),
+			mockPublishConfig: func() *MockPublishSearchConfigurationChangedConfig {
+				terms := make([]string, 25)
+				for i := range terms {
+					terms[i] = fmt.Sprintf("id:feat-%d", i)
+				}
+				q := strings.Join(terms, " OR ")
+
+				return &MockPublishSearchConfigurationChangedConfig{
+					expectedResp: &backend.SavedSearchResponse{
+						Id:             "searchID1",
+						Name:           "test name",
+						Query:          q,
+						Description:    nil,
+						Permissions:    nil,
+						BookmarkStatus: nil,
+						CreatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						UpdatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					},
+					expectedUserID:     "testID1",
+					expectedIsCreation: true,
+					err:                nil,
+				}
+			}(),
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: func() *http.Request {
+				terms := make([]string, 25)
+				for i := range terms {
+					terms[i] = fmt.Sprintf("id:feat-%d", i)
+				}
+				q := strings.Join(terms, " OR ")
+
+				return httptest.NewRequestWithContext(t.Context(),
+					http.MethodPost,
+					"/v1/saved-searches",
+					strings.NewReader(fmt.Sprintf(`{"query": %q, "name" : "test name"}`, q)),
+				)
+			}(),
+			expectedResponse: testJSONResponse(201,
+				func() string {
+					terms := make([]string, 25)
+					for i := range terms {
+						terms[i] = fmt.Sprintf("id:feat-%d", i)
+					}
+					q := strings.Join(terms, " OR ")
+
+					return fmt.Sprintf(`{
+						"id":"searchID1",
+						"name":"test name",
+						"query":%q,
+						"created_at":"2000-01-01T00:00:00Z",
+						"updated_at":"2000-01-01T00:00:00Z"
+					}`, q)
+				}(),
+			),
+		},
+		{
 			name:                            "missing body creation error",
 			mockCreateUserSavedSearchConfig: nil,
 			mockPublishConfig:               nil,
@@ -218,7 +469,7 @@ func TestCreateSavedSearch(t *testing.T) {
 					"code":400,
 					"errors":{
 						"name":"name must be between 1 and 32 characters long",
-						"query":"query must be between 1 and 256 characters long"
+						"query":"query must be between 1 and 2048 characters long"
 					},
 					"message":"input validation errors"
 				}`,

--- a/backend/pkg/httpserver/update_saved_search.go
+++ b/backend/pkg/httpserver/update_saved_search.go
@@ -150,7 +150,7 @@ func (s *Server) UpdateSavedSearch(
 	err = s.eventPublisher.PublishSearchConfigurationChanged(ctx, output, user.ID, false)
 	if err != nil {
 		// We should not mark this as a failure. Only log it.
-		slog.ErrorContext(ctx, "unable to publish search configuration changed event during update", "error", err)
+		slog.WarnContext(ctx, "unable to publish search configuration changed event during update", "error", err)
 	}
 
 	return backend.UpdateSavedSearch200JSONResponse(*output), nil

--- a/backend/pkg/httpserver/update_saved_search_test.go
+++ b/backend/pkg/httpserver/update_saved_search_test.go
@@ -15,6 +15,7 @@
 package httpserver
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -128,10 +129,163 @@ func TestUpdateSavedSearch(t *testing.T) {
 					"code":400,
 					"errors":{
 						"name":"name must be between 1 and 32 characters long",
-						"query":"query must be between 1 and 256 characters long"
+						"query":"query must be between 1 and 2048 characters long"
 					},
 					"message":"input validation errors"
 				}`,
+			),
+		},
+		{
+			name:                 "query is 2049 characters long",
+			cfg:                  nil,
+			publishCfg:           nil,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodPatch,
+				"/v1/saved-searches/saved-search-id",
+				strings.NewReader(`{"query": "`+createStringOfNLength(2049)+`", "update_mask": ["query"]}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"query":"query must be between 1 and 2048 characters long"
+					},
+					"message":"input validation errors"
+				}`),
+		},
+		{
+			name:                 "query has bad syntax",
+			cfg:                  nil,
+			publishCfg:           nil,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodPatch,
+				"/v1/saved-searches/saved-search-id",
+				strings.NewReader(`{"query": "name:", "update_mask": ["query"]}`),
+			),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"query":"query does not match grammar"
+					},
+					"message":"input validation errors"
+				}`),
+		},
+		{
+			name:                 "query exceeds max AST complexity",
+			cfg:                  nil,
+			publishCfg:           nil,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: func() *http.Request {
+				terms := make([]string, 26)
+				for i := range terms {
+					terms[i] = fmt.Sprintf("id:feat-%d", i)
+				}
+				query := strings.Join(terms, " OR ")
+
+				return httptest.NewRequestWithContext(t.Context(),
+					http.MethodPatch,
+					"/v1/saved-searches/saved-search-id",
+					strings.NewReader(fmt.Sprintf(`{"query": %q, "update_mask": ["query"]}`, query)),
+				)
+			}(),
+			expectedResponse: testJSONResponse(400,
+				`{
+					"code":400,
+					"errors":{
+						"query":"search query complexity limit exceeded"
+					},
+					"message":"input validation errors"
+				}`),
+		},
+		{
+			name: "query with exactly 50 AST nodes (right at limit)",
+			cfg: func() *MockUpdateUserSavedSearchConfig {
+				terms := make([]string, 25)
+				for i := range terms {
+					terms[i] = fmt.Sprintf("id:feat-%d", i)
+				}
+				q := strings.Join(terms, " OR ")
+
+				return &MockUpdateUserSavedSearchConfig{
+					expectedSavedSearchID: "saved-search-id",
+					expectedUserID:        "testID1",
+					expectedUpdateRequest: &backend.SavedSearchUpdateRequest{
+						Name:        nil,
+						Description: nil,
+						Query:       &q,
+						UpdateMask: []backend.SavedSearchUpdateRequestUpdateMask{
+							backend.SavedSearchUpdateRequestMaskQuery,
+						},
+					},
+					output: &backend.SavedSearchResponse{
+						Id:             "saved-search-id",
+						Name:           "test name",
+						Query:          q,
+						Description:    nil,
+						Permissions:    nil,
+						BookmarkStatus: nil,
+						CreatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						UpdatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					},
+					err: nil,
+				}
+			}(),
+			publishCfg: func() *MockPublishSearchConfigurationChangedConfig {
+				terms := make([]string, 25)
+				for i := range terms {
+					terms[i] = fmt.Sprintf("id:feat-%d", i)
+				}
+				q := strings.Join(terms, " OR ")
+
+				return &MockPublishSearchConfigurationChangedConfig{
+					expectedResp: &backend.SavedSearchResponse{
+						Id:             "saved-search-id",
+						Name:           "test name",
+						Query:          q,
+						Description:    nil,
+						Permissions:    nil,
+						BookmarkStatus: nil,
+						CreatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+						UpdatedAt:      time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+					},
+					expectedUserID:     "testID1",
+					expectedIsCreation: false,
+					err:                nil,
+				}
+			}(),
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: func() *http.Request {
+				terms := make([]string, 25)
+				for i := range terms {
+					terms[i] = fmt.Sprintf("id:feat-%d", i)
+				}
+				q := strings.Join(terms, " OR ")
+
+				return httptest.NewRequestWithContext(t.Context(),
+					http.MethodPatch,
+					"/v1/saved-searches/saved-search-id",
+					strings.NewReader(fmt.Sprintf(`{"query": %q, "update_mask": ["query"]}`, q)),
+				)
+			}(),
+			expectedResponse: testJSONResponse(200,
+				func() string {
+					terms := make([]string, 25)
+					for i := range terms {
+						terms[i] = fmt.Sprintf("id:feat-%d", i)
+					}
+					q := strings.Join(terms, " OR ")
+
+					return fmt.Sprintf(`{
+						"id":"saved-search-id",
+						"name":"test name",
+						"query":%q,
+						"created_at":"2000-01-01T00:00:00Z",
+						"updated_at":"2000-01-01T00:00:00Z"
+					}`, q)
+				}(),
 			),
 		},
 		{

--- a/frontend/src/static/js/api/errors.ts
+++ b/frontend/src/static/js/api/errors.ts
@@ -29,6 +29,20 @@ export function createAPIError(
     typeof error.message === 'string'
   ) {
     message = error.message;
+    if (
+      'errors' in error &&
+      error.errors instanceof Object &&
+      error.errors !== null
+    ) {
+      const entries = Object.entries(error.errors);
+      const fieldMsgs = entries
+        .filter(([, msg]) => typeof msg === 'string')
+        .map(([field, msg]) => `${field}: ${msg}`)
+        .join(', ');
+      if (fieldMsgs) {
+        message = fieldMsgs;
+      }
+    }
     if ('code' in error && typeof error.code === 'number') {
       code = error.code;
     }

--- a/frontend/src/static/js/components/webstatus-saved-search-editor.ts
+++ b/frontend/src/static/js/components/webstatus-saved-search-editor.ts
@@ -43,9 +43,9 @@ const SavedSearchInputConstraints = {
   NameMinLength: 1,
   NameMaxLength: 32,
   // There is no minimum length for the description. We drop the description if it is an empty string.
-  DescriptionMaxLength: 256,
+  DescriptionMaxLength: 1024,
   QueryMinLength: 1,
-  QueryMaxLength: 256,
+  QueryMaxLength: 2048,
 };
 
 @customElement('webstatus-saved-search-editor')

--- a/lib/backendtypes/types.go
+++ b/lib/backendtypes/types.go
@@ -79,7 +79,13 @@ var (
 	ErrQueryConsistsEntirelyOfSavedSearch = errors.New(
 		"query cannot consist entirely of a single saved search or hotlist",
 	)
+
+	// ErrQueryComplexityExceeded indicates that the search query AST complexity exceeds the maximum allowed limit.
+	ErrQueryComplexityExceeded = errors.New("search query complexity limit exceeded")
 )
+
+// MaxASTNodes specifies the maximum allowed AST node complexity after deduplication.
+const MaxASTNodes = 50
 
 type QueryParseError struct {
 	BadQuery string

--- a/lib/gcpspanner/searchtypes/features_search_parse_test.go
+++ b/lib/gcpspanner/searchtypes/features_search_parse_test.go
@@ -1808,3 +1808,66 @@ func TestParseQueryBadInput(t *testing.T) {
 		})
 	}
 }
+
+func TestDeduplicateAndCountNodes(t *testing.T) {
+	parser := FeaturesSearchQueryParser{}
+
+	t.Run("Deduplicate repeated terms under AND", func(t *testing.T) {
+		input := "group:layout AND group:layout AND group:layout"
+		ast, err := parser.Parse(input)
+		if err != nil {
+			t.Fatalf("unexpected parse error: %v", err)
+		}
+
+		initialCount := CountNodes(ast)
+		if initialCount < 4 {
+			t.Errorf("expected at least 4 nodes initially, got %d", initialCount)
+		}
+
+		dedup := Deduplicate(ast)
+		dedupCount := CountNodes(dedup)
+		if dedupCount >= initialCount {
+			t.Errorf("expected deduplicated count to be smaller than initial %d, got %d", initialCount, dedupCount)
+		}
+	})
+
+	t.Run("Deduplicate repeated terms under OR", func(t *testing.T) {
+		input := "group:layout OR group:layout OR group:layout"
+		ast, err := parser.Parse(input)
+		if err != nil {
+			t.Fatalf("unexpected parse error: %v", err)
+		}
+
+		initialCount := CountNodes(ast)
+		dedup := Deduplicate(ast)
+		dedupCount := CountNodes(dedup)
+		if dedupCount >= initialCount {
+			t.Errorf("expected OR deduplication to reduce nodes from %d, got %d", initialCount, dedupCount)
+		}
+	})
+
+	t.Run("CountNodes and Deduplicate nil safety", func(t *testing.T) {
+		if CountNodes(nil) != 0 {
+			t.Errorf("expected CountNodes(nil) == 0")
+		}
+		if Deduplicate(nil) != nil {
+			t.Errorf("expected Deduplicate(nil) == nil")
+		}
+		if !EqualSearchNode(nil, nil) {
+			t.Errorf("expected EqualSearchNode(nil, nil) == true")
+		}
+	})
+
+	t.Run("CountNodes on complex query", func(t *testing.T) {
+		input := "id:feat1 OR id:feat2 OR id:feat3"
+		ast, err := parser.Parse(input)
+		if err != nil {
+			t.Fatalf("unexpected parse error: %v", err)
+		}
+
+		count := CountNodes(ast)
+		if count <= 0 {
+			t.Errorf("expected positive node count, got %d", count)
+		}
+	})
+}

--- a/lib/gcpspanner/searchtypes/searchtypes.go
+++ b/lib/gcpspanner/searchtypes/searchtypes.go
@@ -95,6 +95,97 @@ func (n SearchNode) IsKeyword() bool {
 	return n.Keyword == KeywordAND || n.Keyword == KeywordOR
 }
 
+// CountNodes returns the total number of nodes in the SearchNode AST tree.
+// Used for structural complexity validation to protect Cloud Spanner against query amplification attacks.
+func CountNodes(node *SearchNode) int {
+	if node == nil {
+		return 0
+	}
+	count := 1
+	for _, child := range node.Children {
+		count += CountNodes(child)
+	}
+
+	return count
+}
+
+// EqualSearchNode checks if two SearchNode trees are structurally identical.
+func EqualSearchNode(a, b *SearchNode) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Keyword != b.Keyword {
+		return false
+	}
+	if (a.Term == nil) != (b.Term == nil) {
+		return false
+	}
+	if a.Term != nil {
+		if a.Term.Identifier != b.Term.Identifier ||
+			a.Term.Operator != b.Term.Operator ||
+			a.Term.Value != b.Term.Value {
+			return false
+		}
+	}
+	if len(a.Children) != len(b.Children) {
+		return false
+	}
+	for i := range a.Children {
+		if !EqualSearchNode(a.Children[i], b.Children[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Deduplicate recursively simplifies an AST by removing duplicate child nodes under AND and OR keywords.
+// By the Idempotent Law of Boolean Algebra (A AND A = A, A OR A = A), deduplicating identical terms
+// produces a 100% logically equivalent query that returns the exact same set of web features,
+// while preventing redundant subquery generation and unnecessary Spanner CPU execution overhead.
+func Deduplicate(node *SearchNode) *SearchNode {
+	if node == nil {
+		return nil
+	}
+
+	newChildren := make([]*SearchNode, 0, len(node.Children))
+	for _, child := range node.Children {
+		dedupChild := Deduplicate(child)
+		if dedupChild == nil {
+			continue
+		}
+
+		if node.IsKeyword() {
+			duplicate := false
+			for _, existing := range newChildren {
+				if EqualSearchNode(existing, dedupChild) {
+					duplicate = true
+
+					break
+				}
+			}
+			if duplicate {
+				continue
+			}
+		}
+
+		newChildren = append(newChildren, dedupChild)
+	}
+
+	if node.IsKeyword() && len(newChildren) == 1 {
+		return newChildren[0]
+	}
+
+	return &SearchNode{
+		Keyword:  node.Keyword,
+		Term:     node.Term,
+		Children: newChildren,
+	}
+}
+
 type SearchTerm struct {
 	Identifier SearchIdentifier
 	Operator   SearchOperator

--- a/lib/gcpspanner/spanner_pipeline_analysis_test.go
+++ b/lib/gcpspanner/spanner_pipeline_analysis_test.go
@@ -1,0 +1,117 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
+)
+
+// TestWorstCaseMaxComplexityQuerySpannerLimits verifies that queries at the maximum allowed
+// AST node complexity (50 nodes) remain well within Cloud Spanner parameter (950) and
+// SQL statement size (1 MB) limits.
+func TestWorstCaseMaxComplexityQuerySpannerLimits(t *testing.T) {
+	terms := []string{
+		"id:feat-01", "id:feat-02", "id:feat-03", "id:feat-04", "id:feat-05",
+		"group:css", "group:layout", "group:dom", "group:canvas", "group:webgl",
+		"snapshot:2023", "snapshot:2024", "snapshot:ecmascript-5",
+		"available_on:chrome", "available_on:firefox", "available_on:safari",
+		"baseline_status:widely", "baseline_status:newly",
+	}
+
+	for len(terms) < 24 {
+		terms = append(terms, fmt.Sprintf("id:extra-feat-%d", len(terms)))
+	}
+
+	rawQuery := fmt.Sprintf("(%s)", strings.Join(terms, " OR "))
+
+	parser := searchtypes.FeaturesSearchQueryParser{}
+	astNode, err := parser.Parse(rawQuery)
+	if err != nil {
+		t.Fatalf("Failed to parse worst-case query: %v", err)
+	}
+
+	dedupNode := searchtypes.Deduplicate(astNode)
+	nodeCount := searchtypes.CountNodes(dedupNode)
+	if nodeCount > 50 {
+		t.Fatalf("expected <= 50 AST nodes, got %d", nodeCount)
+	}
+
+	builder := NewFeatureSearchFilterBuilder()
+	compiledFilter, err := builder.Build(dedupNode)
+	if err != nil {
+		t.Fatalf("Failed to build compiled filter: %v", err)
+	}
+
+	queryBuilder := FeatureSearchQueryBuilder{
+		baseQuery:     GCPFeatureSearchBaseQuery{},
+		wptMetricView: WPTSubtestView,
+		browsers:      []string{"chrome", "firefox", "safari"},
+		offsetCursor:  nil,
+	}
+
+	sort := NewFeatureNameSort(true)
+	stmt := queryBuilder.Build(compiledFilter, sort, 25)
+
+	// Parameter count assertion: Spanner hard limit is 950
+	if len(stmt.Params) > 100 {
+		t.Errorf("Param count %d exceeds safety threshold of 100 (Spanner max 950)", len(stmt.Params))
+	}
+
+	// SQL statement size assertion: Spanner hard limit is 1MB (1,048,576 bytes)
+	if len(stmt.SQL) > 50000 {
+		t.Errorf("SQL length %d bytes exceeds safety threshold of 50KB (Spanner max 1MB)", len(stmt.SQL))
+	}
+}
+
+func TestSpannerQueryGeneration35Features(t *testing.T) {
+	var ids []string
+	for i := 1; i <= 35; i++ {
+		ids = append(ids, fmt.Sprintf("id:feature-id-%02d", i))
+	}
+	rawQuery := fmt.Sprintf("(%s) AND baseline_status:widely", strings.Join(ids, " OR "))
+
+	parser := searchtypes.FeaturesSearchQueryParser{}
+	astNode, err := parser.Parse(rawQuery)
+	if err != nil {
+		t.Fatalf("Failed to parse query: %v", err)
+	}
+
+	builder := NewFeatureSearchFilterBuilder()
+	compiledFilter, err := builder.Build(astNode)
+	if err != nil {
+		t.Fatalf("Failed to build compiled filter: %v", err)
+	}
+
+	queryBuilder := FeatureSearchQueryBuilder{
+		baseQuery:     GCPFeatureSearchBaseQuery{},
+		wptMetricView: WPTSubtestView,
+		browsers:      []string{"chrome", "firefox", "safari"},
+		offsetCursor:  nil,
+	}
+
+	sort := NewFeatureNameSort(true)
+	stmt := queryBuilder.Build(compiledFilter, sort, 25)
+
+	if len(stmt.Params) == 0 {
+		t.Error("expected non-empty parameters for 35 feature ID query")
+	}
+	if len(stmt.SQL) == 0 {
+		t.Error("expected non-empty SQL statement for 35 feature ID query")
+	}
+}

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -1598,9 +1598,17 @@ func (s *Backend) ValidateQueryReferences(ctx context.Context, query string, upd
 	// Run expansion as a dry-run check mechanism.
 	// Starting with depth = maxAncestorDist ensures that any transitive ancestors
 	// won't exceed the global depth limit of 2.
-	_, _, err = s.expandSavedSearches(ctx, node, maxAncestorDist, map[string]struct{}{})
+	expandedNode, _, err := s.expandSavedSearches(ctx, node, maxAncestorDist, map[string]struct{}{})
+	if err != nil {
+		return err
+	}
 
-	return err
+	dedupExpanded := searchtypes.Deduplicate(expandedNode)
+	if searchtypes.CountNodes(dedupExpanded) > backendtypes.MaxASTNodes {
+		return backendtypes.ErrQueryComplexityExceeded
+	}
+
+	return nil
 }
 
 func (s *Backend) getMaxAncestorDistance(ctx context.Context, id string, currentDist int) (int, error) {

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -5127,6 +5128,24 @@ func TestValidateQueryReferences(t *testing.T) {
 			userSearches:        nil,
 			referencingSearches: nil,
 			expectedError:       backendtypes.ErrQueryConsistsEntirelyOfSavedSearch,
+		},
+		{
+			name:                "expanded query exceeds max AST complexity",
+			query:               "(saved:child) OR id:extra",
+			updateID:            nil,
+			systemSearches:      nil,
+			referencingSearches: nil,
+			userSearches: func() map[string]*gcpspanner.SavedSearch {
+				terms := make([]string, 25)
+				for i := range terms {
+					terms[i] = fmt.Sprintf("id:feat-%d", i)
+				}
+
+				return map[string]*gcpspanner.SavedSearch{
+					"child": {Query: strings.Join(terms, " OR ")},
+				}
+			}(),
+			expectedError: backendtypes.ErrQueryComplexityExceeded,
 		},
 	}
 

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -1832,7 +1832,7 @@ components:
         query:
           type: string
           minLength: 1
-          maxLength: 256
+          maxLength: 2048
       required:
         - name
         - query
@@ -1847,13 +1847,16 @@ components:
         name:
           type: string
           minLength: 1
+          maxLength: 32
         description:
           type: string
           nullable: true
           minLength: 1
+          maxLength: 1024
         query:
           type: string
           minLength: 1
+          maxLength: 2048
         update_mask:
           type: array
           description: >


### PR DESCRIPTION
## Summary

This PR resolves [Issue #2604](https://github.com/GoogleChrome/webstatus.dev/issues/2604) by expanding the `SavedSearch.query` character length limit from 256 to 2048 characters across OpenAPI schemas, Go HTTP backend validation handlers, and Lit frontend components.

To permit users to bookmark long feature ID lists (e.g., 33+ feature IDs) while protecting Cloud Spanner against parameter exhaustion limits (950 max parameters) and query amplification attacks, this change introduces upstream AST deduplication and structural complexity validation.

---

## What Was Changed

1. **OpenAPI Schema Definitions (`openapi/backend/openapi.yaml`):**
   - Updated `SavedSearch.query` `maxLength: 2048` (was 256).
   - Updated `SavedSearchUpdateRequest.query` `maxLength: 2048` and `description` `maxLength: 1024`.
   - Updated `SavedSearchUpdateRequest.name` `maxLength: 32`.
   - Regenerated Go and TypeScript OpenAPI types (`make openapi`).

2. **Upstream Go Backend Validation (`backend/pkg/httpserver` & `lib/backendtypes`):**
   - Updated `savedSearchQueryMaxLength = 2048`.
   - Defined `const MaxASTNodes = 50` in `lib/backendtypes/types.go`.
   - Implemented AST deduplication (`searchtypes.Deduplicate`) and node complexity validation (`CountNodes(dedupNode) <= 50`) in `CreateSavedSearch` and `UpdateSavedSearch`.
   - Mapped `backendtypes.ErrQueryComplexityExceeded` to HTTP `400 Bad Request`.

3. **Spanner Adapter Expansion Safeguard (`lib/gcpspanner/spanneradapters`):**
   - Enforced `CountNodes(Deduplicate(expandedNode)) <= 50` in `ValidateQueryReferences` after recursive `@saved-search` resolution to prevent expansion amplification bypasses.

4. **Frontend Constraints & Error Formatting (`frontend/src/static/js`):**
   - Set `QueryMaxLength: 2048` and `DescriptionMaxLength: 1024` in `webstatus-saved-search-editor.ts`.
   - Enhanced `frontend/src/static/js/api/errors.ts` to format `fieldErrorMap` strings directly for Toast notifications.

5. **Test Suite & Verification:**
   - Added HTTP boundary test cases for 2048 length, 50 AST nodes, >50 AST nodes, and duplicate deduplication in `create_saved_search_test.go` and `update_saved_search_test.go`.
   - Added AST deduplication and `nil` safety unit tests in `features_search_parse_test.go`.
   - Added `TestWorstCaseMaxComplexityQuerySpannerLimits` in `spanner_pipeline_analysis_test.go` verifying that a worst-case 50-node query consumes only 27 / 950 parameters (2.84% of limit) and 5.7 KB / 1 MB SQL text (0.55% of limit).

---

## Corrected Assumptions / Learnings

- **AST Deduplication Unwrapping:** When parsing left-associative binary `AND`/`OR` trees from ANTLR, deduplicating children leaves single-child `Keyword` nodes `(A)`. Unwrapping single-child `Keyword` nodes (`if node.IsKeyword() && len(children) == 1 { return children[0] }`) collapses binary tree chains like `(((A AND A) AND A) AND A)` down to `A`.
- **Expansion Complexity Validation:** Upstream validation must run both on the unexpanded query string (in HTTP handlers) and after `expandSavedSearches` (in `ValidateQueryReferences`) to prevent nested `@saved-search` references from amplifying AST node complexity post-validation.

Fixes #2604