### PR TITLE
feat(backend): add /v1/healthchecks/liveness endpoint

### DIFF
--- a/backend/pkg/httpserver/get_healthcheck_liveness.go
+++ b/backend/pkg/httpserver/get_healthcheck_liveness.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+const healthyStatus = "healthy"
+
+// GetHealthcheckLiveness implements backend.StrictServerInterface.
+// nolint: ireturn // Name generated from openapi
+func (s *Server) GetHealthcheckLiveness(
+	_ context.Context,
+	_ backend.GetHealthcheckLivenessRequestObject,
+) (backend.GetHealthcheckLivenessResponseObject, error) {
+	return backend.GetHealthcheckLiveness200JSONResponse{
+		Status: healthyStatus,
+	}, nil
+}

--- a/backend/pkg/httpserver/get_healthcheck_liveness_test.go
+++ b/backend/pkg/httpserver/get_healthcheck_liveness_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetHealthcheckLiveness(t *testing.T) {
+	testCases := []struct {
+		name             string
+		request          *http.Request
+		expectedResponse *http.Response
+	}{
+		{
+			name: "success",
+			request: httptest.NewRequestWithContext(
+				t.Context(),
+				http.MethodGet,
+				"/v1/healthchecks/liveness",
+				nil,
+			),
+			expectedResponse: testJSONResponse(http.StatusOK, `{"status":"healthy"}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := setupTestServer(t)
+			assertTestServerRequest(t, server, tc.request, tc.expectedResponse)
+		})
+	}
+}

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -1676,6 +1676,16 @@ func (m *mockServerInterface) DeleteSubscription(ctx context.Context,
 	panic("unimplemented")
 }
 
+// GetHealthcheckLiveness implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) GetHealthcheckLiveness(ctx context.Context,
+	_ backend.GetHealthcheckLivenessRequestObject) (
+	backend.GetHealthcheckLivenessResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
 func (m *mockServerInterface) assertCallCount(expectedCallCount int) {
 	if m.callCount != expectedCallCount {
 		m.t.Errorf("expected mock server to be used %d times. only used %d times", expectedCallCount, m.callCount)

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -24,6 +24,20 @@ servers:
   - url: https://api.webstatus.dev
     description: Production
 paths:
+  /v1/healthchecks/liveness:
+    get:
+      summary: Service liveness health check
+      description: Returns a 200 OK status to indicate that the service process is alive and responsive.
+      operationId: getHealthcheckLiveness
+      tags:
+        - Healthchecks
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthcheckResponse'
   /v1/features:
     get:
       summary: List features
@@ -1512,6 +1526,15 @@ components:
         for desktop browsers with a corresponding mobile browser.
       required: false
   schemas:
+    HealthcheckResponse:
+      type: object
+      description: Response indicating the health status of the service
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          example: 'healthy'
     SupportedBrowsers:
       type: string
       description: List of supported browsers that webstatus.dev currently ingests


### PR DESCRIPTION
Introduces `GET /v1/healthchecks/liveness` to provide a lightweight, non-blocking health check endpoint for Cloud Monitoring uptime checks and Cloud Run liveness probes without querying Spanner on every ping.

### Summary of Changes

1. **OpenAPI Specification:**
   - Adds `/v1/healthchecks/liveness` path returning `200 OK` with `HealthcheckResponse` schema (`{"status": "healthy"}`).
   - Scoped under the `/v1/healthchecks/*` resource namespace.

2. **Backend HTTP Server:**
   - Implements `GetHealthcheckLiveness` in `backend/pkg/httpserver/get_healthcheck_liveness.go` returning `GetHealthcheckLiveness200JSONResponse`.
   - Adds unit test in `get_healthcheck_liveness_test.go` verifying HTTP router request handling.
   - Updates `mockServerInterface` in `server_test.go`.

