### PR TITLE
fix(auth): pin Firebase to 12.16.0 to restore GitHub login

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -64,7 +64,7 @@
     "@shoelace-style/shoelace": "^2.20.1",
     "@types/google.visualization": "^0.0.74",
     "@vaadin/router": "2.0.0",
-    "firebase": "^12.17.0",
+    "firebase": "12.16.0",
     "lit": "^3.3.3",
     "openapi-fetch": "^0.17.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@shoelace-style/shoelace": "^2.20.1",
         "@types/google.visualization": "^0.0.74",
         "@vaadin/router": "2.0.0",
-        "firebase": "^12.17.0",
+        "firebase": "12.16.0",
         "lit": "^3.3.3",
         "openapi-fetch": "^0.17.0"
       },
@@ -1548,15 +1548,15 @@
       }
     },
     "node_modules/@firebase/ai": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.14.0.tgz",
-      "integrity": "sha512-TYEQqCQUTyVHuG/HVi9vau6F9kvEaS49o/hmdn/yUuN6ZXQkwIml2nNJTIBfjNl/r9LOxwUNILgcOY16nxObug==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.13.1.tgz",
+      "integrity": "sha512-RhT/VViTPBSplhQSuEp62HhLvfsV+LowMh8ZUo5MMRDzG7oFtSget4Kmg5oHP50hDVyWQuQj6to9iPFEZk08Tw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.4",
-        "@firebase/component": "0.7.4",
+        "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1568,15 +1568,15 @@
       }
     },
     "node_modules/@firebase/analytics": {
-      "version": "0.10.23",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.23.tgz",
-      "integrity": "sha512-34ALWXzWA6PTRUA5hipZmsm1RKzeecw5J1+qTCXsiMzwLqONC+GuTIQSdmm91MmTAEA+wG1Q5t0IFahcYQOqAA==",
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
-        "@firebase/installations": "0.6.23",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1584,19 +1584,18 @@
       }
     },
     "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.29.tgz",
-      "integrity": "sha512-allztvCvCUlItZzD97TiRAtGoFJzR1FQFmLxbaLc6PvgscqD9cl5NdKPTtka6keShVYXvCZJpzWcRoH4TME8rw==",
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/analytics": "0.10.23",
+        "@firebase/analytics": "0.10.22",
         "@firebase/analytics-types": "0.8.4",
-        "@firebase/component": "0.7.4",
-        "@firebase/util": "1.15.2",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
@@ -1607,14 +1606,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.16.0.tgz",
-      "integrity": "sha512-G+ZGEyVP8YTb3ay6A+XpcYgFH3sTESHcnHU/EyTktodqhz2BHkLq+QEP7IVwjiMX0cxYwpVKip0/wC0KZcn9vQ==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.15.1.tgz",
+      "integrity": "sha512-iD9+Z5HcPo0Uop5f72/VYMeXwKucBhW7iFrISkJFvQ+lSZikTNgTz0FgAtaaTkAG0pEZSnCymA2Fu49n0rcufQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
+        "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -1623,14 +1622,14 @@
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.13.0.tgz",
-      "integrity": "sha512-AbMttBKazQvGVXBZhQdVAdPzRhwHyJAY3Ghu5y2C7IZKIDIppzNYz0shTZ1mP4FBJa+28BuC4t+5h1Q6pT3Asg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.12.0.tgz",
+      "integrity": "sha512-wMeT6HLWRAuW7Cp/5UjWBGKgjPNxWNOoNf4PRIv0weljoGMZVeqbUY7wNBWTI2/31cX1NlXx8gQruDLsUShB3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
+        "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1641,23 +1640,22 @@
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.6.tgz",
-      "integrity": "sha512-2pzNEZEkX84jSqy6TH6FI1HSLA1lc7kakRUybBbKjg9YhIttPlW/XX3N9CDtChji2PTTPWVPZiWhB10exHfA+A==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.5.tgz",
+      "integrity": "sha512-JI17mVcZs34zO6ZeSCrw4U2iohqy+n6GIzkbmsA+TbVjmvFLkUKt3bs5M+qRBteQm/0IWzqSHYFzEQLzDTQebg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check": "0.13.0",
+        "@firebase/app-check": "0.12.0",
         "@firebase/app-check-types": "0.5.4",
-        "@firebase/component": "0.7.4",
+        "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
@@ -1674,15 +1672,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.16.tgz",
-      "integrity": "sha512-shQq37O8qELDzvsVwYPlDXwD1zlcrZ0m2bpBF5ov2HSbY8x+AHsnL5TtJ2e1JAfkQN05qHao1AfabS69PN6GiA==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.15.tgz",
+      "integrity": "sha512-HaiSM9TwbGIR4b7F6+UncHWlqdH89eeY7VUskaOGOlI2PxHS5Z+6hHsYGvNLy0SHDE6zyXO+3QSA6a4aqQxsqA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app": "0.16.0",
-        "@firebase/component": "0.7.4",
+        "@firebase/app": "0.15.1",
+        "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1699,14 +1697,14 @@
       }
     },
     "node_modules/@firebase/auth": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.4.tgz",
-      "integrity": "sha512-s+NS1aV0DDyyfoIMeSz53HXnVTv7ufJjJfrP63XyaWHweJ5vOoxKWrTm5tO7S7PDqvyOa/Wi3oP0dgAo6JTMMA==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.3.tgz",
+      "integrity": "sha512-bqiq4uubDN2YyQkdvSWPQeJyXAv2O76ImF41En9b6UhV5JuBVYDoHYrrrE3NzIuGkpFMKagfhMRP4Vz6t+yQSQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
+        "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1723,22 +1721,21 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.9.tgz",
-      "integrity": "sha512-/hHeTBmQ61+N5J1RECls+WfskZTY78JXr7aO5EMOfUpqJvDqvoS+568k0rp6Ss/4UWwBjadILs+H+SGy1zCS3A==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.8.tgz",
+      "integrity": "sha512-llcBREUC4iSNKZ6rvwud7Oz9Q7aAWU6KuQLa6pdu7Q+QAQsy4JLw6yFgxwtmzabsgznHmmcsX2UjHLLzqUxi3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth": "1.13.4",
+        "@firebase/auth": "1.13.3",
         "@firebase/auth-types": "0.13.1",
-        "@firebase/component": "0.7.4",
-        "@firebase/util": "1.15.2",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
@@ -1759,12 +1756,12 @@
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.4.tgz",
-      "integrity": "sha512-tLpOaaCol9ugUIYp2R3CbWPPA8Ajg/papX/XHEy8U52b/QXH3BbX8tTJX9aShDCjp+9sMAxMLD94i7lresdugQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1772,15 +1769,15 @@
       }
     },
     "node_modules/@firebase/data-connect": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.2.tgz",
-      "integrity": "sha512-Z64TRTp5KsvZtuCS1BhEg0H63TTDIi6k7idGG+z1ImAnP2qHv+xt0S5rzAONpiO7Z1geldWhpu1iY/ju+l3a3w==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.1.tgz",
+      "integrity": "sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/auth-interop-types": "0.2.5",
-        "@firebase/component": "0.7.4",
+        "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -1788,16 +1785,16 @@
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.4.tgz",
-      "integrity": "sha512-D+j4+8uhGtNd1tVD+X+c8JrC4ppStGJKyujSQt2NPwdN26QcCk0BeIxue+UqspHkHiFHyQOimwlzjLewGq6S+A==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.4",
         "@firebase/auth-interop-types": "0.2.5",
-        "@firebase/component": "0.7.4",
+        "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       },
@@ -1806,57 +1803,45 @@
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.5.tgz",
-      "integrity": "sha512-m2KZDNXrg8DBzXWQNbbrjOhsJnM+ctsSFaDYKrqj1gEetQ8BSAwRuMUdeWLM9a6qPBgOvOA+o09j1BSEzdFqOg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
-        "@firebase/database": "1.1.4",
-        "@firebase/database-types": "1.0.21",
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@firebase/app": "0.x",
-        "@firebase/app-compat": "0.x"
-      },
-      "peerDependenciesMeta": {
-        "@firebase/app": {
-          "optional": true
-        },
-        "@firebase/app-compat": {
-          "optional": true
-        }
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.21.tgz",
-      "integrity": "sha512-SX1jUqhttKgg/m9dYRTvqU9QvucBooziWfA986r4cpsbi4zlsvewe424j3Vpduwd6DG1MSAMfBVT2VqA61FnkA==",
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-types": "0.9.5",
-        "@firebase/util": "1.15.2"
+        "@firebase/util": "1.15.1"
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.17.0.tgz",
-      "integrity": "sha512-P9tof6pyO1bnLlMWbux+5O7WFJqlb7OTPMKxxOiXKYiQl7mxykAvxr1BFCgWeEXUU7DZxQncyJ040B0IhFVZCg==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.16.0.tgz",
+      "integrity": "sha512-qdHMHMvMr0nRMuZyWNR/ArWa0YlPE3C4eAbmxTASJMYXAesKPL0Y54p70moggrNPzaK7MSIIq5RDJJyntQyIYA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
+        "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "@firebase/webchannel-wrapper": "1.0.6",
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
-        "re2js": "^2.8.3",
+        "re2js": "^0.4.2",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1867,22 +1852,21 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.12.tgz",
-      "integrity": "sha512-k2uX81Ao/S0jnFcWGPOQpKK1cPlJHvD9WIqh/RE1XBDP2yg5zhE4rHhSg1rtB11k39q3nKon9XLNDDrPjGclag==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.11.tgz",
+      "integrity": "sha512-W7o1WdwWq5aABK5Up2ncSvTQs/QGLR/fy7cVpFBNqhsXtxoMtflHf2xBIG6+aoptcuGAobddq4g2Sq27wqHaYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
-        "@firebase/firestore": "4.17.0",
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.16.0",
         "@firebase/firestore-types": "3.0.4",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
@@ -1897,16 +1881,16 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.6.tgz",
-      "integrity": "sha512-9obLnzeQUivK5lmtGFOU2ucQ38BjTp+jpPtbfFp/mDsdVCvEpRqdWNvMMQ6aQwR4vcVc/utsvngm5BRkXbc7ZA==",
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.5.tgz",
+      "integrity": "sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.4",
         "@firebase/auth-interop-types": "0.2.5",
-        "@firebase/component": "0.7.4",
+        "@firebase/component": "0.7.3",
         "@firebase/messaging-interop-types": "0.2.5",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -1917,22 +1901,21 @@
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.6.tgz",
-      "integrity": "sha512-dj9sOet+FIU91jeU4A3vGJoXHty7NqkSfjRLCwLgJXPDk1m72KFuxD3nlFgw/yXx/Fr7UjqzbxZ0LrIOdpx7+w==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.5.tgz",
+      "integrity": "sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
-        "@firebase/functions": "0.13.6",
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.5",
         "@firebase/functions-types": "0.6.4",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
@@ -1943,13 +1926,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/installations": {
-      "version": "0.6.23",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.23.tgz",
-      "integrity": "sha512-MBkbcQfd+3qHjW+slsH4s7jH5qTdGlYpwqmxEZ7QcIpgDxu1SKyU0f+mCZhCt1BCacLNiOWF5L0R06N0LtlfMg==",
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
-        "@firebase/util": "1.15.2",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -1958,19 +1941,18 @@
       }
     },
     "node_modules/@firebase/installations-compat": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.23.tgz",
-      "integrity": "sha512-isaXmjb9roM83eVeXAe+ZRNKYNsSo2s0aNM+cy04AAGEyVL/d8Aa11GwEXovRFeYjl9+1yRAOxRDTOukZRwTxA==",
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
-        "@firebase/installations": "0.6.23",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
         "@firebase/installations-types": "0.5.4",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
@@ -1996,15 +1978,15 @@
       }
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.1.tgz",
-      "integrity": "sha512-kL8fdjbNBI7hprlXJrUjktDWosrpT4JtfwXtVVevImPF/rBRAsC+LS/jIs+kgQVuotnvMhaBCgAFipBoY9YU9g==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.0.tgz",
+      "integrity": "sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
-        "@firebase/installations": "0.6.23",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
         "@firebase/messaging-interop-types": "0.2.5",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -2013,18 +1995,17 @@
       }
     },
     "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.28.tgz",
-      "integrity": "sha512-/AmMqHRnSQhPsdeED3ocs+s30/tpFvZDiiwIYY2uXFRvLujo1fnbPOeCFoe4Y+dRy1LCSjpvJf+dy5ZTsxi1yg==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.27.tgz",
+      "integrity": "sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
-        "@firebase/messaging": "0.13.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
@@ -2035,15 +2016,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/performance": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.13.tgz",
-      "integrity": "sha512-1u6fuXP9cj0s+lkTFAspr/ttfPebPbEdpx+5Wdr4mPZbp8qH2KCMxOddEAR1ZMRa5GI0E7hDYSnolEmbqOFOAg==",
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
-        "@firebase/installations": "0.6.23",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0",
         "web-vitals": "^4.2.4"
       },
@@ -2052,20 +2033,19 @@
       }
     },
     "node_modules/@firebase/performance-compat": {
-      "version": "0.2.26",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.26.tgz",
-      "integrity": "sha512-jgoocXLN6ao26xWQ8pzosmzQ33uLzGBJQPNK0NTbVy1XvIHr5pfgBf9hWLOxsWe+R7sJq5bjD+8ybXprmt61mA==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
+        "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
-        "@firebase/performance": "0.7.13",
+        "@firebase/performance": "0.7.12",
         "@firebase/performance-types": "0.2.4",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
@@ -2076,15 +2056,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.9.1.tgz",
-      "integrity": "sha512-nzQUSJnk1zAZEl2Q5O3I7Z61cYLK5JI4H6wyyOiHkVZ+bmgy1YXNNMptNbVjixMQ/eCzgA6nZRaC+1eBcJGUFA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.9.0.tgz",
+      "integrity": "sha512-aNn6/eJhsSC+gXSToiXiYPv3ypLP9lFtzl+/q9kSOBPB7D6rae0Rt2uENZZLXGYbEgHYKQblOhijJAXGbbJjtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
-        "@firebase/installations": "0.6.23",
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
         "@firebase/logger": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -2092,20 +2072,19 @@
       }
     },
     "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.28.tgz",
-      "integrity": "sha512-kEO9Gn6fbmVj7eNUtZ6d59mLgUDUD0qo7aCicGOWNfuRWTaUv3CF9DMYychO61zaEQ3cfA+CEny4V1E8A1gRGA==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.27.tgz",
+      "integrity": "sha512-FYwYWwSbUdza/pRX4NpSBm/Pimntum3jEIBpnDn5Ey1jHNWgjxrE8Z5SB4mCHd5wGCoYd3koJzxARl/VWIEx0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
+        "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
-        "@firebase/remote-config": "0.9.1",
+        "@firebase/remote-config": "0.9.0",
         "@firebase/remote-config-types": "0.5.1",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
-        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
@@ -2116,13 +2095,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/storage": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.4.tgz",
-      "integrity": "sha512-jfzEWZb3Fpsq3FwAB2ifoc8mcSh935qXdDou3TpyjDWa45hhNcZUv8/w28/10njByhfK7snbakKN30nwnzQ3/w==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
-        "@firebase/util": "1.15.2",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
@@ -2133,22 +2112,21 @@
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.4.tgz",
-      "integrity": "sha512-qSRgCB9f2R/nCp8t/8OC101cIFBFeUazlRInOMdzbnLzvrQBzEfx19SrR4pvdj/0+M+P/y8AK/a2s+3EB+B1Pw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.7.4",
-        "@firebase/storage": "0.14.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
         "@firebase/storage-types": "0.8.4",
-        "@firebase/util": "1.15.2",
+        "@firebase/util": "1.15.1",
         "tslib": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
@@ -2163,9 +2141,9 @@
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.2.tgz",
-      "integrity": "sha512-974pWIZVLDMc5GW5YAsj8y0XxULxIy/sPUy7tsxmWbF93KRIyh9xpuHlh0zDL+shUcf5nHDjFOg9YLiQ763eiA==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8221,39 +8199,39 @@
       }
     },
     "node_modules/firebase": {
-      "version": "12.17.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.17.0.tgz",
-      "integrity": "sha512-8iENFg2/k7asnybijN3ZrmTag0BuyiihUXrRZkX+yCW+YocknpzPZ4DUkdbyA/rdrdaCssBqHH8zpdDliv+4ng==",
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.16.0.tgz",
+      "integrity": "sha512-CNw6hFBdONkzF8UGLDx/RDRY9gVa5VmJNHd7qi4gdmA3ZuLkuOrhmWefB2l+FN+OxFpN77Itq7aO6zlTi780ag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/ai": "2.14.0",
-        "@firebase/analytics": "0.10.23",
-        "@firebase/analytics-compat": "0.2.29",
-        "@firebase/app": "0.16.0",
-        "@firebase/app-check": "0.13.0",
-        "@firebase/app-check-compat": "0.4.6",
-        "@firebase/app-compat": "0.5.16",
+        "@firebase/ai": "2.13.1",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.15.1",
+        "@firebase/app-check": "0.12.0",
+        "@firebase/app-check-compat": "0.4.5",
+        "@firebase/app-compat": "0.5.15",
         "@firebase/app-types": "0.9.5",
-        "@firebase/auth": "1.13.4",
-        "@firebase/auth-compat": "0.6.9",
-        "@firebase/data-connect": "0.7.2",
-        "@firebase/database": "1.1.4",
-        "@firebase/database-compat": "2.1.5",
-        "@firebase/firestore": "4.17.0",
-        "@firebase/firestore-compat": "0.4.12",
-        "@firebase/functions": "0.13.6",
-        "@firebase/functions-compat": "0.4.6",
-        "@firebase/installations": "0.6.23",
-        "@firebase/installations-compat": "0.2.23",
-        "@firebase/messaging": "0.13.1",
-        "@firebase/messaging-compat": "0.2.28",
-        "@firebase/performance": "0.7.13",
-        "@firebase/performance-compat": "0.2.26",
-        "@firebase/remote-config": "0.9.1",
-        "@firebase/remote-config-compat": "0.2.28",
-        "@firebase/storage": "0.14.4",
-        "@firebase/storage-compat": "0.4.4",
-        "@firebase/util": "1.15.2"
+        "@firebase/auth": "1.13.3",
+        "@firebase/auth-compat": "0.6.8",
+        "@firebase/data-connect": "0.7.1",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.16.0",
+        "@firebase/firestore-compat": "0.4.11",
+        "@firebase/functions": "0.13.5",
+        "@firebase/functions-compat": "0.4.5",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.13.0",
+        "@firebase/messaging-compat": "0.2.27",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.9.0",
+        "@firebase/remote-config-compat": "0.2.27",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
       }
     },
     "node_modules/flat-cache": {
@@ -12433,13 +12411,10 @@
       }
     },
     "node_modules/re2js": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/re2js/-/re2js-2.8.6.tgz",
-      "integrity": "sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      }
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-0.4.3.tgz",
+      "integrity": "sha512-EuNmh7jurhHEE8Ge/lBo9JuMLb3qf866Xjjfyovw3wPc7+hlqDkZq4LwhrCQMEI+ARWfrKrHozEndzlpNT0WDg==",
+      "license": "MIT"
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",


### PR DESCRIPTION
## Summary

- Pin `firebase` to 12.16.0.
- Update the lockfile to restore `@firebase/auth` 1.13.3 and the matching Firebase package set.

## Problem

GitHub popup login currently fails with:

```text
Failed to login: Database is closing/hidden
```

#2690 upgraded `firebase` from 12.16.0 to 12.17.0, which upgraded `@firebase/auth` from 1.13.3 to 1.13.4. The newer Auth package closes its IndexedDB connection when a `visibilitychange` event marks the opener document hidden. An authentication popup can trigger that state, and persisting the returned user then throws `Database is closing/hidden`.

This is tracked upstream in firebase/firebase-js-sdk#10264.

## Why an exact pin

Using `^12.16.0` would allow a fresh install to resolve 12.17.0 again. The exact `12.16.0` constraint keeps GitHub login on the last known-good Auth implementation until Firebase ships an upstream fix.

## Verification

- `npm ci --include-workspace-root=true`
- `npm run build -w frontend`
- Frontend unit tests in Chromium, Firefox, and WebKit with an `en-US` / `UTC` browser context: 454 passed and 2 skipped per browser
- `git diff --check`
- Minimal persistence reproduction:
  - `firebase` 12.16.0 / `@firebase/auth` 1.13.3: succeeds while the document is hidden
  - `firebase` 12.17.0 / `@firebase/auth` 1.13.4: throws `Database is closing/hidden`

Fixes #2695

Upstream issue: <https://github.com/firebase/firebase-js-sdk/issues/10264>
