### PR TITLE
feat(auth): add RS256 JWT minting and cached GitHub App token provider

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v1.0.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/gomodule/redigo v1.9.3 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -137,6 +137,8 @@ github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf4
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=

--- a/lib/gh/jwt.go
+++ b/lib/gh/jwt.go
@@ -15,6 +15,7 @@
 package gh
 
 import (
+	"crypto/rsa"
 	"errors"
 	"fmt"
 	"time"
@@ -30,12 +31,12 @@ var (
 	ErrEmptyAppID = errors.New("app id must not be empty")
 )
 
-// MintAppJWT generates an RS256-signed JSON Web Token for authenticating as a GitHub App.
+// mintAppJWT generates an RS256-signed JSON Web Token for authenticating as a GitHub App.
 // Claims:
 // - iat: now - 60s (handles clock skew)
-// - exp: now + 10m (GitHub maximum validity)
+// - exp: now + 9m (effective validity = 10m with -60s iat, conforming to GitHub's 10m maximum)
 // - iss: appID.
-func MintAppJWT(appID string, privateKeyPEM []byte) (string, error) {
+func mintAppJWT(appID string, privateKeyPEM []byte) (string, error) {
 	if appID == "" {
 		return "", ErrEmptyAppID
 	}
@@ -43,6 +44,17 @@ func MintAppJWT(appID string, privateKeyPEM []byte) (string, error) {
 	key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyPEM)
 	if err != nil {
 		return "", fmt.Errorf("%w: %w", ErrInvalidPrivateKey, err)
+	}
+
+	return mintAppJWTWithKey(appID, key)
+}
+
+func mintAppJWTWithKey(appID string, key *rsa.PrivateKey) (string, error) {
+	if appID == "" {
+		return "", ErrEmptyAppID
+	}
+	if key == nil {
+		return "", ErrInvalidPrivateKey
 	}
 
 	now := time.Now().UTC()

--- a/lib/gh/jwt.go
+++ b/lib/gh/jwt.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+var (
+	// ErrInvalidPrivateKey is returned when the PEM block cannot be parsed as an RSA private key.
+	ErrInvalidPrivateKey = errors.New("invalid rsa private key")
+
+	// ErrEmptyAppID is returned when app ID is empty.
+	ErrEmptyAppID = errors.New("app id must not be empty")
+)
+
+// MintAppJWT generates an RS256-signed JSON Web Token for authenticating as a GitHub App.
+// Claims:
+// - iat: now - 60s (handles clock skew)
+// - exp: now + 10m (GitHub maximum validity)
+// - iss: appID.
+func MintAppJWT(appID string, privateKeyPEM []byte) (string, error) {
+	if appID == "" {
+		return "", ErrEmptyAppID
+	}
+
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyPEM)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalidPrivateKey, err)
+	}
+
+	now := time.Now().UTC()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.RegisteredClaims{
+		Issuer:    appID,
+		Subject:   "",
+		Audience:  nil,
+		ExpiresAt: jwt.NewNumericDate(now.Add(9 * time.Minute)),
+		NotBefore: nil,
+		IssuedAt:  jwt.NewNumericDate(now.Add(-60 * time.Second)),
+		ID:        "",
+	})
+
+	signedStr, err := token.SignedString(key)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign jwt with rsa private key: %w", err)
+	}
+
+	return signedStr, nil
+}

--- a/lib/gh/jwt_test.go
+++ b/lib/gh/jwt_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func generateTestRSAPEM(t *testing.T) (*rsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey failed: %v", err)
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	return key, pemBytes
+}
+
+func TestMintAppJWT(t *testing.T) {
+	t.Parallel()
+
+	privKey, pemBytes := generateTestRSAPEM(t)
+	appID := "webstatus-github-app-123"
+
+	tokenStr, err := MintAppJWT(appID, pemBytes)
+	if err != nil {
+		t.Fatalf("MintAppJWT failed: %v", err)
+	}
+
+	parts := strings.Split(tokenStr, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 JWT parts, got %d", len(parts))
+	}
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("failed to decode header: %v", err)
+	}
+	var header map[string]string
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		t.Fatalf("failed to unmarshal header: %v", err)
+	}
+	if header["alg"] != "RS256" || header["typ"] != "JWT" {
+		t.Errorf("unexpected header: %v", header)
+	}
+
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("failed to decode payload: %v", err)
+	}
+	var claims struct {
+		Iss string `json:"iss"`
+		Iat int64  `json:"iat"`
+		Exp int64  `json:"exp"`
+	}
+	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+	if claims.Iss != appID {
+		t.Errorf("iss = %s, want %s", claims.Iss, appID)
+	}
+	now := time.Now().Unix()
+	if claims.Exp-claims.Iat != 600 {
+		t.Errorf("token lifespan = %d, want 600s", claims.Exp-claims.Iat)
+	}
+	if claims.Iat > now || claims.Exp < now {
+		t.Errorf("invalid token timestamps: iat=%d, exp=%d, now=%d", claims.Iat, claims.Exp, now)
+	}
+
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("failed to decode signature: %v", err)
+	}
+	signedContent := parts[0] + "." + parts[1]
+	hasher := sha256.New()
+	hasher.Write([]byte(signedContent))
+	hashed := hasher.Sum(nil)
+
+	if err := rsa.VerifyPKCS1v15(&privKey.PublicKey, crypto.SHA256, hashed, sigBytes); err != nil {
+		t.Errorf("RSA PKCS1v15 signature verification failed: %v", err)
+	}
+}
+
+func TestMintAppJWTErrors(t *testing.T) {
+	t.Parallel()
+
+	_, validPEM := generateTestRSAPEM(t)
+
+	tests := []struct {
+		name      string
+		appID     string
+		pemData   []byte
+		targetErr error
+	}{
+		{
+			name:      "empty app ID",
+			appID:     "",
+			pemData:   validPEM,
+			targetErr: ErrEmptyAppID,
+		},
+		{
+			name:      "invalid PEM format",
+			appID:     "123",
+			pemData:   []byte("not a pem block"),
+			targetErr: ErrInvalidPrivateKey,
+		},
+		{
+			name:  "corrupted PEM block bytes",
+			appID: "123",
+			pemData: pem.EncodeToMemory(&pem.Block{
+				Type:    "RSA PRIVATE KEY",
+				Headers: nil,
+				Bytes:   []byte("garbage"),
+			}),
+			targetErr: ErrInvalidPrivateKey,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := MintAppJWT(tc.appID, tc.pemData)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !errors.Is(err, tc.targetErr) {
+				t.Errorf("expected error %v, got %v", tc.targetErr, err)
+			}
+		})
+	}
+}

--- a/lib/gh/jwt_test.go
+++ b/lib/gh/jwt_test.go
@@ -51,9 +51,9 @@ func TestMintAppJWT(t *testing.T) {
 	privKey, pemBytes := generateTestRSAPEM(t)
 	appID := "webstatus-github-app-123"
 
-	tokenStr, err := MintAppJWT(appID, pemBytes)
+	tokenStr, err := mintAppJWT(appID, pemBytes)
 	if err != nil {
-		t.Fatalf("MintAppJWT failed: %v", err)
+		t.Fatalf("mintAppJWT failed: %v", err)
 	}
 
 	parts := strings.Split(tokenStr, ".")
@@ -148,7 +148,7 @@ func TestMintAppJWTErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := MintAppJWT(tc.appID, tc.pemData)
+			_, err := mintAppJWT(tc.appID, tc.pemData)
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}

--- a/lib/gh/token_provider.go
+++ b/lib/gh/token_provider.go
@@ -16,15 +16,20 @@ package gh
 
 import (
 	"context"
+	"crypto/rsa"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/go-github/v79/github"
+	"golang.org/x/sync/singleflight"
 )
 
 var (
@@ -43,46 +48,37 @@ type TokenCacher interface {
 	Cache(ctx context.Context, key string, in []byte) error
 }
 
+type cachedInstallationToken struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
 // TokenProvider manages RS256 JWT minting and cached GitHub App installation access tokens.
 type TokenProvider struct {
-	appID         string
-	privateKeyPEM []byte
-	httpClient    *http.Client
-	baseURL       string
-	cacher        TokenCacher
+	appID      string
+	privateKey *rsa.PrivateKey
+	httpClient *http.Client
+	baseURL    string
+	cacher     TokenCacher
+	flight     singleflight.Group
 }
 
-// TokenProviderOption configures a TokenProvider.
-type TokenProviderOption func(*TokenProvider)
-
-// WithTokenProviderHTTPClient sets a custom HTTP client for the TokenProvider.
-func WithTokenProviderHTTPClient(client *http.Client) TokenProviderOption {
-	return func(tp *TokenProvider) {
-		if client != nil {
-			tp.httpClient = client
-		}
+// NewTokenProvider returns a new TokenProvider configured with the given cacher and standard HTTP transport.
+// Validates appID and parses privateKeyPEM at construction time to fail fast on invalid credentials.
+func NewTokenProvider(appID string, privateKeyPEM []byte, cacher TokenCacher) (*TokenProvider, error) {
+	if appID == "" {
+		return nil, ErrEmptyAppID
 	}
-}
 
-// WithTokenProviderBaseURL sets a custom base URL for testing against WireMock or mock servers.
-func WithTokenProviderBaseURL(baseURL string) TokenProviderOption {
-	return func(tp *TokenProvider) {
-		tp.baseURL = strings.TrimRight(baseURL, "/")
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidPrivateKey, err)
 	}
-}
 
-// WithTokenCacher sets a custom TokenCacher for caching installation tokens across workers.
-func WithTokenCacher(cacher TokenCacher) TokenProviderOption {
-	return func(tp *TokenProvider) {
-		tp.cacher = cacher
-	}
-}
-
-// NewTokenProvider returns a new TokenProvider configured with standard HTTP transport.
-func NewTokenProvider(appID string, privateKeyPEM []byte, opts ...TokenProviderOption) *TokenProvider {
-	tp := &TokenProvider{
-		appID:         appID,
-		privateKeyPEM: privateKeyPEM,
+	return &TokenProvider{
+		appID:      appID,
+		privateKey: key,
+		cacher:     cacher,
 		httpClient: &http.Client{
 			Transport:     nil,
 			CheckRedirect: nil,
@@ -90,41 +86,36 @@ func NewTokenProvider(appID string, privateKeyPEM []byte, opts ...TokenProviderO
 			Timeout:       10 * time.Second,
 		},
 		baseURL: "https://api.github.com",
-		cacher:  nil,
-	}
-
-	for _, opt := range opts {
-		opt(tp)
-	}
-
-	return tp
+		flight:  singleflight.Group{},
+	}, nil
 }
 
-// GetInstallationToken returns a valid GitHub App installation access token.
-func (tp *TokenProvider) GetInstallationToken(ctx context.Context, installationID string) (string, error) {
-	if installationID == "" {
-		return "", ErrEmptyInstallationID
+func (tp *TokenProvider) getCachedToken(ctx context.Context, cacheKey string) (string, bool) {
+	cachedBytes, cacheErr := tp.cacher.Get(ctx, cacheKey)
+	if cacheErr != nil || len(cachedBytes) == 0 {
+		return "", false
 	}
 
-	instID, err := strconv.ParseInt(installationID, 10, 64)
-	if err != nil {
-		return "", fmt.Errorf("invalid installation id %q: %w", installationID, err)
+	var cached cachedInstallationToken
+	if err := json.Unmarshal(cachedBytes, &cached); err != nil {
+		return "", false
 	}
 
-	cacheKey := "gh:inst_token:" + installationID
-	if tp.cacher != nil {
-		cachedBytes, cacheErr := tp.cacher.Get(ctx, cacheKey)
-		if cacheErr == nil && len(cachedBytes) > 0 {
-			return string(cachedBytes), nil
-		}
+	if cached.Token != "" && time.Now().UTC().Add(time.Minute).Before(cached.ExpiresAt) {
+		return cached.Token, true
 	}
 
-	jwtToken, mintErr := MintAppJWT(tp.appID, tp.privateKeyPEM)
+	return "", false
+}
+
+func (tp *TokenProvider) createInstallationToken(ctx context.Context, instID int64) (string, time.Time, error) {
+	jwtToken, mintErr := mintAppJWTWithKey(tp.appID, tp.privateKey)
 	if mintErr != nil {
-		return "", fmt.Errorf("failed to mint app jwt: %w", mintErr)
+		return "", time.Time{}, fmt.Errorf("failed to mint app jwt: %w", mintErr)
 	}
 
-	// Detach background context with 10s timeout to prevent cache poison on client ctx cancel
+	// Note: context.WithoutCancel is available in Go 1.21+ (repo uses Go 1.24).
+	// Detach background context with 10s timeout to prevent cache poison on client ctx cancel.
 	reqCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 	defer cancel()
 
@@ -139,16 +130,73 @@ func (tp *TokenProvider) GetInstallationToken(ctx context.Context, installationI
 
 	token, _, createErr := appClient.Apps.CreateInstallationToken(reqCtx, instID, nil)
 	if createErr != nil {
-		return "", fmt.Errorf("failed to create installation token: %w", createErr)
+		return "", time.Time{}, fmt.Errorf("failed to create installation token: %w", createErr)
 	}
 
 	tokenStr := token.GetToken()
 	if tokenStr == "" {
-		return "", errors.New("empty installation access token received from github")
+		return "", time.Time{}, errors.New("empty installation access token received from github")
 	}
 
-	if tp.cacher != nil {
-		_ = tp.cacher.Cache(ctx, cacheKey, []byte(tokenStr))
+	expiresAt := time.Now().UTC().Add(1 * time.Hour)
+	if token.ExpiresAt != nil {
+		expiresAt = token.GetExpiresAt().Time
+	}
+
+	return tokenStr, expiresAt, nil
+}
+
+// GetInstallationToken returns a valid GitHub App installation access token.
+func (tp *TokenProvider) GetInstallationToken(ctx context.Context, installationID string) (string, error) {
+	if installationID == "" {
+		return "", ErrEmptyInstallationID
+	}
+
+	instID, err := strconv.ParseInt(installationID, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid installation id %q: %w", installationID, err)
+	}
+
+	cacheKey := "gh:inst_token:" + installationID
+	if tok, ok := tp.getCachedToken(ctx, cacheKey); ok {
+		return tok, nil
+	}
+
+	res, err, _ := tp.flight.Do(installationID, func() (any, error) {
+		if tok, ok := tp.getCachedToken(ctx, cacheKey); ok {
+			return tok, nil
+		}
+
+		tokenStr, expiresAt, createErr := tp.createInstallationToken(ctx, instID)
+		if createErr != nil {
+			return "", createErr
+		}
+
+		cachedJSON, marshalErr := json.Marshal(cachedInstallationToken{
+			Token:     tokenStr,
+			ExpiresAt: expiresAt,
+		})
+		if marshalErr != nil {
+			slog.WarnContext(ctx, "failed to marshal installation token for cache",
+				"error", marshalErr,
+				"installation_id", installationID)
+		} else if cacheErr := tp.cacher.Cache(ctx, cacheKey, cachedJSON); cacheErr != nil {
+			slog.WarnContext(ctx, "failed to cache installation token",
+				"error", cacheErr,
+				"installation_id", installationID)
+		}
+
+		return tokenStr, nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Note: singleflight.Group currently returns (any, error).
+	// TODO: Replace type assertion once golang.org/x/sync/singleflight adds generic support.
+	tokenStr, ok := res.(string)
+	if !ok {
+		return "", errors.New("unexpected token type from singleflight")
 	}
 
 	return tokenStr, nil

--- a/lib/gh/token_provider.go
+++ b/lib/gh/token_provider.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v79/github"
+)
+
+var (
+	// ErrEmptyInstallationID is returned when an installation ID is empty.
+	ErrEmptyInstallationID = errors.New("installation id must not be empty")
+)
+
+// InstallationTokenProvider retrieves a valid installation access token for a GitHub App installation.
+type InstallationTokenProvider interface {
+	GetInstallationToken(ctx context.Context, installationID string) (string, error)
+}
+
+// TokenCacher caches installation access tokens.
+type TokenCacher interface {
+	Get(ctx context.Context, key string) ([]byte, error)
+	Cache(ctx context.Context, key string, in []byte) error
+}
+
+// TokenProvider manages RS256 JWT minting and cached GitHub App installation access tokens.
+type TokenProvider struct {
+	appID         string
+	privateKeyPEM []byte
+	httpClient    *http.Client
+	baseURL       string
+	cacher        TokenCacher
+}
+
+// TokenProviderOption configures a TokenProvider.
+type TokenProviderOption func(*TokenProvider)
+
+// WithTokenProviderHTTPClient sets a custom HTTP client for the TokenProvider.
+func WithTokenProviderHTTPClient(client *http.Client) TokenProviderOption {
+	return func(tp *TokenProvider) {
+		if client != nil {
+			tp.httpClient = client
+		}
+	}
+}
+
+// WithTokenProviderBaseURL sets a custom base URL for testing against WireMock or mock servers.
+func WithTokenProviderBaseURL(baseURL string) TokenProviderOption {
+	return func(tp *TokenProvider) {
+		tp.baseURL = strings.TrimRight(baseURL, "/")
+	}
+}
+
+// WithTokenCacher sets a custom TokenCacher for caching installation tokens across workers.
+func WithTokenCacher(cacher TokenCacher) TokenProviderOption {
+	return func(tp *TokenProvider) {
+		tp.cacher = cacher
+	}
+}
+
+// NewTokenProvider returns a new TokenProvider configured with standard HTTP transport.
+func NewTokenProvider(appID string, privateKeyPEM []byte, opts ...TokenProviderOption) *TokenProvider {
+	tp := &TokenProvider{
+		appID:         appID,
+		privateKeyPEM: privateKeyPEM,
+		httpClient: &http.Client{
+			Transport:     nil,
+			CheckRedirect: nil,
+			Jar:           nil,
+			Timeout:       10 * time.Second,
+		},
+		baseURL: "https://api.github.com",
+		cacher:  nil,
+	}
+
+	for _, opt := range opts {
+		opt(tp)
+	}
+
+	return tp
+}
+
+// GetInstallationToken returns a valid GitHub App installation access token.
+func (tp *TokenProvider) GetInstallationToken(ctx context.Context, installationID string) (string, error) {
+	if installationID == "" {
+		return "", ErrEmptyInstallationID
+	}
+
+	instID, err := strconv.ParseInt(installationID, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid installation id %q: %w", installationID, err)
+	}
+
+	cacheKey := "gh:inst_token:" + installationID
+	if tp.cacher != nil {
+		cachedBytes, cacheErr := tp.cacher.Get(ctx, cacheKey)
+		if cacheErr == nil && len(cachedBytes) > 0 {
+			return string(cachedBytes), nil
+		}
+	}
+
+	jwtToken, mintErr := MintAppJWT(tp.appID, tp.privateKeyPEM)
+	if mintErr != nil {
+		return "", fmt.Errorf("failed to mint app jwt: %w", mintErr)
+	}
+
+	// Detach background context with 10s timeout to prevent cache poison on client ctx cancel
+	reqCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+
+	appClient := github.NewClient(tp.httpClient).WithAuthToken(jwtToken)
+	if tp.baseURL != "https://api.github.com" && tp.baseURL != "" {
+		baseURLWithSlash := strings.TrimRight(tp.baseURL, "/") + "/"
+		customURL, parseErr := url.Parse(baseURLWithSlash)
+		if parseErr == nil {
+			appClient.BaseURL = customURL
+		}
+	}
+
+	token, _, createErr := appClient.Apps.CreateInstallationToken(reqCtx, instID, nil)
+	if createErr != nil {
+		return "", fmt.Errorf("failed to create installation token: %w", createErr)
+	}
+
+	tokenStr := token.GetToken()
+	if tokenStr == "" {
+		return "", errors.New("empty installation access token received from github")
+	}
+
+	if tp.cacher != nil {
+		_ = tp.cacher.Cache(ctx, cacheKey, []byte(tokenStr))
+	}
+
+	return tokenStr, nil
+}

--- a/lib/gh/token_provider_test.go
+++ b/lib/gh/token_provider_test.go
@@ -1,0 +1,226 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+//nolint:gosec // Mock test tokens for unit testing
+const (
+	mockInstToken1 = "mock_val_sample_123"
+	mockInstToken2 = "mock_val_coalesce_456"
+	mockInstToken3 = "mock_val_detached_789"
+	mockInstToken4 = "mock_val_recovered_000"
+)
+
+type mockTokenCacher struct {
+	mu    sync.RWMutex
+	store map[string][]byte
+}
+
+func newMockTokenCacher() *mockTokenCacher {
+	return &mockTokenCacher{
+		mu:    sync.RWMutex{},
+		store: make(map[string][]byte),
+	}
+}
+
+func (m *mockTokenCacher) Get(_ context.Context, key string) ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	val, ok := m.store[key]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+
+	return val, nil
+}
+
+func (m *mockTokenCacher) Cache(_ context.Context, key string, in []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.store[key] = in
+
+	return nil
+}
+
+type testTokenResp struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+func TestTokenProvider_GetInstallationToken(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+	var requestCount int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/app/installations/123/access_tokens" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") == "" {
+			t.Errorf("missing Authorization header")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(testTokenResp{
+			Token:     mockInstToken1,
+			ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+		})
+	}))
+	defer server.Close()
+
+	cacher := newMockTokenCacher()
+	tp := NewTokenProvider("app-99", privPEM,
+		WithTokenProviderBaseURL(server.URL),
+		WithTokenProviderHTTPClient(server.Client()),
+		WithTokenCacher(cacher))
+
+	// 1. Initial token fetch (cache miss, calls HTTP API)
+	token, err := tp.GetInstallationToken(context.Background(), "123")
+	if err != nil {
+		t.Fatalf("GetInstallationToken failed: %v", err)
+	}
+	if token != mockInstToken1 {
+		t.Errorf("unexpected token: %s", token)
+	}
+
+	// 2. Cache hit (no additional network call)
+	token2, err := tp.GetInstallationToken(context.Background(), "123")
+	if err != nil {
+		t.Fatalf("second GetInstallationToken failed: %v", err)
+	}
+	if token2 != token {
+		t.Errorf("cached token mismatch: %s != %s", token2, token)
+	}
+
+	if count := atomic.LoadInt64(&requestCount); count != 1 {
+		t.Errorf("expected 1 HTTP request, got %d", count)
+	}
+}
+
+func TestTokenProvider_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+	tp := NewTokenProvider("app-99", privPEM)
+
+	// 1. Empty installation ID
+	_, err := tp.GetInstallationToken(context.Background(), "")
+	if !errors.Is(err, ErrEmptyInstallationID) {
+		t.Errorf("expected ErrEmptyInstallationID, got: %v", err)
+	}
+
+	// 2. Invalid non-numeric installation ID
+	_, err = tp.GetInstallationToken(context.Background(), "non-numeric-id")
+	if err == nil {
+		t.Errorf("expected error for non-numeric installation ID, got nil")
+	}
+}
+
+func TestTokenProviderDetachedContext(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(30 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(testTokenResp{
+			Token:     mockInstToken3,
+			ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+		})
+	}))
+	defer server.Close()
+
+	tp := NewTokenProvider("app-99", privPEM,
+		WithTokenProviderBaseURL(server.URL),
+		WithTokenProviderHTTPClient(server.Client()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	// Calling with short timeout context that cancels before server responds
+	token, err := tp.GetInstallationToken(ctx, "789")
+	if err != nil {
+		t.Fatalf("expected token acquisition to succeed despite caller cancel, got: %v", err)
+	}
+	if token != mockInstToken3 {
+		t.Errorf("unexpected token: %s", token)
+	}
+}
+
+func TestTokenProviderErrorRecovery(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+	var callCount int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := atomic.AddInt64(&callCount, 1)
+		if count == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("internal github error"))
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(testTokenResp{
+			Token:     mockInstToken4,
+			ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+		})
+	}))
+	defer server.Close()
+
+	tp := NewTokenProvider("app-99", privPEM,
+		WithTokenProviderBaseURL(server.URL),
+		WithTokenProviderHTTPClient(server.Client()))
+
+	// First call fails
+	_, err := tp.GetInstallationToken(context.Background(), "456")
+	if err == nil {
+		t.Fatalf("expected error on first call, got nil")
+	}
+
+	// Second call should succeed
+	token, err := tp.GetInstallationToken(context.Background(), "456")
+	if err != nil {
+		t.Fatalf("expected second call to succeed, got: %v", err)
+	}
+	if token != mockInstToken4 {
+		t.Errorf("unexpected token: %s", token)
+	}
+}

--- a/lib/gh/token_provider_test.go
+++ b/lib/gh/token_provider_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -101,10 +102,12 @@ func TestTokenProvider_GetInstallationToken(t *testing.T) {
 	defer server.Close()
 
 	cacher := newMockTokenCacher()
-	tp := NewTokenProvider("app-99", privPEM,
-		WithTokenProviderBaseURL(server.URL),
-		WithTokenProviderHTTPClient(server.Client()),
-		WithTokenCacher(cacher))
+	tp, err := NewTokenProvider("app-99", privPEM, cacher)
+	if err != nil {
+		t.Fatalf("NewTokenProvider failed: %v", err)
+	}
+	tp.baseURL = server.URL
+	tp.httpClient = server.Client()
 
 	// 1. Initial token fetch (cache miss, calls HTTP API)
 	token, err := tp.GetInstallationToken(context.Background(), "123")
@@ -129,14 +132,27 @@ func TestTokenProvider_GetInstallationToken(t *testing.T) {
 	}
 }
 
+type testNoopTokenCacher struct{}
+
+func (testNoopTokenCacher) Get(_ context.Context, _ string) ([]byte, error) {
+	return nil, errors.New("not found")
+}
+
+func (testNoopTokenCacher) Cache(_ context.Context, _ string, _ []byte) error {
+	return nil
+}
+
 func TestTokenProvider_ValidationErrors(t *testing.T) {
 	t.Parallel()
 
 	_, privPEM := generateTestRSAPEM(t)
-	tp := NewTokenProvider("app-99", privPEM)
+	tp, err := NewTokenProvider("app-99", privPEM, testNoopTokenCacher{})
+	if err != nil {
+		t.Fatalf("NewTokenProvider failed: %v", err)
+	}
 
 	// 1. Empty installation ID
-	_, err := tp.GetInstallationToken(context.Background(), "")
+	_, err = tp.GetInstallationToken(context.Background(), "")
 	if !errors.Is(err, ErrEmptyInstallationID) {
 		t.Errorf("expected ErrEmptyInstallationID, got: %v", err)
 	}
@@ -164,9 +180,12 @@ func TestTokenProviderDetachedContext(t *testing.T) {
 	}))
 	defer server.Close()
 
-	tp := NewTokenProvider("app-99", privPEM,
-		WithTokenProviderBaseURL(server.URL),
-		WithTokenProviderHTTPClient(server.Client()))
+	tp, err := NewTokenProvider("app-99", privPEM, testNoopTokenCacher{})
+	if err != nil {
+		t.Fatalf("NewTokenProvider failed: %v", err)
+	}
+	tp.baseURL = server.URL
+	tp.httpClient = server.Client()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
 	defer cancel()
@@ -181,21 +200,154 @@ func TestTokenProviderDetachedContext(t *testing.T) {
 	}
 }
 
-func TestTokenProviderErrorRecovery(t *testing.T) {
+func TestNewTokenProvider_Validation(t *testing.T) {
 	t.Parallel()
 
 	_, privPEM := generateTestRSAPEM(t)
-	var callCount int64
+
+	// 1. Empty app ID
+	_, err := NewTokenProvider("", privPEM, testNoopTokenCacher{})
+	if !errors.Is(err, ErrEmptyAppID) {
+		t.Errorf("expected ErrEmptyAppID, got: %v", err)
+	}
+
+	// 2. Invalid PEM block
+	_, err = NewTokenProvider("app-99", []byte("invalid pem data"), testNoopTokenCacher{})
+	if !errors.Is(err, ErrInvalidPrivateKey) {
+		t.Errorf("expected ErrInvalidPrivateKey, got: %v", err)
+	}
+}
+
+func TestTokenProvider_CacheExpiration(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+	var requestCount int64
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		count := atomic.AddInt64(&callCount, 1)
-		if count == 1 {
-			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = w.Write([]byte("internal github error"))
+		count := atomic.AddInt64(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(testTokenResp{
+			Token:     fmt.Sprintf("token-version-%d", count),
+			ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+		})
+	}))
+	defer server.Close()
 
-			return
+	cacher := newMockTokenCacher()
+	tp, err := NewTokenProvider("app-99", privPEM, cacher)
+	if err != nil {
+		t.Fatalf("NewTokenProvider failed: %v", err)
+	}
+	tp.baseURL = server.URL
+	tp.httpClient = server.Client()
+
+	// 1. Manually insert expired token into cache
+	expiredJSON, _ := json.Marshal(cachedInstallationToken{
+		Token:     "expired-token",
+		ExpiresAt: time.Now().UTC().Add(-10 * time.Minute), // expired in past
+	})
+	_ = cacher.Cache(context.Background(), "gh:inst_token:123", expiredJSON)
+
+	// 2. Fetch should ignore expired cache entry and fetch fresh token
+	token, err := tp.GetInstallationToken(context.Background(), "123")
+	if err != nil {
+		t.Fatalf("GetInstallationToken failed: %v", err)
+	}
+	if token != "token-version-1" {
+		t.Errorf("expected fresh token-version-1, got: %s", token)
+	}
+	if count := atomic.LoadInt64(&requestCount); count != 1 {
+		t.Errorf("expected 1 HTTP request, got %d", count)
+	}
+
+	// 3. Second call with fresh unexpired cache entry should reuse token without HTTP request
+	token2, err := tp.GetInstallationToken(context.Background(), "123")
+	if err != nil {
+		t.Fatalf("second GetInstallationToken failed: %v", err)
+	}
+	if token2 != "token-version-1" {
+		t.Errorf("expected cached token-version-1, got: %s", token2)
+	}
+	if count := atomic.LoadInt64(&requestCount); count != 1 {
+		t.Errorf("expected still 1 HTTP request, got %d", count)
+	}
+}
+
+func TestTokenProvider_SingleflightCoalescing(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+	var requestCount int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+		time.Sleep(30 * time.Millisecond) // slow server to ensure concurrent in-flight requests
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(testTokenResp{
+			Token:     mockInstToken2,
+			ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+		})
+	}))
+	defer server.Close()
+
+	cacher := newMockTokenCacher()
+	tp, err := NewTokenProvider("app-99", privPEM, cacher)
+	if err != nil {
+		t.Fatalf("NewTokenProvider failed: %v", err)
+	}
+	tp.baseURL = server.URL
+	tp.httpClient = server.Client()
+
+	const concurrentCallers = 10
+	var wg sync.WaitGroup
+	tokens := make([]string, concurrentCallers)
+	errorsList := make([]error, concurrentCallers)
+
+	for i := range concurrentCallers {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			tok, callErr := tp.GetInstallationToken(context.Background(), "999")
+			tokens[idx] = tok
+			errorsList[idx] = callErr
+		}(i)
+	}
+	wg.Wait()
+
+	for i := range concurrentCallers {
+		if errorsList[i] != nil {
+			t.Errorf("caller %d failed: %v", i, errorsList[i])
 		}
+		if tokens[i] != mockInstToken2 {
+			t.Errorf("caller %d got %s, want %s", i, tokens[i], mockInstToken2)
+		}
+	}
 
+	// Concurrent requests should coalesce into exactly 1 HTTP request
+	if count := atomic.LoadInt64(&requestCount); count != 1 {
+		t.Errorf("expected exactly 1 HTTP request due to concurrent coalescing, got %d", count)
+	}
+}
+
+type errorTokenCacher struct{}
+
+func (e errorTokenCacher) Get(_ context.Context, _ string) ([]byte, error) {
+	return nil, errors.New("cache get failed")
+}
+
+func (e errorTokenCacher) Cache(_ context.Context, _ string, _ []byte) error {
+	return errors.New("cache write failed")
+}
+
+func TestTokenProvider_CacheFailureGracefulDegradation(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(testTokenResp{
@@ -205,22 +357,18 @@ func TestTokenProviderErrorRecovery(t *testing.T) {
 	}))
 	defer server.Close()
 
-	tp := NewTokenProvider("app-99", privPEM,
-		WithTokenProviderBaseURL(server.URL),
-		WithTokenProviderHTTPClient(server.Client()))
-
-	// First call fails
-	_, err := tp.GetInstallationToken(context.Background(), "456")
-	if err == nil {
-		t.Fatalf("expected error on first call, got nil")
-	}
-
-	// Second call should succeed
-	token, err := tp.GetInstallationToken(context.Background(), "456")
+	tp, err := NewTokenProvider("app-99", privPEM, errorTokenCacher{})
 	if err != nil {
-		t.Fatalf("expected second call to succeed, got: %v", err)
+		t.Fatalf("NewTokenProvider failed: %v", err)
+	}
+	tp.baseURL = server.URL
+	tp.httpClient = server.Client()
+
+	token, err := tp.GetInstallationToken(context.Background(), "444")
+	if err != nil {
+		t.Fatalf("expected token fetch to succeed despite cache errors, got: %v", err)
 	}
 	if token != mockInstToken4 {
-		t.Errorf("unexpected token: %s", token)
+		t.Errorf("expected token %s, got %s", mockInstToken4, token)
 	}
 }

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/deckarep/golang-set v1.8.0
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-github/v79 v79.0.0
 	github.com/oapi-codegen/runtime v1.7.0
 	github.com/stretchr/testify v1.12.1
@@ -45,7 +46,6 @@ require (
 	github.com/getkin/kin-openapi v0.146.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-openapi/jsonpointer v1.0.0 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-github/v89 v89.0.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/getkin/kin-openapi v0.146.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-openapi/jsonpointer v1.0.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-github/v89 v89.0.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -154,7 +155,7 @@ require (
 	golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0
-	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -133,7 +133,6 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -133,6 +133,9 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/workers/email/go.sum
+++ b/workers/email/go.sum
@@ -122,6 +122,9 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/workers/event_producer/go.sum
+++ b/workers/event_producer/go.sum
@@ -126,6 +126,9 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/workers/push_delivery/go.sum
+++ b/workers/push_delivery/go.sum
@@ -122,6 +122,9 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/workers/webhook/go.sum
+++ b/workers/webhook/go.sum
@@ -122,6 +122,9 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=

--- a/workflows/steps/services/bcd_consumer/go.mod
+++ b/workflows/steps/services/bcd_consumer/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v1.0.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/gomodule/redigo v1.9.3 // indirect
 	github.com/google/go-github/v79 v79.0.0 // indirect
 	github.com/google/go-github/v89 v89.0.0 // indirect

--- a/workflows/steps/services/bcd_consumer/go.sum
+++ b/workflows/steps/services/bcd_consumer/go.sum
@@ -120,6 +120,8 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/workflows/steps/services/chromium_histogram_enums/go.sum
+++ b/workflows/steps/services/chromium_histogram_enums/go.sum
@@ -118,6 +118,9 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/workflows/steps/services/developer_signals_consumer/go.sum
+++ b/workflows/steps/services/developer_signals_consumer/go.sum
@@ -120,6 +120,9 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/workflows/steps/services/uma_export/go.sum
+++ b/workflows/steps/services/uma_export/go.sum
@@ -122,6 +122,9 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/workflows/steps/services/web_feature_consumer/go.mod
+++ b/workflows/steps/services/web_feature_consumer/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/go-logr/logr v1.4.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v1.0.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/gomodule/redigo v1.9.3 // indirect
 	github.com/google/go-github/v79 v79.0.0 // indirect
 	github.com/google/go-github/v89 v89.0.0 // indirect

--- a/workflows/steps/services/web_feature_consumer/go.sum
+++ b/workflows/steps/services/web_feature_consumer/go.sum
@@ -118,6 +118,8 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/workflows/steps/services/web_features_mapping_consumer/go.sum
+++ b/workflows/steps/services/web_features_mapping_consumer/go.sum
@@ -120,6 +120,9 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/workflows/steps/services/wpt_consumer/go.sum
+++ b/workflows/steps/services/wpt_consumer/go.sum
@@ -120,6 +120,9 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=


### PR DESCRIPTION
Refs #2712, #2717

### What
Implements RS256 JWT generation for GitHub App authentication and provides a cached GitHub App installation access token provider in `lib/gh/`.

### Why
GitHub App API operations (reading Git trees, inspecting file blobs, and creating notification issues) require short-lived installation access tokens. Minting tokens via RS256 JWT and caching them across worker tasks prevents redundant API calls and eliminates rate-limit exhaustion.

### How
- **JWT Minting (`lib/gh/jwt.go`)**:
  - `mintAppJWT` & `mintAppJWTWithKey`: Unexported helpers generating RS256-signed JWTs using `jwt.RegisteredClaims` with 9-minute expiration (effective validity = 10m with -60s backdated `iat` to accommodate clock skew, conforming to GitHub's 10-minute maximum).
  - Returns strongly-typed sentinel errors `ErrInvalidPrivateKey` and `ErrEmptyAppID`.
- **Token Provider (`lib/gh/token_provider.go`)**:
  - `InstallationTokenProvider`: Interface defining `GetInstallationToken(ctx, installationID)`.
  - `TokenCacher`: Interface defining `Get(ctx, key)` and `Cache(ctx, key, in)`. Callers provide a valid token cacher implementation.
  - `TokenProvider`: Direct struct managing token requests, fail-fast constructor validation, and expiry-aware distributed/in-memory caching.
  - `NewTokenProvider(appID, privateKeyPEM, cacher)`: Parses and validates the RSA private key at construction time, failing fast on invalid credentials and avoiding key re-parsing on subsequent requests.
  - `cachedInstallationToken`: Caches token string alongside its `ExpiresAt` metadata; stale or expired tokens (>59 minutes old) are automatically refreshed.
  - `singleflight.Group`: Deduplicates concurrent token requests for the same installation ID.
  - Context isolation: Uses `context.WithoutCancel(ctx)` with a 10s timeout when communicating with GitHub's `CreateInstallationToken` endpoint to prevent cache poisoning on client cancellation.
- **Testing (`lib/gh/jwt_test.go`, `lib/gh/token_provider_test.go`)**:
  - Full cryptographic verification of JWT headers, claims, and RSA signatures using in-memory generated 2048-bit keys.
  - Unit tests verifying constructor validation, cache hits, cache misses, token reuse, cache expiration handling, and singleflight concurrency coalescing against `httptest.Server`.

### Corrected Assumptions / Learnings
- **Direct Token Cacher Assumption**: Eliminated internal no-op defaults and nil checks in production code; `NewTokenProvider` directly accepts the caller's `TokenCacher`.
- **Expiry-Aware Caching**: Storing `{ token, expires_at }` JSON payloads ensures expired tokens are never returned from cache.
- **Concurrency Deduplication**: Integrating `singleflight.Group` collapses thundering herd calls for the same installation ID into a single GitHub API request.
- **Constructor Validation**: Parsing `*rsa.PrivateKey` at initialization time fails fast on invalid credentials and avoids re-parsing 2048-bit RSA keys on every request.

TAG=agy