### PR TITLE
feat: add Cloud Build 2nd Gen CD pipeline and make deployment scripts dual-mode

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,41 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  # ---------------------------------------------------------------------------
+  # Step 0: Execute CI/CD Deployment Loop (Plan, Migrate, Apply, Promote)
+  # ---------------------------------------------------------------------------
+  - id: 'deploy-ci'
+    name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
+    entrypoint: 'bash'
+    secretEnv: ['GH_TOKEN']
+    env:
+      - 'CI=true'
+      - 'CLOUD_BUILD=true'
+      - '_DEPLOY_ENV=${_DEPLOY_ENV}'
+      - '_FORCE_DEPLOY=${_FORCE_DEPLOY}'
+      - '_SKIP_ISSUE_CREATION=${_SKIP_ISSUE_CREATION}'
+    args:
+      - './util/deployment/deploy-ci'
+
+availableSecrets:
+  secretManager:
+    - versionName: projects/interop-tooling-ops/secrets/interop-bot-gh-token/versions/latest
+      env: 'GH_TOKEN'
+
+options:
+  machineType: 'E2_HIGHCPU_8'
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: '7200s'

--- a/util/deployment/create-deployment-issue
+++ b/util/deployment/create-deployment-issue
@@ -1,14 +1,41 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: create-deployment-issue [-q]"
+  echo "  -q : Disable interactive prompts and run in non-interactive CI/CD mode"
+}
+
+QUIET="${QUIET:-false}"
+CI="${CI:-false}"
+CLOUD_BUILD="${CLOUD_BUILD:-false}"
+
+while getopts ':fqh' flag; do
+  case "${flag}" in
+    f) ;;
+    q) QUIET='true' ;;
+    h) usage && exit 0 ;;
+    *) usage >&2 && exit 1 ;;
+  esac
+done
+
+# If CI or CLOUD_BUILD environment variables are true, default QUIET to true
+if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" ]]; then
+  QUIET="true"
+fi
 
 # Ensure we are in the project root
-if [ "$(git rev-parse --git-dir 2>/dev/null)" != ".git" ]; then
+if [ "$(git rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)" ]; then
   echo "Please run this script from the root of the webstatus.dev repository."
   exit 1
 fi
 
 echo "Checking GitHub CLI authentication status..."
 if ! gh auth status > /dev/null 2>&1; then
+  if [[ "${QUIET}" == "true" ]]; then
+    echo "Error: GitHub CLI is not authenticated in non-interactive CI/CD mode. Ensure GH_TOKEN or GITHUB_TOKEN environment variable is set." >&2
+    exit 1
+  fi
   echo "You are not logged into the GitHub CLI. Starting login process..."
   gh auth login
   # Re-check auth status after login attempt
@@ -19,13 +46,30 @@ if ! gh auth status > /dev/null 2>&1; then
 fi
 echo "Authenticated."
 
-PREVIOUS_SHORT_SHA=$(gh issue list --state=closed --label="release" --json title --repo "GoogleChrome/webstatus.dev" | jq -r '.[0].title' | awk '{print $NF}')
+PREVIOUS_SHORT_SHA=$(gh issue list --state=closed --label="release" --json title --repo "GoogleChrome/webstatus.dev" | jq -r '.[0].title // ""' | awk '{print $NF}')
+CHANGELOG=""
+
 if [ -z "$PREVIOUS_SHORT_SHA" ]; then
-  echo "Could not determine the previous release SHA. Please check closed release issues."
-  exit 1
+  if [[ "${QUIET}" == "true" ]]; then
+    echo "Could not determine the previous release SHA from closed issues. Generating recent 20 commits..."
+    CHANGELOG=$(git log -n 20 --oneline --format="- %C(auto) %h %s")
+    PREVIOUS_SHORT_SHA=$(git rev-parse --short HEAD~20 2>/dev/null || git rev-parse --short HEAD)
+  else
+    echo "Could not determine the previous release SHA. Please check closed release issues."
+    exit 1
+  fi
+else
+  if ! CHANGELOG=$(git log --oneline "$PREVIOUS_SHORT_SHA..HEAD" --format="- %C(auto) %h %s" 2>/dev/null); then
+    if [[ "${QUIET}" == "true" ]]; then
+      echo "Previous commit ($PREVIOUS_SHORT_SHA) not directly in DAG or shallow clone; generating recent 20 commits..."
+      CHANGELOG=$(git log -n 20 --oneline --format="- %C(auto) %h %s")
+    else
+      echo "Failed to run git log for $PREVIOUS_SHORT_SHA..HEAD."
+      exit 1
+    fi
+  fi
 fi
 
-CHANGELOG=$(git log --oneline "$PREVIOUS_SHORT_SHA..HEAD" --format="- %C(auto) %h %s")
 NEW_SHA=$(git rev-parse --short HEAD)
 
 DIRTY_PREFIX=""
@@ -36,14 +80,14 @@ fi
 ISSUE_TITLE="Deploy $DIRTY_PREFIX$NEW_SHA"
 
 echo "Checking for existing issue with title: $ISSUE_TITLE"
-EXISTING_ISSUE_JSON=$(gh issue list --search "\"$ISSUE_TITLE\" in:title" --label release --state all --repo "GoogleChrome/webstatus.dev" --json number,title,state,url | jq --arg title "$ISSUE_TITLE" '.[] | select(.title == $title)')
+EXISTING_ISSUE_JSON=$(gh issue list --search "$NEW_SHA" --label release --state all --repo "GoogleChrome/webstatus.dev" --json number,title,state,url | jq --arg title "$ISSUE_TITLE" '.[] | select(.title == $title)')
 
 if [[ -n "$EXISTING_ISSUE_JSON" ]]; then
   ISSUE_STATE=$(echo "$EXISTING_ISSUE_JSON" | jq -r '.state')
   ISSUE_URL=$(echo "$EXISTING_ISSUE_JSON" | jq -r '.url')
   if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
-    echo -e "Deployment has already been completed for $NEW_SHA. A closed\nissue with the title '$ISSUE_TITLE' was found:\n  $ISSUE_URL"
-    exit 1
+    echo -e "Deployment has already been completed for $NEW_SHA. Closed issue:\n  $ISSUE_URL"
+    exit 0
   else # It must be OPEN
     echo -e "An open issue with the title '$ISSUE_TITLE' already exists:\n  $ISSUE_URL"
     exit 0
@@ -67,10 +111,15 @@ echo "Title: $ISSUE_TITLE"
 echo "Body:"
 echo "$ISSUE_BODY"
 echo "---"
-echo "Press enter to create the issue, or Ctrl+C to cancel."
-read -r
 
-if ( ! gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "release" -R "GoogleChrome/webstatus.dev"); then
+if [[ "${QUIET}" == "true" ]]; then
+  echo "Non-interactive CI/CD mode (-q): Creating GitHub issue automatically..."
+else
+  echo "Press enter to create the issue, or Ctrl+C to cancel."
+  read -r
+fi
+
+if ! gh issue create --title "$ISSUE_TITLE" --body "$ISSUE_BODY" --label "release" -R "GoogleChrome/webstatus.dev"; then
   echo "GitHub issue creation failed."
   exit 1
 fi

--- a/util/deployment/deploy-ci
+++ b/util/deployment/deploy-ci
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: deploy-ci <staging|prod> [-f] [-b]"
+  echo "  staging|prod : Target environment to deploy"
+  echo "  -f           : Force deployment"
+  echo "  -b           : Skip GitHub issue creation/update (prod only)"
+}
+
+DEPLOY_ENV="${_DEPLOY_ENV:-${1:-}}"
+if [[ "${DEPLOY_ENV}" == "production" ]]; then
+  DEPLOY_ENV="prod"
+fi
+
+if [[ -z "${DEPLOY_ENV}" || ! "${DEPLOY_ENV}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  echo "Error: Target environment name required (e.g. staging, prod, pr-123)." >&2
+  usage
+  exit 1
+fi
+
+if [[ -n "${1:-}" && ! "${1:-}" =~ ^- ]]; then
+  shift
+fi
+
+FORCE_DEPLOY="${_FORCE_DEPLOY:-false}"
+SKIP_ISSUE_CREATION="${_SKIP_ISSUE_CREATION:-false}"
+PLAN_ONLY="${PLAN_ONLY:-false}"
+APPLY_ONLY="${APPLY_ONLY:-false}"
+
+while getopts ':fbqpah' flag; do
+  case "${flag}" in
+    f) FORCE_DEPLOY='true' ;;
+    b) SKIP_ISSUE_CREATION='true' ;;
+    q) ;;
+    p) PLAN_ONLY='true' ;;
+    a) APPLY_ONLY='true' ;;
+    h) usage && exit 0 ;;
+    *) usage >&2 && exit 1 ;;
+  esac
+done
+
+if [[ "${PLAN_ONLY}" == "true" && "${APPLY_ONLY}" == "true" ]]; then
+  echo "Error: -p (plan-only) and -a (apply-only) flags cannot be used together." >&2
+  exit 1
+fi
+
+FLAGS="-q"
+if [[ "${FORCE_DEPLOY}" == "true" ]]; then FLAGS="${FLAGS} -f"; fi
+if [[ "${SKIP_ISSUE_CREATION}" == "true" && "${DEPLOY_ENV}" == "prod" ]]; then FLAGS="${FLAGS} -b"; fi
+
+echo "================================================================"
+echo "Installing Docker, Go, & DevContainer CLI (@devcontainers/cli)..."
+echo "================================================================"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq docker.io nodejs npm jq golang-go
+npm install -g @devcontainers/cli json5
+
+# Ensure checkout is in /workspace/webstatus.dev on host volume so Docker daemon resolves bind mounts
+if [[ ! -d "/workspace/webstatus.dev/.git" ]]; then
+  echo "Moving checkout into /workspace/webstatus.dev for DevContainer bind mounts..."
+  mkdir -p /tmp/stage
+  shopt -s dotglob
+  mv /workspace/* /tmp/stage/ 2>/dev/null || true
+  mkdir -p /workspace/webstatus.dev
+  mv /tmp/stage/* /workspace/webstatus.dev/
+  shopt -u dotglob
+fi
+
+chown -R 1000:1000 /workspace/webstatus.dev
+mkdir -p /workspace/webstatus.dev/.devcontainer/cache/go/go-build /workspace/webstatus.dev/.devcontainer/cache/go/pkg /workspace/webstatus.dev/.devcontainer/cache/node/.npm
+chown -R 1000:1000 /workspace/webstatus.dev/.devcontainer/cache
+
+cd /workspace/webstatus.dev
+
+echo "================================================================"
+echo "Building and starting DevContainer environment..."
+echo "================================================================"
+trap 'rm -f /tmp/devcontainer-ci.json' EXIT
+json5 .devcontainer/devcontainer.json | jq '.runArgs += ["--network=host"] | .mounts += ["source=/root/.config/gcloud,target=/home/vscode/.config/gcloud,type=bind"]' > /tmp/devcontainer-ci.json
+devcontainer up --workspace-folder /workspace/webstatus.dev --config .devcontainer/devcontainer.json --override-config /tmp/devcontainer-ci.json
+
+echo "================================================================"
+echo "Executing CI/CD deployment for DEPLOY_ENV=${DEPLOY_ENV}..."
+echo "================================================================"
+
+AUTH_TOKEN=$(gcloud auth print-access-token --scopes="https://www.googleapis.com/auth/cloud-platform" 2>/dev/null) || {
+  echo "Error: Failed to obtain GCP access token via gcloud auth." >&2
+  exit 1
+}
+
+META_FLAGS=""
+if [[ -n "${GCE_METADATA_HOST:-}" ]]; then
+  META_FLAGS="${META_FLAGS} --remote-env GCE_METADATA_HOST=${GCE_METADATA_HOST}"
+fi
+if [[ -n "${GCE_METADATA_IP:-}" ]]; then
+  META_FLAGS="${META_FLAGS} --remote-env GCE_METADATA_IP=${GCE_METADATA_IP}"
+fi
+
+if [[ "${DEPLOY_ENV}" == "prod" ]]; then
+  DEPLOY_SCRIPT="./util/deployment/deploy-production"
+elif [[ -f "./util/deployment/deploy-${DEPLOY_ENV}" ]]; then
+  DEPLOY_SCRIPT="./util/deployment/deploy-${DEPLOY_ENV}"
+else
+  DEPLOY_SCRIPT="./util/deployment/deploy-env"
+fi
+
+if [[ "${APPLY_ONLY}" != "true" ]]; then
+  echo "--- Phase 1/4: Validating infrastructure plan inside DevContainer (-p) ---"
+  # shellcheck disable=SC2086
+  devcontainer exec --workspace-folder /workspace/webstatus.dev ${META_FLAGS} \
+    --remote-env GOOGLE_OAUTH_ACCESS_TOKEN="${AUTH_TOKEN}" \
+    --remote-env CLOUDSDK_AUTH_ACCESS_TOKEN="${AUTH_TOKEN}" \
+    --remote-env GH_TOKEN="${GH_TOKEN:-}" \
+    --remote-env GITHUB_TOKEN="${GH_TOKEN:-}" \
+    bash -l -c "${DEPLOY_SCRIPT} -p ${FLAGS}"
+fi
+
+if [[ "${PLAN_ONLY}" != "true" ]]; then
+  # ARCHITECTURAL NOTE: Why we run Spanner schema migrations natively on outer Cloud Build host:
+  # Running wrench inside the DevContainer over --network=host causes Google Cloud metadata queries
+  # (http://169.254.169.254) to fall back to the worker VM compute identity (cloudbuild-untrusted@...)
+  # which has restricted scopes (devstorage.read_only), throwing 403 "insufficient authentication scopes".
+  # By executing go tool wrench directly on the outer Cloud Build host container in Phase 2, wrench
+  # natively inherits Cloud Build's ambient step identity (sa-deploy-webstatus-*) without needing any
+  # custom JSON service account keys (adc.json) or token forwarding hacks.
+  echo "--- Phase 2/4: Applying Spanner schema migrations natively on outer Cloud Build host ---"
+  export SPANNER_PROJECT_ID="${SPANNER_PROJECT_ID:-webstatus-dev-internal-${DEPLOY_ENV}}"
+  export SPANNER_INSTANCE_ID="${SPANNER_INSTANCE_ID:-${DEPLOY_ENV}-spanner}"
+  export SPANNER_DATABASE_ID="${SPANNER_DATABASE_ID:-${DEPLOY_ENV}-database}"
+  (cd tools && go tool wrench migrate up --directory ../infra/storage/spanner/)
+fi
+
+if [[ "${PLAN_ONLY}" != "true" ]]; then
+  echo "--- Phase 3/4: Applying infrastructure changes inside DevContainer (-a) ---"
+  # shellcheck disable=SC2086
+  devcontainer exec --workspace-folder /workspace/webstatus.dev ${META_FLAGS} \
+    --remote-env GOOGLE_OAUTH_ACCESS_TOKEN="${AUTH_TOKEN}" \
+    --remote-env CLOUDSDK_AUTH_ACCESS_TOKEN="${AUTH_TOKEN}" \
+    --remote-env GH_TOKEN="${GH_TOKEN:-}" \
+    --remote-env GITHUB_TOKEN="${GH_TOKEN:-}" \
+    bash -l -c "${DEPLOY_SCRIPT} -a ${FLAGS}"
+fi
+
+if [[ "${DEPLOY_ENV}" == "staging" && "${PLAN_ONLY}" != "true" ]]; then
+  echo "--- Phase 4/4: Promoting staging tag & chaining production build ---"
+  ./util/deployment/promote-and-chain-staging "${DEPLOY_ENV}"
+fi
+
+echo "CI/CD deployment for ${DEPLOY_ENV} completed successfully."

--- a/util/deployment/deploy-env
+++ b/util/deployment/deploy-env
@@ -1,8 +1,45 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 # This is a helper script for deploying to a specific environment.
 # It is called by the deploy-staging and deploy-production scripts.
+
+usage() {
+  echo "Usage: deploy-env [-q] [-f] [-p] [-a]"
+  echo "  -q : Disable interactive prompts and run in non-interactive CI/CD mode"
+  echo "  -f : Force deployment"
+  echo "  -p : Execute terraform plan only and exit"
+  echo "  -a : Execute terraform apply only and exit"
+}
+
+QUIET="${QUIET:-false}"
+FORCE_DEPLOY="${FORCE_DEPLOY:-false}"
+PLAN_ONLY="${PLAN_ONLY:-false}"
+APPLY_ONLY="${APPLY_ONLY:-false}"
+CI="${CI:-false}"
+CLOUD_BUILD="${CLOUD_BUILD:-false}"
+
+while getopts ':fqpah' flag; do
+  case "${flag}" in
+    f) FORCE_DEPLOY='true' ;;
+    q) QUIET='true' ;;
+    p) PLAN_ONLY='true' ;;
+    a) APPLY_ONLY='true' ;;
+    h) usage && exit 0 ;;
+    *) usage >&2 && exit 1 ;;
+  esac
+done
+
+# If CI or CLOUD_BUILD environment variables are true, default QUIET to true
+if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" ]]; then
+  QUIET="true"
+fi
+
+if [[ "${PLAN_ONLY}" == "true" && "${APPLY_ONLY}" == "true" ]]; then
+  echo "Error: -p (plan-only) and -a (apply-only) flags cannot be used together." >&2
+  usage
+  exit 1
+fi
 
 # Check that all required environment variables are set.
 if [ -z "$DEPLOY_ENV" ] || [ -z "$GCP_PROJECT" ] || \
@@ -16,7 +53,7 @@ fi
 echo "Starting deployment for $DEPLOY_ENV environment..."
 
 # Ensure we are in the project root
-if [ "$(git rev-parse --git-dir 2>/dev/null)" != ".git" ]; then
+if [ "$(git rev-parse --show-toplevel 2>/dev/null)" != "$(pwd -P)" ]; then
   echo "Please run this script from the root of the webstatus.dev repository."
   exit 1
 fi
@@ -26,36 +63,73 @@ make build
 
 cd infra
 
-echo "Authenticating with gcloud for project $GCP_PROJECT..."
-gcloud auth login
-gcloud auth application-default login --project="$GCP_PROJECT"
+if [[ "${QUIET}" == "true" ]]; then
+  echo "Non-interactive CI/CD mode (-q): Using existing/ambient gcloud credentials for project $GCP_PROJECT..."
+  gcloud config set project "$GCP_PROJECT" --quiet || true
+  export TF_IN_AUTOMATION=1
+  INPUT_FLAG="-input=false"
+else
+  echo "Authenticating with gcloud for project $GCP_PROJECT..."
+  gcloud auth login
+  gcloud auth application-default login --project="$GCP_PROJECT"
+  INPUT_FLAG=""
+fi
 gcloud auth configure-docker europe-west1-docker.pkg.dev --quiet
 
 export TF_WORKSPACE=${DEPLOY_ENV}
 
 echo "Initializing Terraform..."
-terraform init -reconfigure --var-file=".envs/${DEPLOY_ENV}.tfvars" --backend-config=".envs/backend-${DEPLOY_ENV}.tfvars"
+terraform init ${INPUT_FLAG} -reconfigure --backend-config=".envs/backend-${DEPLOY_ENV}.tfvars"
 
-echo "Planning Terraform changes..."
-terraform plan \
-    -var-file=".envs/${DEPLOY_ENV}.tfvars" \
-    -var "env_id=${DEPLOY_ENV}"
+TF_COMMON_ARGS=(-parallelism=2 -var-file=".envs/${DEPLOY_ENV}.tfvars" -var "env_id=${DEPLOY_ENV}")
 
-echo
-echo "Review the plan above. If it looks correct, you will be prompted to apply the changes."
-echo "Press enter to continue, or Ctrl+C to cancel."
-read -r
+if [[ "${APPLY_ONLY}" != "true" ]]; then
+  echo "Planning Terraform changes..."
+  terraform plan ${INPUT_FLAG:+"${INPUT_FLAG}"} "${TF_COMMON_ARGS[@]}"
 
-echo "Migrating database schema (if needed)..."
-export SPANNER_PROJECT_ID=${SPANNER_PROJECT}
-export SPANNER_DATABASE_ID=${DEPLOY_ENV}-database
-export SPANNER_INSTANCE_ID=${DEPLOY_ENV}-spanner
-(cd .. && go tool wrench migrate up --directory ./infra/storage/spanner/)
+  if [[ "${PLAN_ONLY}" == "true" ]]; then
+    echo "Plan-only mode (-p) complete. Exiting cleanly before schema migration or apply."
+    exit 0
+  fi
+
+  if [[ "${QUIET}" == "true" ]]; then
+    echo "Non-interactive CI/CD mode (-q): Auto-approving Terraform plan and continuing..."
+  else
+    echo
+    echo "Review the plan above. If it looks correct, you will be prompted to apply the changes."
+    echo "Press enter to continue, or Ctrl+C to cancel."
+    read -r
+  fi
+fi
+
+# ARCHITECTURAL NOTE: Why we skip Spanner migrations inside DevContainer during CI/CD (-q):
+# In Cloud Build CI/CD, running inside the DevContainer over --network=host causes Google Cloud
+# metadata queries (http://169.254.169.254) to fall back to the underlying GCE VM compute identity
+# (cloudbuild-untrusted@...) which has restricted scopes (devstorage.read_only), causing wrench
+# to fail with 403 "Request had insufficient authentication scopes".
+# Therefore, in non-interactive CI/CD mode (-q), we decouple database migrations from Terraform
+# and execute go tool wrench natively on the outer Cloud Build host container (Phase 2 of deploy-ci),
+# where it cleanly inherits Cloud Build's ambient service account identity without custom JSON files.
+if [[ "${QUIET}" == "true" ]]; then
+  echo "Non-interactive CI/CD mode (-q): Spanner schema migration is handled by the outer Cloud Build step."
+else
+  echo "Migrating database schema (if needed)..."
+  export SPANNER_PROJECT_ID=${SPANNER_PROJECT}
+  export SPANNER_DATABASE_ID=${DEPLOY_ENV}-database
+  export SPANNER_INSTANCE_ID=${DEPLOY_ENV}-spanner
+  (cd .. && go tool wrench migrate up --directory ./infra/storage/spanner/)
+fi
 
 echo "Applying Terraform changes..."
-terraform apply \
-    -var-file=".envs/${DEPLOY_ENV}.tfvars" \
-    -var "env_id=${DEPLOY_ENV}"
+APPLY_FLAGS=()
+if [[ "${QUIET}" == "true" ]]; then
+  APPLY_FLAGS+=("-auto-approve")
+fi
+if [[ -n "${INPUT_FLAG}" ]]; then
+  APPLY_FLAGS+=("${INPUT_FLAG}")
+fi
+
+terraform apply "${APPLY_FLAGS[@]}" "${TF_COMMON_ARGS[@]}"
 
 echo "$DEPLOY_ENV deployment complete."
 echo "Please verify the deployment at:"

--- a/util/deployment/deploy-production
+++ b/util/deployment/deploy-production
@@ -1,22 +1,114 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Verify we are on the main branch
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ "$BRANCH" != "main" ]; then
-  echo "Not on the main branch. Aborting deployment."
+usage() {
+  echo "Usage: deploy-production [-b] [-f] [-q] [-p] [-a]"
+  echo "  -b : Skip GitHub issue creation/update"
+  echo "  -f : Force deployment (bypass main branch check, uncommitted changes prompt, and verified-staging-latest guardrail)"
+  echo "  -q : Disable interactive prompts and run in non-interactive CI/CD mode"
+  echo "  -p : Execute terraform plan only and exit"
+  echo "  -a : Execute terraform apply only and exit"
+}
+
+QUIET="${QUIET:-false}"
+FORCE_DEPLOY="${FORCE_DEPLOY:-false}"
+SKIP_ISSUE_CREATION="${SKIP_ISSUE_CREATION:-false}"
+PLAN_ONLY="${PLAN_ONLY:-false}"
+APPLY_ONLY="${APPLY_ONLY:-false}"
+CI="${CI:-false}"
+CLOUD_BUILD="${CLOUD_BUILD:-false}"
+
+while getopts ':bfqpah' flag; do
+  case "${flag}" in
+    b) SKIP_ISSUE_CREATION='true' ;;
+    f) FORCE_DEPLOY='true' ;;
+    q) QUIET='true' ;;
+    p) PLAN_ONLY='true' ;;
+    a) APPLY_ONLY='true' ;;
+    h) usage && exit 0 ;;
+    *) usage >&2 && exit 1 ;;
+  esac
+done
+
+# If CI or CLOUD_BUILD environment variables are true, default QUIET to true
+if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" ]]; then
+  QUIET="true"
+fi
+
+if [[ "${PLAN_ONLY}" == "true" && "${APPLY_ONLY}" == "true" ]]; then
+  echo "Error: -p (plan-only) and -a (apply-only) flags cannot be used together." >&2
+  usage
   exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# Branch & Staging Verification Guardrails
+# ---------------------------------------------------------------------------
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+COMMIT_SHORT=$(git rev-parse --short HEAD)
+
+# Unconditionally fetch main and verified-staging-latest tag for ancestry checks
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  AUTH_HEADER=$(printf "interop-tooling-ops-bot:%s" "${GH_TOKEN}" | base64 | tr -d '\r\n')
+  git -c http.https://github.com/.extraheader="Authorization: Basic ${AUTH_HEADER}" fetch origin main 2>/dev/null || true
+  git -c http.https://github.com/.extraheader="Authorization: Basic ${AUTH_HEADER}" fetch origin tag verified-staging-latest 2>/dev/null || true
+else
+  git fetch origin main 2>/dev/null || true
+  git fetch origin tag verified-staging-latest 2>/dev/null || true
+fi
+
+if [[ "${FORCE_DEPLOY}" == "true" ]]; then
+  echo "FORCE_DEPLOY=true (-f): Bypassing branch and staging guardrails."
+elif [[ "${BRANCH}" == "main" ]]; then
+  echo "On main branch. Proceeding with production deployment."
+else
+  echo "Not on main branch (${BRANCH}). Checking git history and staging verification..."
+  STAGING_TAG_SHA=$(git rev-parse -q --verify refs/tags/verified-staging-latest 2>/dev/null || git rev-parse -q --verify verified-staging-latest 2>/dev/null || echo "")
+
+  if git merge-base --is-ancestor HEAD main 2>/dev/null || git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+    echo "Commit ${COMMIT_SHORT} is merged into main. Proceeding with deployment."
+  elif [[ -n "${STAGING_TAG_SHA}" ]] && { [[ "${STAGING_TAG_SHA}" == "$(git rev-parse HEAD 2>/dev/null)" ]] || git merge-base --is-ancestor refs/tags/verified-staging-latest HEAD 2>/dev/null || git merge-base --is-ancestor verified-staging-latest HEAD 2>/dev/null; }; then
+    echo "Commit ${COMMIT_SHORT} passed staging verification (verified-staging-latest=${STAGING_TAG_SHA:0:7}). Proceeding with deployment."
+  else
+    echo "Error: Commit ${COMMIT_SHORT} on branch '${BRANCH}' is not on main and has not passed staging verification." >&2
+    echo "Aborting production deployment to prevent regression. Pass -f (or _FORCE_DEPLOY=true) to force." >&2
+    exit 1
+  fi
+fi
+
 # Check for uncommitted changes
-if [ -n "$(git status --porcelain)" ]; then
+if [[ -n "$(git status --porcelain)" ]]; then
   echo "Uncommitted changes detected:"
   git status
-  read -p "Do you want to proceed with the deployment? (y/n) " -n 1 -r
-  echo
-  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    echo "Deployment aborted."
+  if [[ "${FORCE_DEPLOY}" == "true" ]]; then
+    echo "FORCE_DEPLOY=true: Proceeding with uncommitted changes."
+  elif [[ "${QUIET}" == "true" ]]; then
+    echo "Non-interactive CI/CD mode (-q) and uncommitted changes detected without -f. Aborting."
     exit 1
+  else
+    read -p "Do you want to proceed with the deployment? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+      echo "Deployment aborted."
+      exit 1
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Anti-Regression & Git Ancestry Guardrail (verified-staging-latest)
+# ---------------------------------------------------------------------------
+# Ensures the commit being deployed has successfully built and verified in staging.
+if git rev-parse -q --verify "refs/tags/verified-staging-latest" >/dev/null 2>&1; then
+  if ! git merge-base --is-ancestor verified-staging-latest HEAD 2>/dev/null; then
+    echo "WARNING: Commit $(git rev-parse --short HEAD) is not equal to or ahead of tag 'verified-staging-latest'."
+    echo "It has either not passed staging verification yet or represents an older historical commit."
+    if [[ "${FORCE_DEPLOY}" != "true" ]]; then
+      echo "Aborting production deployment to prevent regression. Pass -f to bypass this guardrail."
+      exit 1
+    else
+      echo "FORCE_DEPLOY=true (-f): Bypassing verified-staging-latest ancestry check."
+    fi
   fi
 fi
 
@@ -24,15 +116,43 @@ fi
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Create the GitHub issue for this deployment if it doesn't already exist.
-"$DIR/create-deployment-issue"
+if [[ "${SKIP_ISSUE_CREATION}" != "true" && "${APPLY_ONLY}" != "true" ]]; then
+  ISSUE_FLAGS=()
+  if [[ "${QUIET}" == "true" ]]; then ISSUE_FLAGS+=("-q"); fi
+  "$DIR/create-deployment-issue" "${ISSUE_FLAGS[@]}"
+fi
 
 export DEPLOY_ENV="prod"
 export GCP_PROJECT="web-compass-prod"
 export SPANNER_PROJECT="webstatus-dev-internal-prod"
 export WEBSITE_URL="https://webstatus.dev/"
 export API_URL="https://api.webstatus.dev/v1/features"
+export QUIET
+export FORCE_DEPLOY
+export SKIP_ISSUE_CREATION
+export PLAN_ONLY
+export APPLY_ONLY
+export CI
+export CLOUD_BUILD
 
-"$DIR/deploy-env"
+FLAGS=()
+if [[ "${QUIET}" == "true" ]]; then FLAGS+=("-q"); fi
+if [[ "${FORCE_DEPLOY}" == "true" ]]; then FLAGS+=("-f"); fi
+if [[ "${PLAN_ONLY}" == "true" ]]; then FLAGS+=("-p"); fi
+if [[ "${APPLY_ONLY}" == "true" ]]; then FLAGS+=("-a"); fi
 
-echo "Remember to close the GitHub release issue."
-echo "https://github.com/GoogleChrome/webstatus.dev/issues?q=is%3Aissue+label%3Arelease+is%3Aopen"
+"$DIR/deploy-env" "${FLAGS[@]}"
+
+if [[ "${SKIP_ISSUE_CREATION}" != "true" && "${PLAN_ONLY}" != "true" ]]; then
+  echo "Closing GitHub release issue..."
+  OPEN_RELEASE_ISSUE=$(gh issue list --state open --label "release" --search "${COMMIT_SHORT}" --limit 1 --json number --repo "GoogleChrome/webstatus.dev" | jq -r '.[0].number // ""')
+  if [[ -z "${OPEN_RELEASE_ISSUE}" ]]; then
+    OPEN_RELEASE_ISSUE=$(gh issue list --state open --label "release" --limit 1 --json number --repo "GoogleChrome/webstatus.dev" | jq -r '.[0].number // ""')
+  fi
+  if [[ -n "${OPEN_RELEASE_ISSUE}" ]]; then
+    gh issue close "${OPEN_RELEASE_ISSUE}" --repo "GoogleChrome/webstatus.dev" -c "Deployment is now complete." || echo "WARNING: Failed to close GitHub issue #${OPEN_RELEASE_ISSUE}." >&2
+    echo "Successfully closed GitHub issue #${OPEN_RELEASE_ISSUE}."
+  else
+    echo "No open issue with label 'release' found to close."
+  fi
+fi

--- a/util/deployment/deploy-staging
+++ b/util/deployment/deploy-staging
@@ -1,5 +1,42 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: deploy-staging [-q] [-f] [-p] [-a]"
+  echo "  -q : Disable interactive prompts and run in non-interactive CI/CD mode"
+  echo "  -f : Force deployment without prompting or guardrail checks"
+  echo "  -p : Execute terraform plan only and exit"
+  echo "  -a : Execute terraform apply only and exit"
+}
+
+QUIET="${QUIET:-false}"
+FORCE_DEPLOY="${FORCE_DEPLOY:-false}"
+PLAN_ONLY="${PLAN_ONLY:-false}"
+APPLY_ONLY="${APPLY_ONLY:-false}"
+CI="${CI:-false}"
+CLOUD_BUILD="${CLOUD_BUILD:-false}"
+
+while getopts ':fqpah' flag; do
+  case "${flag}" in
+    f) FORCE_DEPLOY='true' ;;
+    q) QUIET='true' ;;
+    p) PLAN_ONLY='true' ;;
+    a) APPLY_ONLY='true' ;;
+    h) usage && exit 0 ;;
+    *) usage >&2 && exit 1 ;;
+  esac
+done
+
+# If CI or CLOUD_BUILD environment variables are true, default QUIET to true
+if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" ]]; then
+  QUIET="true"
+fi
+
+if [[ "${PLAN_ONLY}" == "true" && "${APPLY_ONLY}" == "true" ]]; then
+  echo "Error: -p (plan-only) and -a (apply-only) flags cannot be used together." >&2
+  usage
+  exit 1
+fi
 
 # Get the directory of the script
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -9,5 +46,17 @@ export GCP_PROJECT="web-compass-staging"
 export SPANNER_PROJECT="webstatus-dev-internal-staging"
 export WEBSITE_URL="https://website-webstatus-dev.corp.goog/"
 export API_URL="https://api-webstatus-dev.corp.goog/v1/features"
+export QUIET
+export FORCE_DEPLOY
+export PLAN_ONLY
+export APPLY_ONLY
+export CI
+export CLOUD_BUILD
 
-"$DIR/deploy-env"
+FLAGS=()
+if [[ "${QUIET}" == "true" ]]; then FLAGS+=("-q"); fi
+if [[ "${FORCE_DEPLOY}" == "true" ]]; then FLAGS+=("-f"); fi
+if [[ "${PLAN_ONLY}" == "true" ]]; then FLAGS+=("-p"); fi
+if [[ "${APPLY_ONLY}" == "true" ]]; then FLAGS+=("-a"); fi
+
+"$DIR/deploy-env" "${FLAGS[@]}"

--- a/util/deployment/promote-and-chain-staging
+++ b/util/deployment/promote-and-chain-staging
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+DEPLOY_ENV="${_DEPLOY_ENV:-${1:-staging}}"
+
+# -----------------------------------------------------------------------------
+# Guard: Staging Promotion & Trigger Chaining is Staging Only
+# -----------------------------------------------------------------------------
+if [[ "${DEPLOY_ENV}" != "staging" ]]; then
+  echo "Skipping staging promotion step (_DEPLOY_ENV=${DEPLOY_ENV})."
+  exit 0
+fi
+
+# Ensure git safe directory inside container environments
+git config --global --add safe.directory '/workspace/webstatus.dev'
+
+# -----------------------------------------------------------------------------
+# 1. Determine Repository Owner and Name from Origin Remote
+# -----------------------------------------------------------------------------
+ORIGIN_URL=$(git config --get remote.origin.url || true)
+if [[ "${ORIGIN_URL}" =~ github\.com[:/]([^/]+)/([^/]+) ]]; then
+  GH_OWNER="${BASH_REMATCH[1]}"
+  RAW_REPO="${BASH_REMATCH[2]}"
+  GH_REPO="${RAW_REPO%.git}"
+else
+  GH_OWNER="GoogleChrome"
+  GH_REPO="webstatus.dev"
+fi
+
+MAIN_SHA=$(git rev-parse HEAD)
+SHORT_SHA=$(git rev-parse --short HEAD)
+
+echo "Staging deployment completed successfully. Tagging HEAD (${SHORT_SHA}) as verified-staging-latest..."
+
+# -----------------------------------------------------------------------------
+# 2. Configure Git Credentials & Push 'verified-staging-latest' Tag
+# -----------------------------------------------------------------------------
+git config user.name "interop-tooling-ops-bot"
+git config user.email "interop-tooling-ops-bot@google.com"
+git remote set-url origin "https://github.com/${GH_OWNER}/${GH_REPO}.git"
+git tag -f verified-staging-latest HEAD
+
+# Guard: Only promote staging tag and trigger production build if HEAD is on main
+git fetch origin main 2>/dev/null || true
+if ! git merge-base --is-ancestor HEAD main 2>/dev/null && ! git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+  echo "Commit $(git rev-parse --short HEAD) is not on main branch. Skipping verified-staging-latest tag promotion and production trigger."
+  exit 0
+fi
+
+if [[ -n "${GH_TOKEN:-}" ]]; then
+  AUTH_HEADER=$(printf "interop-tooling-ops-bot:%s" "${GH_TOKEN}" | base64 | tr -d '\r\n')
+  git -c http.https://github.com/.extraheader="Authorization: Basic ${AUTH_HEADER}" push -f origin verified-staging-latest
+else
+  echo "Warning: GH_TOKEN environment variable not set. Attempting default git push..."
+  git push -f origin verified-staging-latest
+fi
+
+# -----------------------------------------------------------------------------
+# 3. Trigger Production Build in PENDING State for Approval
+# -----------------------------------------------------------------------------
+echo "Chaining deployment to trigger-webstatus-prod (creating PENDING build for sheriff approval)..."
+gcloud builds triggers run trigger-webstatus-prod \
+  --project=interop-tooling-ops \
+  --region=us-central1 \
+  --sha="${MAIN_SHA}" \
+  --substitutions=_DEPLOY_ENV=prod,_FORCE_DEPLOY=false,_SKIP_ISSUE_CREATION=false


### PR DESCRIPTION
> [!NOTE]
> **TL;DR for Reviewers & Rotation Sheriffs**:
> - **Continuous Staging**: Every merge to `main` automatically builds, migrates, and deploys to the `staging` environment.
> - **Queued Production Releases**: Upon successful staging deployment, a production release build is automatically queued in `PENDING` state and tagged with `verified-staging-latest`.
> - **Rotation Workflow**: The sheriff or developer on rotation simply navigates to GCP Cloud Build Console and clicks **Approve** on the latest pending production build to trigger production deployment.

## Description

Automates `webstatus.dev` staging and production deployments in Cloud Build using DevContainers (`@devcontainers/cli`). Staging deploys automatically on `main` merges, tags `verified-staging-latest` upon success, and chains a pending production build awaiting 1-click sheriff approval.

## Context & Purpose

Modernizes `webstatus.dev` infrastructure deployment to align with centralized Google Cloud Build 2nd Gen architecture (`interop-tooling-ops` project). Eliminates manual local deployments and unauthenticated step failures by standardizing all deployment logic into a unified, dual-mode shell orchestration pipeline.

## Architectural Implementation

1. **DevContainer Parity (`@devcontainers/cli`)**:
   - Executes all CI/CD steps inside the exact container environment defined by `.devcontainer/devcontainer.json`.
   - Guarantees identical toolchain versions (Go 1.24+, Node 22+, Terraform 1.15+, gcloud 559+, ANTLR 4) between local dev and Cloud Build.

2. **4-Phase Deployment Loop (`util/deployment/deploy-ci`)**:
   - **Phase 1 (-p)**: Runs `terraform plan -parallelism=2` inside DevContainer. In production, authenticates `gh` CLI, opens the GitHub release issue, and verifies staging tag ancestry (`verified-staging-latest`).
   - **Phase 2 (Spanner Migration)**: Executes `go tool wrench migrate up` natively on the outer host container. Unlike Terraform (which accepts OAuth tokens), Go SDK ADC ignores env tokens over `--network=host` and requires host execution to inherit ambient runner service account credentials without 403 scope errors.
   - **Phase 3 (-a)**: Runs `terraform apply -parallelism=2 -auto-approve` inside DevContainer, closing the release issue upon completion.
   - **Phase 4 (Staging Promote & Chain)**: Tags `verified-staging-latest` and triggers `trigger-webstatus-prod` in `PENDING` state (guarded to `main` branch ancestor commits).

3. **Single-Step Declarative `cloudbuild.yaml`**:
   - Reduced `cloudbuild.yaml` to a single 40-line step runner calling `./util/deployment/deploy-ci` with zero inline shell scripts.

4. **Script Hardening**:
   - Standardized `set -euo pipefail`, array flag construction (`"${FLAGS[@]}"`), and `EXIT` traps for temporary files.
   - Scoped `safe.directory` specifically to `'/workspace/webstatus.dev'`.
   - Used in-memory `git HTTP extraheaders` for tag promotion to prevent PAT token leakage and dubious ownership errors.

## Corrected Assumptions & Learnings

- **Go SDK ADC Host Execution**: Spanner migrations via `wrench` must run natively on the host container (`cloud-sdk:latest`) rather than inside `devcontainer exec`, because Go SDK ADC ignores static env OAuth tokens (`CLOUDSDK_AUTH_ACCESS_TOKEN`) over Docker bridge networks.
- **GitHub CLI Flag Support**: `gh issue list` does not support `--sort created --order desc` flags. Searching by 7-character commit SHA (`--search "${COMMIT_SHORT}"`) with default creation-date ordering correctly identifies release issues.
- **GH_TOKEN Single Source of Truth**: Cloud Build 2nd Gen runner steps use `GH_TOKEN` injected from Secret Manager (`projects/interop-tooling-ops/secrets/interop-bot-gh-token`). `GITHUB_TOKEN` fallbacks are unnecessary in Cloud Build.
- **Unauthenticated DevContainer Git Operations**: Any `git fetch` operations executing inside `devcontainer exec` must explicitly pass `GH_TOKEN` HTTP extraheaders to prevent unauthenticated silent failures.
