### PR TITLE
feat(deps): configure Dependabot for Go modules and add auto-tidy workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,15 +14,300 @@
 
 version: 2
 updates:
-  # Go Modules
-  # TODO - revisit when dependabot has better support for multi-module projects that reference each other.
-  # https://github.com/dependabot/dependabot-core/issues/6012
+  # =========================================================================
+  # Go Modules (Configured per Module Directory with Staggered Monday Run Times)
+  # =========================================================================
+
+  # Core Libraries & Shared Generators (02:00 AM PST)
+  - package-ecosystem: 'gomod'
+    directory: '/lib'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '02:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directory: '/lib/gen'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '02:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directory: '/util'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '02:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directory: '/tools'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '02:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  # Backend API Service (03:00 AM PST)
+  - package-ecosystem: 'gomod'
+    directory: '/backend'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '03:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  # Workers (04:00 AM PST)
+  - package-ecosystem: 'gomod'
+    directory: '/workers/email'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '04:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directory: '/workers/webhook'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '04:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directory: '/workers/event_producer'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '04:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directory: '/workers/push_delivery'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '04:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  # Workflow Step Services (05:00 AM PST)
+  - package-ecosystem: 'gomod'
+    directory: '/workflows/steps/services/bcd_consumer'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '05:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directory: '/workflows/steps/services/chromium_histogram_enums'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '05:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directory: '/workflows/steps/services/developer_signals_consumer'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '05:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directory: '/workflows/steps/services/uma_export'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '05:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directory: '/workflows/steps/services/web_feature_consumer'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '05:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directory: '/workflows/steps/services/web_features_mapping_consumer'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '05:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  - package-ecosystem: 'gomod'
+    directory: '/workflows/steps/services/wpt_consumer'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '05:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'
+    groups:
+      go_modules:
+        patterns:
+          - '*'
+
+  # =========================================================================
+  # Other Ecosystems (06:00 AM PST)
+  # =========================================================================
 
   # NPM
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
     versioning-strategy: 'increase'
     ignore:
       - dependency-name: '@types/node'
@@ -37,41 +322,81 @@ updates:
     directory: '/.dev/datastore'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'docker'
     directory: '/.dev/gcs'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'docker'
     directory: '/.dev/valkey'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'docker'
     directory: '/.dev/spanner'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'docker'
     directory: '/.dev/wiremock'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'docker'
     directory: '/.dev/pubsub'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'docker'
     directory: '/.devcontainer'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'docker'
     directory: '/images'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: 'node'
         versions:
@@ -82,6 +407,11 @@ updates:
     directory: '/.dev/auth'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: 'node'
         versions:
@@ -93,15 +423,30 @@ updates:
     directory: '/infra'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
 
   # DevContainer
   - package-ecosystem: 'devcontainers'
     directory: '/.devcontainer'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7
 
   # GitHub Actions
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/Los_Angeles'
+    cooldown:
+      default-days: 7

--- a/.github/workflows/dependabot-tidy.yml
+++ b/.github/workflows/dependabot-tidy.yml
@@ -1,0 +1,91 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Dependabot Go Auto-Tidy'
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number to run auto-tidy on'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-tidy:
+    if: >-
+      (github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR Branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if PR modified Go files
+        id: check_go
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+        run: |
+          CHANGED_GO_FILES=$(gh pr diff "$PR_NUMBER" --name-only | grep -E '(go\.mod|go\.sum)$' || true)
+          if [ -n "$CHANGED_GO_FILES" ]; then
+            echo "is_go_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_go_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get Repo Owner
+        if: steps.check_go.outputs.is_go_pr == 'true'
+        env:
+          REPO_OWNER_RAW: ${{ github.repository_owner }}
+        run: |
+          REPO_OWNER=$(echo "$REPO_OWNER_RAW" | tr '[:upper:]' '[:lower:]')
+          echo "REPO_OWNER=$REPO_OWNER" >> "$GITHUB_ENV"
+
+      - name: Run multi-pass go-tidy in DevContainer
+        if: steps.check_go.outputs.is_go_pr == 'true'
+        uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3
+        with:
+          cacheFrom: ghcr.io/${{ env.REPO_OWNER }}/webstatus-dev-devcontainer
+          push: never
+          runCmd: |
+            make go-workspace-setup
+            make go-tidy
+            make go-tidy
+            make go-workspace-clean
+
+      - name: Push Reconciled Go Diffs
+        if: steps.check_go.outputs.is_go_pr == 'true'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add **/go.mod **/go.sum
+            git commit -m "chore: run go mod tidy across workspace modules"
+            git push origin "HEAD:${HEAD_REF}"
+          else
+            echo "No workspace module drift detected."
+          fi


### PR DESCRIPTION
## What
- Configures `.github/dependabot.yml` with explicit `gomod` ecosystem entries for all 16 Go module directories (`backend`, `lib`, `lib/gen`, `tools`, `util`, 4 `workers/*`, 7 `workflows/steps/services/*`).
- Adds supply-chain ignore rules (`ignore: [{dependency-name: 'github.com/GoogleChrome/webstatus.dev/*'}]`) to prevent Dependabot from resolving internal monorepo packages against the public Go proxy.
- Staggers Monday morning execution times across module tiers (Core at `02:00`, Backend at `03:00`, Workers at `04:00`, Workflows at `05:00`, Non-Go at `06:00` PST) with `open-pull-requests-limit: 2` to eliminate CI concurrency spikes.
- Normalizes all non-Go ecosystems (NPM, Docker, Terraform, DevContainers, GitHub Actions) to Monday `06:00` PST.
- Adds `.github/workflows/dependabot-tidy.yml` to automatically run multi-pass `go-tidy` inside the DevContainer when Dependabot opens a Go PR and commit back reconciled workspace diffs.

## Why
- Go modules were previously excluded from automated Dependabot updates pending workspace auto-discovery (`dependabot/dependabot-core#6012`), requiring manual security and version updates.
- Sibling Go modules in `webstatus.dev` reference each other locally (e.g. `backend` -> `lib` -> `lib/gen`, `util`). Single-directory Dependabot updates cause `make precommit` to fail due to uncommitted transitive checksum changes in sibling modules.
- Weekly Dependabot runs had drifted to Thursdays because `schedule.day` was omitted.

## How
- Declares all 16 Go module directories under `package-ecosystem: 'gomod'` with `groups.go_modules` to batch minor/patch updates.
- Uses `devcontainers/ci@v0.3` in the auto-tidy workflow to execute `make go-workspace-setup` and `make go-tidy` using the exact Go toolchain from `devcontainer.json` without hardcoding Go versions.
- Uses `gh pr diff` to verify Go file changes and standard `git` with verified `github-actions[bot]` credentials for zero-dependency pushbacks.

## Corrected Assumptions / Learnings
- **Dependabot `go.work` Support:** Dependabot does not provide zero-config `go.work` workspace auto-discovery; each `go.mod` directory must be listed explicitly.
- **`go.work` Version Control in Microservice Monorepos:** For repositories with modular Docker builds (`images/go_service.Dockerfile`), `go.work` and `go.work.sum` must remain gitignored to prevent build failures when only a subset of submodules is copied into builder images.
- **Scheduler Day Anchor:** When `schedule.day` is omitted, GitHub Dependabot automatically assigns a weekday or anchors to the day the configuration was updated (locking into Thursdays). Explicitly setting `day: 'monday'` restores predictable Monday morning execution.