### PR TITLE
feat(spanner): implement scoped repository synchronizer and delivery lock manager

### DIFF
--- a/lib/gcpspanner/code_subscription.go
+++ b/lib/gcpspanner/code_subscription.go
@@ -53,6 +53,17 @@ type SubscriptionOccurrence struct {
 	CommentSnippet string `json:"comment_snippet"`
 }
 
+// CodeSubscriptionInput represents an AST scan result to be synchronized in Spanner.
+type CodeSubscriptionInput struct {
+	VCSProvider        VCSProvider
+	VCSInstallationID  string
+	VCSRepositoryID    string
+	RepositoryFullName string
+	TargetQuery        string
+	Triggers           []string
+	Occurrences        []SubscriptionOccurrence
+}
+
 // CodeSubscription represents a subscription anchored to a code repository AST pattern.
 type CodeSubscription struct {
 	ID                 string

--- a/lib/gcpspanner/code_subscriptions.go
+++ b/lib/gcpspanner/code_subscriptions.go
@@ -1,0 +1,494 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/uuid"
+)
+
+var (
+	// ErrDeliveryAlreadyDelivered indicates the delivery task is already completed.
+	ErrDeliveryAlreadyDelivered = errors.New("delivery already delivered")
+	// ErrDeliveryAlreadyLocked indicates the delivery task is currently leased by another worker.
+	ErrDeliveryAlreadyLocked = errors.New("delivery already locked by another worker")
+	// ErrWebhookAlreadyDelivered indicates the webhook delivery GUID was already processed.
+	ErrWebhookAlreadyDelivered = errors.New("webhook delivery already recorded")
+	// ErrDuplicateTargetQuery indicates multiple incoming subscriptions have the same TargetQuery.
+	ErrDuplicateTargetQuery = errors.New("duplicate target query in incoming subscriptions")
+)
+
+type codeSubscriptionAllByRepoKey struct {
+	VCSProvider VCSProvider
+	RepoID      string
+}
+
+type codeSubscriptionAllByRepoMapper struct{}
+
+func (m codeSubscriptionAllByRepoMapper) Table() string { return codeSubscriptionTable }
+
+func (m codeSubscriptionAllByRepoMapper) SelectAllByKeys(key codeSubscriptionAllByRepoKey) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSInstallationID, VCSRepositoryID, RepositoryFullName,
+			TargetQuery, Triggers, Status, Occurrences, CreatedAt, UpdatedAt
+		FROM CodeSubscriptions
+		WHERE VCSProvider = @vcsProvider AND VCSRepositoryID = @repoID`,
+		Params: map[string]any{
+			"vcsProvider": string(key.VCSProvider),
+			"repoID":      key.RepoID,
+		},
+	}
+}
+
+// ListCodeSubscriptionsRequest is a request to list code subscriptions for a repository with pagination.
+type ListCodeSubscriptionsRequest struct {
+	VCSProvider VCSProvider
+	RepoID      string
+	PageSize    int
+	PageToken   *string
+}
+
+func (r ListCodeSubscriptionsRequest) GetPageSize() int {
+	return r.PageSize
+}
+
+func (r ListCodeSubscriptionsRequest) GetPageToken() *string {
+	return r.PageToken
+}
+
+type codeSubscriptionCursor struct {
+	LastID        string    `json:"last_id"`
+	LastCreatedAt time.Time `json:"last_created_at"`
+}
+
+type listCodeSubscriptionsMapper struct{ codeSubscriptionMapper }
+
+func (m listCodeSubscriptionsMapper) EncodePageToken(item spannerCodeSubscription) string {
+	return encodeCursor(codeSubscriptionCursor{
+		LastID:        item.ID,
+		LastCreatedAt: item.CreatedAt,
+	})
+}
+
+func (m listCodeSubscriptionsMapper) SelectList(req ListCodeSubscriptionsRequest) spanner.Statement {
+	var pageFilter string
+	params := map[string]any{
+		"vcsProvider": string(req.VCSProvider),
+		"repoID":      req.RepoID,
+		"pageSize":    req.PageSize,
+	}
+	if req.PageToken != nil {
+		cursor, err := decodeCursor[codeSubscriptionCursor](*req.PageToken)
+		if err == nil {
+			params["lastID"] = cursor.LastID
+			params["lastCreatedAt"] = cursor.LastCreatedAt
+			pageFilter = " AND (CreatedAt < @lastCreatedAt OR (CreatedAt = @lastCreatedAt AND ID > @lastID))"
+		}
+	}
+	query := fmt.Sprintf(`SELECT
+		ID, VCSProvider, VCSInstallationID, VCSRepositoryID, RepositoryFullName,
+		TargetQuery, Triggers, Status, Occurrences, CreatedAt, UpdatedAt
+	FROM CodeSubscriptions
+	WHERE VCSProvider = @vcsProvider AND VCSRepositoryID = @repoID AND Status = 'ACTIVE' %s
+	ORDER BY CreatedAt DESC, ID ASC
+	LIMIT @pageSize`, pageFilter)
+
+	stmt := spanner.NewStatement(query)
+	stmt.Params = params
+
+	return stmt
+}
+
+type codeSubscriptionsByTargetQueryMapper struct{}
+
+func (m codeSubscriptionsByTargetQueryMapper) Table() string { return codeSubscriptionTable }
+
+func (m codeSubscriptionsByTargetQueryMapper) SelectAllByKeys(targetQuery string) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSInstallationID, VCSRepositoryID, RepositoryFullName,
+			TargetQuery, Triggers, Status, Occurrences, CreatedAt, UpdatedAt
+		FROM CodeSubscriptions
+		WHERE TargetQuery = @targetQuery AND Status = 'ACTIVE'`,
+		Params: map[string]any{
+			"targetQuery": targetQuery,
+		},
+	}
+}
+
+func readExistingRepositorySubscriptions(
+	ctx context.Context,
+	tx *spanner.ReadWriteTransaction,
+	vcsProvider VCSProvider,
+	repoID string,
+) (map[string]CodeSubscription, error) {
+	key := codeSubscriptionAllByRepoKey{
+		VCSProvider: vcsProvider,
+		RepoID:      repoID,
+	}
+	spannerSubs, err := newAllByKeysEntityReader[
+		codeSubscriptionAllByRepoMapper, codeSubscriptionAllByRepoKey, spannerCodeSubscription,
+	](nil).readAllByKeysWithTransaction(ctx, key, tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read existing code subscriptions: %w", err)
+	}
+
+	existingMap := make(map[string]CodeSubscription, len(spannerSubs))
+	for _, scs := range spannerSubs {
+		sub, err := scs.toCodeSubscription()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse code subscription: %w", err)
+		}
+		existingMap[sub.TargetQuery] = *sub
+	}
+
+	return existingMap, nil
+}
+
+func computeSyncMutations(
+	incoming []CodeSubscription,
+	existingMap map[string]CodeSubscription,
+	now time.Time,
+) ([]*spanner.Mutation, error) {
+	// Validate uniqueness of TargetQuery across incoming subscriptions.
+	seenTargets := make(map[string]struct{}, len(incoming))
+	for _, in := range incoming {
+		if _, exists := seenTargets[in.TargetQuery]; exists {
+			return nil, fmt.Errorf("%w: %q", ErrDuplicateTargetQuery, in.TargetQuery)
+		}
+		seenTargets[in.TargetQuery] = struct{}{}
+	}
+
+	var mutations []*spanner.Mutation
+	incomingMatched := make(map[string]bool, len(incoming))
+
+	for _, in := range incoming {
+		incomingMatched[in.TargetQuery] = true
+		if existing, found := existingMap[in.TargetQuery]; found {
+			// Existing subscription or re-added subscription:
+			// Preserve original ID and CreatedAt, update occurrences, and ensure Status = ACTIVE (revival).
+			in.ID = existing.ID
+			in.CreatedAt = existing.CreatedAt
+			in.Status = SubscriptionActive
+		} else {
+			// New subscription:
+			in.CreatedAt = now
+			in.Status = SubscriptionActive
+		}
+		in.UpdatedAt = now
+
+		scs := fromCodeSubscription(&in)
+		mut, mutErr := spanner.InsertOrUpdateStruct(codeSubscriptionTable, scs)
+		if mutErr != nil {
+			return nil, fmt.Errorf("failed to create code subscription mutation: %w", mutErr)
+		}
+		mutations = append(mutations, mut)
+	}
+
+	for targetQuery, existing := range existingMap {
+		// If an active subscription is missing from the incoming code scan, transition to OBSOLETE.
+		if !incomingMatched[targetQuery] && existing.Status == SubscriptionActive {
+			existing.Status = SubscriptionObsolete
+			existing.UpdatedAt = now
+			scs := fromCodeSubscription(&existing)
+			mut, mutErr := spanner.InsertOrUpdateStruct(codeSubscriptionTable, scs)
+			if mutErr != nil {
+				return nil, fmt.Errorf("failed to create obsolete mutation: %w", mutErr)
+			}
+			mutations = append(mutations, mut)
+		}
+	}
+
+	return mutations, nil
+}
+
+// SynchronizeRepositoryCodeSubscriptions transactionally updates the active code subscriptions
+// for a specific repository, inserting new subscriptions, updating modified occurrences, and
+// marking missing ones as obsolete.
+func (c *Client) SynchronizeRepositoryCodeSubscriptions(
+	ctx context.Context,
+	vcsProvider VCSProvider,
+	repoID string,
+	incoming []CodeSubscription,
+) error {
+	now := c.timeNow()
+
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
+		existingMap, err := readExistingRepositorySubscriptions(ctx, tx, vcsProvider, repoID)
+		if err != nil {
+			return err
+		}
+
+		mutations, err := computeSyncMutations(incoming, existingMap, now)
+		if err != nil {
+			return err
+		}
+
+		if len(mutations) > 0 {
+			if err := tx.BufferWrite(mutations); err != nil {
+				return fmt.Errorf("failed to buffer write mutations: %w", err)
+			}
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+// ListCodeSubscriptionsByRepository returns active code subscriptions for a repository with pagination.
+func (c *Client) ListCodeSubscriptionsByRepository(
+	ctx context.Context,
+	req ListCodeSubscriptionsRequest,
+) ([]CodeSubscription, *string, error) {
+	if req.PageToken != nil {
+		if _, err := decodeCursor[codeSubscriptionCursor](*req.PageToken); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	items, token, err := newEntityLister[listCodeSubscriptionsMapper](c).list(ctx, req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to query code subscriptions: %w", err)
+	}
+
+	results := make([]CodeSubscription, 0, len(items))
+	for _, scs := range items {
+		sub, err := scs.toCodeSubscription()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse code subscription: %w", err)
+		}
+		results = append(results, *sub)
+	}
+
+	return results, token, nil
+}
+
+// ListCodeSubscriptionsByTargetQuery returns all active subscriptions matching targetQuery and trigger.
+func (c *Client) ListCodeSubscriptionsByTargetQuery(
+	ctx context.Context,
+	targetQuery, trigger string,
+) ([]CodeSubscription, error) {
+	spannerSubs, err := newAllByKeysEntityReader[
+		codeSubscriptionsByTargetQueryMapper, string, spannerCodeSubscription,
+	](c).readAllByKeys(ctx, targetQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query code subscriptions by target: %w", err)
+	}
+
+	results := make([]CodeSubscription, 0, len(spannerSubs))
+	for _, scs := range spannerSubs {
+		sub, err := scs.toCodeSubscription()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse code subscription: %w", err)
+		}
+
+		if slices.Contains(sub.Triggers, trigger) {
+			results = append(results, *sub)
+		}
+	}
+
+	return results, nil
+}
+
+// RecordVCSWebhookDelivery checks and inserts a webhook delivery GUID for replay protection.
+// Returns true if new delivery recorded, false if already processed.
+func (c *Client) RecordVCSWebhookDelivery(
+	ctx context.Context,
+	delivery VCSWebhookDelivery,
+) (bool, error) {
+	mutator := newEntityMutator[vcsWebhookDeliveryMapper, spannerVCSWebhookDelivery, vcsWebhookDeliveryKey](c)
+
+	key := vcsWebhookDeliveryKey{
+		VCSProvider:  delivery.VCSProvider,
+		DeliveryGUID: delivery.DeliveryGUID,
+	}
+
+	err := mutator.readInspectMutate(
+		ctx,
+		key,
+		func(_ context.Context, existing *spannerVCSWebhookDelivery) (*spanner.Mutation, error) {
+			if existing != nil {
+				return nil, ErrWebhookAlreadyDelivered
+			}
+
+			spannerWebhook := fromVCSWebhookDelivery(&delivery)
+
+			mut, mutErr := spanner.InsertOrUpdateStruct(vcsWebhookDeliveryTable, spannerWebhook)
+			if mutErr != nil {
+				return nil, fmt.Errorf("failed to create webhook delivery mutation: %w", mutErr)
+			}
+
+			return mut, nil
+		},
+	)
+
+	if errors.Is(err, ErrWebhookAlreadyDelivered) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// InsertCodeSubscriptionScanLog stores an AST scan audit log entry using entityWriter.
+func (c *Client) InsertCodeSubscriptionScanLog(
+	ctx context.Context,
+	scanLog CodeSubscriptionScanLog,
+) error {
+	if scanLog.ID == "" {
+		scanLog.ID = uuid.NewString()
+	}
+	if scanLog.ScannedAt.IsZero() {
+		scanLog.ScannedAt = c.timeNow()
+	}
+
+	return newEntityWriter[
+		codeSubscriptionScanLogMapper,
+		CodeSubscriptionScanLog,
+		spannerCodeSubscriptionScanLog,
+		string,
+	](c).upsert(ctx, scanLog)
+}
+
+// AcquireDeliveryLock attempts to atomically lease a delivery task for a worker.
+// Note: DeliveryChannel is currently initialized to DeliveryChannelGitHubIssue as GitHub Issues
+// are the only supported code subscription delivery channel in this phase.
+func (c *Client) AcquireDeliveryLock(
+	ctx context.Context,
+	subscriptionID, deliveryID, workerID string,
+	ttl time.Duration,
+) (bool, error) {
+	mutator := newEntityMutator[codeSubscriptionDeliveryMapper, spannerCodeSubscriptionDelivery, string](c)
+
+	err := mutator.readInspectMutate(
+		ctx,
+		deliveryID,
+		func(_ context.Context, existing *spannerCodeSubscriptionDelivery) (*spanner.Mutation, error) {
+			now := c.timeNow()
+			lockExpires := now.Add(ttl)
+
+			if existing == nil {
+				// Delivery record does not exist yet; insert a new locked delivery
+				newDelivery := spannerCodeSubscriptionDelivery{
+					ID:               deliveryID,
+					SubscriptionID:   subscriptionID,
+					DeliveryStatus:   string(DeliveryStatusPending),
+					DeliveryChannel:  string(DeliveryChannelGitHubIssue),
+					DeliveredAt:      spanner.NullTime{Valid: false, Time: time.Time{}},
+					ExternalIssueID:  spanner.NullString{Valid: false, StringVal: ""},
+					ExternalIssueURL: spanner.NullString{Valid: false, StringVal: ""},
+					ErrorMessage:     spanner.NullString{Valid: false, StringVal: ""},
+					LockExpiresAt:    spanner.NullTime{Valid: true, Time: lockExpires},
+					WorkerLockID:     spanner.NullString{Valid: true, StringVal: workerID},
+					CreatedAt:        now,
+					UpdatedAt:        now,
+				}
+
+				return spanner.InsertOrUpdateStruct(codeSubscriptionDeliveryTable, newDelivery)
+			}
+
+			if existing.DeliveryStatus == string(DeliveryStatusDelivered) {
+				return nil, ErrDeliveryAlreadyDelivered
+			}
+
+			if existing.LockExpiresAt.Valid && existing.LockExpiresAt.Time.After(now) {
+				// Lock still active by another worker
+				return nil, ErrDeliveryAlreadyLocked
+			}
+
+			// Lock acquired / renewed
+			existing.DeliveryStatus = string(DeliveryStatusPending)
+			existing.LockExpiresAt = spanner.NullTime{Valid: true, Time: lockExpires}
+			existing.WorkerLockID = spanner.NullString{Valid: true, StringVal: workerID}
+			existing.UpdatedAt = now
+
+			return spanner.UpdateStruct(codeSubscriptionDeliveryTable, *existing)
+		},
+	)
+
+	if errors.Is(err, ErrDeliveryAlreadyDelivered) || errors.Is(err, ErrDeliveryAlreadyLocked) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// RecordDeliverySuccess records successful issue delivery.
+func (c *Client) RecordDeliverySuccess(
+	ctx context.Context,
+	deliveryID, issueID, issueURL string,
+) error {
+	mutator := newEntityMutator[codeSubscriptionDeliveryMapper, spannerCodeSubscriptionDelivery, string](c)
+
+	return mutator.readInspectMutate(
+		ctx,
+		deliveryID,
+		func(_ context.Context, existing *spannerCodeSubscriptionDelivery) (*spanner.Mutation, error) {
+			if existing == nil {
+				return nil, ErrCodeSubscriptionDeliveryNotFound
+			}
+
+			now := c.timeNow()
+			existing.DeliveryStatus = string(DeliveryStatusDelivered)
+			existing.DeliveredAt = spanner.NullTime{Valid: true, Time: now}
+			existing.ExternalIssueID = spanner.NullString{Valid: true, StringVal: issueID}
+			existing.ExternalIssueURL = spanner.NullString{Valid: true, StringVal: issueURL}
+			existing.LockExpiresAt = spanner.NullTime{Valid: false, Time: time.Time{}}
+			existing.WorkerLockID = spanner.NullString{Valid: false, StringVal: ""}
+			existing.UpdatedAt = now
+
+			return spanner.UpdateStruct(codeSubscriptionDeliveryTable, *existing)
+		},
+	)
+}
+
+// ReleaseDeliveryLock clears worker lock lease on transient errors.
+// This operation is idempotent and returns nil if the delivery record does not exist.
+func (c *Client) ReleaseDeliveryLock(ctx context.Context, deliveryID string) error {
+	mutator := newEntityMutator[codeSubscriptionDeliveryMapper, spannerCodeSubscriptionDelivery, string](c)
+
+	err := mutator.readInspectMutate(
+		ctx,
+		deliveryID,
+		func(_ context.Context, existing *spannerCodeSubscriptionDelivery) (*spanner.Mutation, error) {
+			if existing == nil {
+				return nil, ErrCodeSubscriptionDeliveryNotFound
+			}
+
+			existing.DeliveryStatus = string(DeliveryStatusPending)
+			existing.LockExpiresAt = spanner.NullTime{Valid: false, Time: time.Time{}}
+			existing.WorkerLockID = spanner.NullString{Valid: false, StringVal: ""}
+			existing.UpdatedAt = c.timeNow()
+
+			return spanner.UpdateStruct(codeSubscriptionDeliveryTable, *existing)
+		},
+	)
+	if errors.Is(err, ErrCodeSubscriptionDeliveryNotFound) {
+		return nil
+	}
+
+	return err
+}

--- a/lib/gcpspanner/code_subscriptions.go
+++ b/lib/gcpspanner/code_subscriptions.go
@@ -33,6 +33,8 @@ var (
 	ErrDeliveryAlreadyLocked = errors.New("delivery already locked by another worker")
 	// ErrDeliveryLockMismatch indicates worker does not own active lease.
 	ErrDeliveryLockMismatch = errors.New("delivery lock mismatch: worker does not own active lease")
+	// ErrDeliveryLockExpired indicates the delivery lock lease has expired.
+	ErrDeliveryLockExpired = errors.New("delivery lock expired")
 	// ErrWebhookAlreadyDelivered indicates the webhook delivery GUID was already processed.
 	ErrWebhookAlreadyDelivered = errors.New("webhook delivery already recorded")
 	// ErrDuplicateTargetQuery indicates multiple incoming subscriptions have the same TargetQuery.
@@ -615,12 +617,18 @@ func (c *Client) RecordDeliverySuccess(
 				return nil, ErrCodeSubscriptionDeliveryNotFound
 			}
 
+			now := c.timeNow()
+
+			// Lock fencing check: verify lock has not expired
+			if !existing.LockExpiresAt.Valid || !existing.LockExpiresAt.Time.After(now) {
+				return nil, ErrDeliveryLockExpired
+			}
+
 			// Lock fencing check: verify worker ownership
 			if existing.WorkerLockID.Valid && existing.WorkerLockID.StringVal != workerID {
 				return nil, ErrDeliveryLockMismatch
 			}
 
-			now := c.timeNow()
 			existing.DeliveryStatus = string(DeliveryStatusDelivered)
 			existing.DeliveredAt = spanner.NullTime{Valid: true, Time: now}
 			existing.ExternalIssueID = spanner.NullString{Valid: true, StringVal: issueID}
@@ -635,8 +643,10 @@ func (c *Client) RecordDeliverySuccess(
 }
 
 // ReleaseDeliveryLock clears worker lock lease on transient errors.
-// Fencing check: only clears the lock if the specified workerID owns the active lock lease.
+// Fencing check: only clears the lock if the specified workerID owns the active lock lease
+// and the lease has not expired.
 // If the caller does not own the lock, ErrDeliveryLockMismatch is returned.
+// If the lock lease has expired, ErrDeliveryLockExpired is returned.
 func (c *Client) ReleaseDeliveryLock(ctx context.Context, deliveryID, workerID string) error {
 	mutator := newEntityMutator[codeSubscriptionDeliveryMapper, spannerCodeSubscriptionDelivery, string](c)
 
@@ -648,6 +658,13 @@ func (c *Client) ReleaseDeliveryLock(ctx context.Context, deliveryID, workerID s
 				return nil, ErrCodeSubscriptionDeliveryNotFound
 			}
 
+			now := c.timeNow()
+
+			// Lock fencing: verify lock has not expired
+			if !existing.LockExpiresAt.Valid || !existing.LockExpiresAt.Time.After(now) {
+				return nil, ErrDeliveryLockExpired
+			}
+
 			// Lock fencing: verify worker ownership
 			if !existing.WorkerLockID.Valid || existing.WorkerLockID.StringVal != workerID {
 				return nil, ErrDeliveryLockMismatch
@@ -656,7 +673,7 @@ func (c *Client) ReleaseDeliveryLock(ctx context.Context, deliveryID, workerID s
 			existing.DeliveryStatus = string(DeliveryStatusPending)
 			existing.LockExpiresAt = spanner.NullTime{Valid: false, Time: time.Time{}}
 			existing.WorkerLockID = spanner.NullString{Valid: false, StringVal: ""}
-			existing.UpdatedAt = c.timeNow()
+			existing.UpdatedAt = now
 
 			return spanner.UpdateStruct(codeSubscriptionDeliveryTable, *existing)
 		},

--- a/lib/gcpspanner/code_subscriptions.go
+++ b/lib/gcpspanner/code_subscriptions.go
@@ -23,6 +23,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"github.com/google/uuid"
+	"google.golang.org/api/iterator"
 )
 
 var (
@@ -30,6 +31,8 @@ var (
 	ErrDeliveryAlreadyDelivered = errors.New("delivery already delivered")
 	// ErrDeliveryAlreadyLocked indicates the delivery task is currently leased by another worker.
 	ErrDeliveryAlreadyLocked = errors.New("delivery already locked by another worker")
+	// ErrDeliveryLockMismatch indicates worker does not own active lease.
+	ErrDeliveryLockMismatch = errors.New("delivery lock mismatch: worker does not own active lease")
 	// ErrWebhookAlreadyDelivered indicates the webhook delivery GUID was already processed.
 	ErrWebhookAlreadyDelivered = errors.New("webhook delivery already recorded")
 	// ErrDuplicateTargetQuery indicates multiple incoming subscriptions have the same TargetQuery.
@@ -163,7 +166,7 @@ func readExistingRepositorySubscriptions(
 }
 
 func computeSyncMutations(
-	incoming []CodeSubscription,
+	incoming []CodeSubscriptionInput,
 	existingMap map[string]CodeSubscription,
 	now time.Time,
 ) ([]*spanner.Mutation, error) {
@@ -181,20 +184,41 @@ func computeSyncMutations(
 
 	for _, in := range incoming {
 		incomingMatched[in.TargetQuery] = true
+		var sub CodeSubscription
 		if existing, found := existingMap[in.TargetQuery]; found {
 			// Existing subscription or re-added subscription:
-			// Preserve original ID and CreatedAt, update occurrences, and ensure Status = ACTIVE (revival).
-			in.ID = existing.ID
-			in.CreatedAt = existing.CreatedAt
-			in.Status = SubscriptionActive
+			// Preserve original ID and CreatedAt, update occurrences/triggers, and ensure Status = ACTIVE (revival).
+			sub = CodeSubscription{
+				ID:                 existing.ID,
+				VCSProvider:        in.VCSProvider,
+				VCSInstallationID:  in.VCSInstallationID,
+				VCSRepositoryID:    in.VCSRepositoryID,
+				RepositoryFullName: in.RepositoryFullName,
+				TargetQuery:        in.TargetQuery,
+				Triggers:           in.Triggers,
+				Status:             SubscriptionActive,
+				Occurrences:        in.Occurrences,
+				CreatedAt:          existing.CreatedAt,
+				UpdatedAt:          now,
+			}
 		} else {
-			// New subscription:
-			in.CreatedAt = now
-			in.Status = SubscriptionActive
+			// New subscription: assign fresh UUID only upon database insertion
+			sub = CodeSubscription{
+				ID:                 uuid.NewString(),
+				VCSProvider:        in.VCSProvider,
+				VCSInstallationID:  in.VCSInstallationID,
+				VCSRepositoryID:    in.VCSRepositoryID,
+				RepositoryFullName: in.RepositoryFullName,
+				TargetQuery:        in.TargetQuery,
+				Triggers:           in.Triggers,
+				Status:             SubscriptionActive,
+				Occurrences:        in.Occurrences,
+				CreatedAt:          now,
+				UpdatedAt:          now,
+			}
 		}
-		in.UpdatedAt = now
 
-		scs := fromCodeSubscription(&in)
+		scs := fromCodeSubscription(&sub)
 		mut, mutErr := spanner.InsertOrUpdateStruct(codeSubscriptionTable, scs)
 		if mutErr != nil {
 			return nil, fmt.Errorf("failed to create code subscription mutation: %w", mutErr)
@@ -226,7 +250,7 @@ func (c *Client) SynchronizeRepositoryCodeSubscriptions(
 	ctx context.Context,
 	vcsProvider VCSProvider,
 	repoID string,
-	incoming []CodeSubscription,
+	incoming []CodeSubscriptionInput,
 ) error {
 	now := c.timeNow()
 
@@ -251,6 +275,145 @@ func (c *Client) SynchronizeRepositoryCodeSubscriptions(
 	})
 
 	return err
+}
+
+// VCSRepository represents a distinct version-controlled repository configured in webstatus.dev.
+type VCSRepository struct {
+	ID                 string
+	VCSProvider        VCSProvider
+	VCSInstallationID  string
+	VCSRepositoryID    string
+	RepositoryFullName string
+}
+
+// ListVCSRepositoriesByProvider returns distinct repositories tracked in CodeSubscriptions for a given VCS provider.
+func (c *Client) ListVCSRepositoriesByProvider(
+	ctx context.Context,
+	provider VCSProvider,
+) ([]VCSRepository, error) {
+	stmt := spanner.Statement{
+		SQL: `SELECT DISTINCT VCSProvider, VCSInstallationID, VCSRepositoryID, RepositoryFullName
+		FROM CodeSubscriptions
+		WHERE VCSProvider = @vcsProvider
+		ORDER BY RepositoryFullName ASC`,
+		Params: map[string]any{
+			"vcsProvider": string(provider),
+		},
+	}
+	txn := c.Single()
+	defer txn.Close()
+	iter := txn.Query(ctx, stmt)
+	defer iter.Stop()
+
+	var repos []VCSRepository
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to query repositories: %w", err)
+		}
+		var s struct {
+			VCSProvider        string `spanner:"VCSProvider"`
+			VCSInstallationID  string `spanner:"VCSInstallationID"`
+			VCSRepositoryID    string `spanner:"VCSRepositoryID"`
+			RepositoryFullName string `spanner:"RepositoryFullName"`
+		}
+		if err := row.ToStruct(&s); err != nil {
+			return nil, fmt.Errorf("failed to parse repository row: %w", err)
+		}
+		p, err := ParseVCSProvider(s.VCSProvider)
+		if err != nil {
+			return nil, err
+		}
+		repos = append(repos, VCSRepository{
+			ID:                 s.VCSRepositoryID,
+			VCSProvider:        p,
+			VCSInstallationID:  s.VCSInstallationID,
+			VCSRepositoryID:    s.VCSRepositoryID,
+			RepositoryFullName: s.RepositoryFullName,
+		})
+	}
+
+	return repos, nil
+}
+
+// ListVCSInstallations returns all VCS installations stored in Spanner.
+func (c *Client) ListVCSInstallations(ctx context.Context) ([]VCSInstallation, error) {
+	stmt := spanner.NewStatement(`SELECT ID, VCSProvider, VCSInstallationID, AccountLogin, AccountType,
+			RepositorySelection, Permissions, CreatedAt, UpdatedAt
+		FROM VCSInstallations`)
+	txn := c.Single()
+	defer txn.Close()
+	iter := txn.Query(ctx, stmt)
+	defer iter.Stop()
+
+	var installations []VCSInstallation
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to query installations: %w", err)
+		}
+		var s spannerVCSInstallation
+		if err := row.ToStruct(&s); err != nil {
+			return nil, fmt.Errorf("failed to parse installation row: %w", err)
+		}
+		inst, err := s.toVCSInstallation()
+		if err != nil {
+			return nil, err
+		}
+		installations = append(installations, *inst)
+	}
+
+	return installations, nil
+}
+
+// ListVCSInstallationsByAccount returns active installations for a specific provider and account login.
+func (c *Client) ListVCSInstallationsByAccount(
+	ctx context.Context,
+	provider VCSProvider,
+	accountLogin string,
+) ([]VCSInstallation, error) {
+	stmt := spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSInstallationID, AccountLogin, AccountType,
+			RepositorySelection, Permissions, CreatedAt, UpdatedAt
+		FROM VCSInstallations
+		WHERE VCSProvider = @vcsProvider AND AccountLogin = @accountLogin`,
+		Params: map[string]any{
+			"vcsProvider":  string(provider),
+			"accountLogin": accountLogin,
+		},
+	}
+	txn := c.Single()
+	defer txn.Close()
+	iter := txn.Query(ctx, stmt)
+	defer iter.Stop()
+
+	var installations []VCSInstallation
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to query installations: %w", err)
+		}
+		var s spannerVCSInstallation
+		if err := row.ToStruct(&s); err != nil {
+			return nil, fmt.Errorf("failed to parse installation row: %w", err)
+		}
+		inst, err := s.toVCSInstallation()
+		if err != nil {
+			return nil, err
+		}
+		installations = append(installations, *inst)
+	}
+
+	return installations, nil
 }
 
 // ListCodeSubscriptionsByRepository returns active code subscriptions for a repository with pagination.
@@ -437,9 +600,10 @@ func (c *Client) AcquireDeliveryLock(
 }
 
 // RecordDeliverySuccess records successful issue delivery.
+// Fencing check: verifies that the workerID owns the active lock lease before recording success.
 func (c *Client) RecordDeliverySuccess(
 	ctx context.Context,
-	deliveryID, issueID, issueURL string,
+	deliveryID, workerID, issueID, issueURL string,
 ) error {
 	mutator := newEntityMutator[codeSubscriptionDeliveryMapper, spannerCodeSubscriptionDelivery, string](c)
 
@@ -449,6 +613,11 @@ func (c *Client) RecordDeliverySuccess(
 		func(_ context.Context, existing *spannerCodeSubscriptionDelivery) (*spanner.Mutation, error) {
 			if existing == nil {
 				return nil, ErrCodeSubscriptionDeliveryNotFound
+			}
+
+			// Lock fencing check: verify worker ownership
+			if existing.WorkerLockID.Valid && existing.WorkerLockID.StringVal != workerID {
+				return nil, ErrDeliveryLockMismatch
 			}
 
 			now := c.timeNow()
@@ -466,8 +635,9 @@ func (c *Client) RecordDeliverySuccess(
 }
 
 // ReleaseDeliveryLock clears worker lock lease on transient errors.
-// This operation is idempotent and returns nil if the delivery record does not exist.
-func (c *Client) ReleaseDeliveryLock(ctx context.Context, deliveryID string) error {
+// Fencing check: only clears the lock if the specified workerID owns the active lock lease.
+// If the caller does not own the lock, ErrDeliveryLockMismatch is returned.
+func (c *Client) ReleaseDeliveryLock(ctx context.Context, deliveryID, workerID string) error {
 	mutator := newEntityMutator[codeSubscriptionDeliveryMapper, spannerCodeSubscriptionDelivery, string](c)
 
 	err := mutator.readInspectMutate(
@@ -476,6 +646,11 @@ func (c *Client) ReleaseDeliveryLock(ctx context.Context, deliveryID string) err
 		func(_ context.Context, existing *spannerCodeSubscriptionDelivery) (*spanner.Mutation, error) {
 			if existing == nil {
 				return nil, ErrCodeSubscriptionDeliveryNotFound
+			}
+
+			// Lock fencing: verify worker ownership
+			if !existing.WorkerLockID.Valid || existing.WorkerLockID.StringVal != workerID {
+				return nil, ErrDeliveryLockMismatch
 			}
 
 			existing.DeliveryStatus = string(DeliveryStatusPending)

--- a/lib/gcpspanner/code_subscriptions.go
+++ b/lib/gcpspanner/code_subscriptions.go
@@ -589,7 +589,7 @@ func (c *Client) AcquireDeliveryLock(
 		},
 	)
 
-	if errors.Is(err, ErrDeliveryAlreadyDelivered) || errors.Is(err, ErrDeliveryAlreadyLocked) {
+	if errors.Is(err, ErrDeliveryAlreadyDelivered) {
 		return false, nil
 	}
 	if err != nil {

--- a/lib/gcpspanner/code_subscriptions_test.go
+++ b/lib/gcpspanner/code_subscriptions_test.go
@@ -264,7 +264,7 @@ func testDeliveryLocking(ctx context.Context, t *testing.T, list []CodeSubscript
 		t.Fatalf("failed to reacquire lock after release: %v", err)
 	}
 
-	// Automatic TTL expiry: acquire short lease, sleep past TTL, then acquire with another worker
+	// Automatic TTL expiry: acquire short lease, sleep past TTL, then test expired release and reacquisition
 	delID3 := uuid.NewString()
 	shortLock, err := spannerClient.AcquireDeliveryLock(ctx, list[0].ID, delID3, "worker-short", 50*time.Millisecond)
 	if err != nil || !shortLock {
@@ -272,6 +272,12 @@ func testDeliveryLocking(ctx context.Context, t *testing.T, list []CodeSubscript
 	}
 
 	time.Sleep(100 * time.Millisecond)
+
+	// Trying to release an already-expired lock should fail with ErrDeliveryLockExpired
+	errExpiredRelease := spannerClient.ReleaseDeliveryLock(ctx, delID3, "worker-short")
+	if !errors.Is(errExpiredRelease, ErrDeliveryLockExpired) {
+		t.Fatalf("expected ErrDeliveryLockExpired for expired worker-short, got %v", errExpiredRelease)
+	}
 
 	expiredLock, err := spannerClient.AcquireDeliveryLock(ctx, list[0].ID, delID3, "worker-after-expiry", 30*time.Second)
 	if err != nil || !expiredLock {

--- a/lib/gcpspanner/code_subscriptions_test.go
+++ b/lib/gcpspanner/code_subscriptions_test.go
@@ -60,40 +60,32 @@ func TestCodeSubscriptions(t *testing.T) {
 	}
 
 	// 2. Test SynchronizeRepositoryCodeSubscriptions (Initial Ingestion)
-	sub1 := CodeSubscription{
-		ID:                 uuid.NewString(),
+	sub1 := CodeSubscriptionInput{
 		VCSProvider:        VCSProviderGitHub,
 		VCSInstallationID:  installationID,
 		VCSRepositoryID:    repoID,
 		RepositoryFullName: repoFullName,
 		TargetQuery:        "id:view-transitions",
 		Triggers:           []string{"feature_baseline_to_widely"},
-		Status:             SubscriptionActive,
 		Occurrences: []SubscriptionOccurrence{
 			{FilePath: "src/app.ts", LineNumber: 10, CommentSnippet: "// TODO(baseline/view-transitions): transition"},
 		},
-		CreatedAt: now,
-		UpdatedAt: now,
 	}
 
-	sub2 := CodeSubscription{
-		ID:                 uuid.NewString(),
+	sub2 := CodeSubscriptionInput{
 		VCSProvider:        VCSProviderGitHub,
 		VCSInstallationID:  installationID,
 		VCSRepositoryID:    repoID,
 		RepositoryFullName: repoFullName,
 		TargetQuery:        "id:subgrid",
 		Triggers:           []string{"feature_baseline_to_widely"},
-		Status:             SubscriptionActive,
 		Occurrences: []SubscriptionOccurrence{
 			{FilePath: "src/grid.css", LineNumber: 5, CommentSnippet: "// TODO(baseline/subgrid): grid"},
 		},
-		CreatedAt: now,
-		UpdatedAt: now,
 	}
 
 	if err := spannerClient.SynchronizeRepositoryCodeSubscriptions(
-		ctx, VCSProviderGitHub, repoID, []CodeSubscription{sub1, sub2}); err != nil {
+		ctx, VCSProviderGitHub, repoID, []CodeSubscriptionInput{sub1, sub2}); err != nil {
 		t.Fatalf("SynchronizeRepositoryCodeSubscriptions failed: %v", err)
 	}
 
@@ -177,21 +169,23 @@ func TestCodeSubscriptions(t *testing.T) {
 
 	// 9. Test Webhook Replay Protection and Scan Log insertion
 	testWebhookDeduplicationAndScanLog(ctx, t, repoID, now)
+
+	// 10. Test ListVCSRepositoriesByProvider and ListVCSInstallationsByAccount
+	testListVCSRepositoriesAndInstallations(ctx, t, repoID)
 }
 
 func testDuplicateTargetQuery(
 	ctx context.Context,
 	t *testing.T,
 	repoID string,
-	sub1 CodeSubscription,
+	sub1 CodeSubscriptionInput,
 ) {
 	t.Helper()
 
 	dupSub := sub1
-	dupSub.ID = uuid.NewString()
 
 	err := spannerClient.SynchronizeRepositoryCodeSubscriptions(
-		ctx, VCSProviderGitHub, repoID, []CodeSubscription{sub1, dupSub})
+		ctx, VCSProviderGitHub, repoID, []CodeSubscriptionInput{sub1, dupSub})
 	if !errors.Is(err, ErrDuplicateTargetQuery) {
 		t.Fatalf("expected ErrDuplicateTargetQuery, got: %v", err)
 	}
@@ -217,8 +211,15 @@ func testDeliveryLocking(ctx context.Context, t *testing.T, list []CodeSubscript
 		t.Errorf("expected second lock acquisition to fail")
 	}
 
+	// Test lock fencing: worker-wrong cannot record delivery success
+	wrongWorkerErr := spannerClient.RecordDeliverySuccess(
+		ctx, delID1, "worker-wrong", "issue-123", "https://github.com/owner/repo/issues/123")
+	if !errors.Is(wrongWorkerErr, ErrDeliveryLockMismatch) {
+		t.Fatalf("expected ErrDeliveryLockMismatch from worker-wrong, got %v", wrongWorkerErr)
+	}
+
 	err = spannerClient.RecordDeliverySuccess(
-		ctx, delID1, "issue-123", "https://github.com/owner/repo/issues/123")
+		ctx, delID1, "worker-1", "issue-123", "https://github.com/owner/repo/issues/123")
 	if err != nil {
 		t.Fatalf("RecordDeliverySuccess failed: %v", err)
 	}
@@ -238,7 +239,19 @@ func testDeliveryLocking(ctx context.Context, t *testing.T, list []CodeSubscript
 		t.Fatalf("failed to acquire initial lock for delivery 2: %v", err)
 	}
 
-	if err := spannerClient.ReleaseDeliveryLock(ctx, delID2); err != nil {
+	// Test lock fencing on release: worker-other cannot clear worker-temp's lock
+	errReleaseOther := spannerClient.ReleaseDeliveryLock(ctx, delID2, "worker-other")
+	if !errors.Is(errReleaseOther, ErrDeliveryLockMismatch) {
+		t.Fatalf("expected ErrDeliveryLockMismatch from worker-other, got %v", errReleaseOther)
+	}
+	// Lock should still be held by worker-temp, so worker-next cannot acquire yet
+	blockedAcquire, err := spannerClient.AcquireDeliveryLock(ctx, list[1].ID, delID2, "worker-next", 30*time.Second)
+	if err != nil || blockedAcquire {
+		t.Fatalf("expected lock to still be held by worker-temp, got acquired=%v, err=%v", blockedAcquire, err)
+	}
+
+	// Now legitimate owner releases lock
+	if err := spannerClient.ReleaseDeliveryLock(ctx, delID2, "worker-temp"); err != nil {
 		t.Fatalf("ReleaseDeliveryLock failed: %v", err)
 	}
 
@@ -266,7 +279,7 @@ func testDeclarativeObsolescenceAndRevival(
 	ctx context.Context,
 	t *testing.T,
 	repoID string,
-	sub1, sub2 CodeSubscription,
+	sub1, sub2 CodeSubscriptionInput,
 	initialList []CodeSubscription,
 ) {
 	t.Helper()
@@ -281,7 +294,7 @@ func testDeclarativeObsolescenceAndRevival(
 	}
 
 	if err := spannerClient.SynchronizeRepositoryCodeSubscriptions(
-		ctx, VCSProviderGitHub, repoID, []CodeSubscription{sub2}); err != nil {
+		ctx, VCSProviderGitHub, repoID, []CodeSubscriptionInput{sub2}); err != nil {
 		t.Fatalf("SynchronizeRepositoryCodeSubscriptions (obsolete sub1) failed: %v", err)
 	}
 	activeList, _, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, ListCodeSubscriptionsRequest{
@@ -298,7 +311,7 @@ func testDeclarativeObsolescenceAndRevival(
 	}
 
 	if err := spannerClient.SynchronizeRepositoryCodeSubscriptions(
-		ctx, VCSProviderGitHub, repoID, []CodeSubscription{sub1, sub2}); err != nil {
+		ctx, VCSProviderGitHub, repoID, []CodeSubscriptionInput{sub1, sub2}); err != nil {
 		t.Fatalf("SynchronizeRepositoryCodeSubscriptions (revival) failed: %v", err)
 	}
 	revivedList, _, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, ListCodeSubscriptionsRequest{
@@ -314,9 +327,12 @@ func testDeclarativeObsolescenceAndRevival(
 		t.Fatalf("expected 2 active subscriptions after revival, got %d", len(revivedList))
 	}
 
-	// Assert original CreatedAt was preserved upon revival
+	// Assert original ID and CreatedAt were preserved upon revival
 	for _, revived := range revivedList {
 		if revived.TargetQuery == sub1.TargetQuery {
+			if revived.ID != originalSub1.ID {
+				t.Errorf("expected durable ID preserved on revival: want %s, got %s", originalSub1.ID, revived.ID)
+			}
 			if !revived.CreatedAt.Equal(originalSub1.CreatedAt) {
 				t.Errorf("expected CreatedAt preserved on revival: want %v, got %v", originalSub1.CreatedAt, revived.CreatedAt)
 			}
@@ -369,5 +385,67 @@ func testWebhookDeduplicationAndScanLog(
 	}
 	if err := spannerClient.InsertCodeSubscriptionScanLog(ctx, scanLog); err != nil {
 		t.Fatalf("InsertCodeSubscriptionScanLog failed: %v", err)
+	}
+}
+
+func testListVCSRepositoriesAndInstallations(
+	ctx context.Context,
+	t *testing.T,
+	repoID string,
+) {
+	t.Helper()
+
+	repos, err := spannerClient.ListVCSRepositoriesByProvider(ctx, VCSProviderGitHub)
+	if err != nil {
+		t.Fatalf("ListVCSRepositoriesByProvider failed: %v", err)
+	}
+	if len(repos) == 0 {
+		t.Errorf("expected at least 1 repository, got 0")
+	}
+	found := false
+	for _, r := range repos {
+		if r.VCSRepositoryID == repoID {
+			found = true
+			if r.RepositoryFullName != "GoogleChrome/webstatus.dev" {
+				t.Errorf("unexpected repo full name: %s", r.RepositoryFullName)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected repoID %s in ListVCSRepositoriesByProvider results", repoID)
+	}
+
+	inst := VCSInstallation{
+		ID:                  uuid.NewString(),
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   "inst-acct-test-1",
+		AccountLogin:        "TestAccountLogin",
+		AccountType:         "Organization",
+		RepositorySelection: "all",
+		Permissions:         VCSPermissions{GitHub: nil},
+		CreatedAt:           time.Now().UTC(),
+		UpdatedAt:           time.Now().UTC(),
+	}
+	if _, err := spannerClient.UpsertVCSInstallation(ctx, inst); err != nil {
+		t.Fatalf("UpsertVCSInstallation failed: %v", err)
+	}
+
+	allInstallations, err := spannerClient.ListVCSInstallations(ctx)
+	if err != nil {
+		t.Fatalf("ListVCSInstallations failed: %v", err)
+	}
+	if len(allInstallations) < 1 {
+		t.Fatalf("expected at least 1 installation, got %d", len(allInstallations))
+	}
+
+	installations, err := spannerClient.ListVCSInstallationsByAccount(ctx, VCSProviderGitHub, "TestAccountLogin")
+	if err != nil {
+		t.Fatalf("ListVCSInstallationsByAccount failed: %v", err)
+	}
+	if len(installations) != 1 {
+		t.Fatalf("expected 1 installation for account, got %d", len(installations))
+	}
+	if installations[0].AccountLogin != "TestAccountLogin" {
+		t.Errorf("unexpected account login: %s", installations[0].AccountLogin)
 	}
 }

--- a/lib/gcpspanner/code_subscriptions_test.go
+++ b/lib/gcpspanner/code_subscriptions_test.go
@@ -204,8 +204,8 @@ func testDeliveryLocking(ctx context.Context, t *testing.T, list []CodeSubscript
 	}
 
 	secondLock, err := spannerClient.AcquireDeliveryLock(ctx, list[0].ID, delID1, "worker-2", 30*time.Second)
-	if err != nil {
-		t.Fatalf("AcquireDeliveryLock 2 failed: %v", err)
+	if !errors.Is(err, ErrDeliveryAlreadyLocked) {
+		t.Fatalf("expected ErrDeliveryAlreadyLocked from AcquireDeliveryLock 2, got %v", err)
 	}
 	if secondLock {
 		t.Errorf("expected second lock acquisition to fail")
@@ -224,7 +224,7 @@ func testDeliveryLocking(ctx context.Context, t *testing.T, list []CodeSubscript
 		t.Fatalf("RecordDeliverySuccess failed: %v", err)
 	}
 
-	// Verify delivery is marked delivered and cannot be re-locked
+	// Verify delivery is marked delivered and cannot be re-locked (returns false, nil)
 	lockedAgain, err := spannerClient.AcquireDeliveryLock(ctx, list[0].ID, delID1, "worker-3", 30*time.Second)
 	if err != nil {
 		t.Fatalf("AcquireDeliveryLock after delivery failed: %v", err)
@@ -246,8 +246,12 @@ func testDeliveryLocking(ctx context.Context, t *testing.T, list []CodeSubscript
 	}
 	// Lock should still be held by worker-temp, so worker-next cannot acquire yet
 	blockedAcquire, err := spannerClient.AcquireDeliveryLock(ctx, list[1].ID, delID2, "worker-next", 30*time.Second)
-	if err != nil || blockedAcquire {
-		t.Fatalf("expected lock to still be held by worker-temp, got acquired=%v, err=%v", blockedAcquire, err)
+	if !errors.Is(err, ErrDeliveryAlreadyLocked) || blockedAcquire {
+		t.Fatalf(
+			"expected lock to still be held by worker-temp (ErrDeliveryAlreadyLocked), got acquired=%v, err=%v",
+			blockedAcquire,
+			err,
+		)
 	}
 
 	// Now legitimate owner releases lock

--- a/lib/gcpspanner/code_subscriptions_test.go
+++ b/lib/gcpspanner/code_subscriptions_test.go
@@ -1,0 +1,373 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestCodeSubscriptions(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	installationID := "inst-" + uuid.NewString()
+	repoID := "repo-" + uuid.NewString()
+	repoFullName := "GoogleChrome/webstatus.dev"
+
+	// 1. Create installation record
+	writeLevel := GitHubPermissionLevelWrite
+	readLevel := GitHubPermissionLevelRead
+	inst := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   installationID,
+		AccountLogin:        "GoogleChrome",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       &writeLevel,
+				Contents:     &readLevel,
+				Metadata:     nil,
+				PullRequests: nil,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+	if _, err := spannerClient.UpsertVCSInstallation(ctx, inst); err != nil {
+		t.Fatalf("UpsertVCSInstallation failed: %v", err)
+	}
+
+	// 2. Test SynchronizeRepositoryCodeSubscriptions (Initial Ingestion)
+	sub1 := CodeSubscription{
+		ID:                 uuid.NewString(),
+		VCSProvider:        VCSProviderGitHub,
+		VCSInstallationID:  installationID,
+		VCSRepositoryID:    repoID,
+		RepositoryFullName: repoFullName,
+		TargetQuery:        "id:view-transitions",
+		Triggers:           []string{"feature_baseline_to_widely"},
+		Status:             SubscriptionActive,
+		Occurrences: []SubscriptionOccurrence{
+			{FilePath: "src/app.ts", LineNumber: 10, CommentSnippet: "// TODO(baseline/view-transitions): transition"},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	sub2 := CodeSubscription{
+		ID:                 uuid.NewString(),
+		VCSProvider:        VCSProviderGitHub,
+		VCSInstallationID:  installationID,
+		VCSRepositoryID:    repoID,
+		RepositoryFullName: repoFullName,
+		TargetQuery:        "id:subgrid",
+		Triggers:           []string{"feature_baseline_to_widely"},
+		Status:             SubscriptionActive,
+		Occurrences: []SubscriptionOccurrence{
+			{FilePath: "src/grid.css", LineNumber: 5, CommentSnippet: "// TODO(baseline/subgrid): grid"},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := spannerClient.SynchronizeRepositoryCodeSubscriptions(
+		ctx, VCSProviderGitHub, repoID, []CodeSubscription{sub1, sub2}); err != nil {
+		t.Fatalf("SynchronizeRepositoryCodeSubscriptions failed: %v", err)
+	}
+
+	// 3. Test ListCodeSubscriptionsByRepository with pagination
+	listReq := ListCodeSubscriptionsRequest{
+		VCSProvider: VCSProviderGitHub,
+		RepoID:      repoID,
+		PageSize:    10,
+		PageToken:   nil,
+	}
+	list, nextPageToken, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, listReq)
+	if err != nil {
+		t.Fatalf("ListCodeSubscriptionsByRepository failed: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 active subscriptions, got %d", len(list))
+	}
+	if nextPageToken != nil {
+		t.Fatalf("expected nil nextPageToken for 2 items with pageSize 10, got %s", *nextPageToken)
+	}
+
+	// 3b. Test pagination page by page (pageSize = 1)
+	pagedReq1 := ListCodeSubscriptionsRequest{
+		VCSProvider: VCSProviderGitHub,
+		RepoID:      repoID,
+		PageSize:    1,
+		PageToken:   nil,
+	}
+	pagedList1, token1, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, pagedReq1)
+	if err != nil {
+		t.Fatalf("ListCodeSubscriptionsByRepository page 1 failed: %v", err)
+	}
+	if len(pagedList1) != 1 || token1 == nil {
+		t.Fatalf("expected 1 item and valid next token on page 1, got len=%d token=%v", len(pagedList1), token1)
+	}
+
+	pagedReq2 := ListCodeSubscriptionsRequest{
+		VCSProvider: VCSProviderGitHub,
+		RepoID:      repoID,
+		PageSize:    1,
+		PageToken:   token1,
+	}
+	pagedList2, _, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, pagedReq2)
+	if err != nil {
+		t.Fatalf("ListCodeSubscriptionsByRepository page 2 failed: %v", err)
+	}
+	if len(pagedList2) != 1 {
+		t.Fatalf("expected 1 item on page 2, got %d", len(pagedList2))
+	}
+	if pagedList1[0].ID == pagedList2[0].ID {
+		t.Fatalf("expected different items on pages 1 and 2, got same ID: %s", pagedList1[0].ID)
+	}
+
+	// 4. Test ListCodeSubscriptionsByTargetQuery
+	targetList, err := spannerClient.ListCodeSubscriptionsByTargetQuery(
+		ctx, "id:view-transitions", "feature_baseline_to_widely")
+	if err != nil {
+		t.Fatalf("ListCodeSubscriptionsByTargetQuery failed: %v", err)
+	}
+	if len(targetList) != 1 {
+		t.Fatalf("expected 1 subscription for targetQuery, got %d", len(targetList))
+	}
+
+	// 5. Test GetCodeSubscription
+	retrieved, err := spannerClient.GetCodeSubscription(ctx, list[0].ID)
+	if err != nil {
+		t.Fatalf("GetCodeSubscription failed: %v", err)
+	}
+	if retrieved.ID != list[0].ID {
+		t.Errorf("retrieved.ID = %s, want %s", retrieved.ID, list[0].ID)
+	}
+
+	// 6. Test AcquireDeliveryLock, RecordDeliverySuccess, ReleaseDeliveryLock
+	testDeliveryLocking(ctx, t, list)
+
+	// 7. Test duplicate TargetQuery validation
+	testDuplicateTargetQuery(ctx, t, repoID, sub1)
+
+	// 8. Test declarative obsolescence (omitting sub1 transitions it to OBSOLETE) and revival
+	testDeclarativeObsolescenceAndRevival(ctx, t, repoID, sub1, sub2, list)
+
+	// 9. Test Webhook Replay Protection and Scan Log insertion
+	testWebhookDeduplicationAndScanLog(ctx, t, repoID, now)
+}
+
+func testDuplicateTargetQuery(
+	ctx context.Context,
+	t *testing.T,
+	repoID string,
+	sub1 CodeSubscription,
+) {
+	t.Helper()
+
+	dupSub := sub1
+	dupSub.ID = uuid.NewString()
+
+	err := spannerClient.SynchronizeRepositoryCodeSubscriptions(
+		ctx, VCSProviderGitHub, repoID, []CodeSubscription{sub1, dupSub})
+	if !errors.Is(err, ErrDuplicateTargetQuery) {
+		t.Fatalf("expected ErrDuplicateTargetQuery, got: %v", err)
+	}
+}
+
+func testDeliveryLocking(ctx context.Context, t *testing.T, list []CodeSubscription) {
+	t.Helper()
+
+	delID1 := uuid.NewString()
+	lockAcquired, err := spannerClient.AcquireDeliveryLock(ctx, list[0].ID, delID1, "worker-1", 30*time.Second)
+	if err != nil {
+		t.Fatalf("AcquireDeliveryLock failed: %v", err)
+	}
+	if !lockAcquired {
+		t.Errorf("expected lock acquisition to succeed")
+	}
+
+	secondLock, err := spannerClient.AcquireDeliveryLock(ctx, list[0].ID, delID1, "worker-2", 30*time.Second)
+	if err != nil {
+		t.Fatalf("AcquireDeliveryLock 2 failed: %v", err)
+	}
+	if secondLock {
+		t.Errorf("expected second lock acquisition to fail")
+	}
+
+	err = spannerClient.RecordDeliverySuccess(
+		ctx, delID1, "issue-123", "https://github.com/owner/repo/issues/123")
+	if err != nil {
+		t.Fatalf("RecordDeliverySuccess failed: %v", err)
+	}
+
+	// Verify delivery is marked delivered and cannot be re-locked
+	lockedAgain, err := spannerClient.AcquireDeliveryLock(ctx, list[0].ID, delID1, "worker-3", 30*time.Second)
+	if err != nil {
+		t.Fatalf("AcquireDeliveryLock after delivery failed: %v", err)
+	}
+	if lockedAgain {
+		t.Errorf("expected lock acquisition on delivered task to return false")
+	}
+
+	delID2 := uuid.NewString()
+	acquired2, err := spannerClient.AcquireDeliveryLock(ctx, list[1].ID, delID2, "worker-temp", 30*time.Second)
+	if err != nil || !acquired2 {
+		t.Fatalf("failed to acquire initial lock for delivery 2: %v", err)
+	}
+
+	if err := spannerClient.ReleaseDeliveryLock(ctx, delID2); err != nil {
+		t.Fatalf("ReleaseDeliveryLock failed: %v", err)
+	}
+
+	reacquired, err := spannerClient.AcquireDeliveryLock(ctx, list[1].ID, delID2, "worker-next", 30*time.Second)
+	if err != nil || !reacquired {
+		t.Fatalf("failed to reacquire lock after release: %v", err)
+	}
+
+	// Automatic TTL expiry: acquire short lease, sleep past TTL, then acquire with another worker
+	delID3 := uuid.NewString()
+	shortLock, err := spannerClient.AcquireDeliveryLock(ctx, list[0].ID, delID3, "worker-short", 50*time.Millisecond)
+	if err != nil || !shortLock {
+		t.Fatalf("failed to acquire short TTL lock: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	expiredLock, err := spannerClient.AcquireDeliveryLock(ctx, list[0].ID, delID3, "worker-after-expiry", 30*time.Second)
+	if err != nil || !expiredLock {
+		t.Fatalf("expected lock reacquisition after TTL expiry, got: %v", err)
+	}
+}
+
+func testDeclarativeObsolescenceAndRevival(
+	ctx context.Context,
+	t *testing.T,
+	repoID string,
+	sub1, sub2 CodeSubscription,
+	initialList []CodeSubscription,
+) {
+	t.Helper()
+
+	var originalSub1 CodeSubscription
+	for _, s := range initialList {
+		if s.TargetQuery == sub1.TargetQuery {
+			originalSub1 = s
+
+			break
+		}
+	}
+
+	if err := spannerClient.SynchronizeRepositoryCodeSubscriptions(
+		ctx, VCSProviderGitHub, repoID, []CodeSubscription{sub2}); err != nil {
+		t.Fatalf("SynchronizeRepositoryCodeSubscriptions (obsolete sub1) failed: %v", err)
+	}
+	activeList, _, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, ListCodeSubscriptionsRequest{
+		VCSProvider: VCSProviderGitHub,
+		RepoID:      repoID,
+		PageSize:    10,
+		PageToken:   nil,
+	})
+	if err != nil {
+		t.Fatalf("ListCodeSubscriptionsByRepository after obsolescence failed: %v", err)
+	}
+	if len(activeList) != 1 || activeList[0].TargetQuery != sub2.TargetQuery {
+		t.Fatalf("expected 1 active subscription (sub2), got %+v", activeList)
+	}
+
+	if err := spannerClient.SynchronizeRepositoryCodeSubscriptions(
+		ctx, VCSProviderGitHub, repoID, []CodeSubscription{sub1, sub2}); err != nil {
+		t.Fatalf("SynchronizeRepositoryCodeSubscriptions (revival) failed: %v", err)
+	}
+	revivedList, _, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, ListCodeSubscriptionsRequest{
+		VCSProvider: VCSProviderGitHub,
+		RepoID:      repoID,
+		PageSize:    10,
+		PageToken:   nil,
+	})
+	if err != nil {
+		t.Fatalf("ListCodeSubscriptionsByRepository after revival failed: %v", err)
+	}
+	if len(revivedList) != 2 {
+		t.Fatalf("expected 2 active subscriptions after revival, got %d", len(revivedList))
+	}
+
+	// Assert original CreatedAt was preserved upon revival
+	for _, revived := range revivedList {
+		if revived.TargetQuery == sub1.TargetQuery {
+			if !revived.CreatedAt.Equal(originalSub1.CreatedAt) {
+				t.Errorf("expected CreatedAt preserved on revival: want %v, got %v", originalSub1.CreatedAt, revived.CreatedAt)
+			}
+		}
+	}
+}
+
+func testWebhookDeduplicationAndScanLog(
+	ctx context.Context,
+	t *testing.T,
+	repoID string,
+	now time.Time,
+) {
+	t.Helper()
+
+	delivery := VCSWebhookDelivery{
+		VCSProvider:     VCSProviderGitHub,
+		DeliveryGUID:    "guid-unique-12345",
+		EventType:       "push",
+		VCSRepositoryID: repoID,
+		ReceivedAt:      now,
+	}
+	inserted1, err := spannerClient.RecordVCSWebhookDelivery(ctx, delivery)
+	if err != nil {
+		t.Fatalf("RecordVCSWebhookDelivery failed: %v", err)
+	}
+	if !inserted1 {
+		t.Errorf("expected inserted1=true for first delivery")
+	}
+
+	inserted2, err := spannerClient.RecordVCSWebhookDelivery(ctx, delivery)
+	if err != nil {
+		t.Fatalf("RecordVCSWebhookDelivery second attempt failed: %v", err)
+	}
+	if inserted2 {
+		t.Errorf("expected inserted2=false for replay delivery")
+	}
+
+	scanLog := CodeSubscriptionScanLog{
+		ID:              uuid.NewString(),
+		VCSProvider:     VCSProviderGitHub,
+		VCSRepositoryID: repoID,
+		CommitSHA:       "abcdef123456",
+		Branch:          "main",
+		ScanStatus:      ScanStatusSuccess,
+		FilesScanned:    12,
+		DirectivesFound: 2,
+		ErrorMessage:    nil,
+		ScannedAt:       now,
+	}
+	if err := spannerClient.InsertCodeSubscriptionScanLog(ctx, scanLog); err != nil {
+		t.Fatalf("InsertCodeSubscriptionScanLog failed: %v", err)
+	}
+}


### PR DESCRIPTION
Refs #2712, #2720

### What
Implements repository-scoped code subscription reconciliation, distributed worker delivery lease management, and webhook replay deduplication in Cloud Spanner (`lib/gcpspanner/code_subscriptions.go`).

### Why
Repository scans must transactionally sync code subscriptions (activating new ones, updating occurrences, marking removed ones obsolete) without race conditions. Delivery workers require distributed leasing to prevent duplicate issue creation.

### How
- **Scoped Repository Synchronization**:
  - `SynchronizeRepositoryCodeSubscriptions`: Executes within a Spanner read-write transaction. Diffs existing active subscriptions against new scan results, updates active records, inserts new subscriptions, and marks removed directives `OBSOLETE`.
- **Distributed Concurrency Leasing**:
  - `AcquireDeliveryLock`: Transactionally leases pending deliveries with a 30-second lease timeout (`LockExpiresAt`) and worker lock ID.
  - `ReleaseDeliveryLock`: Replaces lock upon transient errors or rate-limit backoffs.
  - `RecordDeliverySuccess`: Updates status to `DELIVERED` and stores issue delivery URL.
- **Webhook Replay Deduplication**:
  - `RecordVCSWebhookDelivery`: Idempotently tracks delivery IDs to prevent duplicate webhook processing.
- **Testing (`lib/gcpspanner/code_subscriptions_test.go`, `lib/gcpspanner/vcs_scanner_test.go`)**:
  - Integration tests executed against the Cloud Spanner emulator verifying transactional sync, lock expiry, and deduplication.

### Corrected Assumptions / Learnings
- **Declarative Reconciliation**: Subscriptions in Spanner are fully reconciled from Git state; deleted directives become `OBSOLETE` without manual user intervention.

TAG=agy