### PR TITLE
fix(spanner): update BrowserReleases.ReleaseDate in Merge and format workflow job errors (#2655)

### DIFF
--- a/lib/gcpspanner/browser_releases.go
+++ b/lib/gcpspanner/browser_releases.go
@@ -62,8 +62,9 @@ func (m browserReleaseSpannerMapper) SelectOne(key browserReleaseKey) spanner.St
 	return stmt
 }
 
-func (m browserReleaseSpannerMapper) Merge(_ BrowserRelease, existing spannerBrowserRelease) spannerBrowserRelease {
-	// If the release exists, it currently does nothing and keeps the existing as-is.
+func (m browserReleaseSpannerMapper) Merge(input BrowserRelease, existing spannerBrowserRelease) spannerBrowserRelease {
+	existing.ReleaseDate = input.ReleaseDate
+
 	return existing
 }
 

--- a/lib/gcpspanner/browser_releases.go
+++ b/lib/gcpspanner/browser_releases.go
@@ -38,6 +38,14 @@ type BrowserRelease struct {
 	ReleaseDate    time.Time `spanner:"ReleaseDate"`
 }
 
+// Equal returns true if all fields of two BrowserRelease structs match, using
+// time.Time.Equal for ReleaseDate comparison.
+func (r BrowserRelease) Equal(other BrowserRelease) bool {
+	return r.BrowserName == other.BrowserName &&
+		r.BrowserVersion == other.BrowserVersion &&
+		r.ReleaseDate.Equal(other.ReleaseDate)
+}
+
 type browserReleaseKey struct {
 	BrowserName    string
 	BrowserVersion string

--- a/lib/gcpspanner/browser_releases_test.go
+++ b/lib/gcpspanner/browser_releases_test.go
@@ -107,4 +107,33 @@ func TestInsertBrowserRelease(t *testing.T) {
 	if !slices.Equal[[]BrowserRelease](sampleBrowserReleases, releases) {
 		t.Errorf("unequal releases. expected %+v actual %+v", sampleBrowserReleases, releases)
 	}
+
+	// Verify that updating a release date for an existing browser release updates ReleaseDate in Spanner
+	updatedRelease := BrowserRelease{
+		BrowserName:    "fooBrowser",
+		BrowserVersion: "0.0.0",
+		ReleaseDate:    time.Date(2000, time.January, 15, 0, 0, 0, 0, time.UTC),
+	}
+	err = spannerClient.InsertBrowserRelease(ctx, updatedRelease)
+	if err != nil {
+		t.Fatalf("unexpected error updating browser release date: %v", err)
+	}
+
+	releases, err = spannerClient.ReadAllBrowserReleases(ctx, t)
+	if err != nil {
+		t.Fatalf("unexpected error reading browser releases: %v", err)
+	}
+
+	foundUpdated := false
+	for _, r := range releases {
+		if r.BrowserName == "fooBrowser" && r.BrowserVersion == "0.0.0" {
+			foundUpdated = true
+			if !r.ReleaseDate.Equal(updatedRelease.ReleaseDate) {
+				t.Errorf("expected updated release date %v, got %v", updatedRelease.ReleaseDate, r.ReleaseDate)
+			}
+		}
+	}
+	if !foundUpdated {
+		t.Error("expected to find updated release in Spanner")
+	}
 }

--- a/lib/gcpspanner/browser_releases_test.go
+++ b/lib/gcpspanner/browser_releases_test.go
@@ -104,7 +104,7 @@ func TestInsertBrowserRelease(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error during read all. %s", err.Error())
 	}
-	if !slices.Equal[[]BrowserRelease](sampleBrowserReleases, releases) {
+	if !slices.EqualFunc(sampleBrowserReleases, releases, (BrowserRelease).Equal) {
 		t.Errorf("unequal releases. expected %+v actual %+v", sampleBrowserReleases, releases)
 	}
 
@@ -124,16 +124,7 @@ func TestInsertBrowserRelease(t *testing.T) {
 		t.Fatalf("unexpected error reading browser releases: %v", err)
 	}
 
-	foundUpdated := false
-	for _, r := range releases {
-		if r.BrowserName == "fooBrowser" && r.BrowserVersion == "0.0.0" {
-			foundUpdated = true
-			if !r.ReleaseDate.Equal(updatedRelease.ReleaseDate) {
-				t.Errorf("expected updated release date %v, got %v", updatedRelease.ReleaseDate, r.ReleaseDate)
-			}
-		}
-	}
-	if !foundUpdated {
-		t.Error("expected to find updated release in Spanner")
+	if !slices.ContainsFunc(releases, updatedRelease.Equal) {
+		t.Errorf("expected to find updated release %+v in Spanner: got %+v", updatedRelease, releases)
 	}
 }

--- a/workflows/steps/services/bcd_consumer/cmd/job/main.go
+++ b/workflows/steps/services/bcd_consumer/cmd/job/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"cmp"
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 
@@ -104,7 +105,7 @@ func main() {
 	// Job Execution and Error Handling
 	errs := pool.Start(ctx, numWorkers, processor, jobs)
 	if len(errs) > 0 {
-		slog.ErrorContext(ctx, "workflow returned errors", "error", errs)
+		slog.ErrorContext(ctx, "workflow returned errors", "error", errors.Join(errs...))
 		os.Exit(1)
 	}
 }

--- a/workflows/steps/services/chromium_histogram_enums/cmd/job/main.go
+++ b/workflows/steps/services/chromium_histogram_enums/cmd/job/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
@@ -78,7 +79,7 @@ func main() {
 	// Job Execution and Error Handling
 	errs := pool.Start(ctx, numWorkers, processor, jobs)
 	if len(errs) > 0 {
-		slog.ErrorContext(ctx, "workflow returned errors", "error", errs)
+		slog.ErrorContext(ctx, "workflow returned errors", "error", errors.Join(errs...))
 		os.Exit(1)
 	}
 }

--- a/workflows/steps/services/developer_signals_consumer/cmd/job/main.go
+++ b/workflows/steps/services/developer_signals_consumer/cmd/job/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
@@ -76,7 +77,7 @@ func main() {
 	// Job Execution And Error Handling
 	errs := pool.Start(ctx, numWorkers, processor, jobs)
 	if len(errs) > 0 {
-		slog.ErrorContext(ctx, "workflow returned errors", "error", errs)
+		slog.ErrorContext(ctx, "workflow returned errors", "error", errors.Join(errs...))
 		os.Exit(1)
 	}
 }

--- a/workflows/steps/services/uma_export/cmd/job/main.go
+++ b/workflows/steps/services/uma_export/cmd/job/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"time"
@@ -88,7 +89,7 @@ func main() {
 	// Job Execution and Error Handling
 	errs := pool.Start(ctx, numWorkers, processor, jobs)
 	if len(errs) > 0 {
-		slog.ErrorContext(ctx, "workflow returned errors", "error", errs)
+		slog.ErrorContext(ctx, "workflow returned errors", "error", errors.Join(errs...))
 		os.Exit(1)
 	}
 }

--- a/workflows/steps/services/web_feature_consumer/cmd/job/main.go
+++ b/workflows/steps/services/web_feature_consumer/cmd/job/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"cmp"
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"time"
@@ -119,7 +120,7 @@ func main() {
 	// Job Execution and Error Handling
 	errs := pool.Start(ctx, numWorkers, processor, jobs)
 	if len(errs) > 0 {
-		slog.ErrorContext(ctx, "workflow returned errors", "error", errs)
+		slog.ErrorContext(ctx, "workflow returned errors", "error", errors.Join(errs...))
 		os.Exit(1)
 	}
 }

--- a/workflows/steps/services/web_features_mapping_consumer/cmd/job/main.go
+++ b/workflows/steps/services/web_features_mapping_consumer/cmd/job/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
@@ -79,7 +80,7 @@ func main() {
 	// Job Execution and Error Handling
 	errs := pool.Start(ctx, numWorkers, processor, jobs)
 	if len(errs) > 0 {
-		slog.ErrorContext(ctx, "workflow returned errors", "error", errs)
+		slog.ErrorContext(ctx, "workflow returned errors", "error", errors.Join(errs...))
 		os.Exit(1)
 	}
 }

--- a/workflows/steps/services/wpt_consumer/cmd/job/main.go
+++ b/workflows/steps/services/wpt_consumer/cmd/job/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"cmp"
 	"context"
+	"errors"
 	"log/slog"
 	"maps"
 	"os"
@@ -158,7 +159,7 @@ func main() {
 	// Job Execution and Error Handling
 	errs := pool.Start(ctx, numWorkers, processor, jobs)
 	if len(errs) > 0 {
-		slog.ErrorContext(ctx, "workflow returned errors", "error", errs)
+		slog.ErrorContext(ctx, "workflow returned errors", "error", errors.Join(errs...))
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

This PR resolves [Issue #2655](https://github.com/GoogleChrome/webstatus.dev/issues/2655) by updating `browserReleaseSpannerMapper.Merge` to update `existing.ReleaseDate = input.ReleaseDate` and fixing error string formatting in Cloud Run workflow job logs.

---

## What Was Changed

1. **Spanner Release Date Upsert Fix (`lib/gcpspanner/browser_releases.go`):**
   - `browserReleaseSpannerMapper.Merge` previously discarded `input.ReleaseDate` and returned `existing` unchanged. 
   - When MDN BCD updated a release date (e.g. Firefox 155 date shifted from `2026-09-15` to `2026-09-01`. See https://github.com/mdn/browser-compat-data/pull/30019), Spanner kept `firefox 155` stored under the old `2026-09-15` date. (it's the first time this has happened in webstatus.dev's lifetime for the browsers we track)
   - Subsequent insertions of later releases (e.g. Firefox 156 on `2026-09-15`) triggered unique index conflicts on `IDX_BrowserReleases_BrowserName_ReleaseDate_U`.
   - Updating `existing.ReleaseDate = input.ReleaseDate` keeps `BrowserReleases` accurately synchronized.

2. **Unmasked Workflow Job Error Logging (`workflows/steps/services/*/cmd/job/main.go`):**
   - Standardized error logging across all 7 workflow services (`bcd_consumer`, `chromium_histogram_enums`, `developer_signals_consumer`, `uma_export`, `web_feature_consumer`, `web_features_mapping_consumer`, `wpt_consumer`).
   - Passing a raw `[]error` slice to `slog.ErrorContext` previously serialized error attributes as empty objects `[ {} ]`.
   - Wrapping `errs` with `errors.Join(errs...)` ensures `slog` formats and prints full error string details into Cloud Logging.

3. **Unit Test Suite (`lib/gcpspanner/browser_releases_test.go`):**
   - Added unit test asserting that re-inserting an existing `BrowserRelease` with an updated `ReleaseDate` updates the database record.

---

Fixes #2655