### PR TITLE
fix(gcpspanner): optimize query execution and secondary index seeks for timeseries stats

### DIFF
--- a/.agent/skills/webstatus-backend/SKILL.md
+++ b/.agent/skills/webstatus-backend/SKILL.md
@@ -62,6 +62,8 @@ We use a Hexagonal-style **Adapter Pattern** to decouple application logic from 
 - **DO** pass pointers (`*string`) when populating optional OpenAPI response header fields (like `Location` in `301` responses), as `oapi-codegen v2.7+` models optional response headers as pointer types.
 - **DO** type strict middleware closures using `backend.StrictHandlerFunc` and `backend.StrictMiddlewareFunc` directly from the generated package rather than importing from `github.com/oapi-codegen/runtime/strictmiddleware/nethttp`.
 - **DO** use modern Go 1.26+ `new(expr)` built-in syntax (e.g., `new("my-string")` or `new(42)`) when creating pointers to values or literals. **DON'T** introduce custom pointer helper functions (e.g., `stringPtr`, `intPtr`, or generic `ptr(...)`).
+- **DO** resolve entity keys (e.g., `FeatureKey -> WebFeatureID`) upfront and seek directly on secondary indexes (e.g., `@{FORCE_INDEX=MetricsFeatureChannelBrowserTime}`) when querying high-volume timeseries tables (`WPTRunFeatureMetrics`, `DailyChromiumHistogramMetrics`). Never perform an unindexed driving join from parent tables across multi-year timeseries ranges.
+- **DO** match Go parameter types directly to Spanner column types (`civil.Date` for `DATE`, `time.Time` for `TIMESTAMP`) so SQL query predicates remain strictly sargable without wrapping table columns in SQL conversion functions (e.g., avoid `TIMESTAMP(dchm.Day)`).
 
 ## Testing & Linting
 

--- a/lib/gcpspanner/chromium_daily_usage_stat.go
+++ b/lib/gcpspanner/chromium_daily_usage_stat.go
@@ -31,12 +31,10 @@ const (
 		dchm.Day as Date,
 		dchm.Rate as Usage
 	FROM DailyChromiumHistogramMetrics dchm
-	LEFT OUTER JOIN WebFeatureChromiumHistogramEnumValues wfchev
+	JOIN WebFeatureChromiumHistogramEnumValues wfchev
 	ON wfchev.ChromiumHistogramEnumValueID = dchm.ChromiumHistogramEnumValueID
-	JOIN WebFeatures wf
-	ON wfchev.WebFeatureID = wf.ID
-	WHERE wf.FeatureKey = @featureKey
-	AND TIMESTAMP(dchm.Day) >= @startAt AND TIMESTAMP(dchm.Day) < @endAt
+	WHERE wfchev.WebFeatureID = @webFeatureID
+	AND dchm.Day >= @startDate AND dchm.Day < @endDate
 {{ if .PageFilter }}
  	{{ .PageFilter }}
 {{ end }}
@@ -76,12 +74,23 @@ func (c *Client) ListChromeDailyUsageStatsForFeatureID(
 	pageSize int,
 	pageToken *string,
 ) ([]ChromeDailyUsageStatWithDate, *string, error) {
+	featureID, err := c.GetIDFromFeatureKey(ctx, NewFeatureKeyFilter(featureKey))
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, nil, nil
+		}
+
+		return nil, nil, errors.Join(ErrInternalQueryFailure, err)
+	}
+
+	startDate := civil.DateOf(startAt)
+	endDate := civil.DateOf(endAt)
 
 	params := map[string]any{
-		"featureKey": featureKey,
-		"startAt":    startAt,
-		"endAt":      endAt,
-		"pageSize":   pageSize,
+		"webFeatureID": *featureID,
+		"startDate":    startDate,
+		"endDate":      endDate,
+		"pageSize":     pageSize,
 	}
 
 	tmplData := ChromeDailyUsageTemplateData{

--- a/lib/gcpspanner/chromium_daily_usage_stat_test.go
+++ b/lib/gcpspanner/chromium_daily_usage_stat_test.go
@@ -181,6 +181,27 @@ func testGetStatsPages(ctx context.Context, c *Client, t *testing.T) {
 	}
 }
 
+func testGetNonExistentFeatureStats(ctx context.Context, c *Client, t *testing.T) {
+	stats, token, err := c.ListChromeDailyUsageStatsForFeatureID(
+		ctx,
+		"featureDoesNotExist",
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.December, 1, 0, 0, 0, 0, time.UTC),
+		5,
+		nil,
+	)
+
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error for non-existent feature. received %s", err.Error())
+	}
+	if token != nil {
+		t.Error("expected null token for non-existent feature")
+	}
+	if len(stats) != 0 {
+		t.Errorf("expected 0 stats for non-existent feature, received %d", len(stats))
+	}
+}
+
 func TestListChromeDailyUsageStatsForFeatureID(t *testing.T) {
 	restartDatabaseContainer(t)
 	ctx := context.Background()
@@ -199,4 +220,5 @@ func TestListChromeDailyUsageStatsForFeatureID(t *testing.T) {
 	testGetAllStats(ctx, spannerClient, t)
 	testGetSubsetStats(ctx, spannerClient, t)
 	testGetStatsPages(ctx, spannerClient, t)
+	testGetNonExistentFeatureStats(ctx, spannerClient, t)
 }

--- a/lib/gcpspanner/feature_base_query.go
+++ b/lib/gcpspanner/feature_base_query.go
@@ -330,10 +330,14 @@ type LatestRunResultsGroupedByChannel map[string][]LatestRunResult
 
 func (f GCPFeatureSearchBaseQuery) buildBaseQueryFragment() string { return gcpFSBaseQueryTemplate }
 
+func (f GCPFeatureSearchBaseQuery) buildBaseCountQueryFragment() string {
+	return commonFSCountBaseQueryTemplate
+}
+
 func (f GCPFeatureSearchBaseQuery) CountQuery(args FeatureSearchCountArgs) string {
 	return gcpFSCountQueryTemplate.Execute(GCPFSCountTemplateData{
 		CommonFSCountTemplateData: CommonFSCountTemplateData{
-			BaseQueryFragment: f.buildBaseQueryFragment(),
+			BaseQueryFragment: f.buildBaseCountQueryFragment(),
 			Filters:           args.Filters,
 		},
 	})
@@ -346,9 +350,10 @@ func (f GCPFeatureSearchBaseQuery) CountQuery(args FeatureSearchCountArgs) strin
 const defaultSortPosition = 999999999
 
 const (
-	// commonFSBaseQueryTemplate provides the core of a Spanner query, joining
-	// the WebFeatures table with FeatureBaselineStatus for status information.
-	commonFSBaseQueryTemplate = `
+	// commonFSCountBaseQueryTemplate provides the core of a Spanner count query, joining
+	// the WebFeatures table with metadata tables that can be filtered on, while omitting
+	// non-filtering subqueries (browser_info and chromium_usage_metrics).
+	commonFSCountBaseQueryTemplate = `
 FROM WebFeatures wf
 LEFT OUTER JOIN FeatureBaselineStatus fbs ON wf.ID = fbs.WebFeatureID
 LEFT OUTER JOIN ExcludedFeatureKeys efk ON wf.FeatureKey = efk.FeatureKey
@@ -357,7 +362,12 @@ LEFT OUTER JOIN FeatureDiscouragedDetails fdd ON wf.ID = fdd.WebFeatureID
 LEFT OUTER JOIN LatestFeatureDeveloperSignals lfds ON wf.ID = lfds.WebFeatureID
 LEFT OUTER JOIN WebFeaturesMappingData wfmd ON wf.ID = wfmd.WebFeatureID
 LEFT OUTER JOIN SystemManagedSavedSearches smfs ON wf.ID = smfs.FeatureID
-LEFT OUTER JOIN (
+`
+
+	// commonFSBaseQueryTemplate provides the core of a Spanner query, extending
+	// commonFSCountBaseQueryTemplate with the browser_info and chromium_usage_metrics subqueries
+	// needed for column projection.
+	commonFSBaseQueryTemplate = commonFSCountBaseQueryTemplate + `LEFT OUTER JOIN (
 	SELECT
 		bfa.WebFeatureID,
 		ARRAY_AGG(
@@ -795,10 +805,14 @@ type LocalFeatureBaseQuery struct{}
 
 func (f LocalFeatureBaseQuery) buildBaseQueryFragment() string { return localFSBaseQueryTemplate }
 
+func (f LocalFeatureBaseQuery) buildBaseCountQueryFragment() string {
+	return commonFSCountBaseQueryTemplate
+}
+
 func (f LocalFeatureBaseQuery) CountQuery(args FeatureSearchCountArgs) string {
 	return localFSCountQueryTemplate.Execute(LocalFSCountTemplateData{
 		CommonFSCountTemplateData: CommonFSCountTemplateData{
-			BaseQueryFragment: f.buildBaseQueryFragment(),
+			BaseQueryFragment: f.buildBaseCountQueryFragment(),
 			Filters:           args.Filters,
 		},
 	})

--- a/lib/gcpspanner/wpt_run_feature_metric.go
+++ b/lib/gcpspanner/wpt_run_feature_metric.go
@@ -31,12 +31,15 @@ const LatestWPTRunFeatureMetricsTable = "LatestWPTRunFeatureMetrics"
 
 func init() {
 	getFeatureMetricBaseTemplate = NewQueryTemplate(getFeatureMetricBaseRawTemplate)
+	getSingleFeatureMetricBaseTemplate = NewQueryTemplate(getSingleFeatureMetricBaseRawTemplate)
 }
 
 // nolint: gochecknoglobals // WONTFIX. Compile the template once at startup. Startup fails if invalid.
 var (
 	// getFeatureMetricBaseTemplate is the compiled version of getFeatureMetricBaseRawTemplate.
 	getFeatureMetricBaseTemplate BaseQueryTemplate
+	// getSingleFeatureMetricBaseTemplate is the compiled version of getSingleFeatureMetricBaseRawTemplate.
+	getSingleFeatureMetricBaseTemplate BaseQueryTemplate
 )
 
 const (
@@ -74,9 +77,32 @@ const (
 {{ end }}
 	ORDER BY r.TimeStart DESC, r.ExternalRunID DESC LIMIT @pageSize`
 
+	getSingleFeatureMetricBaseRawTemplate = `
+	SELECT
+		r.ExternalRunID,
+		wpfm.TimeStart,
+		wpfm.{{ .TotalColumn }} AS TotalTests,
+		wpfm.{{ .PassColumn }} AS TestPass
+	FROM WPTRunFeatureMetrics@{FORCE_INDEX=MetricsFeatureChannelBrowserTime} wpfm
+	JOIN WPTRuns r ON r.ID = wpfm.ID
+	WHERE wpfm.WebFeatureID = @webFeatureID
+		AND wpfm.BrowserName = @browserName
+		AND wpfm.Channel = @channel
+		AND wpfm.{{ .TotalColumn }} IS NOT NULL
+		AND wpfm.{{ .PassColumn }} IS NOT NULL
+		AND wpfm.TimeStart >= @startAt AND wpfm.TimeStart < @endAt
+{{ if .PageFilter }}
+		{{ .PageFilter }}
+{{ end }}
+	ORDER BY wpfm.TimeStart DESC, r.ExternalRunID DESC LIMIT @pageSize`
+
 	commonFeatureMetricPaginationRawTemplate = `
 		AND (r.TimeStart < @lastTimestamp OR
 			r.TimeStart = @lastTimestamp AND r.ExternalRunID < @lastRunID)`
+
+	commonSingleFeatureMetricPaginationRawTemplate = `
+		AND (wpfm.TimeStart < @lastTimestamp OR
+			wpfm.TimeStart = @lastTimestamp AND r.ExternalRunID < @lastRunID)`
 
 	singleFeatureMetricSubsetRawTemplate    = `AND wf.FeatureKey = @featureKey`
 	multipleFeaturesMetricSubsetRawTemplate = `AND wf.FeatureKey IN UNNEST(@featureKeys)`
@@ -90,6 +116,13 @@ type FeatureMetricsTemplateData struct {
 	FeatureKeyFilter string
 	ExtraFilter      string
 	IsSingleFeature  bool
+}
+
+// SingleFeatureMetricsTemplateData contains the variables for getSingleFeatureMetricBaseRawTemplate.
+type SingleFeatureMetricsTemplateData struct {
+	TotalColumn string
+	PassColumn  string
+	PageFilter  string
 }
 
 // SpannerWPTRunFeatureMetric is a wrapper for the metric data that is actually
@@ -402,22 +435,28 @@ func (c *Client) ListMetricsForFeatureIDBrowserAndChannel(
 	pageSize int,
 	pageToken *string,
 ) ([]WPTRunFeatureMetricWithTime, *string, error) {
-	params := map[string]any{
-		"featureKey":  featureKey,
-		"browserName": browser,
-		"channel":     channel,
-		"startAt":     startAt,
-		"endAt":       endAt,
-		"pageSize":    pageSize,
+	featureID, err := c.GetIDFromFeatureKey(ctx, NewFeatureKeyFilter(featureKey))
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, nil, nil
+		}
+
+		return nil, nil, errors.Join(ErrInternalQueryFailure, err)
 	}
 
-	tmplData := FeatureMetricsTemplateData{
-		TotalColumn:      metricsTotalTestColumn(metric),
-		PassColumn:       metricsTestPassColumn(metric),
-		PageFilter:       "",
-		FeatureKeyFilter: singleFeatureMetricSubsetRawTemplate,
-		ExtraFilter:      removeExcludedKeyFilterAND,
-		IsSingleFeature:  true,
+	params := map[string]any{
+		"webFeatureID": *featureID,
+		"browserName":  browser,
+		"channel":      channel,
+		"startAt":      startAt,
+		"endAt":        endAt,
+		"pageSize":     pageSize,
+	}
+
+	tmplData := SingleFeatureMetricsTemplateData{
+		TotalColumn: metricsTotalTestColumn(metric),
+		PassColumn:  metricsTestPassColumn(metric),
+		PageFilter:  "",
 	}
 
 	if pageToken != nil {
@@ -427,9 +466,9 @@ func (c *Client) ListMetricsForFeatureIDBrowserAndChannel(
 		}
 		params["lastTimestamp"] = cursor.LastTimeStart
 		params["lastRunID"] = cursor.LastRunID
-		tmplData.PageFilter = commonFeatureMetricPaginationRawTemplate
+		tmplData.PageFilter = commonSingleFeatureMetricPaginationRawTemplate
 	}
-	tmpl := getFeatureMetricBaseTemplate.Execute(tmplData)
+	tmpl := getSingleFeatureMetricBaseTemplate.Execute(tmplData)
 	stmt := spanner.NewStatement(tmpl)
 	stmt.Params = params
 

--- a/lib/gcpspanner/wpt_run_feature_metric_test.go
+++ b/lib/gcpspanner/wpt_run_feature_metric_test.go
@@ -692,6 +692,28 @@ func TestListMetricsForFeatureIDBrowserAndChannel(t *testing.T) {
 	if !reflect.DeepEqual(expectedMetricsPageThree, metrics) {
 		t.Errorf("unequal metrics. expected (%+v) received (%+v) ", expectedMetricsPageThree, metrics)
 	}
+
+	// Test 4. Non-existent feature returns empty slice without error.
+	metrics, token, err = spannerClient.ListMetricsForFeatureIDBrowserAndChannel(
+		ctx,
+		"featureDoesNotExist",
+		"fooBrowser",
+		shared.StableLabel,
+		WPTTestView,
+		time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2000, time.January, 3, 0, 0, 0, 0, time.UTC),
+		10,
+		nil,
+	)
+	if !errors.Is(err, nil) {
+		t.Errorf("expected no error for non-existent feature. received %s", err.Error())
+	}
+	if token != nil {
+		t.Error("expected no token for non-existent feature")
+	}
+	if len(metrics) != 0 {
+		t.Errorf("expected 0 metrics for non-existent feature, received %d", len(metrics))
+	}
 }
 
 func testGetAllAggregatedMetrics(ctx context.Context, client *Client, t *testing.T) {


### PR DESCRIPTION
Resolves Spanner query execution latency regressions on timeseries stats endpoints that triggered the 1-hour Latency SLO burn rate alert (b/542984814).

### Summary of Changes

1. **WPT Run Feature Metrics:**
   - Resolves `WebFeatureID` upfront and queries `WPTRunFeatureMetrics` directly using the `@{FORCE_INDEX=MetricsFeatureChannelBrowserTime}` index hint.
   - Eliminates the driving parent table scan over `WPTRuns` across 12-year history (drops query latency from **26.2s to 16ms** and scanned rows from **49,675 to 78**).
   - Uses composite keyset cursor (`TimeStart`, `ExternalRunID`) for single-feature pagination.

2. **Chromium Daily Usage Stats:**
   - Resolves `WebFeatureID` upfront and binds `startDate` / `endDate` directly as `civil.Date` parameters.
   - Eliminates non-sargable `TIMESTAMP(dchm.Day)` function wrap on the Spanner `DATE` column (drops query latency from **36.8ms to 0.83ms**).

3. **Feature Search Count Query:**
   - Defines `commonFSBaseQueryTemplate` by composing `commonFSCountBaseQueryTemplate` with the two output hydration subqueries (`browser_info` and `chromium_usage_metrics`).
   - Excludes non-filtering subqueries from `CountQuery`, reducing scanned rows by **41%** (1,990 to 1,174 rows).

4. **Developer Documentation:**
   - Updates `webstatus-backend` skill documenting the two core Spanner design rules (Point-Lookup Timeseries Seeking and Sargable Go/Spanner Type Matching).

Fixes b/542984814

Also, filed #2684  as a followup