### PR TITLE
feat(spanner): add migration 000037.sql for scan logs and webhook deduplication

### DIFF
--- a/infra/storage/spanner/migrations/000037.sql
+++ b/infra/storage/spanner/migrations/000037.sql
@@ -1,0 +1,43 @@
+-- Copyright 2026 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Migration: 000037.sql
+-- Description: Add CodeSubscriptionScanLogs and VCSWebhookDeliveries tables with native row deletion policies.
+
+CREATE TABLE IF NOT EXISTS CodeSubscriptionScanLogs (
+    ID STRING(36) NOT NULL,
+    VCSProvider STRING(32) NOT NULL,
+    VCSRepositoryID STRING(128) NOT NULL,
+    CommitSHA STRING(64) NOT NULL,
+    Branch STRING(256) NOT NULL,
+    ScanStatus STRING(32) NOT NULL,
+    FilesScanned INT64 NOT NULL,
+    DirectivesFound INT64 NOT NULL,
+    ErrorMessage STRING(2048),
+    ScannedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+) PRIMARY KEY (ID),
+ROW DELETION POLICY (OLDER_THAN(ScannedAt, INTERVAL 30 DAY));
+
+CREATE INDEX IF NOT EXISTS IDX_CodeSubscriptionScanLogs_Repo_ScannedAt ON CodeSubscriptionScanLogs(VCSProvider, VCSRepositoryID, ScannedAt DESC);
+
+CREATE TABLE IF NOT EXISTS VCSWebhookDeliveries (
+    VCSProvider STRING(32) NOT NULL,
+    DeliveryGUID STRING(128) NOT NULL,
+    EventType STRING(64) NOT NULL,
+    VCSRepositoryID STRING(128) NOT NULL,
+    ReceivedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+) PRIMARY KEY (VCSProvider, DeliveryGUID),
+ROW DELETION POLICY (OLDER_THAN(ReceivedAt, INTERVAL 7 DAY));
+
+CREATE INDEX IF NOT EXISTS IDX_VCSWebhookDeliveries_ReceivedAt ON VCSWebhookDeliveries(ReceivedAt);

--- a/lib/gcpspanner/scan_log_and_webhook.go
+++ b/lib/gcpspanner/scan_log_and_webhook.go
@@ -1,0 +1,315 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+const (
+	codeSubscriptionScanLogTable = "CodeSubscriptionScanLogs"
+	vcsWebhookDeliveryTable      = "VCSWebhookDeliveries"
+)
+
+var (
+	// ErrScanLogNotFound indicates that the scan log record was not found.
+	ErrScanLogNotFound = errors.New("scan log not found")
+	// ErrVCSWebhookDeliveryNotFound indicates that the webhook delivery record was not found.
+	ErrVCSWebhookDeliveryNotFound = errors.New("vcs webhook delivery not found")
+	// ErrUnknownScanStatus indicates an unrecognized scan status.
+	ErrUnknownScanStatus = errors.New("unknown scan status")
+)
+
+// ScanStatus represents the completion status of an AST repository scan.
+type ScanStatus string
+
+const (
+	ScanStatusSuccess   ScanStatus = "SUCCESS"
+	ScanStatusTruncated ScanStatus = "TRUNCATED"
+	ScanStatusFailed    ScanStatus = "FAILED"
+)
+
+// CodeSubscriptionScanLog stores the audit log of an AST repository scan for a commit.
+type CodeSubscriptionScanLog struct {
+	ID              string
+	VCSProvider     VCSProvider
+	VCSRepositoryID string
+	CommitSHA       string
+	Branch          string
+	ScanStatus      ScanStatus
+	FilesScanned    int64
+	DirectivesFound int64
+	ErrorMessage    *string
+	ScannedAt       time.Time
+}
+
+// spannerCodeSubscriptionScanLog is the internal struct for Spanner column mapping.
+type spannerCodeSubscriptionScanLog struct {
+	ID              string             `spanner:"ID"`
+	VCSProvider     string             `spanner:"VCSProvider"`
+	VCSRepositoryID string             `spanner:"VCSRepositoryID"`
+	CommitSHA       string             `spanner:"CommitSHA"`
+	Branch          string             `spanner:"Branch"`
+	ScanStatus      string             `spanner:"ScanStatus"`
+	FilesScanned    int64              `spanner:"FilesScanned"`
+	DirectivesFound int64              `spanner:"DirectivesFound"`
+	ErrorMessage    spanner.NullString `spanner:"ErrorMessage"`
+	ScannedAt       time.Time          `spanner:"ScannedAt"`
+}
+
+type codeSubscriptionScanLogMapper struct{}
+
+func (m codeSubscriptionScanLogMapper) Table() string { return codeSubscriptionScanLogTable }
+
+func (m codeSubscriptionScanLogMapper) SelectOne(id string) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSRepositoryID, CommitSHA, Branch, ScanStatus,
+			FilesScanned, DirectivesFound, ErrorMessage, ScannedAt
+		FROM CodeSubscriptionScanLogs
+		WHERE ID = @id`,
+		Params: map[string]any{"id": id},
+	}
+}
+
+func (m codeSubscriptionScanLogMapper) GetKeyFromExternal(in CodeSubscriptionScanLog) string {
+	return in.ID
+}
+
+func (m codeSubscriptionScanLogMapper) NewEntity(
+	id string,
+	in CodeSubscriptionScanLog,
+) (spannerCodeSubscriptionScanLog, error) {
+	var errMsg spanner.NullString
+	if in.ErrorMessage != nil {
+		errMsg = spanner.NullString{StringVal: *in.ErrorMessage, Valid: true}
+	}
+
+	entityID := id
+	if in.ID != "" {
+		entityID = in.ID
+	}
+
+	return spannerCodeSubscriptionScanLog{
+		ID:              entityID,
+		VCSProvider:     string(in.VCSProvider),
+		VCSRepositoryID: in.VCSRepositoryID,
+		CommitSHA:       in.CommitSHA,
+		Branch:          in.Branch,
+		ScanStatus:      string(in.ScanStatus),
+		FilesScanned:    in.FilesScanned,
+		DirectivesFound: in.DirectivesFound,
+		ErrorMessage:    errMsg,
+		ScannedAt:       in.ScannedAt,
+	}, nil
+}
+
+func (m codeSubscriptionScanLogMapper) Merge(
+	in CodeSubscriptionScanLog,
+	existing spannerCodeSubscriptionScanLog,
+) spannerCodeSubscriptionScanLog {
+	var errMsg spanner.NullString
+	if in.ErrorMessage != nil {
+		errMsg = spanner.NullString{StringVal: *in.ErrorMessage, Valid: true}
+	}
+
+	return spannerCodeSubscriptionScanLog{
+		ID:              existing.ID,
+		VCSProvider:     string(in.VCSProvider),
+		VCSRepositoryID: in.VCSRepositoryID,
+		CommitSHA:       in.CommitSHA,
+		Branch:          in.Branch,
+		ScanStatus:      string(in.ScanStatus),
+		FilesScanned:    in.FilesScanned,
+		DirectivesFound: in.DirectivesFound,
+		ErrorMessage:    errMsg,
+		ScannedAt:       in.ScannedAt,
+	}
+}
+
+// ParseScanStatus parses and validates a raw scan status string into a typed ScanStatus.
+func ParseScanStatus(val string) (ScanStatus, error) {
+	status := ScanStatus(val)
+	switch status {
+	case ScanStatusSuccess,
+		ScanStatusTruncated,
+		ScanStatusFailed:
+		return status, nil
+	}
+
+	return "", fmt.Errorf("%w: %q", ErrUnknownScanStatus, val)
+}
+
+func (s *spannerCodeSubscriptionScanLog) toCodeSubscriptionScanLog() (*CodeSubscriptionScanLog, error) {
+	provider, err := ParseVCSProvider(s.VCSProvider)
+	if err != nil {
+		return nil, err
+	}
+	status, err := ParseScanStatus(s.ScanStatus)
+	if err != nil {
+		return nil, err
+	}
+
+	var errMsg *string
+	if s.ErrorMessage.Valid {
+		errMsg = &s.ErrorMessage.StringVal
+	}
+
+	return &CodeSubscriptionScanLog{
+		ID:              s.ID,
+		VCSProvider:     provider,
+		VCSRepositoryID: s.VCSRepositoryID,
+		CommitSHA:       s.CommitSHA,
+		Branch:          s.Branch,
+		ScanStatus:      status,
+		FilesScanned:    s.FilesScanned,
+		DirectivesFound: s.DirectivesFound,
+		ErrorMessage:    errMsg,
+		ScannedAt:       s.ScannedAt,
+	}, nil
+}
+
+func fromCodeSubscriptionScanLog(log *CodeSubscriptionScanLog) *spannerCodeSubscriptionScanLog {
+	var errMsg spanner.NullString
+	if log.ErrorMessage != nil {
+		errMsg = spanner.NullString{StringVal: *log.ErrorMessage, Valid: true}
+	}
+
+	return &spannerCodeSubscriptionScanLog{
+		ID:              log.ID,
+		VCSProvider:     string(log.VCSProvider),
+		VCSRepositoryID: log.VCSRepositoryID,
+		CommitSHA:       log.CommitSHA,
+		Branch:          log.Branch,
+		ScanStatus:      string(log.ScanStatus),
+		FilesScanned:    log.FilesScanned,
+		DirectivesFound: log.DirectivesFound,
+		ErrorMessage:    errMsg,
+		ScannedAt:       log.ScannedAt,
+	}
+}
+
+// VCSWebhookDelivery represents an idempotency record for a received webhook delivery.
+type VCSWebhookDelivery struct {
+	VCSProvider     VCSProvider
+	DeliveryGUID    string
+	EventType       string
+	VCSRepositoryID string
+	ReceivedAt      time.Time
+}
+
+// spannerVCSWebhookDelivery is the internal struct for Spanner column mapping.
+type spannerVCSWebhookDelivery struct {
+	VCSProvider     string    `spanner:"VCSProvider"`
+	DeliveryGUID    string    `spanner:"DeliveryGUID"`
+	EventType       string    `spanner:"EventType"`
+	VCSRepositoryID string    `spanner:"VCSRepositoryID"`
+	ReceivedAt      time.Time `spanner:"ReceivedAt"`
+}
+
+type vcsWebhookDeliveryKey struct {
+	VCSProvider  VCSProvider
+	DeliveryGUID string
+}
+
+type vcsWebhookDeliveryMapper struct{}
+
+func (m vcsWebhookDeliveryMapper) Table() string { return vcsWebhookDeliveryTable }
+
+func (m vcsWebhookDeliveryMapper) SelectOne(key vcsWebhookDeliveryKey) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT VCSProvider, DeliveryGUID, EventType, VCSRepositoryID, ReceivedAt
+		FROM VCSWebhookDeliveries
+		WHERE VCSProvider = @vcsProvider AND DeliveryGUID = @deliveryGUID`,
+		Params: map[string]any{
+			"vcsProvider":  string(key.VCSProvider),
+			"deliveryGUID": key.DeliveryGUID,
+		},
+	}
+}
+
+func (s *spannerVCSWebhookDelivery) toVCSWebhookDelivery() (*VCSWebhookDelivery, error) {
+	provider, err := ParseVCSProvider(s.VCSProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VCSWebhookDelivery{
+		VCSProvider:     provider,
+		DeliveryGUID:    s.DeliveryGUID,
+		EventType:       s.EventType,
+		VCSRepositoryID: s.VCSRepositoryID,
+		ReceivedAt:      s.ReceivedAt,
+	}, nil
+}
+
+func fromVCSWebhookDelivery(d *VCSWebhookDelivery) *spannerVCSWebhookDelivery {
+	return &spannerVCSWebhookDelivery{
+		VCSProvider:     string(d.VCSProvider),
+		DeliveryGUID:    d.DeliveryGUID,
+		EventType:       d.EventType,
+		VCSRepositoryID: d.VCSRepositoryID,
+		ReceivedAt:      d.ReceivedAt,
+	}
+}
+
+// GetCodeSubscriptionScanLog retrieves a scan log record by ID.
+func (c *Client) GetCodeSubscriptionScanLog(
+	ctx context.Context,
+	id string,
+) (*CodeSubscriptionScanLog, error) {
+	r := newEntityReader[
+		codeSubscriptionScanLogMapper, spannerCodeSubscriptionScanLog, CodeSubscriptionScanLog, string,
+	](c)
+	spannerLog, err := r.readRowByKey(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, ErrScanLogNotFound
+		}
+
+		return nil, err
+	}
+
+	return spannerLog.toCodeSubscriptionScanLog()
+}
+
+// GetVCSWebhookDelivery retrieves a webhook delivery idempotency record by provider and delivery GUID.
+func (c *Client) GetVCSWebhookDelivery(
+	ctx context.Context,
+	provider VCSProvider,
+	deliveryGUID string,
+) (*VCSWebhookDelivery, error) {
+	key := vcsWebhookDeliveryKey{
+		VCSProvider:  provider,
+		DeliveryGUID: deliveryGUID,
+	}
+	r := newEntityReader[
+		vcsWebhookDeliveryMapper, spannerVCSWebhookDelivery, VCSWebhookDelivery, vcsWebhookDeliveryKey,
+	](c)
+	spannerDel, err := r.readRowByKey(ctx, key)
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, ErrVCSWebhookDeliveryNotFound
+		}
+
+		return nil, err
+	}
+
+	return spannerDel.toVCSWebhookDelivery()
+}

--- a/lib/gcpspanner/scan_log_and_webhook_test.go
+++ b/lib/gcpspanner/scan_log_and_webhook_test.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+)
+
+func TestCodeSubscriptionScanLogConversion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	errMsg := "rate limited by GitHub API"
+
+	testCases := []struct {
+		name     string
+		original CodeSubscriptionScanLog
+	}{
+		{
+			name: "Populated error message roundtrip",
+			original: CodeSubscriptionScanLog{
+				ID:              "scan-uuid-1",
+				VCSProvider:     VCSProviderGitHub,
+				VCSRepositoryID: "repo-999",
+				CommitSHA:       "abcdef123456",
+				Branch:          "main",
+				ScanStatus:      ScanStatusFailed,
+				FilesScanned:    42,
+				DirectivesFound: 3,
+				ErrorMessage:    &errMsg,
+				ScannedAt:       now,
+			},
+		},
+		{
+			name: "Nil error message roundtrip",
+			original: CodeSubscriptionScanLog{
+				ID:              "scan-uuid-nil-err",
+				VCSProvider:     VCSProviderGitHub,
+				VCSRepositoryID: "repo-999",
+				CommitSHA:       "abcdef123456",
+				Branch:          "main",
+				ScanStatus:      ScanStatusSuccess,
+				FilesScanned:    100,
+				DirectivesFound: 5,
+				ErrorMessage:    nil,
+				ScannedAt:       now,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			scsl := fromCodeSubscriptionScanLog(&tc.original)
+			converted, err := scsl.toCodeSubscriptionScanLog()
+			if err != nil {
+				t.Fatalf("unexpected toCodeSubscriptionScanLog error: %v", err)
+			}
+
+			if diff := cmp.Diff(&tc.original, converted); diff != "" {
+				t.Errorf("CodeSubscriptionScanLog conversion mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCodeSubscriptionScanLog_InvalidEnums(t *testing.T) {
+	t.Parallel()
+
+	invalidProvider := spannerCodeSubscriptionScanLog{
+		ID:              "scan-1",
+		VCSProvider:     "invalid_provider",
+		VCSRepositoryID: "repo-1",
+		CommitSHA:       "sha-1",
+		Branch:          "main",
+		ScanStatus:      "SUCCESS",
+		FilesScanned:    10,
+		DirectivesFound: 1,
+		ErrorMessage:    spanner.NullString{StringVal: "", Valid: false},
+		ScannedAt:       time.Now(),
+	}
+	_, err := invalidProvider.toCodeSubscriptionScanLog()
+	if err == nil {
+		t.Fatalf("expected error for invalid vcs provider, got nil")
+	}
+	if !errors.Is(err, ErrUnknownVCSProvider) {
+		t.Fatalf("expected ErrUnknownVCSProvider, got %v", err)
+	}
+
+	invalidStatus := spannerCodeSubscriptionScanLog{
+		ID:              "scan-2",
+		VCSProvider:     "github",
+		VCSRepositoryID: "repo-1",
+		CommitSHA:       "sha-1",
+		Branch:          "main",
+		ScanStatus:      "INVALID_SCAN_STATUS",
+		FilesScanned:    10,
+		DirectivesFound: 1,
+		ErrorMessage:    spanner.NullString{StringVal: "", Valid: false},
+		ScannedAt:       time.Now(),
+	}
+	_, err = invalidStatus.toCodeSubscriptionScanLog()
+	if err == nil {
+		t.Fatalf("expected error for invalid scan status, got nil")
+	}
+	if !errors.Is(err, ErrUnknownScanStatus) {
+		t.Fatalf("expected ErrUnknownScanStatus, got %v", err)
+	}
+}
+
+func testScanLogAndWebhookDeliveryNotFound(ctx context.Context, t *testing.T) {
+	_, err := spannerClient.GetCodeSubscriptionScanLog(ctx, "non-existent-scan-id")
+	if !errors.Is(err, ErrScanLogNotFound) {
+		t.Fatalf("expected ErrScanLogNotFound, got: %v", err)
+	}
+
+	_, err = spannerClient.GetVCSWebhookDelivery(ctx, VCSProviderGitHub, "non-existent-guid")
+	if !errors.Is(err, ErrVCSWebhookDeliveryNotFound) {
+		t.Fatalf("expected ErrVCSWebhookDeliveryNotFound, got: %v", err)
+	}
+}
+
+func testScanLogInsertAndGet(ctx context.Context, t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	scanID := uuid.NewString()
+	errMsg := "rate limit backoff"
+
+	log := CodeSubscriptionScanLog{
+		ID:              scanID,
+		VCSProvider:     VCSProviderGitHub,
+		VCSRepositoryID: "repo-123",
+		CommitSHA:       "sha-abc",
+		Branch:          "main",
+		ScanStatus:      ScanStatusFailed,
+		FilesScanned:    15,
+		DirectivesFound: 2,
+		ErrorMessage:    &errMsg,
+		ScannedAt:       now,
+	}
+
+	spannerLog := fromCodeSubscriptionScanLog(&log)
+	logMut, err := spanner.InsertStruct(codeSubscriptionScanLogTable, spannerLog)
+	if err != nil {
+		t.Fatalf("InsertStruct scan log failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{logMut}); err != nil {
+		t.Fatalf("Apply scan log mutation failed: %v", err)
+	}
+
+	retrievedLog, err := spannerClient.GetCodeSubscriptionScanLog(ctx, scanID)
+	if err != nil {
+		t.Fatalf("GetCodeSubscriptionScanLog failed: %v", err)
+	}
+	if retrievedLog.ID != scanID || *retrievedLog.ErrorMessage != errMsg {
+		t.Fatalf("retrieved scan log mismatch: %+v", retrievedLog)
+	}
+	if retrievedLog.ScanStatus != ScanStatusFailed {
+		t.Errorf("expected ScanStatus %s, got %s", ScanStatusFailed, retrievedLog.ScanStatus)
+	}
+}
+
+func testWebhookDeliveryInsertAndGet(ctx context.Context, t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	guid := uuid.NewString()
+
+	delivery := VCSWebhookDelivery{
+		VCSProvider:     VCSProviderGitHub,
+		DeliveryGUID:    guid,
+		EventType:       "push",
+		VCSRepositoryID: "repo-123",
+		ReceivedAt:      now,
+	}
+
+	spannerDelivery := fromVCSWebhookDelivery(&delivery)
+	deliveryMut, err := spanner.InsertStruct(vcsWebhookDeliveryTable, spannerDelivery)
+	if err != nil {
+		t.Fatalf("InsertStruct webhook delivery failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{deliveryMut}); err != nil {
+		t.Fatalf("Apply webhook delivery mutation failed: %v", err)
+	}
+
+	retrievedDelivery, err := spannerClient.GetVCSWebhookDelivery(ctx, VCSProviderGitHub, guid)
+	if err != nil {
+		t.Fatalf("GetVCSWebhookDelivery failed: %v", err)
+	}
+	if retrievedDelivery.DeliveryGUID != guid || retrievedDelivery.EventType != "push" {
+		t.Fatalf("retrieved webhook delivery mismatch: %+v", retrievedDelivery)
+	}
+}
+
+func TestClient_GetScanLogAndWebhookDelivery(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	t.Run("NotFound returns expected sentinel errors", func(t *testing.T) {
+		testScanLogAndWebhookDeliveryNotFound(ctx, t)
+	})
+	t.Run("Insert and retrieve scan log", func(t *testing.T) {
+		testScanLogInsertAndGet(ctx, t)
+	})
+	t.Run("Insert and retrieve webhook delivery idempotency record", func(t *testing.T) {
+		testWebhookDeliveryInsertAndGet(ctx, t)
+	})
+}


### PR DESCRIPTION
Refs #2712, #2715

Adds Spanner migration `000037.sql` for scan audit logs and webhook replay protection.

- `infra/storage/spanner/migrations/000037.sql`: `CodeSubscriptionScanLogs` (30-day TTL) and `VCSWebhookDeliveries` (7-day TTL).
- `lib/gcpspanner/scan_log_and_webhook.go`: Models, enum parsers, and getters.
- `lib/gcpspanner/scan_log_and_webhook_test.go`: Unit and emulator integration tests.