### PR TITLE
feat(spanner): add migration 000034.sql and VCSInstallations entity mappers

### DIFF
--- a/infra/storage/spanner/migrations/000034.sql
+++ b/infra/storage/spanner/migrations/000034.sql
@@ -1,0 +1,31 @@
+-- Copyright 2026 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Migration: 000034.sql
+-- Description: Add VCSInstallations table for GitHub App and multi-VCS connections.
+
+CREATE TABLE IF NOT EXISTS VCSInstallations (
+    ID STRING(36) NOT NULL,
+    VCSProvider STRING(32) NOT NULL,
+    VCSInstallationID STRING(128) NOT NULL,
+    AccountLogin STRING(256) NOT NULL,
+    AccountType STRING(32) NOT NULL,
+    RepositorySelection STRING(32) NOT NULL,
+    Permissions JSON NOT NULL,
+    CreatedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+    UpdatedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+) PRIMARY KEY (ID);
+
+CREATE UNIQUE INDEX IF NOT EXISTS IDX_VCSInstallations_Provider_InstallationID ON VCSInstallations(VCSProvider, VCSInstallationID);
+CREATE INDEX IF NOT EXISTS IDX_VCSInstallations_Provider_AccountLogin ON VCSInstallations(VCSProvider, AccountLogin);

--- a/lib/gcpspanner/vcs_installation.go
+++ b/lib/gcpspanner/vcs_installation.go
@@ -1,0 +1,308 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/uuid"
+)
+
+const vcsInstallationTable = "VCSInstallations"
+
+var (
+	// ErrVCSInstallationNotFound indicates that the installation record does not exist.
+	ErrVCSInstallationNotFound = errors.New("vcs installation not found")
+	// ErrUnknownVCSProvider indicates an unrecognized VCS provider.
+	ErrUnknownVCSProvider = errors.New("unknown vcs provider")
+)
+
+// VCSProvider represents a supported version control system provider.
+type VCSProvider string
+
+const (
+	VCSProviderGitHub VCSProvider = "github"
+)
+
+// GitHubPermissionLevel represents a GitHub App permission level.
+type GitHubPermissionLevel string
+
+const (
+	GitHubPermissionLevelRead  GitHubPermissionLevel = "read"
+	GitHubPermissionLevelWrite GitHubPermissionLevel = "write"
+	GitHubPermissionLevelAdmin GitHubPermissionLevel = "admin"
+)
+
+// GitHubPermissions represents GitHub App permission levels for an installation.
+type GitHubPermissions struct {
+	Issues       *GitHubPermissionLevel `json:"issues,omitempty"`
+	Contents     *GitHubPermissionLevel `json:"contents,omitempty"`
+	Metadata     *GitHubPermissionLevel `json:"metadata,omitempty"`
+	PullRequests *GitHubPermissionLevel `json:"pull_requests,omitempty"`
+	Workflows    *GitHubPermissionLevel `json:"workflows,omitempty"`
+	Actions      *GitHubPermissionLevel `json:"actions,omitempty"`
+}
+
+// VCSPermissions encapsulates provider-specific permissions.
+type VCSPermissions struct {
+	GitHub *GitHubPermissions `json:"github,omitempty"`
+}
+
+// VCSInstallation represents an installed GitHub App instance for an account.
+type VCSInstallation struct {
+	ID                  string
+	VCSProvider         VCSProvider
+	VCSInstallationID   string
+	AccountLogin        string
+	AccountType         string
+	RepositorySelection string
+	Permissions         VCSPermissions
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+type spannerVCSInstallation struct {
+	ID                  string           `spanner:"ID"`
+	VCSProvider         string           `spanner:"VCSProvider"`
+	VCSInstallationID   string           `spanner:"VCSInstallationID"`
+	AccountLogin        string           `spanner:"AccountLogin"`
+	AccountType         string           `spanner:"AccountType"`
+	RepositorySelection string           `spanner:"RepositorySelection"`
+	Permissions         spanner.NullJSON `spanner:"Permissions"`
+	CreatedAt           time.Time        `spanner:"CreatedAt"`
+	UpdatedAt           time.Time        `spanner:"UpdatedAt"`
+}
+
+type vcsInstallationKey struct {
+	VCSProvider       VCSProvider
+	VCSInstallationID string
+}
+
+type vcsInstallationMapper struct{}
+
+func (m vcsInstallationMapper) Table() string { return vcsInstallationTable }
+
+func (m vcsInstallationMapper) GetKeyFromExternal(in VCSInstallation) vcsInstallationKey {
+	return vcsInstallationKey{
+		VCSProvider:       in.VCSProvider,
+		VCSInstallationID: in.VCSInstallationID,
+	}
+}
+
+func (m vcsInstallationMapper) SelectOne(key vcsInstallationKey) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSInstallationID, AccountLogin, AccountType,
+			RepositorySelection, Permissions, CreatedAt, UpdatedAt
+		FROM VCSInstallations
+		WHERE VCSProvider = @vcsProvider AND VCSInstallationID = @vcsInstallationID`,
+		Params: map[string]any{
+			"vcsProvider":       string(key.VCSProvider),
+			"vcsInstallationID": key.VCSInstallationID,
+		},
+	}
+}
+
+func (m vcsInstallationMapper) GetID(key vcsInstallationKey) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID
+		FROM VCSInstallations
+		WHERE VCSProvider = @vcsProvider AND VCSInstallationID = @vcsInstallationID
+		LIMIT 1`,
+		Params: map[string]any{
+			"vcsProvider":       string(key.VCSProvider),
+			"vcsInstallationID": key.VCSInstallationID,
+		},
+	}
+}
+
+func (m vcsInstallationMapper) GetIDFromInternal(s spannerVCSInstallation) string {
+	return s.ID
+}
+
+func extractPermissionsValue(in VCSInstallation) any {
+	switch in.VCSProvider {
+	case VCSProviderGitHub:
+		if in.Permissions.GitHub != nil {
+			return in.Permissions.GitHub
+		}
+	}
+
+	return map[string]any{}
+}
+
+func (m vcsInstallationMapper) NewEntityWithID(in VCSInstallation) (spannerVCSInstallation, string, error) {
+	id := in.ID
+	if id == "" {
+		id = uuid.NewString()
+	}
+
+	return spannerVCSInstallation{
+		ID:                  id,
+		VCSProvider:         string(in.VCSProvider),
+		VCSInstallationID:   in.VCSInstallationID,
+		AccountLogin:        in.AccountLogin,
+		AccountType:         in.AccountType,
+		RepositorySelection: in.RepositorySelection,
+		Permissions: spanner.NullJSON{
+			Value: extractPermissionsValue(in),
+			Valid: true,
+		},
+		CreatedAt: spanner.CommitTimestamp,
+		UpdatedAt: spanner.CommitTimestamp,
+	}, id, nil
+}
+
+func (m vcsInstallationMapper) Merge(
+	in VCSInstallation,
+	existing spannerVCSInstallation,
+) spannerVCSInstallation {
+	return spannerVCSInstallation{
+		ID:                  existing.ID,
+		VCSProvider:         string(in.VCSProvider),
+		VCSInstallationID:   in.VCSInstallationID,
+		AccountLogin:        in.AccountLogin,
+		AccountType:         in.AccountType,
+		RepositorySelection: in.RepositorySelection,
+		Permissions: spanner.NullJSON{
+			Value: extractPermissionsValue(in),
+			Valid: true,
+		},
+		CreatedAt: existing.CreatedAt,
+		UpdatedAt: spanner.CommitTimestamp,
+	}
+}
+
+// ParseVCSProvider parses and validates a raw provider string into a typed VCSProvider.
+func ParseVCSProvider(provider string) (VCSProvider, error) {
+	p := VCSProvider(provider)
+	switch p {
+	case VCSProviderGitHub:
+		return p, nil
+	}
+
+	return "", fmt.Errorf("%w: %q", ErrUnknownVCSProvider, provider)
+}
+
+func loadVCSPermissions(provider VCSProvider, permissionsJSON spanner.NullJSON) (VCSPermissions, error) {
+	var ret VCSPermissions
+	if !permissionsJSON.Valid || permissionsJSON.Value == nil {
+		return ret, nil
+	}
+
+	bytes, err := json.Marshal(permissionsJSON.Value)
+	if err != nil {
+		return ret, fmt.Errorf("failed to marshal permissions json: %w", err)
+	}
+
+	switch provider {
+	case VCSProviderGitHub:
+		var gh GitHubPermissions
+		if err := json.Unmarshal(bytes, &gh); err != nil {
+			return ret, fmt.Errorf("failed to unmarshal github permissions: %w", err)
+		}
+		if gh.Issues != nil || gh.Contents != nil || gh.Metadata != nil ||
+			gh.PullRequests != nil || gh.Workflows != nil || gh.Actions != nil {
+			ret.GitHub = &gh
+		}
+	}
+
+	return ret, nil
+}
+
+func (s *spannerVCSInstallation) toVCSInstallation() (*VCSInstallation, error) {
+	provider, err := ParseVCSProvider(s.VCSProvider)
+	if err != nil {
+		return nil, err
+	}
+	permissions, err := loadVCSPermissions(provider, s.Permissions)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VCSInstallation{
+		ID:                  s.ID,
+		VCSProvider:         provider,
+		VCSInstallationID:   s.VCSInstallationID,
+		AccountLogin:        s.AccountLogin,
+		AccountType:         s.AccountType,
+		RepositorySelection: s.RepositorySelection,
+		Permissions:         permissions,
+		CreatedAt:           s.CreatedAt,
+		UpdatedAt:           s.UpdatedAt,
+	}, nil
+}
+
+type vcsInstallationByIDMapper struct{}
+
+func (m vcsInstallationByIDMapper) SelectOne(id string) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSInstallationID, AccountLogin, AccountType,
+			RepositorySelection, Permissions, CreatedAt, UpdatedAt
+		FROM VCSInstallations
+		WHERE ID = @id`,
+		Params: map[string]any{"id": id},
+	}
+}
+
+// GetVCSInstallation retrieves a VCS installation by internal ID.
+func (c *Client) GetVCSInstallation(ctx context.Context, id string) (*VCSInstallation, error) {
+	r := newEntityReader[vcsInstallationByIDMapper, spannerVCSInstallation, VCSInstallation, string](c)
+	spannerInst, err := r.readRowByKey(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, ErrVCSInstallationNotFound
+		}
+
+		return nil, err
+	}
+
+	return spannerInst.toVCSInstallation()
+}
+
+// GetVCSInstallationByProviderID retrieves a VCS installation by provider and installation ID.
+func (c *Client) GetVCSInstallationByProviderID(
+	ctx context.Context,
+	provider VCSProvider,
+	vcsInstallationID string,
+) (*VCSInstallation, error) {
+	key := vcsInstallationKey{
+		VCSProvider:       provider,
+		VCSInstallationID: vcsInstallationID,
+	}
+	r := newEntityReader[vcsInstallationMapper, spannerVCSInstallation, VCSInstallation, vcsInstallationKey](c)
+	spannerInst, err := r.readRowByKey(ctx, key)
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, ErrVCSInstallationNotFound
+		}
+
+		return nil, err
+	}
+
+	return spannerInst.toVCSInstallation()
+}
+
+// UpsertVCSInstallation creates or updates a VCS installation in Spanner atomically using entityWriterWithIDRetrieval.
+// It returns the ID of the installation.
+func (c *Client) UpsertVCSInstallation(ctx context.Context, in VCSInstallation) (*string, error) {
+	return newEntityWriterWithIDRetrieval[
+		vcsInstallationMapper, string, VCSInstallation, spannerVCSInstallation, vcsInstallationKey,
+	](c).upsertAndGetID(ctx, in)
+}

--- a/lib/gcpspanner/vcs_installation_test.go
+++ b/lib/gcpspanner/vcs_installation_test.go
@@ -1,0 +1,433 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+)
+
+func TestVCSInstallation_PermissionsMapping(t *testing.T) {
+	t.Parallel()
+
+	writeLevel := GitHubPermissionLevelWrite
+	readLevel := GitHubPermissionLevelRead
+
+	testCases := []struct {
+		name        string
+		input       VCSInstallation
+		checkOutput func(t *testing.T, converted *VCSInstallation)
+	}{
+		{
+			name: "Populated GitHub permissions roundtrip",
+			input: VCSInstallation{
+				ID:                  "test-inst-1",
+				VCSProvider:         VCSProviderGitHub,
+				VCSInstallationID:   "12345678",
+				AccountLogin:        "GoogleChrome",
+				AccountType:         "Organization",
+				RepositorySelection: "selected",
+				Permissions: VCSPermissions{
+					GitHub: &GitHubPermissions{
+						Issues:       &writeLevel,
+						Contents:     &readLevel,
+						Metadata:     nil,
+						PullRequests: nil,
+						Workflows:    nil,
+						Actions:      nil,
+					},
+				},
+				CreatedAt: time.Unix(100, 0).UTC(),
+				UpdatedAt: time.Unix(100, 0).UTC(),
+			},
+			checkOutput: func(t *testing.T, converted *VCSInstallation) {
+				if converted.Permissions.GitHub == nil ||
+					converted.Permissions.GitHub.Issues == nil ||
+					*converted.Permissions.GitHub.Issues != writeLevel {
+					t.Errorf("unexpected issues permission: %v", converted.Permissions.GitHub)
+				}
+			},
+		},
+		{
+			name: "Nil GitHub permissions handled cleanly",
+			input: VCSInstallation{
+				ID:                  "test-inst-nil-perm",
+				VCSProvider:         VCSProviderGitHub,
+				VCSInstallationID:   "87654321",
+				AccountLogin:        "GoogleChrome",
+				AccountType:         "Organization",
+				RepositorySelection: "all",
+				Permissions:         VCSPermissions{GitHub: nil},
+				CreatedAt:           time.Unix(100, 0).UTC(),
+				UpdatedAt:           time.Unix(100, 0).UTC(),
+			},
+			checkOutput: func(t *testing.T, converted *VCSInstallation) {
+				if converted.Permissions.GitHub != nil {
+					t.Errorf("expected nil GitHub permissions, got %+v", converted.Permissions.GitHub)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mapper := vcsInstallationMapper{}
+			wrapper, _, err := mapper.NewEntityWithID(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected NewEntityWithID error: %v", err)
+			}
+			converted, err := wrapper.toVCSInstallation()
+			if err != nil {
+				t.Fatalf("unexpected toVCSInstallation error: %v", err)
+			}
+			tc.checkOutput(t, converted)
+		})
+	}
+}
+
+func TestVCSInstallation_InvalidProvider(t *testing.T) {
+	t.Parallel()
+
+	invalidWrapper := spannerVCSInstallation{
+		ID:                  "test-id",
+		VCSProvider:         "unsupported-provider",
+		VCSInstallationID:   "123",
+		AccountLogin:        "user",
+		AccountType:         "User",
+		RepositorySelection: "all",
+		Permissions:         spanner.NullJSON{Value: nil, Valid: false},
+		CreatedAt:           time.Now(),
+		UpdatedAt:           time.Now(),
+	}
+
+	_, err := invalidWrapper.toVCSInstallation()
+	if err == nil {
+		t.Fatalf("expected error for invalid provider, got nil")
+	}
+	if !errors.Is(err, ErrUnknownVCSProvider) {
+		t.Fatalf("expected ErrUnknownVCSProvider, got %v", err)
+	}
+}
+
+func testVCSInstallationNotFound(ctx context.Context, t *testing.T) {
+	_, err := spannerClient.GetVCSInstallation(ctx, "non-existent-id")
+	if !errors.Is(err, ErrVCSInstallationNotFound) {
+		t.Fatalf("expected ErrVCSInstallationNotFound, got %v", err)
+	}
+
+	_, err = spannerClient.GetVCSInstallationByProviderID(ctx, VCSProviderGitHub, "non-existent-external-id")
+	if !errors.Is(err, ErrVCSInstallationNotFound) {
+		t.Fatalf("expected ErrVCSInstallationNotFound, got %v", err)
+	}
+}
+
+func testVCSInstallationInsertAndGet(ctx context.Context, t *testing.T) {
+	instID := uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	writeLevel := GitHubPermissionLevelWrite
+	readLevel := GitHubPermissionLevelRead
+	inst := VCSInstallation{
+		ID:                  instID,
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   "inst-insert-1",
+		AccountLogin:        "GoogleChrome",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       &writeLevel,
+				Contents:     &readLevel,
+				Metadata:     nil,
+				PullRequests: nil,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	insertedID, err := spannerClient.UpsertVCSInstallation(ctx, inst)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation failed: %v", err)
+	}
+	if insertedID == nil || *insertedID != instID {
+		t.Fatalf("expected inserted ID %s, got %v", instID, insertedID)
+	}
+
+	retrieved, err := spannerClient.GetVCSInstallation(ctx, instID)
+	if err != nil {
+		t.Fatalf("GetVCSInstallation failed: %v", err)
+	}
+
+	//nolint:exhaustruct // Ignore CreatedAt and UpdatedAt
+	ignoreFields := cmpopts.IgnoreFields(VCSInstallation{}, "CreatedAt", "UpdatedAt")
+	if diff := cmp.Diff(&inst, retrieved, ignoreFields); diff != "" {
+		t.Errorf("GetVCSInstallation mismatch (-want +got):\n%s", diff)
+	}
+	if retrieved.CreatedAt.IsZero() || retrieved.UpdatedAt.IsZero() {
+		t.Errorf("expected non-zero commit timestamps")
+	}
+}
+
+func testVCSInstallationGetByProviderID(ctx context.Context, t *testing.T) {
+	extID := "ext-inst-query-2"
+	inst := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   extID,
+		AccountLogin:        "GoogleChrome-Ext",
+		AccountType:         "User",
+		RepositorySelection: "all",
+		Permissions:         VCSPermissions{GitHub: nil},
+		CreatedAt:           time.Time{},
+		UpdatedAt:           time.Time{},
+	}
+
+	idPtr, err := spannerClient.UpsertVCSInstallation(ctx, inst)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation failed: %v", err)
+	}
+
+	byProvider, err := spannerClient.GetVCSInstallationByProviderID(ctx, VCSProviderGitHub, extID)
+	if err != nil {
+		t.Fatalf("GetVCSInstallationByProviderID failed: %v", err)
+	}
+	if byProvider.ID != *idPtr {
+		t.Errorf("expected ID %s, got %s", *idPtr, byProvider.ID)
+	}
+	if byProvider.Permissions.GitHub != nil {
+		t.Errorf("expected nil GitHub permissions, got %+v", byProvider.Permissions.GitHub)
+	}
+}
+
+func testVCSInstallationPartialPermissions(ctx context.Context, t *testing.T) {
+	writeLevel := GitHubPermissionLevelWrite
+	extID := "ext-inst-partial-3"
+	inst := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   extID,
+		AccountLogin:        "GoogleChrome-Partial",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       nil,
+				Contents:     nil,
+				Metadata:     nil,
+				PullRequests: &writeLevel,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+
+	idPtr, err := spannerClient.UpsertVCSInstallation(ctx, inst)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation (partial permissions) failed: %v", err)
+	}
+
+	retrieved, err := spannerClient.GetVCSInstallation(ctx, *idPtr)
+	if err != nil {
+		t.Fatalf("GetVCSInstallation failed: %v", err)
+	}
+	if retrieved.Permissions.GitHub == nil {
+		t.Fatalf("expected non-nil GitHub permissions")
+	}
+	if retrieved.Permissions.GitHub.PullRequests == nil ||
+		*retrieved.Permissions.GitHub.PullRequests != writeLevel {
+		t.Errorf("expected PullRequests write, got %+v", retrieved.Permissions.GitHub.PullRequests)
+	}
+	if retrieved.Permissions.GitHub.Issues != nil ||
+		retrieved.Permissions.GitHub.Contents != nil ||
+		retrieved.Permissions.GitHub.Metadata != nil ||
+		retrieved.Permissions.GitHub.Workflows != nil ||
+		retrieved.Permissions.GitHub.Actions != nil {
+		t.Errorf("expected all other permission fields to remain nil, got %+v", retrieved.Permissions.GitHub)
+	}
+}
+
+func testVCSInstallationMergeSemantics(ctx context.Context, t *testing.T) {
+	writeLevel := GitHubPermissionLevelWrite
+	readLevel := GitHubPermissionLevelRead
+	extID := "ext-inst-merge-4"
+	now := time.Now().UTC().Add(-10 * time.Minute).Truncate(time.Microsecond)
+	initial := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   extID,
+		AccountLogin:        "GoogleChrome-Initial",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       &writeLevel,
+				Contents:     &readLevel,
+				Metadata:     nil,
+				PullRequests: nil,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	idPtr, err := spannerClient.UpsertVCSInstallation(ctx, initial)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation (initial) failed: %v", err)
+	}
+	retrievedInitial, err := spannerClient.GetVCSInstallation(ctx, *idPtr)
+	if err != nil {
+		t.Fatalf("GetVCSInstallation (initial) failed: %v", err)
+	}
+	initialCreatedAt := retrievedInitial.CreatedAt
+
+	updateTime := now.Add(5 * time.Minute)
+	spannerClient.setTimeNowForTesting(func() time.Time { return updateTime })
+	defer spannerClient.setTimeNowForTesting(time.Now)
+
+	updated := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   extID,
+		AccountLogin:        "GoogleChrome-Updated",
+		AccountType:         "Organization",
+		RepositorySelection: "all",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       &writeLevel,
+				Contents:     nil,
+				Metadata:     nil,
+				PullRequests: &writeLevel,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+
+	updatedID, err := spannerClient.UpsertVCSInstallation(ctx, updated)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation (update) failed: %v", err)
+	}
+	if updatedID == nil || *updatedID != *idPtr {
+		t.Fatalf("expected preserved ID %s, got %v", *idPtr, updatedID)
+	}
+
+	retrievedUpdated, err := spannerClient.GetVCSInstallation(ctx, *idPtr)
+	if err != nil {
+		t.Fatalf("GetVCSInstallation after update failed: %v", err)
+	}
+	if retrievedUpdated.AccountLogin != "GoogleChrome-Updated" {
+		t.Errorf("expected AccountLogin GoogleChrome-Updated, got %s", retrievedUpdated.AccountLogin)
+	}
+	if retrievedUpdated.RepositorySelection != "all" {
+		t.Errorf("expected RepositorySelection all, got %s", retrievedUpdated.RepositorySelection)
+	}
+	if retrievedUpdated.Permissions.GitHub == nil ||
+		retrievedUpdated.Permissions.GitHub.PullRequests == nil ||
+		*retrievedUpdated.Permissions.GitHub.PullRequests != writeLevel {
+		t.Errorf("unexpected permissions after update: %+v", retrievedUpdated.Permissions.GitHub)
+	}
+	if !retrievedUpdated.CreatedAt.Equal(initialCreatedAt) {
+		t.Errorf("CreatedAt was not preserved: got %v, want %v", retrievedUpdated.CreatedAt, initialCreatedAt)
+	}
+}
+
+func testVCSInstallationUniqueIndex(ctx context.Context, t *testing.T) {
+	instA := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   "ext-inst-distinct-A",
+		AccountLogin:        "AccountA",
+		AccountType:         "Organization",
+		RepositorySelection: "all",
+		Permissions:         VCSPermissions{GitHub: nil},
+		CreatedAt:           time.Time{},
+		UpdatedAt:           time.Time{},
+	}
+	instB := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   "ext-inst-distinct-B",
+		AccountLogin:        "AccountB",
+		AccountType:         "Organization",
+		RepositorySelection: "all",
+		Permissions:         VCSPermissions{GitHub: nil},
+		CreatedAt:           time.Time{},
+		UpdatedAt:           time.Time{},
+	}
+
+	idAPtr, err := spannerClient.UpsertVCSInstallation(ctx, instA)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation instA failed: %v", err)
+	}
+	idBPtr, err := spannerClient.UpsertVCSInstallation(ctx, instB)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation instB failed: %v", err)
+	}
+	if *idAPtr == *idBPtr {
+		t.Fatalf("expected distinct IDs for distinct installations, got identical: %s", *idAPtr)
+	}
+
+	retrievedA, err := spannerClient.GetVCSInstallation(ctx, *idAPtr)
+	if err != nil {
+		t.Fatalf("GetVCSInstallation A failed: %v", err)
+	}
+	retrievedB, err := spannerClient.GetVCSInstallation(ctx, *idBPtr)
+	if err != nil {
+		t.Fatalf("GetVCSInstallation B failed: %v", err)
+	}
+	if retrievedA.AccountLogin != "AccountA" || retrievedB.AccountLogin != "AccountB" {
+		t.Errorf("account logins mismatch: A=%s B=%s", retrievedA.AccountLogin, retrievedB.AccountLogin)
+	}
+}
+
+func TestClient_VCSInstallation(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	t.Run("NotFound returns ErrVCSInstallationNotFound", func(t *testing.T) {
+		testVCSInstallationNotFound(ctx, t)
+	})
+	t.Run("Insert and retrieve by ID", func(t *testing.T) {
+		testVCSInstallationInsertAndGet(ctx, t)
+	})
+	t.Run("Retrieve by provider and external installation ID", func(t *testing.T) {
+		testVCSInstallationGetByProviderID(ctx, t)
+	})
+	t.Run("Partial permissions payload (only pull_requests)", func(t *testing.T) {
+		testVCSInstallationPartialPermissions(ctx, t)
+	})
+	t.Run("Merge semantics update mutable fields and preserve CreatedAt", func(t *testing.T) {
+		testVCSInstallationMergeSemantics(ctx, t)
+	})
+	t.Run("Unique index allows distinct installations per provider", func(t *testing.T) {
+		testVCSInstallationUniqueIndex(ctx, t)
+	})
+}


### PR DESCRIPTION
Refs #2712, #2713

Adds Spanner migration `000034.sql` and Go models for VCS installations and GitHub app permissions.

- `infra/storage/spanner/migrations/000034.sql`: `VCSInstallations` table with composite index on `(VCSProvider, VCSInstallationID)`.
- `lib/gcpspanner/vcs_installation.go`: Entity models, JSON permission parsers, and `UpsertVCSInstallation` / `GetVCSInstallation`.
- `lib/gcpspanner/vcs_installation_test.go`: Unit and emulator integration tests.