### PR TITLE
feat(spanner): add migration 000035.sql for code subscriptions

### DIFF
--- a/infra/storage/spanner/migrations/000035.sql
+++ b/infra/storage/spanner/migrations/000035.sql
@@ -1,0 +1,34 @@
+-- Copyright 2026 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Migration: 000035.sql
+-- Description: Add CodeSubscriptions table.
+
+CREATE TABLE IF NOT EXISTS CodeSubscriptions (
+    ID STRING(36) NOT NULL,
+    VCSProvider STRING(32) NOT NULL,
+    VCSInstallationID STRING(128) NOT NULL,
+    VCSRepositoryID STRING(128) NOT NULL,
+    RepositoryFullName STRING(256) NOT NULL,
+    TargetQuery STRING(2048) NOT NULL,
+    Triggers ARRAY<STRING(64)> NOT NULL,
+    Status STRING(32) NOT NULL,
+    Occurrences JSON NOT NULL,
+    CreatedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+    UpdatedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+) PRIMARY KEY (ID);
+
+CREATE UNIQUE INDEX IF NOT EXISTS IDX_CodeSubscriptions_Provider_Repo_Target ON CodeSubscriptions(VCSProvider, VCSRepositoryID, TargetQuery);
+CREATE INDEX IF NOT EXISTS IDX_CodeSubscriptions_Provider_Repo ON CodeSubscriptions(VCSProvider, VCSRepositoryID);
+CREATE INDEX IF NOT EXISTS IDX_CodeSubscriptions_TargetQuery ON CodeSubscriptions(TargetQuery);

--- a/lib/gcpspanner/code_subscription.go
+++ b/lib/gcpspanner/code_subscription.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+const codeSubscriptionTable = "CodeSubscriptions"
+
+var (
+	// ErrCodeSubscriptionNotFound indicates that the code subscription was not found.
+	ErrCodeSubscriptionNotFound = errors.New("code subscription not found")
+	// ErrUnknownSubscriptionStatus indicates an unrecognized subscription status.
+	ErrUnknownSubscriptionStatus = errors.New("unknown subscription status")
+)
+
+// SubscriptionStatus represents the lifecycle state of a code subscription.
+type SubscriptionStatus string
+
+const (
+	SubscriptionActive    SubscriptionStatus = "ACTIVE"
+	SubscriptionTriggered SubscriptionStatus = "TRIGGERED"
+	SubscriptionDelivered SubscriptionStatus = "DELIVERED"
+	SubscriptionResolved  SubscriptionStatus = "RESOLVED"
+	SubscriptionObsolete  SubscriptionStatus = "OBSOLETE"
+	SubscriptionDeleted   SubscriptionStatus = "DELETED"
+	SubscriptionError     SubscriptionStatus = "ERROR"
+)
+
+// SubscriptionOccurrence represents a code location where a directive is used.
+type SubscriptionOccurrence struct {
+	FilePath       string `json:"file_path"`
+	LineNumber     int64  `json:"line_number"`
+	CommentSnippet string `json:"comment_snippet"`
+}
+
+// CodeSubscription represents a subscription anchored to a code repository AST pattern.
+type CodeSubscription struct {
+	ID                 string
+	VCSProvider        VCSProvider
+	VCSInstallationID  string
+	VCSRepositoryID    string
+	RepositoryFullName string
+	TargetQuery        string
+	Triggers           []string
+	Status             SubscriptionStatus
+	Occurrences        []SubscriptionOccurrence
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+// spannerCodeSubscription is the internal struct for Spanner column mapping.
+type spannerCodeSubscription struct {
+	ID                 string           `spanner:"ID"`
+	VCSProvider        string           `spanner:"VCSProvider"`
+	VCSInstallationID  string           `spanner:"VCSInstallationID"`
+	VCSRepositoryID    string           `spanner:"VCSRepositoryID"`
+	RepositoryFullName string           `spanner:"RepositoryFullName"`
+	TargetQuery        string           `spanner:"TargetQuery"`
+	Triggers           []string         `spanner:"Triggers"`
+	Status             string           `spanner:"Status"`
+	Occurrences        spanner.NullJSON `spanner:"Occurrences"`
+	CreatedAt          time.Time        `spanner:"CreatedAt"`
+	UpdatedAt          time.Time        `spanner:"UpdatedAt"`
+}
+
+type codeSubscriptionMapper struct{}
+
+func (m codeSubscriptionMapper) Table() string { return codeSubscriptionTable }
+
+func (m codeSubscriptionMapper) SelectOne(id string) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSInstallationID, VCSRepositoryID, RepositoryFullName,
+			TargetQuery, Triggers, Status, Occurrences, CreatedAt, UpdatedAt
+		FROM CodeSubscriptions
+		WHERE ID = @id`,
+		Params: map[string]any{"id": id},
+	}
+}
+
+// ParseSubscriptionStatus parses and validates a raw subscription status string into a typed SubscriptionStatus.
+func ParseSubscriptionStatus(val string) (SubscriptionStatus, error) {
+	status := SubscriptionStatus(val)
+	switch status {
+	case SubscriptionActive,
+		SubscriptionTriggered,
+		SubscriptionDelivered,
+		SubscriptionResolved,
+		SubscriptionObsolete,
+		SubscriptionDeleted,
+		SubscriptionError:
+		return status, nil
+	}
+
+	return "", fmt.Errorf("%w: %q", ErrUnknownSubscriptionStatus, val)
+}
+
+func (s *spannerCodeSubscription) toCodeSubscription() (*CodeSubscription, error) {
+	provider, err := ParseVCSProvider(s.VCSProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	status, err := ParseSubscriptionStatus(s.Status)
+	if err != nil {
+		return nil, err
+	}
+
+	var occurrences []SubscriptionOccurrence
+	if s.Occurrences.Valid && s.Occurrences.Value != nil {
+		bytes, err := json.Marshal(s.Occurrences.Value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal occurrences: %w", err)
+		}
+		if err := json.Unmarshal(bytes, &occurrences); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal occurrences: %w", err)
+		}
+	} else {
+		occurrences = []SubscriptionOccurrence{}
+	}
+
+	return &CodeSubscription{
+		ID:                 s.ID,
+		VCSProvider:        provider,
+		VCSInstallationID:  s.VCSInstallationID,
+		VCSRepositoryID:    s.VCSRepositoryID,
+		RepositoryFullName: s.RepositoryFullName,
+		TargetQuery:        s.TargetQuery,
+		Triggers:           s.Triggers,
+		Status:             status,
+		Occurrences:        occurrences,
+		CreatedAt:          s.CreatedAt,
+		UpdatedAt:          s.UpdatedAt,
+	}, nil
+}
+
+func fromCodeSubscription(sub *CodeSubscription) *spannerCodeSubscription {
+	occurrences := sub.Occurrences
+	if occurrences == nil {
+		occurrences = []SubscriptionOccurrence{}
+	}
+
+	return &spannerCodeSubscription{
+		ID:                 sub.ID,
+		VCSProvider:        string(sub.VCSProvider),
+		VCSInstallationID:  sub.VCSInstallationID,
+		VCSRepositoryID:    sub.VCSRepositoryID,
+		RepositoryFullName: sub.RepositoryFullName,
+		TargetQuery:        sub.TargetQuery,
+		Triggers:           sub.Triggers,
+		Status:             string(sub.Status),
+		Occurrences: spanner.NullJSON{
+			Value: occurrences,
+			Valid: true,
+		},
+		CreatedAt: sub.CreatedAt,
+		UpdatedAt: sub.UpdatedAt,
+	}
+}
+
+// GetCodeSubscription retrieves a code subscription by ID.
+func (c *Client) GetCodeSubscription(ctx context.Context, id string) (*CodeSubscription, error) {
+	r := newEntityReader[
+		codeSubscriptionMapper, spannerCodeSubscription, CodeSubscription, string,
+	](c)
+	spannerSub, err := r.readRowByKey(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, ErrCodeSubscriptionNotFound
+		}
+
+		return nil, err
+	}
+
+	return spannerSub.toCodeSubscription()
+}

--- a/lib/gcpspanner/code_subscription_test.go
+++ b/lib/gcpspanner/code_subscription_test.go
@@ -1,0 +1,266 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/uuid"
+)
+
+func TestCodeSubscriptionConversion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	testCases := []struct {
+		name        string
+		input       CodeSubscription
+		checkOutput func(t *testing.T, converted *CodeSubscription)
+	}{
+		{
+			name: "Populated occurrences roundtrip",
+			input: CodeSubscription{
+				ID:                 "sub-uuid-1",
+				VCSProvider:        VCSProviderGitHub,
+				VCSInstallationID:  "123456",
+				VCSRepositoryID:    "987654",
+				RepositoryFullName: "owner/repo",
+				TargetQuery:        "id:css-subgrid AND baseline_status:widely",
+				Triggers:           []string{"feature_baseline_to_widely"},
+				Status:             SubscriptionActive,
+				Occurrences: []SubscriptionOccurrence{
+					{
+						FilePath:       "src/styles.css",
+						LineNumber:     42,
+						CommentSnippet: "// TODO(baseline/subgrid): remove flex fallback",
+					},
+				},
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			checkOutput: func(t *testing.T, converted *CodeSubscription) {
+				if len(converted.Occurrences) != 1 {
+					t.Fatalf("expected 1 occurrence, got %d", len(converted.Occurrences))
+				}
+				if converted.Occurrences[0].LineNumber != 42 {
+					t.Errorf("expected line 42, got %d", converted.Occurrences[0].LineNumber)
+				}
+			},
+		},
+		{
+			name: "Nil occurrences deserializes as non-nil empty slice",
+			input: CodeSubscription{
+				ID:                 "sub-uuid-nil-occ",
+				VCSProvider:        VCSProviderGitHub,
+				VCSInstallationID:  "123456",
+				VCSRepositoryID:    "987654",
+				RepositoryFullName: "owner/repo",
+				TargetQuery:        "id:css-subgrid",
+				Triggers:           []string{"feature_baseline_to_widely"},
+				Status:             SubscriptionActive,
+				Occurrences:        nil,
+				CreatedAt:          now,
+				UpdatedAt:          now,
+			},
+			checkOutput: func(t *testing.T, converted *CodeSubscription) {
+				if converted.Occurrences == nil {
+					t.Errorf("expected non-nil empty slice for occurrences, got nil")
+				}
+				if len(converted.Occurrences) != 0 {
+					t.Errorf("expected 0 occurrences, got %d", len(converted.Occurrences))
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			scs := fromCodeSubscription(&tc.input)
+			converted, err := scs.toCodeSubscription()
+			if err != nil {
+				t.Fatalf("unexpected toCodeSubscription error: %v", err)
+			}
+			tc.checkOutput(t, converted)
+		})
+	}
+}
+
+func TestCodeSubscription_InvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	invalid := spannerCodeSubscription{
+		ID:                 "sub-invalid-status",
+		VCSProvider:        "github",
+		VCSInstallationID:  "123",
+		VCSRepositoryID:    "456",
+		RepositoryFullName: "owner/repo",
+		TargetQuery:        "query",
+		Triggers:           []string{"trigger"},
+		Status:             "INVALID_STATUS",
+		Occurrences:        spanner.NullJSON{Value: nil, Valid: false},
+		CreatedAt:          time.Now(),
+		UpdatedAt:          time.Now(),
+	}
+
+	_, err := invalid.toCodeSubscription()
+	if err == nil {
+		t.Fatalf("expected error for invalid status, got nil")
+	}
+	if !errors.Is(err, ErrUnknownSubscriptionStatus) {
+		t.Fatalf("expected ErrUnknownSubscriptionStatus, got %v", err)
+	}
+}
+
+func testCodeSubscriptionNotFound(ctx context.Context, t *testing.T) {
+	_, err := spannerClient.GetCodeSubscription(ctx, "non-existent-sub-id")
+	if !errors.Is(err, ErrCodeSubscriptionNotFound) {
+		t.Fatalf("expected ErrCodeSubscriptionNotFound, got: %v", err)
+	}
+}
+
+func testCodeSubscriptionInsertWithOccurrences(ctx context.Context, t *testing.T, instID string) {
+	subID := uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	sub := CodeSubscription{
+		ID:                 subID,
+		VCSProvider:        VCSProviderGitHub,
+		VCSInstallationID:  instID,
+		VCSRepositoryID:    "repo-123",
+		RepositoryFullName: "GoogleChrome/webstatus.dev",
+		TargetQuery:        "id:view-transitions",
+		Triggers:           []string{"feature_baseline_to_widely"},
+		Status:             SubscriptionActive,
+		Occurrences: []SubscriptionOccurrence{
+			{
+				FilePath:       "src/app.ts",
+				LineNumber:     10,
+				CommentSnippet: "// TODO(baseline/view-transitions)",
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	spannerSub := fromCodeSubscription(&sub)
+	subMut, err := spanner.InsertStruct(codeSubscriptionTable, spannerSub)
+	if err != nil {
+		t.Fatalf("InsertStruct failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{subMut}); err != nil {
+		t.Fatalf("Apply subscription mutation failed: %v", err)
+	}
+
+	retrievedSub, err := spannerClient.GetCodeSubscription(ctx, subID)
+	if err != nil {
+		t.Fatalf("GetCodeSubscription failed: %v", err)
+	}
+	if retrievedSub.ID != subID || len(retrievedSub.Occurrences) != 1 {
+		t.Fatalf("retrieved subscription mismatch: %+v", retrievedSub)
+	}
+	if retrievedSub.VCSProvider != VCSProviderGitHub {
+		t.Errorf("expected VCSProvider %s, got %s", VCSProviderGitHub, retrievedSub.VCSProvider)
+	}
+	if retrievedSub.Status != SubscriptionActive {
+		t.Errorf("expected Status %s, got %s", SubscriptionActive, retrievedSub.Status)
+	}
+	if retrievedSub.Occurrences[0].FilePath != "src/app.ts" || retrievedSub.Occurrences[0].LineNumber != 10 {
+		t.Errorf("unexpected occurrence data: %+v", retrievedSub.Occurrences[0])
+	}
+}
+
+func testCodeSubscriptionEmptyOccurrences(ctx context.Context, t *testing.T, instID string) {
+	emptySubID := uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	emptySub := CodeSubscription{
+		ID:                 emptySubID,
+		VCSProvider:        VCSProviderGitHub,
+		VCSInstallationID:  instID,
+		VCSRepositoryID:    "repo-empty-occ",
+		RepositoryFullName: "GoogleChrome/webstatus.dev",
+		TargetQuery:        "id:subgrid",
+		Triggers:           []string{"feature_baseline_to_widely"},
+		Status:             SubscriptionActive,
+		Occurrences:        []SubscriptionOccurrence{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	spannerEmptySub := fromCodeSubscription(&emptySub)
+	emptyMut, err := spanner.InsertStruct(codeSubscriptionTable, spannerEmptySub)
+	if err != nil {
+		t.Fatalf("InsertStruct failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{emptyMut}); err != nil {
+		t.Fatalf("Apply empty subscription mutation failed: %v", err)
+	}
+
+	retrieved, err := spannerClient.GetCodeSubscription(ctx, emptySubID)
+	if err != nil {
+		t.Fatalf("GetCodeSubscription failed: %v", err)
+	}
+	if retrieved.Occurrences == nil {
+		t.Errorf("expected non-nil empty occurrences slice, got nil")
+	}
+	if len(retrieved.Occurrences) != 0 {
+		t.Errorf("expected 0 occurrences, got %d", len(retrieved.Occurrences))
+	}
+}
+
+func TestClient_GetCodeSubscription(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// Create parent installation for foreign key / relationship
+	writeLevel := GitHubPermissionLevelWrite
+	inst := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   "12345678",
+		AccountLogin:        "GoogleChrome",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       &writeLevel,
+				Contents:     nil,
+				Metadata:     nil,
+				PullRequests: nil,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+	instIDPtr, err := spannerClient.UpsertVCSInstallation(ctx, inst)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation failed: %v", err)
+	}
+	instID := *instIDPtr
+
+	t.Run("NotFound returns ErrCodeSubscriptionNotFound", func(t *testing.T) {
+		testCodeSubscriptionNotFound(ctx, t)
+	})
+	t.Run("Insert and retrieve with occurrences", func(t *testing.T) {
+		testCodeSubscriptionInsertWithOccurrences(ctx, t, instID)
+	})
+	t.Run("Roundtrip with empty occurrences", func(t *testing.T) {
+		testCodeSubscriptionEmptyOccurrences(ctx, t, instID)
+	})
+}


### PR DESCRIPTION
Refs #2712, #2714

Adds Spanner migration `000035.sql` and Go models for code subscriptions.

- `infra/storage/spanner/migrations/000035.sql`: `CodeSubscriptions` table with JSON occurrences storage.
- `lib/gcpspanner/code_subscription.go`: Entity models, enum parsers, and `GetCodeSubscription`.
- `lib/gcpspanner/code_subscription_test.go`: Unit and emulator integration tests.

*Note: Subscription creation, updates, and obsolescence are handled via repository-scoped sync in PR #2738 (`SynchronizeRepositoryCodeSubscriptions`). Delivery tracking is in PR #2761.*