### PR TITLE
feat(scanner): implement AST comment directive and browserslist parsers

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -23,3 +23,5 @@ workflows/steps/services/bcd_consumer/pkg/data/testdata/data.json
 workflows/steps/services/web_feature_consumer/pkg/data/testdata/v3.data.json
 workflows/steps/services/developer_signals_consumer/pkg/data/testdata/web-features-signals.json
 workflows/steps/services/web_features_mapping_consumer/pkg/data/testdata/combined-data.json
+lib/codescan/testdata/**
+

--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,8 @@ ADDLICENSE_ARGS := -c "${COPYRIGHT_NAME}" \
 	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload.golden.json' \
 	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload_query_error.golden.json' \
 	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload_resolved_query_error.golden.json' \
-	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload_combined_errors_and_features.golden.json'
+	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload_combined_errors_and_features.golden.json' \
+	-ignore 'lib/codescan/testdata/**'
 
 license-check: go-install-tools
 	go tool addlicense -check $(ADDLICENSE_ARGS) .

--- a/lib/codescan/browserslist.go
+++ b/lib/codescan/browserslist.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codescan
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	BrowserslistBaselineWidely = "baseline widely available"
+	BrowserslistBaselineNewly  = "baseline newly available"
+)
+
+// ParseBrowserslistLine evaluates a single query line from a browserslist configuration.
+// It returns the recognized baseline target if exact ("widely" or "newly"),
+// a warning message if an unsupported baseline query is detected (no default applied),
+// and a boolean indicating whether the line matched a baseline query.
+func ParseBrowserslistLine(line, sourceFile string) (target string, warning string, isBaseline bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return "", "", false
+	}
+
+	lower := strings.ToLower(trimmed)
+	if !strings.HasPrefix(lower, "baseline") {
+		return "", "", false
+	}
+
+	switch lower {
+	case BrowserslistBaselineWidely:
+		return TargetWidely, "", true
+	case BrowserslistBaselineNewly:
+		return TargetNewly, "", true
+	default:
+		warning = fmt.Sprintf(
+			"unsupported browserslist baseline query %q in %s: "+
+				"webstatus.dev currently only supports %q and %q. "+
+				"No project-level default was applied.",
+			trimmed, sourceFile, BrowserslistBaselineWidely, BrowserslistBaselineNewly,
+		)
+
+		return "", warning, true
+	}
+}
+
+// IsBrowserslistFile reports whether the filename is a standard browserslist configuration file.
+func IsBrowserslistFile(fileName string) bool {
+	base := filepath.Base(fileName)
+	switch base {
+	case ".browserslistrc", ".browserslist", "browserslist", "package.json":
+		return true
+	default:
+		return false
+	}
+}
+
+// ParseBrowserslistConfig parses content from a .browserslistrc or package.json file.
+func ParseBrowserslistConfig(content []byte, fileName string) (target string, warnings []string, err error) {
+	base := filepath.Base(fileName)
+	if base == "package.json" {
+		return parsePackageJSONBrowserslist(content, fileName)
+	}
+
+	return parseBrowserslistRC(content, fileName)
+}
+
+func parseBrowserslistRC(content []byte, fileName string) (string, []string, error) {
+	var target string
+	var warnings []string
+
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			continue
+		}
+		t, w, isBaseline := ParseBrowserslistLine(line, fileName)
+		if w != "" {
+			warnings = append(warnings, w)
+		}
+		if isBaseline && t != "" && target == "" {
+			target = t
+		}
+	}
+
+	return target, warnings, scanner.Err()
+}
+
+func parsePackageJSONBrowserslist(content []byte, fileName string) (string, []string, error) {
+	var pkg struct {
+		Browserslist any `json:"browserslist"`
+	}
+	if err := json.Unmarshal(content, &pkg); err != nil {
+		return "", nil, err
+	}
+
+	if pkg.Browserslist == nil {
+		return "", nil, nil
+	}
+
+	items := extractBrowserslistItems(pkg.Browserslist)
+
+	var target string
+	var warnings []string
+
+	for _, item := range items {
+		t, w, isBaseline := ParseBrowserslistLine(item, fileName)
+		if w != "" {
+			warnings = append(warnings, w)
+		}
+		if isBaseline && t != "" && target == "" {
+			target = t
+		}
+	}
+
+	return target, warnings, nil
+}
+
+func extractBrowserslistItems(raw any) []string {
+	switch v := raw.(type) {
+	case string:
+		return splitQueryString(v)
+	case []any:
+		return toStringSlice(v)
+	case map[string]any:
+		if prod, ok := v["production"]; ok {
+			return extractBrowserslistItems(prod)
+		}
+		var all []string
+		for _, envVal := range v {
+			all = append(all, extractBrowserslistItems(envVal)...)
+		}
+
+		return all
+	default:
+		return nil
+	}
+}
+
+func splitQueryString(s string) []string {
+	var items []string
+	for line := range strings.SplitSeq(s, "\n") {
+		for item := range strings.SplitSeq(line, ",") {
+			trimmed := strings.TrimSpace(item)
+			if trimmed != "" {
+				items = append(items, trimmed)
+			}
+		}
+	}
+
+	return items
+}
+
+func toStringSlice(slice []any) []string {
+	var items []string
+	for _, item := range slice {
+		if str, ok := item.(string); ok {
+			trimmed := strings.TrimSpace(str)
+			if trimmed != "" {
+				items = append(items, trimmed)
+			}
+		}
+	}
+
+	return items
+}

--- a/lib/codescan/browserslist_test.go
+++ b/lib/codescan/browserslist_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codescan
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseBrowserslistConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		fileName     string
+		content      string
+		wantTarget   string
+		wantWarnings int
+		checkWarning string
+	}{
+		{
+			name:         ".browserslistrc with baseline newly available",
+			fileName:     ".browserslistrc",
+			content:      "# Browserslist configuration\n> 0.5%\nlast 2 versions\nnot dead\nbaseline newly available\n",
+			wantTarget:   TargetNewly,
+			wantWarnings: 0,
+			checkWarning: "",
+		},
+		{
+			name:         ".browserslistrc with baseline widely available",
+			fileName:     ".browserslistrc",
+			content:      "baseline widely available\n",
+			wantTarget:   TargetWidely,
+			wantWarnings: 0,
+			checkWarning: "",
+		},
+		{
+			name:         ".browserslistrc with section headers",
+			fileName:     ".browserslistrc",
+			content:      "[production]\nbaseline newly available\n[development]\nlast 1 chrome version\n",
+			wantTarget:   TargetNewly,
+			wantWarnings: 0,
+			checkWarning: "",
+		},
+		{
+			name:         ".browserslistrc with unsupported with downstream suffix",
+			fileName:     ".browserslistrc",
+			content:      "baseline widely available with downstream chrome\n",
+			wantTarget:   "", // No default applied
+			wantWarnings: 1,
+			checkWarning: "unsupported browserslist baseline query",
+		},
+		{
+			name:         ".browserslistrc with unsupported including kaios suffix",
+			fileName:     ".browserslistrc",
+			content:      "baseline newly available including kaios\n",
+			wantTarget:   "",
+			wantWarnings: 1,
+			checkWarning: "unsupported browserslist baseline query",
+		},
+		{
+			name:         ".browserslistrc with unsupported date cutoff",
+			fileName:     ".browserslistrc",
+			content:      "baseline widely available on 2024-01-01\n",
+			wantTarget:   "",
+			wantWarnings: 1,
+			checkWarning: "unsupported browserslist baseline query",
+		},
+		{
+			name:         ".browserslistrc with unsupported year checkpoint",
+			fileName:     ".browserslistrc",
+			content:      "baseline 2022\n",
+			wantTarget:   "",
+			wantWarnings: 1,
+			checkWarning: "unsupported browserslist baseline query",
+		},
+		{
+			name:         "package.json with array containing baseline newly available",
+			fileName:     "package.json",
+			content:      `{"name": "my-app", "browserslist": ["> 0.2%", "baseline newly available", "not dead"]}`,
+			wantTarget:   TargetNewly,
+			wantWarnings: 0,
+			checkWarning: "",
+		},
+		{
+			name:         "package.json with string baseline widely available",
+			fileName:     "package.json",
+			content:      `{"name": "my-app", "browserslist": "baseline widely available"}`,
+			wantTarget:   TargetWidely,
+			wantWarnings: 0,
+			checkWarning: "",
+		},
+		{
+			name:     "package.json with environment map",
+			fileName: "package.json",
+			content: `{"browserslist": {` +
+				`"production": ["baseline newly available"], ` +
+				`"development": ["last 1 chrome version"]}}`,
+			wantTarget:   TargetNewly,
+			wantWarnings: 0,
+			checkWarning: "",
+		},
+		{
+			name:         "package.json without browserslist",
+			fileName:     "package.json",
+			content:      `{"name": "my-app", "version": "1.0.0"}`,
+			wantTarget:   "",
+			wantWarnings: 0,
+			checkWarning: "",
+		},
+		{
+			name:         "package.json with unsupported baseline query",
+			fileName:     "package.json",
+			content:      `{"browserslist": ["baseline 2024"]}`,
+			wantTarget:   "",
+			wantWarnings: 1,
+			checkWarning: "unsupported browserslist baseline query",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			target, warnings, err := ParseBrowserslistConfig([]byte(tc.content), tc.fileName)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if target != tc.wantTarget {
+				t.Errorf("target = %q, want %q", target, tc.wantTarget)
+			}
+			if len(warnings) != tc.wantWarnings {
+				t.Errorf("got %d warnings, want %d (warnings: %v)", len(warnings), tc.wantWarnings, warnings)
+			}
+			if tc.checkWarning != "" && len(warnings) > 0 {
+				if !strings.Contains(warnings[0], tc.checkWarning) {
+					t.Errorf("warning %q does not contain %q", warnings[0], tc.checkWarning)
+				}
+			}
+		})
+	}
+}

--- a/lib/codescan/comment_parser.go
+++ b/lib/codescan/comment_parser.go
@@ -54,8 +54,13 @@ var inlineTodoRegex = regexp.MustCompile(
 		`(?::\s*([^,\n]+))?`,
 )
 
-// ParseReader reads from an io.Reader and extracts all valid @webstatus directives.
-func ParseReader(r io.Reader, filePath string, defaultTarget string) ([]Directive, error) {
+// ParseReader reads from an io.Reader and extracts all valid @webstatus and TODO directives.
+func ParseReader(
+	r io.Reader,
+	filePath string,
+	defaultTrigger SubscriptionTrigger,
+	defaultTargetQuery string,
+) ([]Directive, error) {
 	var directives []Directive
 	scanner := bufio.NewScanner(r)
 	buf := make([]byte, 64*1024)
@@ -65,10 +70,8 @@ func ParseReader(r io.Reader, filePath string, defaultTarget string) ([]Directiv
 	inCBlock := false
 	inHTMLBlock := false
 
-	defaultTrigger := SubscriptionTriggerFeatureBaselinePromoteToWidely
-	if defaultTarget == TargetNewly || defaultTarget == string(SubscriptionTriggerFeatureBaselinePromoteToNewly) ||
-		defaultTarget == "newly_available" {
-		defaultTrigger = SubscriptionTriggerFeatureBaselinePromoteToNewly
+	if defaultTrigger == "" {
+		defaultTrigger = SubscriptionTriggerFeatureBaselinePromoteToWidely
 	}
 
 	for scanner.Scan() {
@@ -92,7 +95,7 @@ func ParseReader(r io.Reader, filePath string, defaultTarget string) ([]Directiv
 		if todoDirs := extractTodoDirectives(cleaned, rawLine, lineNum, filePath, defaultTrigger); len(todoDirs) > 0 {
 			directives = append(directives, todoDirs...)
 		} else if dirs, ok := extractWebstatusDirective(
-			cleaned, rawLine, lineNum, filePath, defaultTarget, defaultTrigger,
+			cleaned, rawLine, lineNum, filePath, defaultTargetQuery, defaultTrigger,
 		); ok {
 			directives = append(directives, dirs...)
 		}
@@ -113,8 +116,13 @@ func ParseReader(r io.Reader, filePath string, defaultTarget string) ([]Directiv
 }
 
 // ParseFileDirectives scans the lines of a source file and extracts all valid @webstatus directives.
-func ParseFileDirectives(content []byte, filePath string, defaultTarget string) []Directive {
-	directives, _ := ParseReader(bytes.NewReader(content), filePath, defaultTarget)
+func ParseFileDirectives(
+	content []byte,
+	filePath string,
+	defaultTrigger SubscriptionTrigger,
+	defaultTargetQuery string,
+) []Directive {
+	directives, _ := ParseReader(bytes.NewReader(content), filePath, defaultTrigger, defaultTargetQuery)
 
 	return directives
 }
@@ -192,7 +200,7 @@ func extractTodoDirectives(
 func extractWebstatusDirective(
 	cleanedLine, rawLine string,
 	lineNum int,
-	filePath, defaultTarget string,
+	filePath, defaultTargetQuery string,
 	defaultTrigger SubscriptionTrigger,
 ) ([]Directive, bool) {
 	matches := webstatusDirectiveRegex.FindStringSubmatch(cleanedLine)
@@ -219,17 +227,18 @@ func extractWebstatusDirective(
 			val = strings.TrimPrefix(val, "id:")
 			ids = append(ids, val)
 		case "trigger":
-			if strings.EqualFold(val, "newly_available") || strings.EqualFold(val, TargetNewly) {
+			switch strings.ToLower(val) {
+			case "newly_available", "newly", string(SubscriptionTriggerFeatureBaselinePromoteToNewly):
 				trigger = SubscriptionTriggerFeatureBaselinePromoteToNewly
-			} else if strings.EqualFold(val, "widely_available") || strings.EqualFold(val, TargetWidely) {
+			case "widely_available", "widely", string(SubscriptionTriggerFeatureBaselinePromoteToWidely):
 				trigger = SubscriptionTriggerFeatureBaselinePromoteToWidely
 			}
 		}
 	}
 
 	if len(ids) == 0 {
-		if defaultTarget != "" {
-			cleanID := strings.TrimPrefix(defaultTarget, "id:")
+		if defaultTargetQuery != "" {
+			cleanID := strings.TrimPrefix(defaultTargetQuery, "id:")
 			ids = append(ids, cleanID)
 		} else {
 			return nil, false

--- a/lib/codescan/comment_parser.go
+++ b/lib/codescan/comment_parser.go
@@ -17,7 +17,6 @@ package codescan
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"regexp"
@@ -35,7 +34,7 @@ const (
 	TargetNewly  = "newly"
 )
 
-// Directive represents a single parsed @webstatus AST comment directive.
+// Directive represents a single parsed TODO(baseline/<id>) AST comment directive.
 type Directive struct {
 	TargetQuery string              `json:"target_query"`
 	Trigger     SubscriptionTrigger `json:"trigger"`
@@ -44,22 +43,14 @@ type Directive struct {
 	FilePath    string              `json:"file_path"`
 }
 
-// Regex matching @webstatus comment directives.
-var webstatusDirectiveRegex = regexp.MustCompile(`(?i)^@webstatus:\s*(.*?)$`)
+// Regex matching canonical TODO(baseline/<id>) comments.
+var baselineTodoRegex = regexp.MustCompile(`(?i)TODO\(baseline/([\w-]+)\)`)
 
-// Regex matching idiomatic TODO(baseline/<id>) or TODO(baseline/<id>, newly) comments.
-var inlineTodoRegex = regexp.MustCompile(
-	`(?i)TODO\(` +
-		`(?:web-features?:\s*([\w-]+)|baseline/\s*([\w-]+)(?:\s*,\s*(newly|widely))?)\s*\)` +
-		`(?::\s*([^,\n]+))?`,
-)
-
-// ParseReader reads from an io.Reader and extracts all valid @webstatus and TODO directives.
+// ParseReader reads from an io.Reader and extracts all valid TODO(baseline/<id>) directives.
 func ParseReader(
 	r io.Reader,
 	filePath string,
 	defaultTrigger SubscriptionTrigger,
-	defaultTargetQuery string,
 ) ([]Directive, error) {
 	var directives []Directive
 	scanner := bufio.NewScanner(r)
@@ -92,12 +83,16 @@ func ParseReader(
 
 		cleaned := cleanCommentLine(rawLine, inCBlock, inHTMLBlock)
 
-		if todoDirs := extractTodoDirectives(cleaned, rawLine, lineNum, filePath, defaultTrigger); len(todoDirs) > 0 {
-			directives = append(directives, todoDirs...)
-		} else if dirs, ok := extractWebstatusDirective(
-			cleaned, rawLine, lineNum, filePath, defaultTargetQuery, defaultTrigger,
-		); ok {
-			directives = append(directives, dirs...)
+		matches := baselineTodoRegex.FindAllStringSubmatch(cleaned, -1)
+		for _, m := range matches {
+			featureID := m[1]
+			directives = append(directives, Directive{
+				TargetQuery: "id:" + featureID,
+				Trigger:     defaultTrigger,
+				RawSnippet:  strings.TrimSpace(rawLine),
+				LineNumber:  lineNum,
+				FilePath:    filePath,
+			})
 		}
 
 		if hasCloseC {
@@ -115,14 +110,13 @@ func ParseReader(
 	return directives, nil
 }
 
-// ParseFileDirectives scans the lines of a source file and extracts all valid @webstatus directives.
+// ParseFileDirectives scans source bytes and extracts all valid TODO(baseline/<id>) directives.
 func ParseFileDirectives(
 	content []byte,
 	filePath string,
 	defaultTrigger SubscriptionTrigger,
-	defaultTargetQuery string,
 ) []Directive {
-	directives, _ := ParseReader(bytes.NewReader(content), filePath, defaultTrigger, defaultTargetQuery)
+	directives, _ := ParseReader(bytes.NewReader(content), filePath, defaultTrigger)
 
 	return directives
 }
@@ -149,156 +143,4 @@ func cleanCommentLine(rawLine string, inCBlock, inHTMLBlock bool) string {
 	trimmed = strings.TrimSuffix(trimmed, "-->")
 
 	return strings.TrimSpace(trimmed)
-}
-
-func extractTodoDirectives(
-	cleanedLine, rawLine string,
-	lineNum int,
-	filePath string,
-	defaultTrigger SubscriptionTrigger,
-) []Directive {
-	matches := inlineTodoRegex.FindAllStringSubmatch(cleanedLine, -1)
-	if len(matches) == 0 {
-		return nil
-	}
-
-	var results []Directive
-	for _, m := range matches {
-		var featureID string
-		var mod string
-
-		if m[1] != "" {
-			featureID = m[1]
-		} else {
-			featureID = m[2]
-			mod = strings.ToLower(m[3])
-		}
-
-		trigger := defaultTrigger
-		if trigger == "" {
-			trigger = SubscriptionTriggerFeatureBaselinePromoteToWidely
-		}
-		switch mod {
-		case TargetNewly:
-			trigger = SubscriptionTriggerFeatureBaselinePromoteToNewly
-		case TargetWidely:
-			trigger = SubscriptionTriggerFeatureBaselinePromoteToWidely
-		}
-
-		results = append(results, Directive{
-			TargetQuery: "id:" + featureID,
-			Trigger:     trigger,
-			RawSnippet:  strings.TrimSpace(rawLine),
-			LineNumber:  lineNum,
-			FilePath:    filePath,
-		})
-	}
-
-	return results
-}
-
-func extractWebstatusDirective(
-	cleanedLine, rawLine string,
-	lineNum int,
-	filePath, defaultTargetQuery string,
-	defaultTrigger SubscriptionTrigger,
-) ([]Directive, bool) {
-	matches := webstatusDirectiveRegex.FindStringSubmatch(cleanedLine)
-	if len(matches) < 2 {
-		return nil, false
-	}
-
-	annotationBody := matches[1]
-	tokens := parseAnnotationTokens(annotationBody)
-
-	var ids []string
-	trigger := defaultTrigger
-
-	for _, token := range tokens {
-		parts := strings.SplitN(token, ":", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		key := strings.ToLower(strings.TrimSpace(parts[0]))
-		val := strings.TrimSpace(parts[1])
-
-		switch key {
-		case "id":
-			val = strings.TrimPrefix(val, "id:")
-			ids = append(ids, val)
-		case "trigger":
-			switch strings.ToLower(val) {
-			case "newly_available", "newly", string(SubscriptionTriggerFeatureBaselinePromoteToNewly):
-				trigger = SubscriptionTriggerFeatureBaselinePromoteToNewly
-			case "widely_available", "widely", string(SubscriptionTriggerFeatureBaselinePromoteToWidely):
-				trigger = SubscriptionTriggerFeatureBaselinePromoteToWidely
-			}
-		}
-	}
-
-	if len(ids) == 0 {
-		if defaultTargetQuery != "" {
-			cleanID := strings.TrimPrefix(defaultTargetQuery, "id:")
-			ids = append(ids, cleanID)
-		} else {
-			return nil, false
-		}
-	}
-
-	var results []Directive
-	for _, id := range ids {
-		targetQuery := id
-		if !strings.HasPrefix(id, "id:") && !strings.HasPrefix(id, "group:") {
-			targetQuery = "id:" + id
-		}
-		results = append(results, Directive{
-			TargetQuery: targetQuery,
-			Trigger:     trigger,
-			RawSnippet:  strings.TrimSpace(rawLine),
-			LineNumber:  lineNum,
-			FilePath:    filePath,
-		})
-	}
-
-	return results, true
-}
-
-func parseAnnotationTokens(body string) []string {
-	var tokens []string
-	fields := strings.FieldsSeq(body)
-	for field := range fields {
-		sub := strings.SplitSeq(field, ",")
-		for s := range sub {
-			trimmed := strings.TrimSpace(s)
-			if trimmed != "" {
-				tokens = append(tokens, trimmed)
-			}
-		}
-	}
-
-	return tokens
-}
-
-// ParseProjectDefaults extracts baseline target from .baseline.json or AGENTS.md.
-func ParseProjectDefaults(content []byte, fileName string) (string, error) {
-	if fileName == ".baseline.json" {
-		var cfg struct {
-			Target string `json:"target"`
-		}
-		if err := json.Unmarshal(content, &cfg); err != nil {
-			return "", err
-		}
-
-		return cfg.Target, nil
-	}
-
-	if fileName == "AGENTS.md" {
-		re := regexp.MustCompile(`(?i)(?:@webstatus:\s*target:|baseline\s*target\s*:\s*"?)\s*([\w-]+)"?`)
-		matches := re.FindSubmatch(content)
-		if len(matches) >= 2 {
-			return string(matches[1]), nil
-		}
-	}
-
-	return "", nil
 }

--- a/lib/codescan/comment_parser.go
+++ b/lib/codescan/comment_parser.go
@@ -1,0 +1,295 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codescan
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// SubscriptionTrigger defines the baseline promotion trigger in the domain.
+type SubscriptionTrigger string
+
+const (
+	SubscriptionTriggerFeatureBaselinePromoteToWidely SubscriptionTrigger = "feature.baseline.promote_to_widely"
+	SubscriptionTriggerFeatureBaselinePromoteToNewly  SubscriptionTrigger = "feature.baseline.promote_to_newly"
+
+	TargetWidely = "widely"
+	TargetNewly  = "newly"
+)
+
+// Directive represents a single parsed @webstatus AST comment directive.
+type Directive struct {
+	TargetQuery string              `json:"target_query"`
+	Trigger     SubscriptionTrigger `json:"trigger"`
+	RawSnippet  string              `json:"raw_snippet"`
+	LineNumber  int                 `json:"line_number"`
+	FilePath    string              `json:"file_path"`
+}
+
+// Regex matching @webstatus comment directives.
+var webstatusDirectiveRegex = regexp.MustCompile(`(?i)^@webstatus:\s*(.*?)$`)
+
+// Regex matching idiomatic TODO(baseline/<id>) or TODO(baseline/<id>, newly) comments.
+var inlineTodoRegex = regexp.MustCompile(
+	`(?i)TODO\(` +
+		`(?:web-features?:\s*([\w-]+)|baseline/\s*([\w-]+)(?:\s*,\s*(newly|widely))?)\s*\)` +
+		`(?::\s*([^,\n]+))?`,
+)
+
+// ParseReader reads from an io.Reader and extracts all valid @webstatus directives.
+func ParseReader(r io.Reader, filePath string, defaultTarget string) ([]Directive, error) {
+	var directives []Directive
+	scanner := bufio.NewScanner(r)
+	buf := make([]byte, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+	lineNum := 0
+
+	inCBlock := false
+	inHTMLBlock := false
+
+	defaultTrigger := SubscriptionTriggerFeatureBaselinePromoteToWidely
+	if defaultTarget == TargetNewly || defaultTarget == string(SubscriptionTriggerFeatureBaselinePromoteToNewly) ||
+		defaultTarget == "newly_available" {
+		defaultTrigger = SubscriptionTriggerFeatureBaselinePromoteToNewly
+	}
+
+	for scanner.Scan() {
+		lineNum++
+		rawLine := scanner.Text()
+
+		hasOpenC := strings.Contains(rawLine, "/*")
+		hasCloseC := strings.Contains(rawLine, "*/")
+		hasOpenHTML := strings.Contains(rawLine, "<!--")
+		hasCloseHTML := strings.Contains(rawLine, "-->")
+
+		if hasOpenC && !hasCloseC {
+			inCBlock = true
+		}
+		if hasOpenHTML && !hasCloseHTML {
+			inHTMLBlock = true
+		}
+
+		cleaned := cleanCommentLine(rawLine, inCBlock, inHTMLBlock)
+
+		if todoDirs := extractTodoDirectives(cleaned, rawLine, lineNum, filePath, defaultTrigger); len(todoDirs) > 0 {
+			directives = append(directives, todoDirs...)
+		} else if dirs, ok := extractWebstatusDirective(
+			cleaned, rawLine, lineNum, filePath, defaultTarget, defaultTrigger,
+		); ok {
+			directives = append(directives, dirs...)
+		}
+
+		if hasCloseC {
+			inCBlock = false
+		}
+		if hasCloseHTML {
+			inHTMLBlock = false
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan %s: %w", filePath, err)
+	}
+
+	return directives, nil
+}
+
+// ParseFileDirectives scans the lines of a source file and extracts all valid @webstatus directives.
+func ParseFileDirectives(content []byte, filePath string, defaultTarget string) []Directive {
+	directives, _ := ParseReader(bytes.NewReader(content), filePath, defaultTarget)
+
+	return directives
+}
+
+func cleanCommentLine(rawLine string, inCBlock, inHTMLBlock bool) string {
+	trimmed := strings.TrimSpace(rawLine)
+
+	prefixes := []string{"//", "#", "/*", "<!--"}
+	for _, p := range prefixes {
+		if after, ok := strings.CutPrefix(trimmed, p); ok {
+			trimmed = after
+
+			break
+		}
+	}
+
+	if inCBlock && strings.HasPrefix(trimmed, "*") {
+		trimmed = strings.TrimPrefix(trimmed, "*")
+	} else if inHTMLBlock && strings.HasPrefix(trimmed, "-->") {
+		return ""
+	}
+
+	trimmed = strings.TrimSuffix(trimmed, "*/")
+	trimmed = strings.TrimSuffix(trimmed, "-->")
+
+	return strings.TrimSpace(trimmed)
+}
+
+func extractTodoDirectives(
+	cleanedLine, rawLine string,
+	lineNum int,
+	filePath string,
+	defaultTrigger SubscriptionTrigger,
+) []Directive {
+	matches := inlineTodoRegex.FindAllStringSubmatch(cleanedLine, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	var results []Directive
+	for _, m := range matches {
+		var featureID string
+		var mod string
+
+		if m[1] != "" {
+			featureID = m[1]
+		} else {
+			featureID = m[2]
+			mod = strings.ToLower(m[3])
+		}
+
+		trigger := defaultTrigger
+		if trigger == "" {
+			trigger = SubscriptionTriggerFeatureBaselinePromoteToWidely
+		}
+		switch mod {
+		case TargetNewly:
+			trigger = SubscriptionTriggerFeatureBaselinePromoteToNewly
+		case TargetWidely:
+			trigger = SubscriptionTriggerFeatureBaselinePromoteToWidely
+		}
+
+		results = append(results, Directive{
+			TargetQuery: "id:" + featureID,
+			Trigger:     trigger,
+			RawSnippet:  strings.TrimSpace(rawLine),
+			LineNumber:  lineNum,
+			FilePath:    filePath,
+		})
+	}
+
+	return results
+}
+
+func extractWebstatusDirective(
+	cleanedLine, rawLine string,
+	lineNum int,
+	filePath, defaultTarget string,
+	defaultTrigger SubscriptionTrigger,
+) ([]Directive, bool) {
+	matches := webstatusDirectiveRegex.FindStringSubmatch(cleanedLine)
+	if len(matches) < 2 {
+		return nil, false
+	}
+
+	annotationBody := matches[1]
+	tokens := parseAnnotationTokens(annotationBody)
+
+	var ids []string
+	trigger := defaultTrigger
+
+	for _, token := range tokens {
+		parts := strings.SplitN(token, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		val := strings.TrimSpace(parts[1])
+
+		switch key {
+		case "id":
+			val = strings.TrimPrefix(val, "id:")
+			ids = append(ids, val)
+		case "trigger":
+			if strings.EqualFold(val, "newly_available") || strings.EqualFold(val, TargetNewly) {
+				trigger = SubscriptionTriggerFeatureBaselinePromoteToNewly
+			} else if strings.EqualFold(val, "widely_available") || strings.EqualFold(val, TargetWidely) {
+				trigger = SubscriptionTriggerFeatureBaselinePromoteToWidely
+			}
+		}
+	}
+
+	if len(ids) == 0 {
+		if defaultTarget != "" {
+			cleanID := strings.TrimPrefix(defaultTarget, "id:")
+			ids = append(ids, cleanID)
+		} else {
+			return nil, false
+		}
+	}
+
+	var results []Directive
+	for _, id := range ids {
+		targetQuery := id
+		if !strings.HasPrefix(id, "id:") && !strings.HasPrefix(id, "group:") {
+			targetQuery = "id:" + id
+		}
+		results = append(results, Directive{
+			TargetQuery: targetQuery,
+			Trigger:     trigger,
+			RawSnippet:  strings.TrimSpace(rawLine),
+			LineNumber:  lineNum,
+			FilePath:    filePath,
+		})
+	}
+
+	return results, true
+}
+
+func parseAnnotationTokens(body string) []string {
+	var tokens []string
+	fields := strings.FieldsSeq(body)
+	for field := range fields {
+		sub := strings.SplitSeq(field, ",")
+		for s := range sub {
+			trimmed := strings.TrimSpace(s)
+			if trimmed != "" {
+				tokens = append(tokens, trimmed)
+			}
+		}
+	}
+
+	return tokens
+}
+
+// ParseProjectDefaults extracts baseline target from .baseline.json or AGENTS.md.
+func ParseProjectDefaults(content []byte, fileName string) (string, error) {
+	if fileName == ".baseline.json" {
+		var cfg struct {
+			Target string `json:"target"`
+		}
+		if err := json.Unmarshal(content, &cfg); err != nil {
+			return "", err
+		}
+
+		return cfg.Target, nil
+	}
+
+	if fileName == "AGENTS.md" {
+		re := regexp.MustCompile(`(?i)(?:@webstatus:\s*target:|baseline\s*target\s*:\s*"?)\s*([\w-]+)"?`)
+		matches := re.FindSubmatch(content)
+		if len(matches) >= 2 {
+			return string(matches[1]), nil
+		}
+	}
+
+	return "", nil
+}

--- a/lib/codescan/comment_parser_test.go
+++ b/lib/codescan/comment_parser_test.go
@@ -1,0 +1,532 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codescan
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseFileDirectives(t *testing.T) {
+	t.Parallel()
+
+	sourceCode := `
+// Normal comment
+const x = 1;
+// TODO(baseline/popover): refactor modal to native popover
+// TODO(baseline/view-transitions, newly): progressive enhancement
+// TODO(web-feature: subgrid): upgrade layout
+/* TODO(baseline/anchor-positioning): anchor tooltip */
+<!-- TODO(baseline/dialog): replace polyfill -->
+// @webstatus: id:view-transitions
+# @webstatus: id:subgrid trigger:newly_available
+/* @webstatus: id:anchor-positioning trigger:widely_available */
+<!-- @webstatus: id:backdrop-filter -->
+// @webstatus: id:compression-streams, id:badging
+// @webstatus: trigger:newly_available
+`
+
+	directives := ParseFileDirectives([]byte(sourceCode), "src/app.ts", "id:default-feature")
+
+	expected := []Directive{
+		{
+			TargetQuery: "id:popover",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "// TODO(baseline/popover): refactor modal to native popover",
+			LineNumber:  4,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:view-transitions",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
+			RawSnippet:  "// TODO(baseline/view-transitions, newly): progressive enhancement",
+			LineNumber:  5,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:subgrid",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "// TODO(web-feature: subgrid): upgrade layout",
+			LineNumber:  6,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:anchor-positioning",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "/* TODO(baseline/anchor-positioning): anchor tooltip */",
+			LineNumber:  7,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:dialog",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "<!-- TODO(baseline/dialog): replace polyfill -->",
+			LineNumber:  8,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:view-transitions",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "// @webstatus: id:view-transitions",
+			LineNumber:  9,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:subgrid",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
+			RawSnippet:  "# @webstatus: id:subgrid trigger:newly_available",
+			LineNumber:  10,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:anchor-positioning",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "/* @webstatus: id:anchor-positioning trigger:widely_available */",
+			LineNumber:  11,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:backdrop-filter",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "<!-- @webstatus: id:backdrop-filter -->",
+			LineNumber:  12,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:compression-streams",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "// @webstatus: id:compression-streams, id:badging",
+			LineNumber:  13,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:badging",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "// @webstatus: id:compression-streams, id:badging",
+			LineNumber:  13,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:default-feature",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
+			RawSnippet:  "// @webstatus: trigger:newly_available",
+			LineNumber:  14,
+			FilePath:    "src/app.ts",
+		},
+	}
+
+	if len(directives) != len(expected) {
+		t.Fatalf("got %d directives, want %d", len(directives), len(expected))
+	}
+
+	for i := range expected {
+		if !reflect.DeepEqual(directives[i], expected[i]) {
+			t.Errorf("directive[%d] mismatch:\ngot  %+v\nwant %+v", i, directives[i], expected[i])
+		}
+	}
+}
+
+func TestParseProjectDefaults(t *testing.T) {
+	t.Parallel()
+
+	// 1. .baseline.json
+	baselineJSON := []byte(`{"target": "group:css-anchor", "trigger": "newly_available"}`)
+	target, err := ParseProjectDefaults(baselineJSON, ".baseline.json")
+	if err != nil {
+		t.Fatalf("unexpected error parsing .baseline.json: %v", err)
+	}
+	if target != "group:css-anchor" {
+		t.Errorf("target = %q, want %q", target, "group:css-anchor")
+	}
+
+	// 2. AGENTS.md
+	agentsMD := []byte(`# AI Agent Guidelines
+<!-- @webstatus: target:widely_available -->
+`)
+	targetMD, err := ParseProjectDefaults(agentsMD, "AGENTS.md")
+	if err != nil {
+		t.Fatalf("unexpected error parsing AGENTS.md: %v", err)
+	}
+	if targetMD != "widely_available" {
+		t.Errorf("targetMD = %q, want %q", targetMD, "widely_available")
+	}
+
+	// 3. Invalid JSON error
+	invalidJSON := []byte(`{invalid-json-content}`)
+	_, err = ParseProjectDefaults(invalidJSON, ".baseline.json")
+	if err == nil {
+		t.Errorf("expected error parsing invalid .baseline.json, got nil")
+	}
+}
+
+func TestParseFileDirectivesEmptyAndBinary(t *testing.T) {
+	t.Parallel()
+
+	// 1. Empty buffer
+	emptyDirectives := ParseFileDirectives([]byte{}, "src/empty.ts", "id:default")
+	if len(emptyDirectives) != 0 {
+		t.Errorf("expected 0 directives for empty buffer, got %d", len(emptyDirectives))
+	}
+
+	// 2. Binary bytes (no matching comments)
+	binaryData := []byte{0x00, 0xFF, 0xFE, 0x01, 0x7F, 0x80}
+	binaryDirectives := ParseFileDirectives(binaryData, "assets/logo.png", "id:default")
+	if len(binaryDirectives) != 0 {
+		t.Errorf("expected 0 directives for binary data, got %d", len(binaryDirectives))
+	}
+}
+
+func TestParseFileDirectives_MultiLineComments(t *testing.T) {
+	t.Parallel()
+
+	sourceCode := `
+/*
+ * TODO(baseline/subgrid): Replace nested grid hack
+ * with native CSS subgrid once widely available.
+ */
+const y = 2;
+<!--
+  TODO(baseline/view-transitions): Multi-line
+  HTML block comment transition handler
+-->
+/*
+ * @webstatus: id:anchor-positioning trigger:newly_available
+ * Multiline webstatus comment
+ */
+`
+
+	directives := ParseFileDirectives([]byte(sourceCode), "src/multi.ts", "id:default")
+	if len(directives) != 3 {
+		t.Fatalf("got %d directives, want 3", len(directives))
+	}
+
+	if directives[0].TargetQuery != "id:subgrid" ||
+		directives[0].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely ||
+		directives[0].LineNumber != 3 {
+		t.Errorf("unexpected directive[0]: %+v", directives[0])
+	}
+	if directives[1].TargetQuery != "id:view-transitions" ||
+		directives[1].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely ||
+		directives[1].LineNumber != 8 {
+		t.Errorf("unexpected directive[1]: %+v", directives[1])
+	}
+	if directives[2].TargetQuery != "id:anchor-positioning" ||
+		directives[2].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly ||
+		directives[2].LineNumber != 12 {
+		t.Errorf("unexpected directive[2]: %+v", directives[2])
+	}
+}
+
+type expectedFixtureDirective struct {
+	FilePath    string              `json:"file_path"`
+	TargetQuery string              `json:"target_query"`
+	Trigger     SubscriptionTrigger `json:"trigger"`
+	LineNumber  int                 `json:"line_number"`
+	RawSnippet  string              `json:"raw_snippet"`
+}
+
+type archetypeFileExpectation struct {
+	Purpose            string                     `json:"purpose"`
+	ExpectedDirectives []expectedFixtureDirective `json:"expectedDirectives"`
+}
+
+type archetypeManifest struct {
+	Scenario    string                              `json:"scenario"`
+	Description string                              `json:"description"`
+	Files       map[string]archetypeFileExpectation `json:"files"`
+}
+
+func assertDirectiveMatch(t *testing.T, relPath string, idx int, got Directive, want expectedFixtureDirective) {
+	t.Helper()
+	if got.TargetQuery != want.TargetQuery {
+		t.Errorf("%s[%d] TargetQuery = %s, want %s", relPath, idx, got.TargetQuery, want.TargetQuery)
+	}
+	if got.Trigger != want.Trigger {
+		t.Errorf("%s[%d] Trigger = %s, want %s", relPath, idx, got.Trigger, want.Trigger)
+	}
+	if got.LineNumber != want.LineNumber {
+		t.Errorf("%s[%d] LineNumber = %d, want %d", relPath, idx, got.LineNumber, want.LineNumber)
+	}
+	if got.RawSnippet != want.RawSnippet {
+		t.Errorf("%s[%d] RawSnippet = %q, want %q", relPath, idx, got.RawSnippet, want.RawSnippet)
+	}
+}
+
+func verifyArchetypeDirectives(t *testing.T, arch string) {
+	t.Helper()
+	archDir := filepath.Join("testdata", "repos", arch)
+	expectedPath := filepath.Join(archDir, "expected.json")
+
+	expectedBytes, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("failed reading %s: %v", expectedPath, err)
+	}
+
+	var manifest archetypeManifest
+	if err := json.Unmarshal(expectedBytes, &manifest); err != nil {
+		t.Fatalf("failed parsing %s: %v", expectedPath, err)
+	}
+
+	// 1. Verify all manifested files match their expected directives
+	for relPath, fileExpectation := range manifest.Files {
+		cleanRelPath := filepath.Clean(relPath)
+		fullPath := filepath.Join(archDir, cleanRelPath)
+
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			t.Fatalf("failed reading manifested file %s: %v", fullPath, err)
+		}
+
+		got := ParseFileDirectives(content, cleanRelPath, "id:default")
+		if len(got) != len(fileExpectation.ExpectedDirectives) {
+			t.Errorf("%s: got %d directives, want %d", cleanRelPath, len(got), len(fileExpectation.ExpectedDirectives))
+
+			continue
+		}
+
+		for i, want := range fileExpectation.ExpectedDirectives {
+			assertDirectiveMatch(t, cleanRelPath, i, got[i], want)
+		}
+	}
+
+	// 2. Ensure every file in the directory is documented in manifest.Files
+	err = filepath.WalkDir(archDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return walkErr
+		}
+
+		relPath, err := filepath.Rel(archDir, path)
+		if err != nil {
+			return err
+		}
+		if relPath == "expected.json" {
+			return nil
+		}
+
+		if _, ok := manifest.Files[relPath]; !ok {
+			t.Errorf("unregistered fixture file found on disk: %s in archetype %s", relPath, arch)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed walking %s: %v", archDir, err)
+	}
+}
+
+func TestParseFileDirectives_ArchetypeFixtures(t *testing.T) {
+	t.Parallel()
+
+	archetypes := []string{
+		"standard-spa",
+		"monorepo-workspaces",
+		"sfc-components",
+	}
+
+	for _, arch := range archetypes {
+		t.Run(arch, func(t *testing.T) {
+			t.Parallel()
+			verifyArchetypeDirectives(t, arch)
+		})
+	}
+}
+
+func TestParseFileDirectives_MultiLineBlocks(t *testing.T) {
+	t.Parallel()
+
+	sourceCode := `
+/*
+ * Multi-line CSS comment
+ * TODO(baseline/subgrid): convert grid fallback
+ * TODO(baseline/has, newly): remove polyfill
+ */
+const y = 2;
+<!--
+  Multi-line HTML comment
+  TODO(baseline/popover): use native popover
+  TODO(baseline/view-transitions, newly): native transitions
+-->
+/* Same line multi-directive: TODO(baseline/dialog) TODO(baseline/invokers, newly) */
+`
+
+	directives := ParseFileDirectives([]byte(sourceCode), "src/multi.css", "")
+
+	expected := []Directive{
+		{
+			TargetQuery: "id:subgrid",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "* TODO(baseline/subgrid): convert grid fallback",
+			LineNumber:  4,
+			FilePath:    "src/multi.css",
+		},
+		{
+			TargetQuery: "id:has",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
+			RawSnippet:  "* TODO(baseline/has, newly): remove polyfill",
+			LineNumber:  5,
+			FilePath:    "src/multi.css",
+		},
+		{
+			TargetQuery: "id:popover",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "TODO(baseline/popover): use native popover",
+			LineNumber:  10,
+			FilePath:    "src/multi.css",
+		},
+		{
+			TargetQuery: "id:view-transitions",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
+			RawSnippet:  "TODO(baseline/view-transitions, newly): native transitions",
+			LineNumber:  11,
+			FilePath:    "src/multi.css",
+		},
+		{
+			TargetQuery: "id:dialog",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "/* Same line multi-directive: TODO(baseline/dialog) TODO(baseline/invokers, newly) */",
+			LineNumber:  13,
+			FilePath:    "src/multi.css",
+		},
+		{
+			TargetQuery: "id:invokers",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
+			RawSnippet:  "/* Same line multi-directive: TODO(baseline/dialog) TODO(baseline/invokers, newly) */",
+			LineNumber:  13,
+			FilePath:    "src/multi.css",
+		},
+	}
+
+	if len(directives) != len(expected) {
+		t.Fatalf("expected %d directives, got %d", len(expected), len(directives))
+	}
+
+	for i, want := range expected {
+		if !reflect.DeepEqual(directives[i], want) {
+			t.Errorf("[%d] got %+v, want %+v", i, directives[i], want)
+		}
+	}
+}
+
+func TestParseReader(t *testing.T) {
+	t.Parallel()
+
+	input := "// TODO(baseline/subgrid): layout upgrade\n"
+	r := strings.NewReader(input)
+
+	directives, err := ParseReader(r, "stdin.ts", "")
+	if err != nil {
+		t.Fatalf("ParseReader failed: %v", err)
+	}
+
+	if len(directives) != 1 {
+		t.Fatalf("expected 1 directive, got %d", len(directives))
+	}
+
+	if directives[0].TargetQuery != "id:subgrid" {
+		t.Errorf("expected id:subgrid, got %s", directives[0].TargetQuery)
+	}
+}
+
+func TestDirective_JSONSerialization(t *testing.T) {
+	t.Parallel()
+
+	d := Directive{
+		TargetQuery: "id:popover",
+		Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+		RawSnippet:  "// TODO(baseline/popover)",
+		LineNumber:  42,
+		FilePath:    "src/app.ts",
+	}
+
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	expectedKeys := []string{"target_query", "trigger", "raw_snippet", "line_number", "file_path"}
+	for _, key := range expectedKeys {
+		if _, ok := parsed[key]; !ok {
+			t.Errorf("missing expected json key %q in serialized output", key)
+		}
+	}
+}
+
+func TestParseFileDirectives_DefaultTargetInheritance(t *testing.T) {
+	t.Parallel()
+
+	sourceCode := `
+// TODO(baseline/popover): standard comment
+// TODO(baseline/dialog, newly): explicit override to newly
+// TODO(baseline/subgrid, widely): explicit override to widely
+`
+
+	// Case 1: defaultTarget is "newly"
+	dirsNewly := ParseFileDirectives([]byte(sourceCode), "src/app.ts", "newly")
+	if len(dirsNewly) != 3 {
+		t.Fatalf("got %d directives, want 3", len(dirsNewly))
+	}
+	if dirsNewly[0].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly {
+		t.Errorf("dirsNewly[0].Trigger = %s, want newly", dirsNewly[0].Trigger)
+	}
+	if dirsNewly[1].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly {
+		t.Errorf("dirsNewly[1].Trigger = %s, want newly", dirsNewly[1].Trigger)
+	}
+	if dirsNewly[2].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely {
+		t.Errorf("dirsNewly[2].Trigger = %s, want widely (explicit override)", dirsNewly[2].Trigger)
+	}
+
+	// Case 2: defaultTarget is "widely" or empty
+	dirsWidely := ParseFileDirectives([]byte(sourceCode), "src/app.ts", "")
+	if len(dirsWidely) != 3 {
+		t.Fatalf("got %d directives, want 3", len(dirsWidely))
+	}
+	if dirsWidely[0].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely {
+		t.Errorf("dirsWidely[0].Trigger = %s, want widely", dirsWidely[0].Trigger)
+	}
+	if dirsWidely[1].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly {
+		t.Errorf("dirsWidely[1].Trigger = %s, want newly (explicit override)", dirsWidely[1].Trigger)
+	}
+	if dirsWidely[2].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely {
+		t.Errorf("dirsWidely[2].Trigger = %s, want widely", dirsWidely[2].Trigger)
+	}
+}
+
+type errReader struct{}
+
+func (e errReader) Read(_ []byte) (int, error) {
+	return 0, errors.New("simulated read error")
+}
+
+func TestParseReader_ScannerError(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseReader(errReader{}, "test.ts", "")
+	if err == nil {
+		t.Fatal("expected error from errReader, got nil")
+	}
+	if !strings.Contains(err.Error(), "simulated read error") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/lib/codescan/comment_parser_test.go
+++ b/lib/codescan/comment_parser_test.go
@@ -43,7 +43,12 @@ const x = 1;
 // @webstatus: trigger:newly_available
 `
 
-	directives := ParseFileDirectives([]byte(sourceCode), "src/app.ts", "id:default-feature")
+	directives := ParseFileDirectives(
+		[]byte(sourceCode),
+		"src/app.ts",
+		SubscriptionTriggerFeatureBaselinePromoteToWidely,
+		"id:default-feature",
+	)
 
 	expected := []Directive{
 		{
@@ -180,14 +185,24 @@ func TestParseFileDirectivesEmptyAndBinary(t *testing.T) {
 	t.Parallel()
 
 	// 1. Empty buffer
-	emptyDirectives := ParseFileDirectives([]byte{}, "src/empty.ts", "id:default")
+	emptyDirectives := ParseFileDirectives(
+		[]byte{},
+		"src/empty.ts",
+		SubscriptionTriggerFeatureBaselinePromoteToWidely,
+		"id:default",
+	)
 	if len(emptyDirectives) != 0 {
 		t.Errorf("expected 0 directives for empty buffer, got %d", len(emptyDirectives))
 	}
 
 	// 2. Binary bytes (no matching comments)
 	binaryData := []byte{0x00, 0xFF, 0xFE, 0x01, 0x7F, 0x80}
-	binaryDirectives := ParseFileDirectives(binaryData, "assets/logo.png", "id:default")
+	binaryDirectives := ParseFileDirectives(
+		binaryData,
+		"assets/logo.png",
+		SubscriptionTriggerFeatureBaselinePromoteToWidely,
+		"id:default",
+	)
 	if len(binaryDirectives) != 0 {
 		t.Errorf("expected 0 directives for binary data, got %d", len(binaryDirectives))
 	}
@@ -212,7 +227,12 @@ const y = 2;
  */
 `
 
-	directives := ParseFileDirectives([]byte(sourceCode), "src/multi.ts", "id:default")
+	directives := ParseFileDirectives(
+		[]byte(sourceCode),
+		"src/multi.ts",
+		SubscriptionTriggerFeatureBaselinePromoteToWidely,
+		"id:default",
+	)
 	if len(directives) != 3 {
 		t.Fatalf("got %d directives, want 3", len(directives))
 	}
@@ -294,7 +314,7 @@ func verifyArchetypeDirectives(t *testing.T, arch string) {
 			t.Fatalf("failed reading manifested file %s: %v", fullPath, err)
 		}
 
-		got := ParseFileDirectives(content, cleanRelPath, "id:default")
+		got := ParseFileDirectives(content, cleanRelPath, SubscriptionTriggerFeatureBaselinePromoteToWidely, "id:default")
 		if len(got) != len(fileExpectation.ExpectedDirectives) {
 			t.Errorf("%s: got %d directives, want %d", cleanRelPath, len(got), len(fileExpectation.ExpectedDirectives))
 
@@ -366,7 +386,12 @@ const y = 2;
 /* Same line multi-directive: TODO(baseline/dialog) TODO(baseline/invokers, newly) */
 `
 
-	directives := ParseFileDirectives([]byte(sourceCode), "src/multi.css", "")
+	directives := ParseFileDirectives(
+		[]byte(sourceCode),
+		"src/multi.css",
+		SubscriptionTriggerFeatureBaselinePromoteToWidely,
+		"",
+	)
 
 	expected := []Directive{
 		{
@@ -430,7 +455,7 @@ func TestParseReader(t *testing.T) {
 	input := "// TODO(baseline/subgrid): layout upgrade\n"
 	r := strings.NewReader(input)
 
-	directives, err := ParseReader(r, "stdin.ts", "")
+	directives, err := ParseReader(r, "stdin.ts", SubscriptionTriggerFeatureBaselinePromoteToWidely, "")
 	if err != nil {
 		t.Fatalf("ParseReader failed: %v", err)
 	}
@@ -480,12 +505,18 @@ func TestParseFileDirectives_DefaultTargetInheritance(t *testing.T) {
 // TODO(baseline/popover): standard comment
 // TODO(baseline/dialog, newly): explicit override to newly
 // TODO(baseline/subgrid, widely): explicit override to widely
+// @webstatus: id:anchor-positioning
 `
 
-	// Case 1: defaultTarget is "newly"
-	dirsNewly := ParseFileDirectives([]byte(sourceCode), "src/app.ts", "newly")
-	if len(dirsNewly) != 3 {
-		t.Fatalf("got %d directives, want 3", len(dirsNewly))
+	// Case 1: defaultTrigger is SubscriptionTriggerFeatureBaselinePromoteToNewly
+	dirsNewly := ParseFileDirectives(
+		[]byte(sourceCode),
+		"src/app.ts",
+		SubscriptionTriggerFeatureBaselinePromoteToNewly,
+		"",
+	)
+	if len(dirsNewly) != 4 {
+		t.Fatalf("got %d directives, want 4", len(dirsNewly))
 	}
 	if dirsNewly[0].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly {
 		t.Errorf("dirsNewly[0].Trigger = %s, want newly", dirsNewly[0].Trigger)
@@ -496,11 +527,19 @@ func TestParseFileDirectives_DefaultTargetInheritance(t *testing.T) {
 	if dirsNewly[2].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely {
 		t.Errorf("dirsNewly[2].Trigger = %s, want widely (explicit override)", dirsNewly[2].Trigger)
 	}
+	if dirsNewly[3].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly {
+		t.Errorf("dirsNewly[3].Trigger = %s, want newly (inherited from default)", dirsNewly[3].Trigger)
+	}
 
-	// Case 2: defaultTarget is "widely" or empty
-	dirsWidely := ParseFileDirectives([]byte(sourceCode), "src/app.ts", "")
-	if len(dirsWidely) != 3 {
-		t.Fatalf("got %d directives, want 3", len(dirsWidely))
+	// Case 2: defaultTrigger is SubscriptionTriggerFeatureBaselinePromoteToWidely
+	dirsWidely := ParseFileDirectives(
+		[]byte(sourceCode),
+		"src/app.ts",
+		SubscriptionTriggerFeatureBaselinePromoteToWidely,
+		"",
+	)
+	if len(dirsWidely) != 4 {
+		t.Fatalf("got %d directives, want 4", len(dirsWidely))
 	}
 	if dirsWidely[0].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely {
 		t.Errorf("dirsWidely[0].Trigger = %s, want widely", dirsWidely[0].Trigger)
@@ -510,6 +549,27 @@ func TestParseFileDirectives_DefaultTargetInheritance(t *testing.T) {
 	}
 	if dirsWidely[2].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely {
 		t.Errorf("dirsWidely[2].Trigger = %s, want widely", dirsWidely[2].Trigger)
+	}
+	if dirsWidely[3].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely {
+		t.Errorf("dirsWidely[3].Trigger = %s, want widely (inherited from default)", dirsWidely[3].Trigger)
+	}
+
+	// Case 3: Bare @webstatus with defaultTargetQuery fallback
+	bareSource := "// @webstatus: trigger:newly_available\n"
+	dirsBare := ParseFileDirectives(
+		[]byte(bareSource),
+		"src/app.ts",
+		SubscriptionTriggerFeatureBaselinePromoteToWidely,
+		"id:fallback-feature",
+	)
+	if len(dirsBare) != 1 {
+		t.Fatalf("got %d directives, want 1", len(dirsBare))
+	}
+	if dirsBare[0].TargetQuery != "id:fallback-feature" {
+		t.Errorf("dirsBare[0].TargetQuery = %s, want id:fallback-feature", dirsBare[0].TargetQuery)
+	}
+	if dirsBare[0].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly {
+		t.Errorf("dirsBare[0].Trigger = %s, want newly_available", dirsBare[0].Trigger)
 	}
 }
 
@@ -522,7 +582,7 @@ func (e errReader) Read(_ []byte) (int, error) {
 func TestParseReader_ScannerError(t *testing.T) {
 	t.Parallel()
 
-	_, err := ParseReader(errReader{}, "test.ts", "")
+	_, err := ParseReader(errReader{}, "test.ts", SubscriptionTriggerFeatureBaselinePromoteToWidely, "")
 	if err == nil {
 		t.Fatal("expected error from errReader, got nil")
 	}

--- a/lib/codescan/comment_parser_test.go
+++ b/lib/codescan/comment_parser_test.go
@@ -31,23 +31,16 @@ func TestParseFileDirectives(t *testing.T) {
 // Normal comment
 const x = 1;
 // TODO(baseline/popover): refactor modal to native popover
-// TODO(baseline/view-transitions, newly): progressive enhancement
-// TODO(web-feature: subgrid): upgrade layout
+// TODO(baseline/view-transitions): progressive enhancement
 /* TODO(baseline/anchor-positioning): anchor tooltip */
 <!-- TODO(baseline/dialog): replace polyfill -->
-// @webstatus: id:view-transitions
-# @webstatus: id:subgrid trigger:newly_available
-/* @webstatus: id:anchor-positioning trigger:widely_available */
-<!-- @webstatus: id:backdrop-filter -->
-// @webstatus: id:compression-streams, id:badging
-// @webstatus: trigger:newly_available
+# TODO(baseline/subgrid): python comment
 `
 
 	directives := ParseFileDirectives(
 		[]byte(sourceCode),
 		"src/app.ts",
 		SubscriptionTriggerFeatureBaselinePromoteToWidely,
-		"id:default-feature",
 	)
 
 	expected := []Directive{
@@ -60,79 +53,30 @@ const x = 1;
 		},
 		{
 			TargetQuery: "id:view-transitions",
-			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
-			RawSnippet:  "// TODO(baseline/view-transitions, newly): progressive enhancement",
-			LineNumber:  5,
-			FilePath:    "src/app.ts",
-		},
-		{
-			TargetQuery: "id:subgrid",
 			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
-			RawSnippet:  "// TODO(web-feature: subgrid): upgrade layout",
-			LineNumber:  6,
+			RawSnippet:  "// TODO(baseline/view-transitions): progressive enhancement",
+			LineNumber:  5,
 			FilePath:    "src/app.ts",
 		},
 		{
 			TargetQuery: "id:anchor-positioning",
 			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
 			RawSnippet:  "/* TODO(baseline/anchor-positioning): anchor tooltip */",
-			LineNumber:  7,
+			LineNumber:  6,
 			FilePath:    "src/app.ts",
 		},
 		{
 			TargetQuery: "id:dialog",
 			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
 			RawSnippet:  "<!-- TODO(baseline/dialog): replace polyfill -->",
-			LineNumber:  8,
-			FilePath:    "src/app.ts",
-		},
-		{
-			TargetQuery: "id:view-transitions",
-			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
-			RawSnippet:  "// @webstatus: id:view-transitions",
-			LineNumber:  9,
+			LineNumber:  7,
 			FilePath:    "src/app.ts",
 		},
 		{
 			TargetQuery: "id:subgrid",
-			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
-			RawSnippet:  "# @webstatus: id:subgrid trigger:newly_available",
-			LineNumber:  10,
-			FilePath:    "src/app.ts",
-		},
-		{
-			TargetQuery: "id:anchor-positioning",
 			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
-			RawSnippet:  "/* @webstatus: id:anchor-positioning trigger:widely_available */",
-			LineNumber:  11,
-			FilePath:    "src/app.ts",
-		},
-		{
-			TargetQuery: "id:backdrop-filter",
-			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
-			RawSnippet:  "<!-- @webstatus: id:backdrop-filter -->",
-			LineNumber:  12,
-			FilePath:    "src/app.ts",
-		},
-		{
-			TargetQuery: "id:compression-streams",
-			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
-			RawSnippet:  "// @webstatus: id:compression-streams, id:badging",
-			LineNumber:  13,
-			FilePath:    "src/app.ts",
-		},
-		{
-			TargetQuery: "id:badging",
-			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
-			RawSnippet:  "// @webstatus: id:compression-streams, id:badging",
-			LineNumber:  13,
-			FilePath:    "src/app.ts",
-		},
-		{
-			TargetQuery: "id:default-feature",
-			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
-			RawSnippet:  "// @webstatus: trigger:newly_available",
-			LineNumber:  14,
+			RawSnippet:  "# TODO(baseline/subgrid): python comment",
+			LineNumber:  8,
 			FilePath:    "src/app.ts",
 		},
 	}
@@ -148,39 +92,6 @@ const x = 1;
 	}
 }
 
-func TestParseProjectDefaults(t *testing.T) {
-	t.Parallel()
-
-	// 1. .baseline.json
-	baselineJSON := []byte(`{"target": "group:css-anchor", "trigger": "newly_available"}`)
-	target, err := ParseProjectDefaults(baselineJSON, ".baseline.json")
-	if err != nil {
-		t.Fatalf("unexpected error parsing .baseline.json: %v", err)
-	}
-	if target != "group:css-anchor" {
-		t.Errorf("target = %q, want %q", target, "group:css-anchor")
-	}
-
-	// 2. AGENTS.md
-	agentsMD := []byte(`# AI Agent Guidelines
-<!-- @webstatus: target:widely_available -->
-`)
-	targetMD, err := ParseProjectDefaults(agentsMD, "AGENTS.md")
-	if err != nil {
-		t.Fatalf("unexpected error parsing AGENTS.md: %v", err)
-	}
-	if targetMD != "widely_available" {
-		t.Errorf("targetMD = %q, want %q", targetMD, "widely_available")
-	}
-
-	// 3. Invalid JSON error
-	invalidJSON := []byte(`{invalid-json-content}`)
-	_, err = ParseProjectDefaults(invalidJSON, ".baseline.json")
-	if err == nil {
-		t.Errorf("expected error parsing invalid .baseline.json, got nil")
-	}
-}
-
 func TestParseFileDirectivesEmptyAndBinary(t *testing.T) {
 	t.Parallel()
 
@@ -189,7 +100,6 @@ func TestParseFileDirectivesEmptyAndBinary(t *testing.T) {
 		[]byte{},
 		"src/empty.ts",
 		SubscriptionTriggerFeatureBaselinePromoteToWidely,
-		"id:default",
 	)
 	if len(emptyDirectives) != 0 {
 		t.Errorf("expected 0 directives for empty buffer, got %d", len(emptyDirectives))
@@ -201,7 +111,6 @@ func TestParseFileDirectivesEmptyAndBinary(t *testing.T) {
 		binaryData,
 		"assets/logo.png",
 		SubscriptionTriggerFeatureBaselinePromoteToWidely,
-		"id:default",
 	)
 	if len(binaryDirectives) != 0 {
 		t.Errorf("expected 0 directives for binary data, got %d", len(binaryDirectives))
@@ -221,20 +130,15 @@ const y = 2;
   TODO(baseline/view-transitions): Multi-line
   HTML block comment transition handler
 -->
-/*
- * @webstatus: id:anchor-positioning trigger:newly_available
- * Multiline webstatus comment
- */
 `
 
 	directives := ParseFileDirectives(
 		[]byte(sourceCode),
 		"src/multi.ts",
 		SubscriptionTriggerFeatureBaselinePromoteToWidely,
-		"id:default",
 	)
-	if len(directives) != 3 {
-		t.Fatalf("got %d directives, want 3", len(directives))
+	if len(directives) != 2 {
+		t.Fatalf("got %d directives, want 2", len(directives))
 	}
 
 	if directives[0].TargetQuery != "id:subgrid" ||
@@ -246,11 +150,6 @@ const y = 2;
 		directives[1].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely ||
 		directives[1].LineNumber != 8 {
 		t.Errorf("unexpected directive[1]: %+v", directives[1])
-	}
-	if directives[2].TargetQuery != "id:anchor-positioning" ||
-		directives[2].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly ||
-		directives[2].LineNumber != 12 {
-		t.Errorf("unexpected directive[2]: %+v", directives[2])
 	}
 }
 
@@ -314,7 +213,7 @@ func verifyArchetypeDirectives(t *testing.T, arch string) {
 			t.Fatalf("failed reading manifested file %s: %v", fullPath, err)
 		}
 
-		got := ParseFileDirectives(content, cleanRelPath, SubscriptionTriggerFeatureBaselinePromoteToWidely, "id:default")
+		got := ParseFileDirectives(content, cleanRelPath, SubscriptionTriggerFeatureBaselinePromoteToWidely)
 		if len(got) != len(fileExpectation.ExpectedDirectives) {
 			t.Errorf("%s: got %d directives, want %d", cleanRelPath, len(got), len(fileExpectation.ExpectedDirectives))
 
@@ -375,22 +274,21 @@ func TestParseFileDirectives_MultiLineBlocks(t *testing.T) {
 /*
  * Multi-line CSS comment
  * TODO(baseline/subgrid): convert grid fallback
- * TODO(baseline/has, newly): remove polyfill
+ * TODO(baseline/has): remove polyfill
  */
 const y = 2;
 <!--
   Multi-line HTML comment
   TODO(baseline/popover): use native popover
-  TODO(baseline/view-transitions, newly): native transitions
+  TODO(baseline/view-transitions): native transitions
 -->
-/* Same line multi-directive: TODO(baseline/dialog) TODO(baseline/invokers, newly) */
+/* Same line multi-directive: TODO(baseline/dialog) TODO(baseline/invokers) */
 `
 
 	directives := ParseFileDirectives(
 		[]byte(sourceCode),
 		"src/multi.css",
 		SubscriptionTriggerFeatureBaselinePromoteToWidely,
-		"",
 	)
 
 	expected := []Directive{
@@ -403,8 +301,8 @@ const y = 2;
 		},
 		{
 			TargetQuery: "id:has",
-			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
-			RawSnippet:  "* TODO(baseline/has, newly): remove polyfill",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "* TODO(baseline/has): remove polyfill",
 			LineNumber:  5,
 			FilePath:    "src/multi.css",
 		},
@@ -417,22 +315,22 @@ const y = 2;
 		},
 		{
 			TargetQuery: "id:view-transitions",
-			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
-			RawSnippet:  "TODO(baseline/view-transitions, newly): native transitions",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "TODO(baseline/view-transitions): native transitions",
 			LineNumber:  11,
 			FilePath:    "src/multi.css",
 		},
 		{
 			TargetQuery: "id:dialog",
 			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
-			RawSnippet:  "/* Same line multi-directive: TODO(baseline/dialog) TODO(baseline/invokers, newly) */",
+			RawSnippet:  "/* Same line multi-directive: TODO(baseline/dialog) TODO(baseline/invokers) */",
 			LineNumber:  13,
 			FilePath:    "src/multi.css",
 		},
 		{
 			TargetQuery: "id:invokers",
-			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
-			RawSnippet:  "/* Same line multi-directive: TODO(baseline/dialog) TODO(baseline/invokers, newly) */",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "/* Same line multi-directive: TODO(baseline/dialog) TODO(baseline/invokers) */",
 			LineNumber:  13,
 			FilePath:    "src/multi.css",
 		},
@@ -455,7 +353,7 @@ func TestParseReader(t *testing.T) {
 	input := "// TODO(baseline/subgrid): layout upgrade\n"
 	r := strings.NewReader(input)
 
-	directives, err := ParseReader(r, "stdin.ts", SubscriptionTriggerFeatureBaselinePromoteToWidely, "")
+	directives, err := ParseReader(r, "stdin.ts", SubscriptionTriggerFeatureBaselinePromoteToWidely)
 	if err != nil {
 		t.Fatalf("ParseReader failed: %v", err)
 	}
@@ -498,37 +396,22 @@ func TestDirective_JSONSerialization(t *testing.T) {
 	}
 }
 
-func TestParseFileDirectives_DefaultTargetInheritance(t *testing.T) {
+func TestParseFileDirectives_DefaultTriggerInheritance(t *testing.T) {
 	t.Parallel()
 
-	sourceCode := `
-// TODO(baseline/popover): standard comment
-// TODO(baseline/dialog, newly): explicit override to newly
-// TODO(baseline/subgrid, widely): explicit override to widely
-// @webstatus: id:anchor-positioning
-`
+	sourceCode := `// TODO(baseline/popover): standard comment`
 
 	// Case 1: defaultTrigger is SubscriptionTriggerFeatureBaselinePromoteToNewly
 	dirsNewly := ParseFileDirectives(
 		[]byte(sourceCode),
 		"src/app.ts",
 		SubscriptionTriggerFeatureBaselinePromoteToNewly,
-		"",
 	)
-	if len(dirsNewly) != 4 {
-		t.Fatalf("got %d directives, want 4", len(dirsNewly))
+	if len(dirsNewly) != 1 {
+		t.Fatalf("got %d directives, want 1", len(dirsNewly))
 	}
 	if dirsNewly[0].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly {
 		t.Errorf("dirsNewly[0].Trigger = %s, want newly", dirsNewly[0].Trigger)
-	}
-	if dirsNewly[1].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly {
-		t.Errorf("dirsNewly[1].Trigger = %s, want newly", dirsNewly[1].Trigger)
-	}
-	if dirsNewly[2].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely {
-		t.Errorf("dirsNewly[2].Trigger = %s, want widely (explicit override)", dirsNewly[2].Trigger)
-	}
-	if dirsNewly[3].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly {
-		t.Errorf("dirsNewly[3].Trigger = %s, want newly (inherited from default)", dirsNewly[3].Trigger)
 	}
 
 	// Case 2: defaultTrigger is SubscriptionTriggerFeatureBaselinePromoteToWidely
@@ -536,40 +419,12 @@ func TestParseFileDirectives_DefaultTargetInheritance(t *testing.T) {
 		[]byte(sourceCode),
 		"src/app.ts",
 		SubscriptionTriggerFeatureBaselinePromoteToWidely,
-		"",
 	)
-	if len(dirsWidely) != 4 {
-		t.Fatalf("got %d directives, want 4", len(dirsWidely))
+	if len(dirsWidely) != 1 {
+		t.Fatalf("got %d directives, want 1", len(dirsWidely))
 	}
 	if dirsWidely[0].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely {
 		t.Errorf("dirsWidely[0].Trigger = %s, want widely", dirsWidely[0].Trigger)
-	}
-	if dirsWidely[1].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly {
-		t.Errorf("dirsWidely[1].Trigger = %s, want newly (explicit override)", dirsWidely[1].Trigger)
-	}
-	if dirsWidely[2].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely {
-		t.Errorf("dirsWidely[2].Trigger = %s, want widely", dirsWidely[2].Trigger)
-	}
-	if dirsWidely[3].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely {
-		t.Errorf("dirsWidely[3].Trigger = %s, want widely (inherited from default)", dirsWidely[3].Trigger)
-	}
-
-	// Case 3: Bare @webstatus with defaultTargetQuery fallback
-	bareSource := "// @webstatus: trigger:newly_available\n"
-	dirsBare := ParseFileDirectives(
-		[]byte(bareSource),
-		"src/app.ts",
-		SubscriptionTriggerFeatureBaselinePromoteToWidely,
-		"id:fallback-feature",
-	)
-	if len(dirsBare) != 1 {
-		t.Fatalf("got %d directives, want 1", len(dirsBare))
-	}
-	if dirsBare[0].TargetQuery != "id:fallback-feature" {
-		t.Errorf("dirsBare[0].TargetQuery = %s, want id:fallback-feature", dirsBare[0].TargetQuery)
-	}
-	if dirsBare[0].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly {
-		t.Errorf("dirsBare[0].Trigger = %s, want newly_available", dirsBare[0].Trigger)
 	}
 }
 
@@ -582,7 +437,7 @@ func (e errReader) Read(_ []byte) (int, error) {
 func TestParseReader_ScannerError(t *testing.T) {
 	t.Parallel()
 
-	_, err := ParseReader(errReader{}, "test.ts", SubscriptionTriggerFeatureBaselinePromoteToWidely, "")
+	_, err := ParseReader(errReader{}, "test.ts", SubscriptionTriggerFeatureBaselinePromoteToWidely)
 	if err == nil {
 		t.Fatal("expected error from errReader, got nil")
 	}

--- a/lib/codescan/testdata/repos/monorepo-workspaces/.browserslistrc
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/.browserslistrc
@@ -1,0 +1,1 @@
+baseline widely available

--- a/lib/codescan/testdata/repos/monorepo-workspaces/apps/legacy-portal/src/table.css
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/apps/legacy-portal/src/table.css
@@ -1,0 +1,5 @@
+/* Legacy portal table */
+.table {
+  display: block;
+  /* TODO(baseline/subgrid): modernize nested table cells */
+}

--- a/lib/codescan/testdata/repos/monorepo-workspaces/apps/modern-pwa/.browserslistrc
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/apps/modern-pwa/.browserslistrc
@@ -1,0 +1,1 @@
+baseline newly available

--- a/lib/codescan/testdata/repos/monorepo-workspaces/apps/modern-pwa/src/camera.ts
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/apps/modern-pwa/src/camera.ts
@@ -1,0 +1,5 @@
+// Modern PWA camera integration
+export function initCamera() {
+  // TODO(baseline/view-transitions, newly): animate camera viewport
+  console.log('Camera ready');
+}

--- a/lib/codescan/testdata/repos/monorepo-workspaces/apps/modern-pwa/src/camera.ts
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/apps/modern-pwa/src/camera.ts
@@ -1,5 +1,5 @@
 // Modern PWA camera integration
 export function initCamera() {
-  // TODO(baseline/view-transitions, newly): animate camera viewport
+  // TODO(baseline/view-transitions): animate camera viewport
   console.log('Camera ready');
 }

--- a/lib/codescan/testdata/repos/monorepo-workspaces/expected.json
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/expected.json
@@ -28,9 +28,9 @@
         {
           "file_path": "apps/modern-pwa/src/camera.ts",
           "target_query": "id:view-transitions",
-          "trigger": "feature.baseline.promote_to_newly",
+          "trigger": "feature.baseline.promote_to_widely",
           "line_number": 3,
-          "raw_snippet": "// TODO(baseline/view-transitions, newly): animate camera viewport"
+          "raw_snippet": "// TODO(baseline/view-transitions): animate camera viewport"
         }
       ]
     },

--- a/lib/codescan/testdata/repos/monorepo-workspaces/expected.json
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/expected.json
@@ -1,0 +1,50 @@
+{
+  "scenario": "Monorepo Workspaces with Hierarchical Overrides",
+  "description": "Demonstrates a multi-package monorepo where the root sets target=widely, legacy apps inherit it, modern sub-apps override with target=newly, and shared packages use explicit modifiers.",
+  "files": {
+    ".browserslistrc": {
+      "purpose": "Root monorepo browserslist configuration setting target=widely",
+      "expectedDirectives": []
+    },
+    "apps/legacy-portal/src/table.css": {
+      "purpose": "Legacy portal application inheriting root target=widely with CSS block comment directive",
+      "expectedDirectives": [
+        {
+          "file_path": "apps/legacy-portal/src/table.css",
+          "target_query": "id:subgrid",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 4,
+          "raw_snippet": "/* TODO(baseline/subgrid): modernize nested table cells */"
+        }
+      ]
+    },
+    "apps/modern-pwa/.browserslistrc": {
+      "purpose": "Sub-app workspace browserslist configuration setting target to newly",
+      "expectedDirectives": []
+    },
+    "apps/modern-pwa/src/camera.ts": {
+      "purpose": "Modern PWA app using explicit baseline-newly modifier",
+      "expectedDirectives": [
+        {
+          "file_path": "apps/modern-pwa/src/camera.ts",
+          "target_query": "id:view-transitions",
+          "trigger": "feature.baseline.promote_to_newly",
+          "line_number": 3,
+          "raw_snippet": "// TODO(baseline/view-transitions, newly): animate camera viewport"
+        }
+      ]
+    },
+    "packages/ui-components/src/dialog.ts": {
+      "purpose": "Shared component package with native dialog directive",
+      "expectedDirectives": [
+        {
+          "file_path": "packages/ui-components/src/dialog.ts",
+          "target_query": "id:dialog",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 2,
+          "raw_snippet": "// TODO(baseline/dialog): native dialog wrapper"
+        }
+      ]
+    }
+  }
+}

--- a/lib/codescan/testdata/repos/monorepo-workspaces/packages/ui-components/src/dialog.ts
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/packages/ui-components/src/dialog.ts
@@ -1,0 +1,3 @@
+// Reusable UI components
+// TODO(baseline/dialog): native dialog wrapper
+export class DialogComponent {}

--- a/lib/codescan/testdata/repos/sfc-components/Modal.vue
+++ b/lib/codescan/testdata/repos/sfc-components/Modal.vue
@@ -1,0 +1,18 @@
+<template>
+  <!-- TODO(baseline/dialog): replace modal container with native dialog -->
+  <div class="modal-dialog">
+    <slot></slot>
+  </div>
+</template>
+
+<script setup lang="ts">
+// TODO(baseline/popover, newly): use popover for action menu
+import { ref } from 'vue';
+</script>
+
+<style scoped>
+/* TODO(baseline/anchor-positioning): position modal anchored to trigger */
+.modal-dialog {
+  position: fixed;
+}
+</style>

--- a/lib/codescan/testdata/repos/sfc-components/Modal.vue
+++ b/lib/codescan/testdata/repos/sfc-components/Modal.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script setup lang="ts">
-// TODO(baseline/popover, newly): use popover for action menu
+// TODO(baseline/popover): use popover for action menu
 import { ref } from 'vue';
 </script>
 

--- a/lib/codescan/testdata/repos/sfc-components/Tooltip.svelte
+++ b/lib/codescan/testdata/repos/sfc-components/Tooltip.svelte
@@ -1,0 +1,15 @@
+<script>
+  // TODO(baseline/popover): use native popover
+  export let text = '';
+</script>
+
+<!-- TODO(baseline/anchor-positioning): anchor tooltip -->
+<div class="tooltip-content">
+  {text}
+</div>
+
+<style>
+  .tooltip-content {
+    display: block;
+  }
+</style>

--- a/lib/codescan/testdata/repos/sfc-components/expected.json
+++ b/lib/codescan/testdata/repos/sfc-components/expected.json
@@ -1,0 +1,51 @@
+{
+  "scenario": "Single-File Components (Vue / Svelte)",
+  "description": "Demonstrates directives inside template, script, and style blocks of modern SFC formats (Vue .vue and Svelte .svelte).",
+  "files": {
+    "Modal.vue": {
+      "purpose": "Vue SFC with directives in <template>, <script>, and <style> blocks",
+      "expectedDirectives": [
+        {
+          "file_path": "Modal.vue",
+          "target_query": "id:dialog",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 2,
+          "raw_snippet": "<!-- TODO(baseline/dialog): replace modal container with native dialog -->"
+        },
+        {
+          "file_path": "Modal.vue",
+          "target_query": "id:popover",
+          "trigger": "feature.baseline.promote_to_newly",
+          "line_number": 9,
+          "raw_snippet": "// TODO(baseline/popover, newly): use popover for action menu"
+        },
+        {
+          "file_path": "Modal.vue",
+          "target_query": "id:anchor-positioning",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 14,
+          "raw_snippet": "/* TODO(baseline/anchor-positioning): position modal anchored to trigger */"
+        }
+      ]
+    },
+    "Tooltip.svelte": {
+      "purpose": "Svelte SFC with directives in <script> and template sections",
+      "expectedDirectives": [
+        {
+          "file_path": "Tooltip.svelte",
+          "target_query": "id:popover",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 2,
+          "raw_snippet": "// TODO(baseline/popover): use native popover"
+        },
+        {
+          "file_path": "Tooltip.svelte",
+          "target_query": "id:anchor-positioning",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 6,
+          "raw_snippet": "<!-- TODO(baseline/anchor-positioning): anchor tooltip -->"
+        }
+      ]
+    }
+  }
+}

--- a/lib/codescan/testdata/repos/sfc-components/expected.json
+++ b/lib/codescan/testdata/repos/sfc-components/expected.json
@@ -15,9 +15,9 @@
         {
           "file_path": "Modal.vue",
           "target_query": "id:popover",
-          "trigger": "feature.baseline.promote_to_newly",
+          "trigger": "feature.baseline.promote_to_widely",
           "line_number": 9,
-          "raw_snippet": "// TODO(baseline/popover, newly): use popover for action menu"
+          "raw_snippet": "// TODO(baseline/popover): use popover for action menu"
         },
         {
           "file_path": "Modal.vue",

--- a/lib/codescan/testdata/repos/standard-spa/.browserslistrc
+++ b/lib/codescan/testdata/repos/standard-spa/.browserslistrc
@@ -1,0 +1,1 @@
+baseline widely available

--- a/lib/codescan/testdata/repos/standard-spa/expected.json
+++ b/lib/codescan/testdata/repos/standard-spa/expected.json
@@ -1,0 +1,60 @@
+{
+  "scenario": "Standard Single-Page TypeScript/CSS Application",
+  "description": "Demonstrates a standard SPA with root .baseline.json configuration, inline TypeScript directives, CSS block directives, and HTML comment directives.",
+  "files": {
+    ".browserslistrc": {
+      "purpose": "Repository root browserslist configuration establishing target=widely",
+      "expectedDirectives": []
+    },
+    "src/app.ts": {
+      "purpose": "Main TypeScript application logic with inline TODO(baseline/popover) and TODO(baseline/view-transitions, newly) comments",
+      "expectedDirectives": [
+        {
+          "file_path": "src/app.ts",
+          "target_query": "id:popover",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 4,
+          "raw_snippet": "// TODO(baseline/popover): replace custom tooltip with native popover"
+        },
+        {
+          "file_path": "src/app.ts",
+          "target_query": "id:view-transitions",
+          "trigger": "feature.baseline.promote_to_newly",
+          "line_number": 7,
+          "raw_snippet": "// TODO(baseline/view-transitions, newly): smooth page transitions"
+        }
+      ]
+    },
+    "src/styles.css": {
+      "purpose": "Application styles with CSS block comment directives for subgrid and anchor-positioning",
+      "expectedDirectives": [
+        {
+          "file_path": "src/styles.css",
+          "target_query": "id:subgrid",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 5,
+          "raw_snippet": "* TODO(baseline/subgrid): upgrade nested grid layout to subgrid"
+        },
+        {
+          "file_path": "src/styles.css",
+          "target_query": "id:anchor-positioning",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 6,
+          "raw_snippet": "* TODO(baseline/anchor-positioning): anchor tooltip to button"
+        }
+      ]
+    },
+    "index.html": {
+      "purpose": "HTML entrypoint with HTML comment directive for native dialog",
+      "expectedDirectives": [
+        {
+          "file_path": "index.html",
+          "target_query": "id:dialog",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 9,
+          "raw_snippet": "<!-- TODO(baseline/dialog): replace third-party modal polyfill with native dialog -->"
+        }
+      ]
+    }
+  }
+}

--- a/lib/codescan/testdata/repos/standard-spa/expected.json
+++ b/lib/codescan/testdata/repos/standard-spa/expected.json
@@ -7,7 +7,7 @@
       "expectedDirectives": []
     },
     "src/app.ts": {
-      "purpose": "Main TypeScript application logic with inline TODO(baseline/popover) and TODO(baseline/view-transitions, newly) comments",
+      "purpose": "Main TypeScript application logic with inline TODO(baseline/popover) and TODO(baseline/view-transitions) comments",
       "expectedDirectives": [
         {
           "file_path": "src/app.ts",
@@ -19,9 +19,9 @@
         {
           "file_path": "src/app.ts",
           "target_query": "id:view-transitions",
-          "trigger": "feature.baseline.promote_to_newly",
+          "trigger": "feature.baseline.promote_to_widely",
           "line_number": 7,
-          "raw_snippet": "// TODO(baseline/view-transitions, newly): smooth page transitions"
+          "raw_snippet": "// TODO(baseline/view-transitions): smooth page transitions"
         }
       ]
     },

--- a/lib/codescan/testdata/repos/standard-spa/index.html
+++ b/lib/codescan/testdata/repos/standard-spa/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Standard SPA</title>
+  <link rel="stylesheet" href="src/styles.css">
+</head>
+<body>
+  <!-- TODO(baseline/dialog): replace third-party modal polyfill with native dialog -->
+  <div id="modal-root"></div>
+  <script src="src/app.ts"></script>
+</body>
+</html>

--- a/lib/codescan/testdata/repos/standard-spa/src/app.ts
+++ b/lib/codescan/testdata/repos/standard-spa/src/app.ts
@@ -1,0 +1,11 @@
+// Standard SPA application entry point
+
+export function setupApp() {
+  // TODO(baseline/popover): replace custom tooltip with native popover
+  const tooltip = document.querySelector('.tooltip');
+
+  // TODO(baseline/view-transitions, newly): smooth page transitions
+  if (document.startViewTransition) {
+    document.startViewTransition();
+  }
+}

--- a/lib/codescan/testdata/repos/standard-spa/src/app.ts
+++ b/lib/codescan/testdata/repos/standard-spa/src/app.ts
@@ -4,7 +4,7 @@ export function setupApp() {
   // TODO(baseline/popover): replace custom tooltip with native popover
   const tooltip = document.querySelector('.tooltip');
 
-  // TODO(baseline/view-transitions, newly): smooth page transitions
+  // TODO(baseline/view-transitions): smooth page transitions
   if (document.startViewTransition) {
     document.startViewTransition();
   }

--- a/lib/codescan/testdata/repos/standard-spa/src/styles.css
+++ b/lib/codescan/testdata/repos/standard-spa/src/styles.css
@@ -1,0 +1,16 @@
+/* Application layout styles */
+
+/*
+ * Layout enhancements:
+ * TODO(baseline/subgrid): upgrade nested grid layout to subgrid
+ * TODO(baseline/anchor-positioning): anchor tooltip to button
+ */
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.tooltip-box {
+  position: absolute;
+}
+


### PR DESCRIPTION
Refs #2712, #2718

### What
Implements the streaming multi-syntax AST comment directive parser in `lib/codescan/comment_parser.go` and project-level Browserslist configuration discovery in `lib/codescan/browserslist.go`.

### Why
Developers track web platform feature adoption by annotating code with canonical `// TODO(baseline/<id>): ...` comment directives. The scanner extracts these directives across diverse web programming languages and discovers project Baseline targets from `.browserslistrc` configuration.

### How
- **Streaming Comment Directive Parser (`lib/codescan/comment_parser.go`)**:
  - Streams source files directly via `bufio.NewScanner(r)` with an initial 64KB buffer and 1MB maximum buffer, avoiding buffering entire files into memory.
  - Linear-time state machine supporting line and block comments across JS/TS (`//`, `/* */`), CSS/SCSS (`/* */`), HTML/Vue/Svelte/Astro (`<!-- -->`), and config/Python/Ruby (`#`).
  - Canonical `TODO(baseline/<id>)` syntax with optional override targets (`newly`, `widely`).
  - Unifies `defaultTrigger` evaluation upfront and propagates `scanner.Err()` on I/O errors.
  - Emits structured `Directive` objects containing `FeatureID`, `Trigger`, `LineNumber`, and `CommentSnippet`.
- **Browserslist Configuration Parser (`lib/codescan/browserslist.go`)**:
  - Discovers and parses `.browserslistrc`, `.browserslist`, `browserslist`, and `package.json` (`"browserslist"` key).
  - Maps `baseline widely available` -> `widely` trigger, and `baseline newly available` -> `newly` trigger.
- **Testing (`lib/codescan/comment_parser_test.go`, `lib/codescan/browserslist_test.go`)**:
  - Table-driven unit tests across all file types, multi-line comment blocks, multiple directives per line, and stream scanner error propagation.

### Corrected Assumptions / Learnings
- **Direct Stream Parsing**: Streaming directly with `bufio.NewScanner` with an explicit buffer limit provides both high performance and memory safety against malicious or massive files.

TAG=agy