### PR TITLE
feat(api): implement HandleVCSWebhook ingress HTTP handler

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -23,3 +23,5 @@ workflows/steps/services/bcd_consumer/pkg/data/testdata/data.json
 workflows/steps/services/web_feature_consumer/pkg/data/testdata/v3.data.json
 workflows/steps/services/developer_signals_consumer/pkg/data/testdata/web-features-signals.json
 workflows/steps/services/web_features_mapping_consumer/pkg/data/testdata/combined-data.json
+lib/codescan/testdata/**
+

--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,8 @@ ADDLICENSE_ARGS := -c "${COPYRIGHT_NAME}" \
 	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload.golden.json' \
 	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload_query_error.golden.json' \
 	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload_resolved_query_error.golden.json' \
-	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload_combined_errors_and_features.golden.json'
+	-ignore 'workers/webhook/pkg/webhook/testdata/slack_payload_combined_errors_and_features.golden.json' \
+	-ignore 'lib/codescan/testdata/**'
 
 license-check: go-install-tools
 	go tool addlicense -check $(ADDLICENSE_ARGS) .

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -217,6 +217,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	var serverOpts []httpserver.ServerOption
+	if secretStr := os.Getenv("GITHUB_WEBHOOK_SECRET"); secretStr != "" {
+		serverOpts = append(serverOpts, httpserver.WithWebhookSecret([]byte(secretStr)))
+	} else if os.Getenv("SPANNER_EMULATOR_HOST") != "" {
+		serverOpts = append(serverOpts, httpserver.WithWebhookSecret([]byte("dev-webhook-secret-for-testing-only-12345")))
+	}
+
 	srv := httpserver.NewHTTPServer(
 		"8080",
 		baseURL,
@@ -232,6 +239,7 @@ func main() {
 		},
 		preRequestMiddlewares,
 		authMiddleware,
+		serverOpts...,
 	)
 
 	err = srv.ListenAndServe()

--- a/backend/pkg/httpserver/code_subscriptions_handlers_test.go
+++ b/backend/pkg/httpserver/code_subscriptions_handlers_test.go
@@ -1,0 +1,263 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/httpmiddlewares"
+)
+
+type customMockCodeSubscriptionStorer struct {
+	*MockWPTMetricsStorer
+	listSubsOutput []backend.CodeSubscriptionResponse
+	listSubsErr    error
+	deleteErr      error
+}
+
+func newMockCodeSubscriptionStorer(
+	t *testing.T,
+	listOutput []backend.CodeSubscriptionResponse,
+	listErr error,
+	deleteErr error,
+) *customMockCodeSubscriptionStorer {
+	t.Helper()
+
+	return &customMockCodeSubscriptionStorer{
+		MockWPTMetricsStorer: newDefaultMockWPTMetricsStorer(t),
+		listSubsOutput:       listOutput,
+		listSubsErr:          listErr,
+		deleteErr:            deleteErr,
+	}
+}
+
+func (m *customMockCodeSubscriptionStorer) ListCodeSubscriptions(
+	_ context.Context,
+	_, _ string,
+) ([]backend.CodeSubscriptionResponse, error) {
+	return m.listSubsOutput, m.listSubsErr
+}
+
+func (m *customMockCodeSubscriptionStorer) DeleteCodeSubscription(
+	_ context.Context,
+	_ string,
+) error {
+	return m.deleteErr
+}
+
+func TestListCodeSubscriptions(t *testing.T) {
+	testUser := &auth.User{ID: "user-123", GitHubUserID: new("12345")}
+	now := time.Now().UTC()
+
+	sampleSub := backend.CodeSubscriptionResponse{
+		Id:                 "sub-1",
+		VcsProvider:        "github",
+		VcsInstallationId:  new("inst-1"),
+		VcsRepositoryId:    "repo-1",
+		RepositoryOwner:    "GoogleChrome",
+		RepositoryName:     "webstatus.dev",
+		RepositoryFullName: "GoogleChrome/webstatus.dev",
+		FeatureId:          new("view-transitions"),
+		TargetQuery:        "id:view-transitions",
+		Triggers:           []backend.SubscriptionTriggerWritable{backend.SubscriptionTriggerFeatureBaselineToWidely},
+		RawDirective:       new("// @webstatus: id:view-transitions"),
+		Occurrences: []backend.SubscriptionOccurrence{
+			{FilePath: "src/app.ts", LineNumber: 10, CommentSnippet: "// @webstatus: id:view-transitions"},
+		},
+		OccurrenceCount: 1,
+		Status:          backend.ACTIVE,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	testCases := []struct {
+		name         string
+		userInCtx    *auth.User
+		storerOutput []backend.CodeSubscriptionResponse
+		storerErr    error
+		expectedCode int
+	}{
+		{
+			name:         "Success",
+			userInCtx:    testUser,
+			storerOutput: []backend.CodeSubscriptionResponse{sampleSub},
+			storerErr:    nil,
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "Missing User in Context",
+			userInCtx:    nil,
+			storerOutput: nil,
+			storerErr:    nil,
+			expectedCode: http.StatusInternalServerError,
+		},
+		{
+			name:         "Database Error",
+			userInCtx:    testUser,
+			storerOutput: nil,
+			storerErr:    errors.New("spanner failure"),
+			expectedCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			storer := newMockCodeSubscriptionStorer(t, tc.storerOutput, tc.storerErr, nil)
+			server := setupTestServer(t, withCustomStorer(storer))
+
+			ctx := context.Background()
+			if tc.userInCtx != nil {
+				ctx = httpmiddlewares.AuthenticatedUserToContext(ctx, tc.userInCtx)
+			}
+
+			req := backend.ListCodeSubscriptionsRequestObject{
+				Provider:     "github",
+				RepositoryId: "repo-1",
+			}
+			resp, err := server.ListCodeSubscriptions(ctx, req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			rec := httptest.NewRecorder()
+			if err := resp.VisitListCodeSubscriptionsResponse(rec); err != nil {
+				t.Fatalf("failed to visit response: %v", err)
+			}
+
+			if rec.Code != tc.expectedCode {
+				t.Errorf("expected status code %d, got %d", tc.expectedCode, rec.Code)
+			}
+		})
+	}
+}
+
+func TestDeleteCodeSubscription_TableDriven(t *testing.T) {
+	testUser := &auth.User{ID: "user-123", GitHubUserID: new("12345")}
+
+	testCases := []struct {
+		name         string
+		userInCtx    *auth.User
+		deleteErr    error
+		expectedCode int
+	}{
+		{
+			name:         "Success",
+			userInCtx:    testUser,
+			deleteErr:    nil,
+			expectedCode: http.StatusNoContent,
+		},
+		{
+			name:         "Missing User in Context",
+			userInCtx:    nil,
+			deleteErr:    nil,
+			expectedCode: http.StatusInternalServerError,
+		},
+		{
+			name:         "Database Error",
+			userInCtx:    testUser,
+			deleteErr:    errors.New("spanner failure"),
+			expectedCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			storer := newMockCodeSubscriptionStorer(t, nil, nil, tc.deleteErr)
+			server := setupTestServer(t, withCustomStorer(storer))
+
+			ctx := context.Background()
+			if tc.userInCtx != nil {
+				ctx = httpmiddlewares.AuthenticatedUserToContext(ctx, tc.userInCtx)
+			}
+
+			req := backend.DeleteCodeSubscriptionRequestObject{
+				Id: "sub-1",
+			}
+			resp, err := server.DeleteCodeSubscription(ctx, req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			rec := httptest.NewRecorder()
+			if err := resp.VisitDeleteCodeSubscriptionResponse(rec); err != nil {
+				t.Fatalf("failed to visit response: %v", err)
+			}
+
+			if rec.Code != tc.expectedCode {
+				t.Errorf("expected status code %d, got %d", tc.expectedCode, rec.Code)
+			}
+		})
+	}
+}
+
+func TestVCSInstallationsAndRepositories_Handlers(t *testing.T) {
+	testUser := &auth.User{ID: "user-123", GitHubUserID: new("12345")}
+	server := setupTestServer(t)
+
+	ctx := httpmiddlewares.AuthenticatedUserToContext(context.Background(), testUser)
+
+	instResp, err := server.ListVCSInstallations(ctx, backend.ListVCSInstallationsRequestObject{Provider: "github"})
+	if err != nil {
+		t.Fatalf("ListVCSInstallations error: %v", err)
+	}
+	instRec := httptest.NewRecorder()
+	if err := instResp.VisitListVCSInstallationsResponse(instRec); err != nil {
+		t.Fatalf("failed to visit installations response: %v", err)
+	}
+	if instRec.Code != http.StatusOK {
+		t.Errorf("expected 200 response, got %d", instRec.Code)
+	}
+
+	repoResp, err := server.ListVCSRepositories(ctx, backend.ListVCSRepositoriesRequestObject{Provider: "github"})
+	if err != nil {
+		t.Fatalf("ListVCSRepositories error: %v", err)
+	}
+	repoRec := httptest.NewRecorder()
+	if err := repoResp.VisitListVCSRepositoriesResponse(repoRec); err != nil {
+		t.Fatalf("failed to visit repositories response: %v", err)
+	}
+	if repoRec.Code != http.StatusOK {
+		t.Errorf("expected 200 response, got %d", repoRec.Code)
+	}
+
+	webhookBody := backend.HandleVCSWebhookJSONRequestBody{}
+	webhookReq := backend.HandleVCSWebhookRequestObject{
+		Provider: "github",
+		Params: backend.HandleVCSWebhookParams{
+			XHubSignature256: nil,
+			XGitHubDelivery:  nil,
+			XGitHubEvent:     nil,
+		},
+		Body: &webhookBody,
+	}
+	webhookResp, err := server.HandleVCSWebhook(context.Background(), webhookReq)
+	if err != nil {
+		t.Fatalf("HandleVCSWebhook error: %v", err)
+	}
+	webhookRec := httptest.NewRecorder()
+	if err := webhookResp.VisitHandleVCSWebhookResponse(webhookRec); err != nil {
+		t.Fatalf("failed to visit webhook response: %v", err)
+	}
+	if webhookRec.Code != http.StatusAccepted {
+		t.Errorf("expected 202 response, got %d", webhookRec.Code)
+	}
+}

--- a/backend/pkg/httpserver/create_notification_channel.go
+++ b/backend/pkg/httpserver/create_notification_channel.go
@@ -64,7 +64,8 @@ func validateNotificationChannel(input *backend.CreateNotificationChannelRequest
 }
 
 // CreateNotificationChannel implements backend.StrictServerInterface.
-// nolint: ireturn // Name generated from openapi
+//
+//nolint:ireturn // Name generated from openapi
 func (s *Server) CreateNotificationChannel(
 	ctx context.Context,
 	request backend.CreateNotificationChannelRequestObject) (

--- a/backend/pkg/httpserver/create_saved_search.go
+++ b/backend/pkg/httpserver/create_saved_search.go
@@ -156,7 +156,8 @@ func sanitizeValidationError(err error) error {
 }
 
 // CreateSavedSearch implements backend.StrictServerInterface.
-// nolint: ireturn // Name generated from openapi
+//
+//nolint:ireturn // Name generated from openapi
 func (s *Server) CreateSavedSearch(ctx context.Context, request backend.CreateSavedSearchRequestObject) (
 	backend.CreateSavedSearchResponseObject, error) {
 	// At this point, the user should be authenticated and in the context.
@@ -184,7 +185,7 @@ func (s *Server) CreateSavedSearch(ctx context.Context, request backend.CreateSa
 	err := s.wptMetricsStorer.ValidateQueryReferences(ctx, request.Body.Query, nil)
 	if err != nil {
 		if safeErr := sanitizeValidationError(err); safeErr != nil {
-			// nolint:nilerr // WONTFIX - false positive when returning structured 400 response instead of Go error.
+			//nolint:nilerr // WONTFIX - false positive when returning structured 400 response instead of Go error.
 			return backend.CreateSavedSearch400JSONResponse{
 				Code:    http.StatusBadRequest,
 				Message: safeErr.Error(),

--- a/backend/pkg/httpserver/create_subscription.go
+++ b/backend/pkg/httpserver/create_subscription.go
@@ -153,7 +153,7 @@ func validateSubscriptionCreation(input *backend.Subscription) *fieldValidationE
 	return nil
 }
 
-// nolint:ireturn, revive // Expected ireturn for openapi generation.
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
 func (s *Server) CreateSubscription(
 	ctx context.Context,
 	request backend.CreateSubscriptionRequestObject,

--- a/backend/pkg/httpserver/delete_code_subscription.go
+++ b/backend/pkg/httpserver/delete_code_subscription.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
+func (s *Server) DeleteCodeSubscription(
+	ctx context.Context,
+	request backend.DeleteCodeSubscriptionRequestObject,
+) (backend.DeleteCodeSubscriptionResponseObject, error) {
+	userCheck := CheckAuthenticatedUser[backend.DeleteCodeSubscriptionResponseObject](
+		ctx, "DeleteCodeSubscription",
+		func(code int, message string) backend.DeleteCodeSubscriptionResponseObject {
+			return backend.DeleteCodeSubscription500JSONResponse(
+				backend.BasicErrorModel{Code: code, Message: message})
+		})
+	if userCheck.User == nil {
+		return userCheck.Response, nil
+	}
+
+	err := s.wptMetricsStorer.DeleteCodeSubscription(ctx, request.Id)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to delete code subscription", "error", err, "id", request.Id)
+
+		return backend.DeleteCodeSubscription500JSONResponse(
+			backend.BasicErrorModel{
+				Code:    http.StatusInternalServerError,
+				Message: "failed to delete code subscription",
+			}), nil
+	}
+
+	return backend.DeleteCodeSubscription204Response{}, nil
+}

--- a/backend/pkg/httpserver/delete_notification_channel.go
+++ b/backend/pkg/httpserver/delete_notification_channel.go
@@ -24,7 +24,8 @@ import (
 )
 
 // DeleteNotificationChannel handles the DELETE request to /v1/users/me/notification-channels/{channel_id}.
-// nolint:ireturn, revive // Expected ireturn for openapi generation.
+//
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
 func (s *Server) DeleteNotificationChannel(
 	ctx context.Context,
 	req backend.DeleteNotificationChannelRequestObject,

--- a/backend/pkg/httpserver/delete_subscription.go
+++ b/backend/pkg/httpserver/delete_subscription.go
@@ -24,7 +24,7 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-// nolint:ireturn, revive // Expected ireturn for openapi generation.
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
 func (s *Server) DeleteSubscription(
 	ctx context.Context,
 	request backend.DeleteSubscriptionRequestObject,

--- a/backend/pkg/httpserver/get_feature.go
+++ b/backend/pkg/httpserver/get_feature.go
@@ -70,7 +70,8 @@ func (v *GetFeatureResultVisitor) VisitSplitFeature(_ context.Context, result ba
 }
 
 // GetFeature implements backend.StrictServerInterface.
-// nolint: revive, ireturn // Name generated from openapi
+//
+//nolint:revive, ireturn // Name generated from openapi
 func (s *Server) GetFeature(
 	ctx context.Context,
 	request backend.GetFeatureRequestObject,

--- a/backend/pkg/httpserver/get_feature_metadata.go
+++ b/backend/pkg/httpserver/get_feature_metadata.go
@@ -26,7 +26,8 @@ import (
 )
 
 // GetFeatureMetadata implements backend.StrictServerInterface.
-// nolint: revive, ireturn // Name generated from openapi
+//
+//nolint:revive, ireturn // Name generated from openapi
 func (s *Server) GetFeatureMetadata(ctx context.Context,
 	request backend.GetFeatureMetadataRequestObject) (backend.GetFeatureMetadataResponseObject, error) {
 	var cachedResponse backend.GetFeatureMetadata200JSONResponse

--- a/backend/pkg/httpserver/get_feature_metadata_test.go
+++ b/backend/pkg/httpserver/get_feature_metadata_test.go
@@ -112,7 +112,7 @@ func TestGetFeatureMetadata(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// nolint: exhaustruct
+			//nolint:exhaustruct
 			mockStorer := &MockWPTMetricsStorer{
 				getIDFromFeatureKeyConfig: tc.mockGetIDConfig,
 				t:                         t,

--- a/backend/pkg/httpserver/get_feature_test.go
+++ b/backend/pkg/httpserver/get_feature_test.go
@@ -48,7 +48,7 @@ func TestGetFeature(t *testing.T) {
 		request            *http.Request
 		expectedResponse   *http.Response
 	}{
-		// nolint:dupl // WONTFIX - being explicit for short list of tests.
+		//nolint:dupl // WONTFIX - being explicit for short list of tests.
 		{
 			name: "Success Case - no optional params - use defaults",
 			mockConfig: &MockGetFeatureByIDConfig{
@@ -129,7 +129,7 @@ func TestGetFeature(t *testing.T) {
 				"system_managed_saved_search_id":"saved-search-1"
 			 }`),
 		},
-		// nolint:dupl // WONTFIX - being explicit for short list of tests.
+		//nolint:dupl // WONTFIX - being explicit for short list of tests.
 		{
 			name:              "Success Case - no optional params - use defaults - cached",
 			mockConfig:        nil,
@@ -172,7 +172,7 @@ func TestGetFeature(t *testing.T) {
 						"system_managed_saved_search_id":"saved-search-1"
 					 }`),
 		},
-		// nolint:dupl // WONTFIX - being explicit for short list of tests.
+		//nolint:dupl // WONTFIX - being explicit for short list of tests.
 		{
 			name: "Success Case - with optional params",
 			mockConfig: &MockGetFeatureByIDConfig{
@@ -269,7 +269,7 @@ func TestGetFeature(t *testing.T) {
 				}`,
 			),
 		},
-		// nolint:dupl // WONTFIX - being explicit for short list of tests.
+		//nolint:dupl // WONTFIX - being explicit for short list of tests.
 		{
 			name:              "Success Case - with optional params - cached",
 			mockConfig:        nil,
@@ -388,7 +388,7 @@ func TestGetFeature(t *testing.T) {
 				nil,
 			),
 			expectedResponse: func() *http.Response {
-				// nolint:exhaustruct
+				//nolint:exhaustruct
 				return &http.Response{
 					StatusCode: http.StatusMovedPermanently,
 					Header: map[string][]string{
@@ -446,7 +446,7 @@ func TestGetFeature(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// nolint: exhaustruct
+			//nolint:exhaustruct
 			mockStorer := &MockWPTMetricsStorer{
 				getFeatureByIDConfig: tc.mockConfig,
 				t:                    t,

--- a/backend/pkg/httpserver/get_features_test.go
+++ b/backend/pkg/httpserver/get_features_test.go
@@ -584,7 +584,7 @@ func TestListFeatures(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// nolint: exhaustruct
+			//nolint:exhaustruct
 			mockStorer := &MockWPTMetricsStorer{
 				featuresSearchCfg: tc.mockConfig,
 				t:                 t,

--- a/backend/pkg/httpserver/get_notification_channel.go
+++ b/backend/pkg/httpserver/get_notification_channel.go
@@ -24,7 +24,8 @@ import (
 )
 
 // GetNotificationChannel handles the GET request to /v1/users/me/notification-channels/{channel_id}.
-// nolint:ireturn, revive // Expected ireturn for openapi generation.
+//
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
 func (s *Server) GetNotificationChannel(
 	ctx context.Context,
 	req backend.GetNotificationChannelRequestObject,

--- a/backend/pkg/httpserver/get_saved_search.go
+++ b/backend/pkg/httpserver/get_saved_search.go
@@ -26,7 +26,8 @@ import (
 )
 
 // GetSavedSearch implements backend.StrictServerInterface.
-// nolint:ireturn, revive // Expected ireturn for openapi generation.
+//
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
 func (s *Server) GetSavedSearch(
 	ctx context.Context, req backend.GetSavedSearchRequestObject) (
 	backend.GetSavedSearchResponseObject, error) {

--- a/backend/pkg/httpserver/get_subscription.go
+++ b/backend/pkg/httpserver/get_subscription.go
@@ -24,7 +24,7 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-// nolint:ireturn, revive // Expected ireturn for openapi generation.
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
 func (s *Server) GetSubscription(
 	ctx context.Context,
 	request backend.GetSubscriptionRequestObject,

--- a/backend/pkg/httpserver/get_subscription_rss.go
+++ b/backend/pkg/httpserver/get_subscription_rss.go
@@ -74,7 +74,8 @@ type Item struct {
 }
 
 // GetSubscriptionRSS handles the request to get an RSS feed for a subscription.
-// nolint: ireturn // Signature generated from OpenAPI.
+//
+//nolint:ireturn // Signature generated from OpenAPI.
 func (s *Server) GetSubscriptionRSS(
 	ctx context.Context,
 	request backend.GetSubscriptionRSSRequestObject,

--- a/backend/pkg/httpserver/handle_vcs_webhook.go
+++ b/backend/pkg/httpserver/handle_vcs_webhook.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+	"github.com/GoogleChrome/webstatus.dev/lib/gh"
+)
+
+type pushPayload struct {
+	Ref          string `json:"ref"`
+	Before       string `json:"before"`
+	After        string `json:"after"`
+	Repository   repo   `json:"repository"`
+	Installation inst   `json:"installation"`
+}
+
+type repo struct {
+	ID            int64  `json:"id"`
+	Name          string `json:"name"`
+	FullName      string `json:"full_name"`
+	DefaultBranch string `json:"default_branch"`
+	Owner         owner  `json:"owner"`
+}
+
+type owner struct {
+	Login string `json:"login"`
+	Name  string `json:"name"`
+}
+
+type inst struct {
+	ID int64 `json:"id"`
+}
+
+func (s *Server) isInvalidSignature(ctx context.Context, rawBody []byte, sigHeader *string) bool {
+	if s.webhookSecret == nil {
+		return false
+	}
+	if sigHeader == nil {
+		slog.WarnContext(ctx, "missing signature header on webhook request")
+
+		return true
+	}
+	if !gh.VerifyWebhookSignature(rawBody, *sigHeader, s.webhookSecret) {
+		slog.WarnContext(ctx, "invalid webhook signature", "header", *sigHeader)
+
+		return true
+	}
+
+	return false
+}
+
+func (s *Server) dispatchPushScanTask(
+	ctx context.Context,
+	provider string,
+	rawBody []byte,
+) {
+	var payload pushPayload
+	if err := json.Unmarshal(rawBody, &payload); err != nil {
+		slog.WarnContext(ctx, "failed to unmarshal push payload", "error", err)
+
+		return
+	}
+
+	isDefault := payload.Ref == fmt.Sprintf("refs/heads/%s", payload.Repository.DefaultBranch)
+
+	task := backendtypes.CodeScanTaskMessage{
+		VCSProvider:        provider,
+		VCSInstallationID:  strconv.FormatInt(payload.Installation.ID, 10),
+		VCSRepositoryID:    strconv.FormatInt(payload.Repository.ID, 10),
+		RepositoryFullName: payload.Repository.FullName,
+		CommitSHA:          payload.After,
+		Branch:             payload.Ref,
+		IsDefaultBranch:    isDefault,
+		ModifiedFiles:      nil,
+	}
+
+	if pubErr := s.eventPublisher.PublishCodeScanTask(ctx, task); pubErr != nil {
+		slog.ErrorContext(ctx, "failed to publish scan task", "error", pubErr, "repo", task.RepositoryFullName)
+	}
+}
+
+func getDeliveryGUIDOrDefault(headerVal *string) string {
+	if headerVal != nil && *headerVal != "" {
+		return *headerVal
+	}
+
+	return fmt.Sprintf("synth-%d", time.Now().UnixNano())
+}
+
+func getEventTypeOrDefault(headerVal *string) string {
+	if headerVal != nil && *headerVal != "" {
+		return *headerVal
+	}
+
+	return "push"
+}
+
+//nolint:ireturn, revive, gocognit // Expected ireturn for openapi generation.
+func (s *Server) HandleVCSWebhook(
+	ctx context.Context,
+	request backend.HandleVCSWebhookRequestObject,
+) (backend.HandleVCSWebhookResponseObject, error) {
+	if request.Provider != "github" {
+		return backend.HandleVCSWebhook400JSONResponse(backend.BasicErrorModel{
+			Code:    http.StatusBadRequest,
+			Message: fmt.Sprintf("unsupported VCS provider: %s", request.Provider),
+		}), nil
+	}
+
+	rawBody, err := json.Marshal(request.Body)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to marshal webhook payload", "error", err)
+
+		return backend.HandleVCSWebhook400JSONResponse(backend.BasicErrorModel{ //nolint:nilerr // Return 400 for bad JSON
+			Code:    http.StatusBadRequest,
+			Message: "invalid webhook payload json",
+		}), nil
+	}
+
+	if s.isInvalidSignature(ctx, rawBody, request.Params.XHubSignature256) {
+		return backend.HandleVCSWebhook401JSONResponse(backend.BasicErrorModel{
+			Code:    http.StatusUnauthorized,
+			Message: "invalid webhook signature",
+		}), nil
+	}
+
+	deliveryGUID := getDeliveryGUIDOrDefault(request.Params.XGitHubDelivery)
+	eventType := getEventTypeOrDefault(request.Params.XGitHubEvent)
+	now := time.Now().UTC()
+
+	var payload pushPayload
+	_ = json.Unmarshal(rawBody, &payload)
+	repoID := strconv.FormatInt(payload.Repository.ID, 10)
+
+	delivery := gcpspanner.VCSWebhookDelivery{
+		VCSProvider:     gcpspanner.VCSProviderGitHub,
+		DeliveryGUID:    deliveryGUID,
+		EventType:       eventType,
+		VCSRepositoryID: repoID,
+		ReceivedAt:      now,
+	}
+
+	if s.wptMetricsStorer != nil {
+		isNew, recordErr := s.wptMetricsStorer.RecordVCSWebhookDelivery(ctx, delivery)
+		if recordErr != nil {
+			slog.ErrorContext(ctx, "failed to record webhook delivery", "error", recordErr, "guid", deliveryGUID)
+
+			return backend.HandleVCSWebhook500JSONResponse(backend.BasicErrorModel{
+				Code:    http.StatusInternalServerError,
+				Message: "failed to record webhook delivery",
+			}), nil
+		}
+		if !isNew {
+			slog.InfoContext(ctx, "duplicate webhook delivery ignored", "guid", deliveryGUID)
+
+			return backend.HandleVCSWebhook202Response{}, nil
+		}
+	}
+
+	if eventType == "push" && s.eventPublisher != nil {
+		s.dispatchPushScanTask(ctx, request.Provider, rawBody)
+	}
+
+	return backend.HandleVCSWebhook202Response{}, nil
+}

--- a/backend/pkg/httpserver/handle_vcs_webhook_test.go
+++ b/backend/pkg/httpserver/handle_vcs_webhook_test.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+type mockWebhookStorer struct {
+	*MockWPTMetricsStorer
+	recordResult bool
+	recordErr    error
+}
+
+func (m *mockWebhookStorer) RecordVCSWebhookDelivery(
+	_ context.Context,
+	_ gcpspanner.VCSWebhookDelivery,
+) (bool, error) {
+	return m.recordResult, m.recordErr
+}
+
+type mockWebhookPublisher struct {
+	MockEventPublisher
+	publishedTask *backendtypes.CodeScanTaskMessage
+	publishErr    error
+}
+
+func (m *mockWebhookPublisher) PublishCodeScanTask(
+	_ context.Context,
+	task backendtypes.CodeScanTaskMessage,
+) error {
+	m.publishedTask = &task
+
+	return m.publishErr
+}
+
+func signPayload(payload []byte, secret []byte) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(payload)
+
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+type webhookTestCase struct {
+	name         string
+	provider     string
+	body         backend.HandleVCSWebhookJSONRequestBody
+	sigHeader    *string
+	deliveryID   *string
+	eventHeader  *string
+	recordResult bool
+	recordErr    error
+	expectedCode int
+	expectTask   bool
+}
+
+func executeWebhookTest(t *testing.T, tc webhookTestCase, secret []byte) {
+	t.Helper()
+
+	storer := &mockWebhookStorer{
+		MockWPTMetricsStorer: newDefaultMockWPTMetricsStorer(t),
+		recordResult:         tc.recordResult,
+		recordErr:            tc.recordErr,
+	}
+	publisher := &mockWebhookPublisher{
+		MockEventPublisher: MockEventPublisher{
+			t: t,
+			callCountPublishSearchConfigurationChanged: 0,
+			publishSearchConfigurationChangedCfg:       nil,
+		},
+		publishedTask: nil,
+		publishErr:    nil,
+	}
+
+	server := setupTestServer(t,
+		withCustomStorer(storer),
+		withCustomEventPublisher(publisher),
+		withWebhookSecret(secret),
+	)
+
+	req := backend.HandleVCSWebhookRequestObject{
+		Provider: tc.provider,
+		Params: backend.HandleVCSWebhookParams{
+			XHubSignature256: tc.sigHeader,
+			XGitHubDelivery:  tc.deliveryID,
+			XGitHubEvent:     tc.eventHeader,
+		},
+		Body: &tc.body,
+	}
+
+	resp, err := server.HandleVCSWebhook(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertWebhookResponse(t, resp, tc.expectedCode)
+
+	if tc.expectTask && publisher.publishedTask == nil {
+		t.Errorf("expected task to be published, but got nil")
+	}
+	if !tc.expectTask && publisher.publishedTask != nil {
+		t.Errorf("expected no task to be published, but got %+v", publisher.publishedTask)
+	}
+}
+
+func assertWebhookResponse(t *testing.T, resp backend.HandleVCSWebhookResponseObject, expectedCode int) {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	if err := resp.VisitHandleVCSWebhookResponse(rec); err != nil {
+		t.Fatalf("failed to visit webhook response: %v", err)
+	}
+
+	if rec.Code != expectedCode {
+		t.Errorf("expected status %d, got %d", expectedCode, rec.Code)
+	}
+}
+
+func TestHandleVCSWebhook(t *testing.T) {
+	secret := []byte("a-very-long-secret-key-16-bytes-min")
+
+	pushBody := backend.HandleVCSWebhookJSONRequestBody{
+		"ref":    "refs/heads/main",
+		"before": "0000000000000000000000000000000000000000",
+		"after":  "1111222233334444555566667777888899990000",
+		"repository": map[string]any{
+			"id":             123456,
+			"name":           "webstatus.dev",
+			"full_name":      "GoogleChrome/webstatus.dev",
+			"default_branch": "main",
+			"owner": map[string]any{
+				"login": "GoogleChrome",
+			},
+		},
+		"installation": map[string]any{
+			"id": 98765,
+		},
+	}
+	bodyBytes, _ := json.Marshal(pushBody)
+	validSignature := signPayload(bodyBytes, secret)
+	invalidSignature := "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+
+	deliveryGUID := "test-guid-1234"
+	eventType := "push"
+
+	testCases := []webhookTestCase{
+		{
+			name:         "Success Valid Signature Push Event",
+			provider:     "github",
+			body:         pushBody,
+			sigHeader:    &validSignature,
+			deliveryID:   &deliveryGUID,
+			eventHeader:  &eventType,
+			recordResult: true,
+			recordErr:    nil,
+			expectedCode: http.StatusAccepted,
+			expectTask:   true,
+		},
+		{
+			name:         "Missing Signature Header",
+			provider:     "github",
+			body:         pushBody,
+			sigHeader:    nil,
+			deliveryID:   &deliveryGUID,
+			eventHeader:  &eventType,
+			recordResult: true,
+			recordErr:    nil,
+			expectedCode: http.StatusUnauthorized,
+			expectTask:   false,
+		},
+		{
+			name:         "Invalid Signature Header",
+			provider:     "github",
+			body:         pushBody,
+			sigHeader:    &invalidSignature,
+			deliveryID:   &deliveryGUID,
+			eventHeader:  &eventType,
+			recordResult: true,
+			recordErr:    nil,
+			expectedCode: http.StatusUnauthorized,
+			expectTask:   false,
+		},
+		{
+			name:         "Unsupported Provider",
+			provider:     "unsupported-vcs",
+			body:         pushBody,
+			sigHeader:    &validSignature,
+			deliveryID:   &deliveryGUID,
+			eventHeader:  &eventType,
+			recordResult: true,
+			recordErr:    nil,
+			expectedCode: http.StatusBadRequest,
+			expectTask:   false,
+		},
+		{
+			name:         "Duplicate Webhook Delivery (Replay Ignored)",
+			provider:     "github",
+			body:         pushBody,
+			sigHeader:    &validSignature,
+			deliveryID:   &deliveryGUID,
+			eventHeader:  &eventType,
+			recordResult: false,
+			recordErr:    nil,
+			expectedCode: http.StatusAccepted,
+			expectTask:   false,
+		},
+		{
+			name:         "Spanner Recording Error",
+			provider:     "github",
+			body:         pushBody,
+			sigHeader:    &validSignature,
+			deliveryID:   &deliveryGUID,
+			eventHeader:  &eventType,
+			recordResult: false,
+			recordErr:    errors.New("spanner failure"),
+			expectedCode: http.StatusInternalServerError,
+			expectTask:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			executeWebhookTest(t, tc, secret)
+		})
+	}
+}

--- a/backend/pkg/httpserver/list_aggregated_baseline_status_counts.go
+++ b/backend/pkg/httpserver/list_aggregated_baseline_status_counts.go
@@ -24,7 +24,8 @@ import (
 )
 
 // ListAggregatedBaselineStatusCounts implements backend.StrictServerInterface.
-// nolint: revive, ireturn // Name generated from openapi
+//
+//nolint:revive, ireturn // Name generated from openapi
 func (s *Server) ListAggregatedBaselineStatusCounts(
 	ctx context.Context, request backend.ListAggregatedBaselineStatusCountsRequestObject) (
 	backend.ListAggregatedBaselineStatusCountsResponseObject, error) {

--- a/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
+++ b/backend/pkg/httpserver/list_aggregated_baseline_status_counts_test.go
@@ -290,7 +290,7 @@ func TestListAggregatedBaselineStatusCounts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// nolint: exhaustruct
+			//nolint:exhaustruct
 			mockStorer := &MockWPTMetricsStorer{
 				listBaselineStatusCountsCfg: tc.mockConfig,
 				t:                           t,

--- a/backend/pkg/httpserver/list_aggregated_feature_support.go
+++ b/backend/pkg/httpserver/list_aggregated_feature_support.go
@@ -41,7 +41,8 @@ func getDesktopsMobileProduct(browser backend.BrowserPathParam) (backend.Browser
 }
 
 // ListAggregatedFeatureSupport implements backend.StrictServerInterface.
-// nolint: ireturn // Signature generated from openapi
+//
+//nolint:ireturn // Signature generated from openapi
 func (s *Server) ListAggregatedFeatureSupport(
 	ctx context.Context,
 	request backend.ListAggregatedFeatureSupportRequestObject) (

--- a/backend/pkg/httpserver/list_aggregated_feature_support_test.go
+++ b/backend/pkg/httpserver/list_aggregated_feature_support_test.go
@@ -307,7 +307,7 @@ func TestListAggregatedFeatureSupport(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// nolint: exhaustruct
+			//nolint:exhaustruct
 			mockStorer := &MockWPTMetricsStorer{
 				listBrowserFeatureCountMetricCfg: tc.mockConfig,
 				t:                                t,

--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics.go
@@ -24,7 +24,8 @@ import (
 )
 
 // ListAggregatedWPTMetrics implements backend.StrictServerInterface.
-// nolint: revive, ireturn // Name generated from openapi
+//
+//nolint:revive, ireturn // Name generated from openapi
 func (s *Server) ListAggregatedWPTMetrics(
 	ctx context.Context,
 	request backend.ListAggregatedWPTMetricsRequestObject,

--- a/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_aggregated_wpt_metrics_test.go
@@ -293,7 +293,7 @@ func TestListAggregatedWPTMetrics(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// nolint: exhaustruct
+			//nolint:exhaustruct
 			mockStorer := &MockWPTMetricsStorer{
 				aggregateCfg: tc.mockConfig,
 				t:            t,

--- a/backend/pkg/httpserver/list_chromium_usage.go
+++ b/backend/pkg/httpserver/list_chromium_usage.go
@@ -24,7 +24,8 @@ import (
 )
 
 // ListChromeDailyUsageStats implements backend.StrictServerInterface.
-// nolint: revive, ireturn // Name generated from openapi
+//
+//nolint:revive, ireturn // Name generated from openapi
 func (s *Server) ListChromeDailyUsageStats(
 	ctx context.Context,
 	request backend.ListChromeDailyUsageStatsRequestObject,

--- a/backend/pkg/httpserver/list_chromium_usage_test.go
+++ b/backend/pkg/httpserver/list_chromium_usage_test.go
@@ -147,7 +147,7 @@ func TestListChromeDailyUsageStats(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// nolint: exhaustruct
+			//nolint:exhaustruct
 			mockStorer := &MockWPTMetricsStorer{
 				listChromeDailyUsageStatsCfg: tc.mockConfig,
 				t:                            t,

--- a/backend/pkg/httpserver/list_code_subscriptions.go
+++ b/backend/pkg/httpserver/list_code_subscriptions.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
+func (s *Server) ListCodeSubscriptions(
+	ctx context.Context,
+	request backend.ListCodeSubscriptionsRequestObject,
+) (backend.ListCodeSubscriptionsResponseObject, error) {
+	userCheck := CheckAuthenticatedUser[backend.ListCodeSubscriptionsResponseObject](
+		ctx, "ListCodeSubscriptions",
+		func(code int, message string) backend.ListCodeSubscriptionsResponseObject {
+			return backend.ListCodeSubscriptions500JSONResponse(
+				backend.BasicErrorModel{Code: code, Message: message})
+		})
+	if userCheck.User == nil {
+		return userCheck.Response, nil
+	}
+
+	subs, err := s.wptMetricsStorer.ListCodeSubscriptions(ctx, request.Provider, request.RepositoryId)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to list code subscriptions", "error", err,
+			"provider", request.Provider, "repo_id", request.RepositoryId)
+
+		return backend.ListCodeSubscriptions500JSONResponse(
+			backend.BasicErrorModel{
+				Code:    http.StatusInternalServerError,
+				Message: "failed to list code subscriptions",
+			}), nil
+	}
+
+	return backend.ListCodeSubscriptions200JSONResponse{
+		Data: subs,
+	}, nil
+}

--- a/backend/pkg/httpserver/list_feature_wpt_metrics.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics.go
@@ -24,7 +24,8 @@ import (
 )
 
 // ListFeatureWPTMetrics implements backend.StrictServerInterface.
-// nolint: revive, ireturn // Name generated from openapi
+//
+//nolint:revive, ireturn // Name generated from openapi
 func (s *Server) ListFeatureWPTMetrics(
 	ctx context.Context,
 	request backend.ListFeatureWPTMetricsRequestObject,

--- a/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
+++ b/backend/pkg/httpserver/list_feature_wpt_metrics_test.go
@@ -289,7 +289,7 @@ func TestListFeatureWPTMetrics(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// nolint: exhaustruct
+			//nolint:exhaustruct
 			mockStorer := &MockWPTMetricsStorer{
 				featureCfg: tc.mockConfig,
 				t:          t,

--- a/backend/pkg/httpserver/list_features.go
+++ b/backend/pkg/httpserver/list_features.go
@@ -27,7 +27,8 @@ import (
 )
 
 // ListFeatures implements backend.StrictServerInterface.
-// nolint:ireturn // Expected ireturn for openapi generation.
+//
+//nolint:ireturn // Expected ireturn for openapi generation.
 func (s *Server) ListFeatures(
 	ctx context.Context,
 	req backend.ListFeaturesRequestObject,

--- a/backend/pkg/httpserver/list_global_saved_searches.go
+++ b/backend/pkg/httpserver/list_global_saved_searches.go
@@ -24,7 +24,8 @@ import (
 )
 
 // ListGlobalSavedSearches implements backend.StrictServerInterface.
-// nolint:ireturn // Expected ireturn for openapi generation.
+//
+//nolint:ireturn // Expected ireturn for openapi generation.
 func (s *Server) ListGlobalSavedSearches(
 	ctx context.Context,
 	req backend.ListGlobalSavedSearchesRequestObject,

--- a/backend/pkg/httpserver/list_global_saved_searches_test.go
+++ b/backend/pkg/httpserver/list_global_saved_searches_test.go
@@ -211,7 +211,7 @@ func TestListGlobalSavedSearches(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// nolint:exhaustruct
+			//nolint:exhaustruct
 			mockStorer := &MockWPTMetricsStorer{
 				listGlobalSavedSearchesCfg: tc.mockCfg,
 				t:                          t,

--- a/backend/pkg/httpserver/list_missing_one_implementation_counts.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_counts.go
@@ -24,7 +24,8 @@ import (
 )
 
 // ListMissingOneImplementationCounts implements backend.StrictServerInterface.
-// nolint: ireturn // Signature generated from openapi
+//
+//nolint:ireturn // Signature generated from openapi
 func (s *Server) ListMissingOneImplementationCounts(
 	ctx context.Context,
 	request backend.ListMissingOneImplementationCountsRequestObject) (

--- a/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_counts_test.go
@@ -338,7 +338,7 @@ func TestListMissingOneImplementationCounts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// nolint: exhaustruct
+			//nolint:exhaustruct
 			mockStorer := &MockWPTMetricsStorer{
 				listMissingOneImplCountCfg: tc.mockConfig,
 				t:                          t,

--- a/backend/pkg/httpserver/list_missing_one_implementation_features.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_features.go
@@ -88,7 +88,8 @@ func PrepareMissingOneBrowserParams(
 }
 
 // ListMissingOneImplementationFeatures implements backend.StrictServerInterface.
-// nolint: ireturn // Signature generated from openapi
+//
+//nolint:ireturn // Signature generated from openapi
 func (s *Server) ListMissingOneImplementationFeatures(
 	ctx context.Context,
 	request backend.ListMissingOneImplementationFeaturesRequestObject) (

--- a/backend/pkg/httpserver/list_missing_one_implementation_features_test.go
+++ b/backend/pkg/httpserver/list_missing_one_implementation_features_test.go
@@ -191,7 +191,7 @@ func TestListMissingOneImplementationFeatures(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// nolint: exhaustruct
+			//nolint:exhaustruct
 			mockStorer := &MockWPTMetricsStorer{
 				listMissingOneImplFeaturesCfg: &tc.mockConfig,
 				t:                             t,

--- a/backend/pkg/httpserver/list_notification_channels.go
+++ b/backend/pkg/httpserver/list_notification_channels.go
@@ -24,7 +24,8 @@ import (
 )
 
 // ListNotificationChannels handles the GET request to /v1/users/me/notification-channels.
-// nolint:ireturn, revive // Expected ireturn for openapi generation.
+//
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
 func (s *Server) ListNotificationChannels(
 	ctx context.Context,
 	req backend.ListNotificationChannelsRequestObject,

--- a/backend/pkg/httpserver/list_subscriptions.go
+++ b/backend/pkg/httpserver/list_subscriptions.go
@@ -21,7 +21,7 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-// nolint:ireturn, revive // Expected ireturn for openapi generation.
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
 func (s *Server) ListSubscriptions(
 	ctx context.Context,
 	request backend.ListSubscriptionsRequestObject,

--- a/backend/pkg/httpserver/list_user_saved_searches.go
+++ b/backend/pkg/httpserver/list_user_saved_searches.go
@@ -26,7 +26,8 @@ import (
 )
 
 // ListUserSavedSearches implements backend.StrictServerInterface.
-// nolint:ireturn // Expected ireturn for openapi generation.
+//
+//nolint:ireturn // Expected ireturn for openapi generation.
 func (s *Server) ListUserSavedSearches(
 	ctx context.Context, request backend.ListUserSavedSearchesRequestObject) (
 	backend.ListUserSavedSearchesResponseObject, error) {

--- a/backend/pkg/httpserver/list_vcs_installations.go
+++ b/backend/pkg/httpserver/list_vcs_installations.go
@@ -20,16 +20,22 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-const healthyStatus = "healthy"
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
+func (s *Server) ListVCSInstallations(
+	ctx context.Context,
+	_ backend.ListVCSInstallationsRequestObject,
+) (backend.ListVCSInstallationsResponseObject, error) {
+	userCheck := CheckAuthenticatedUser[backend.ListVCSInstallationsResponseObject](
+		ctx, "ListVCSInstallations",
+		func(code int, message string) backend.ListVCSInstallationsResponseObject {
+			return backend.ListVCSInstallations500JSONResponse(
+				backend.BasicErrorModel{Code: code, Message: message})
+		})
+	if userCheck.User == nil {
+		return userCheck.Response, nil
+	}
 
-// GetHealthcheckLiveness implements backend.StrictServerInterface.
-//
-//nolint:ireturn // Name generated from openapi
-func (s *Server) GetHealthcheckLiveness(
-	_ context.Context,
-	_ backend.GetHealthcheckLivenessRequestObject,
-) (backend.GetHealthcheckLivenessResponseObject, error) {
-	return backend.GetHealthcheckLiveness200JSONResponse{
-		Status: healthyStatus,
+	return backend.ListVCSInstallations200JSONResponse{
+		Data: []backend.VCSInstallationSummary{},
 	}, nil
 }

--- a/backend/pkg/httpserver/list_vcs_repositories.go
+++ b/backend/pkg/httpserver/list_vcs_repositories.go
@@ -20,16 +20,22 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-const healthyStatus = "healthy"
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
+func (s *Server) ListVCSRepositories(
+	ctx context.Context,
+	_ backend.ListVCSRepositoriesRequestObject,
+) (backend.ListVCSRepositoriesResponseObject, error) {
+	userCheck := CheckAuthenticatedUser[backend.ListVCSRepositoriesResponseObject](
+		ctx, "ListVCSRepositories",
+		func(code int, message string) backend.ListVCSRepositoriesResponseObject {
+			return backend.ListVCSRepositories500JSONResponse(
+				backend.BasicErrorModel{Code: code, Message: message})
+		})
+	if userCheck.User == nil {
+		return userCheck.Response, nil
+	}
 
-// GetHealthcheckLiveness implements backend.StrictServerInterface.
-//
-//nolint:ireturn // Name generated from openapi
-func (s *Server) GetHealthcheckLiveness(
-	_ context.Context,
-	_ backend.GetHealthcheckLivenessRequestObject,
-) (backend.GetHealthcheckLivenessResponseObject, error) {
-	return backend.GetHealthcheckLiveness200JSONResponse{
-		Status: healthyStatus,
+	return backend.ListVCSRepositories200JSONResponse{
+		Data: []backend.VCSRepositorySummary{},
 	}, nil
 }

--- a/backend/pkg/httpserver/ping_user.go
+++ b/backend/pkg/httpserver/ping_user.go
@@ -23,7 +23,8 @@ import (
 )
 
 // PingUser implements backend.StrictServerInterface.
-// nolint: ireturn // Name generated from openapi
+//
+//nolint:ireturn // Name generated from openapi
 func (s *Server) PingUser(
 	ctx context.Context,
 	req backend.PingUserRequestObject,

--- a/backend/pkg/httpserver/ping_user_test.go
+++ b/backend/pkg/httpserver/ping_user_test.go
@@ -256,7 +256,7 @@ func TestPingUser(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			authMiddlewareOption := withAuthMiddleware(tc.authMiddleware)
 			myServer := setupTestServer(t,
-				// nolint:exhaustruct
+				//nolint:exhaustruct
 				withCustomStorer(&MockWPTMetricsStorer{t: t, syncUserProfileInfoCfg: tc.syncUserProfileInfoCfg}),
 				withCustomGitHubClientFactory(setupMockGitHubUserClient(
 					t,

--- a/backend/pkg/httpserver/put_user_saved_search_bookmark.go
+++ b/backend/pkg/httpserver/put_user_saved_search_bookmark.go
@@ -25,7 +25,8 @@ import (
 )
 
 // PutUserSavedSearchBookmark implements backend.StrictServerInterface.
-// nolint: ireturn // Name generated from openapi
+//
+//nolint:ireturn // Name generated from openapi
 func (s *Server) PutUserSavedSearchBookmark(
 	ctx context.Context, request backend.PutUserSavedSearchBookmarkRequestObject) (
 	backend.PutUserSavedSearchBookmarkResponseObject, error) {

--- a/backend/pkg/httpserver/put_user_saved_search_bookmark_test.go
+++ b/backend/pkg/httpserver/put_user_saved_search_bookmark_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint: dupl // WONTFIX
+//nolint:dupl // WONTFIX
 package httpserver
 
 import (

--- a/backend/pkg/httpserver/remove_saved_search.go
+++ b/backend/pkg/httpserver/remove_saved_search.go
@@ -25,7 +25,8 @@ import (
 )
 
 // RemoveSavedSearch implements backend.StrictServerInterface.
-// nolint: ireturn // Name generated from openapi
+//
+//nolint:ireturn // Name generated from openapi
 func (s *Server) RemoveSavedSearch(
 	ctx context.Context, request backend.RemoveSavedSearchRequestObject) (
 	backend.RemoveSavedSearchResponseObject, error) {

--- a/backend/pkg/httpserver/remove_user_saved_search_bookmark.go
+++ b/backend/pkg/httpserver/remove_user_saved_search_bookmark.go
@@ -25,7 +25,8 @@ import (
 )
 
 // RemoveUserSavedSearchBookmark implements backend.StrictServerInterface.
-// nolint: ireturn // Name generated from openapi
+//
+//nolint:ireturn // Name generated from openapi
 func (s *Server) RemoveUserSavedSearchBookmark(
 	ctx context.Context, request backend.RemoveUserSavedSearchBookmarkRequestObject) (
 	backend.RemoveUserSavedSearchBookmarkResponseObject, error) {

--- a/backend/pkg/httpserver/remove_user_saved_search_bookmark_test.go
+++ b/backend/pkg/httpserver/remove_user_saved_search_bookmark_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint: dupl // WONTFIX
+//nolint:dupl // WONTFIX
 package httpserver
 
 import (

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -18,6 +18,7 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net"
 	"net/http"
@@ -327,4 +328,47 @@ func GenericErrorFn(ctx context.Context, statusCode int, w http.ResponseWriter, 
 	if err != nil {
 		slog.WarnContext(ctx, "unable to write generic error", "error", encoderErr)
 	}
+}
+
+// Stubs to satisfy backend.StrictServerInterface on openapi branch.
+// Concrete implementations and tests are in the api-handlers branch.
+
+// nolint: ireturn // WONTFIX - generated method signature
+func (s *Server) ListCodeSubscriptions(
+	_ context.Context,
+	_ backend.ListCodeSubscriptionsRequestObject,
+) (backend.ListCodeSubscriptionsResponseObject, error) {
+	return nil, errors.New("not implemented")
+}
+
+// nolint: ireturn // WONTFIX - generated method signature
+func (s *Server) DeleteCodeSubscription(
+	_ context.Context,
+	_ backend.DeleteCodeSubscriptionRequestObject,
+) (backend.DeleteCodeSubscriptionResponseObject, error) {
+	return nil, errors.New("not implemented")
+}
+
+// nolint: ireturn // WONTFIX - generated method signature
+func (s *Server) ListVCSInstallations(
+	_ context.Context,
+	_ backend.ListVCSInstallationsRequestObject,
+) (backend.ListVCSInstallationsResponseObject, error) {
+	return nil, errors.New("not implemented")
+}
+
+// nolint: ireturn // WONTFIX - generated method signature
+func (s *Server) ListVCSRepositories(
+	_ context.Context,
+	_ backend.ListVCSRepositoriesRequestObject,
+) (backend.ListVCSRepositoriesResponseObject, error) {
+	return nil, errors.New("not implemented")
+}
+
+// nolint: ireturn // WONTFIX - generated method signature
+func (s *Server) HandleVCSWebhook(
+	_ context.Context,
+	_ backend.HandleVCSWebhookRequestObject,
+) (backend.HandleVCSWebhookResponseObject, error) {
+	return nil, errors.New("not implemented")
 }

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -18,7 +18,6 @@ import (
 	"cmp"
 	"context"
 	"encoding/json"
-	"errors"
 	"log/slog"
 	"net"
 	"net/http"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	"github.com/GoogleChrome/webstatus.dev/lib/gh"
@@ -193,6 +193,18 @@ type WPTMetricsStorer interface {
 		userID, subscriptionID string,
 		req backend.UpdateSubscriptionRequest,
 	) (*backend.SubscriptionResponse, error)
+	ListCodeSubscriptions(
+		ctx context.Context,
+		vcsProvider, repoID string,
+	) ([]backend.CodeSubscriptionResponse, error)
+	DeleteCodeSubscription(
+		ctx context.Context,
+		id string,
+	) error
+	RecordVCSWebhookDelivery(
+		ctx context.Context,
+		delivery gcpspanner.VCSWebhookDelivery,
+	) (bool, error)
 }
 
 type Server struct {
@@ -203,6 +215,7 @@ type Server struct {
 	userGitHubClientFactory UserGitHubClientFactory
 	eventPublisher          EventPublisher
 	rssRenderer             *RSSRenderer
+	webhookSecret           []byte
 }
 
 type GitHubUserClient interface {
@@ -257,6 +270,17 @@ type RouteCacheOptions struct {
 type EventPublisher interface {
 	PublishSearchConfigurationChanged(ctx context.Context, resp *backend.SavedSearchResponse,
 		userID string, isCreation bool) error
+	PublishCodeScanTask(ctx context.Context, task backendtypes.CodeScanTaskMessage) error
+}
+
+// ServerOption configures options for the HTTP server.
+type ServerOption func(*Server)
+
+// WithWebhookSecret configures the HMAC webhook secret for verifying incoming webhooks.
+func WithWebhookSecret(secret []byte) ServerOption {
+	return func(s *Server) {
+		s.webhookSecret = secret
+	}
 }
 
 func NewHTTPServer(
@@ -269,7 +293,8 @@ func NewHTTPServer(
 	routeCacheOptions RouteCacheOptions,
 	userGitHubClientFactory UserGitHubClientFactory,
 	preRequestValidationMiddlewares []func(http.Handler) http.Handler,
-	authMiddleware func(http.Handler) http.Handler) *http.Server {
+	authMiddleware func(http.Handler) http.Handler,
+	opts ...ServerOption) *http.Server {
 	// Create an instance of our handler which satisfies the generated interface
 	srv := &Server{
 		metadataStorer:          metadataStorer,
@@ -279,6 +304,11 @@ func NewHTTPServer(
 		baseURL:                 baseURL,
 		userGitHubClientFactory: userGitHubClientFactory,
 		rssRenderer:             NewRSSRenderer(),
+		webhookSecret:           nil,
+	}
+
+	for _, opt := range opts {
+		opt(srv)
 	}
 
 	return createOpenAPIServerServer(port, srv, preRequestValidationMiddlewares, authMiddleware)
@@ -302,7 +332,7 @@ func createOpenAPIServerServer(
 	// Now wrap the middlewares
 	wrappedHandler := applyPreRequestValidationMiddlewares(r, preRequestValidationMiddlewares)
 
-	// nolint:exhaustruct // No need to populate 3rd party struct
+	//nolint:exhaustruct // No need to populate 3rd party struct
 	return &http.Server{
 		Handler:           wrappedHandler,
 		Addr:              net.JoinHostPort("0.0.0.0", port),
@@ -328,47 +358,4 @@ func GenericErrorFn(ctx context.Context, statusCode int, w http.ResponseWriter, 
 	if err != nil {
 		slog.WarnContext(ctx, "unable to write generic error", "error", encoderErr)
 	}
-}
-
-// Stubs to satisfy backend.StrictServerInterface on openapi branch.
-// Concrete implementations and tests are in the api-handlers branch.
-
-// nolint: ireturn // WONTFIX - generated method signature
-func (s *Server) ListCodeSubscriptions(
-	_ context.Context,
-	_ backend.ListCodeSubscriptionsRequestObject,
-) (backend.ListCodeSubscriptionsResponseObject, error) {
-	return nil, errors.New("not implemented")
-}
-
-// nolint: ireturn // WONTFIX - generated method signature
-func (s *Server) DeleteCodeSubscription(
-	_ context.Context,
-	_ backend.DeleteCodeSubscriptionRequestObject,
-) (backend.DeleteCodeSubscriptionResponseObject, error) {
-	return nil, errors.New("not implemented")
-}
-
-// nolint: ireturn // WONTFIX - generated method signature
-func (s *Server) ListVCSInstallations(
-	_ context.Context,
-	_ backend.ListVCSInstallationsRequestObject,
-) (backend.ListVCSInstallationsResponseObject, error) {
-	return nil, errors.New("not implemented")
-}
-
-// nolint: ireturn // WONTFIX - generated method signature
-func (s *Server) ListVCSRepositories(
-	_ context.Context,
-	_ backend.ListVCSRepositoriesRequestObject,
-) (backend.ListVCSRepositoriesResponseObject, error) {
-	return nil, errors.New("not implemented")
-}
-
-// nolint: ireturn // WONTFIX - generated method signature
-func (s *Server) HandleVCSWebhook(
-	_ context.Context,
-	_ backend.HandleVCSWebhookRequestObject,
-) (backend.HandleVCSWebhookResponseObject, error) {
-	return nil, errors.New("not implemented")
 }

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -1686,6 +1686,55 @@ func (m *mockServerInterface) GetHealthcheckLiveness(ctx context.Context,
 	panic("unimplemented")
 }
 
+// DeleteCodeSubscription implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) DeleteCodeSubscription(ctx context.Context,
+	_ backend.DeleteCodeSubscriptionRequestObject) (
+	backend.DeleteCodeSubscriptionResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
+// HandleVCSWebhook implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) HandleVCSWebhook(_ context.Context,
+	_ backend.HandleVCSWebhookRequestObject) (
+	backend.HandleVCSWebhookResponseObject, error) {
+	m.callCount++
+	panic("unimplemented")
+}
+
+// ListCodeSubscriptions implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) ListCodeSubscriptions(ctx context.Context,
+	_ backend.ListCodeSubscriptionsRequestObject) (
+	backend.ListCodeSubscriptionsResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
+// ListVCSInstallations implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) ListVCSInstallations(ctx context.Context,
+	_ backend.ListVCSInstallationsRequestObject) (
+	backend.ListVCSInstallationsResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
+// ListVCSRepositories implements backend.StrictServerInterface.
+// nolint: ireturn // WONTFIX - generated method signature
+func (m *mockServerInterface) ListVCSRepositories(ctx context.Context,
+	_ backend.ListVCSRepositoriesRequestObject) (
+	backend.ListVCSRepositoriesResponseObject, error) {
+	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
+	m.callCount++
+	panic("unimplemented")
+}
+
 func (m *mockServerInterface) assertCallCount(expectedCallCount int) {
 	if m.callCount != expectedCallCount {
 		m.t.Errorf("expected mock server to be used %d times. only used %d times", expectedCallCount, m.callCount)

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/GoogleChrome/webstatus.dev/lib/auth"
 	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	"github.com/GoogleChrome/webstatus.dev/lib/gh"
@@ -1111,6 +1112,28 @@ func (m *MockWPTMetricsStorer) GetGlobalSavedSearch(
 	return nil, errors.New("basic mock") // basic mock
 }
 
+func (m *MockWPTMetricsStorer) ListCodeSubscriptions(
+	_ context.Context,
+	_ string,
+	_ string,
+) ([]backend.CodeSubscriptionResponse, error) {
+	return []backend.CodeSubscriptionResponse{}, nil
+}
+
+func (m *MockWPTMetricsStorer) DeleteCodeSubscription(
+	_ context.Context,
+	_ string,
+) error {
+	return nil
+}
+
+func (m *MockWPTMetricsStorer) RecordVCSWebhookDelivery(
+	_ context.Context,
+	_ gcpspanner.VCSWebhookDelivery,
+) (bool, error) {
+	return true, nil
+}
+
 type MockPublishSearchConfigurationChangedConfig struct {
 	expectedResp       *backend.SavedSearchResponse
 	expectedUserID     string
@@ -1143,6 +1166,13 @@ func (m *MockEventPublisher) PublishSearchConfigurationChanged(
 	return m.publishSearchConfigurationChangedCfg.err
 }
 
+func (m *MockEventPublisher) PublishCodeScanTask(
+	_ context.Context,
+	_ backendtypes.CodeScanTaskMessage,
+) error {
+	return nil
+}
+
 func TestGetPageSizeOrDefault(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -1166,7 +1196,7 @@ func TestGetPageSizeOrDefault(t *testing.T) {
 }
 
 func createEmptyBodyResponse(status int) *http.Response {
-	// nolint:exhaustruct // WONTFIX - only for test purposes
+	//nolint:exhaustruct // WONTFIX - only for test purposes
 	return &http.Response{
 		StatusCode: status,
 		// For no content, the openapi library currently just returns an
@@ -1176,7 +1206,7 @@ func createEmptyBodyResponse(status int) *http.Response {
 	}
 }
 
-// nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var (
 	inputPageToken = new("input-token")
 	nextPageToken  = new("next-page-token")
@@ -1185,7 +1215,7 @@ var (
 )
 
 func testJSONResponse(statusCode int, body string) *http.Response {
-	// nolint:exhaustruct // WONTFIX - only for test purposes
+	//nolint:exhaustruct // WONTFIX - only for test purposes
 	return &http.Response{
 		StatusCode: statusCode,
 		Header: http.Header{
@@ -1381,7 +1411,8 @@ type mockServerInterface struct {
 }
 
 // ListAggregatedBaselineStatusCounts implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListAggregatedBaselineStatusCounts(
 	ctx context.Context, _ backend.ListAggregatedBaselineStatusCountsRequestObject) (
 	backend.ListAggregatedBaselineStatusCountsResponseObject, error) {
@@ -1391,7 +1422,8 @@ func (m *mockServerInterface) ListAggregatedBaselineStatusCounts(
 }
 
 // CreateSavedSearch implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) CreateSavedSearch(ctx context.Context, _ backend.CreateSavedSearchRequestObject) (
 	backend.CreateSavedSearchResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
@@ -1400,7 +1432,8 @@ func (m *mockServerInterface) CreateSavedSearch(ctx context.Context, _ backend.C
 }
 
 // GetFeature implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) GetFeature(ctx context.Context, _ backend.GetFeatureRequestObject) (
 	backend.GetFeatureResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
@@ -1409,7 +1442,8 @@ func (m *mockServerInterface) GetFeature(ctx context.Context, _ backend.GetFeatu
 }
 
 // GetFeatureMetadata implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) GetFeatureMetadata(ctx context.Context, _ backend.GetFeatureMetadataRequestObject) (
 	backend.GetFeatureMetadataResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
@@ -1418,7 +1452,8 @@ func (m *mockServerInterface) GetFeatureMetadata(ctx context.Context, _ backend.
 }
 
 // GetSavedSearch implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) GetSavedSearch(ctx context.Context, _ backend.GetSavedSearchRequestObject) (
 	backend.GetSavedSearchResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
@@ -1427,7 +1462,8 @@ func (m *mockServerInterface) GetSavedSearch(ctx context.Context, _ backend.GetS
 }
 
 // ListAggregatedFeatureSupport implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListAggregatedFeatureSupport(ctx context.Context,
 	_ backend.ListAggregatedFeatureSupportRequestObject) (
 	backend.ListAggregatedFeatureSupportResponseObject, error) {
@@ -1437,7 +1473,8 @@ func (m *mockServerInterface) ListAggregatedFeatureSupport(ctx context.Context,
 }
 
 // ListAggregatedWPTMetrics implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListAggregatedWPTMetrics(ctx context.Context,
 	_ backend.ListAggregatedWPTMetricsRequestObject) (backend.ListAggregatedWPTMetricsResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
@@ -1446,7 +1483,8 @@ func (m *mockServerInterface) ListAggregatedWPTMetrics(ctx context.Context,
 }
 
 // ListChromeDailyUsageStats implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListChromeDailyUsageStats(ctx context.Context,
 	_ backend.ListChromeDailyUsageStatsRequestObject) (
 	backend.ListChromeDailyUsageStatsResponseObject, error) {
@@ -1456,7 +1494,8 @@ func (m *mockServerInterface) ListChromeDailyUsageStats(ctx context.Context,
 }
 
 // ListFeatureWPTMetrics implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListFeatureWPTMetrics(ctx context.Context,
 	_ backend.ListFeatureWPTMetricsRequestObject) (backend.ListFeatureWPTMetricsResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
@@ -1465,7 +1504,8 @@ func (m *mockServerInterface) ListFeatureWPTMetrics(ctx context.Context,
 }
 
 // ListFeatures implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListFeatures(ctx context.Context,
 	_ backend.ListFeaturesRequestObject) (backend.ListFeaturesResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
@@ -1474,7 +1514,8 @@ func (m *mockServerInterface) ListFeatures(ctx context.Context,
 }
 
 // ListMissingOneImplementationCounts implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListMissingOneImplementationCounts(ctx context.Context,
 	_ backend.ListMissingOneImplementationCountsRequestObject) (
 	backend.ListMissingOneImplementationCountsResponseObject, error) {
@@ -1484,7 +1525,8 @@ func (m *mockServerInterface) ListMissingOneImplementationCounts(ctx context.Con
 }
 
 // ListUserSavedSearches implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListUserSavedSearches(ctx context.Context,
 	_ backend.ListUserSavedSearchesRequestObject) (backend.ListUserSavedSearchesResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
@@ -1493,7 +1535,8 @@ func (m *mockServerInterface) ListUserSavedSearches(ctx context.Context,
 }
 
 // PutUserSavedSearchBookmark implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) PutUserSavedSearchBookmark(ctx context.Context,
 	_ backend.PutUserSavedSearchBookmarkRequestObject) (backend.PutUserSavedSearchBookmarkResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
@@ -1502,7 +1545,8 @@ func (m *mockServerInterface) PutUserSavedSearchBookmark(ctx context.Context,
 }
 
 // RemoveSavedSearch implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) RemoveSavedSearch(ctx context.Context,
 	_ backend.RemoveSavedSearchRequestObject) (backend.RemoveSavedSearchResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
@@ -1511,7 +1555,8 @@ func (m *mockServerInterface) RemoveSavedSearch(ctx context.Context,
 }
 
 // RemoveUserSavedSearchBookmark implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) RemoveUserSavedSearchBookmark(ctx context.Context,
 	_ backend.RemoveUserSavedSearchBookmarkRequestObject) (
 	backend.RemoveUserSavedSearchBookmarkResponseObject, error) {
@@ -1521,7 +1566,8 @@ func (m *mockServerInterface) RemoveUserSavedSearchBookmark(ctx context.Context,
 }
 
 // UpdateSavedSearch implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) UpdateSavedSearch(ctx context.Context,
 	_ backend.UpdateSavedSearchRequestObject) (backend.UpdateSavedSearchResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
@@ -1530,7 +1576,8 @@ func (m *mockServerInterface) UpdateSavedSearch(ctx context.Context,
 }
 
 // DeleteNotificationChannel implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) DeleteNotificationChannel(
 	ctx context.Context,
 	_ backend.DeleteNotificationChannelRequestObject,
@@ -1541,7 +1588,8 @@ func (m *mockServerInterface) DeleteNotificationChannel(
 }
 
 // CreateNotificationChannel implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) CreateNotificationChannel(
 	ctx context.Context,
 	_ backend.CreateNotificationChannelRequestObject,
@@ -1552,7 +1600,8 @@ func (m *mockServerInterface) CreateNotificationChannel(
 }
 
 // UpdateNotificationChannel implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) UpdateNotificationChannel(
 	ctx context.Context,
 	_ backend.UpdateNotificationChannelRequestObject,
@@ -1563,7 +1612,8 @@ func (m *mockServerInterface) UpdateNotificationChannel(
 }
 
 // GetNotificationChannel implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) GetNotificationChannel(
 	ctx context.Context,
 	_ backend.GetNotificationChannelRequestObject,
@@ -1574,7 +1624,8 @@ func (m *mockServerInterface) GetNotificationChannel(
 }
 
 // ListNotificationChannels implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListNotificationChannels(
 	ctx context.Context,
 	_ backend.ListNotificationChannelsRequestObject,
@@ -1585,7 +1636,8 @@ func (m *mockServerInterface) ListNotificationChannels(
 }
 
 // ListGlobalSavedSearches implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListGlobalSavedSearches(
 	ctx context.Context,
 	_ backend.ListGlobalSavedSearchesRequestObject,
@@ -1596,7 +1648,8 @@ func (m *mockServerInterface) ListGlobalSavedSearches(
 }
 
 // PingUser implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) PingUser(
 	ctx context.Context,
 	_ backend.PingUserRequestObject,
@@ -1608,7 +1661,8 @@ func (m *mockServerInterface) PingUser(
 }
 
 // ListMissingOneImplementationFeatures implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListMissingOneImplementationFeatures(ctx context.Context,
 	_ backend.ListMissingOneImplementationFeaturesRequestObject) (
 	backend.ListMissingOneImplementationFeaturesResponseObject, error) {
@@ -1618,7 +1672,8 @@ func (m *mockServerInterface) ListMissingOneImplementationFeatures(ctx context.C
 }
 
 // CreateSubscription implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) CreateSubscription(ctx context.Context,
 	_ backend.CreateSubscriptionRequestObject) (
 	backend.CreateSubscriptionResponseObject, error) {
@@ -1628,7 +1683,8 @@ func (m *mockServerInterface) CreateSubscription(ctx context.Context,
 }
 
 // UpdateSubscription implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) UpdateSubscription(ctx context.Context,
 	_ backend.UpdateSubscriptionRequestObject) (
 	backend.UpdateSubscriptionResponseObject, error) {
@@ -1638,7 +1694,8 @@ func (m *mockServerInterface) UpdateSubscription(ctx context.Context,
 }
 
 // ListSubscriptions implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListSubscriptions(ctx context.Context,
 	_ backend.ListSubscriptionsRequestObject) (
 	backend.ListSubscriptionsResponseObject, error) {
@@ -1648,7 +1705,8 @@ func (m *mockServerInterface) ListSubscriptions(ctx context.Context,
 }
 
 // GetSubscription implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) GetSubscription(ctx context.Context,
 	_ backend.GetSubscriptionRequestObject) (
 	backend.GetSubscriptionResponseObject, error) {
@@ -1658,7 +1716,8 @@ func (m *mockServerInterface) GetSubscription(ctx context.Context,
 }
 
 // GetSubscriptionRSS implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) GetSubscriptionRSS(ctx context.Context, _ backend.GetSubscriptionRSSRequestObject) (
 	backend.GetSubscriptionRSSResponseObject, error) {
 	assertUserInCtx(ctx, m.t, m.expectedUserInCtx)
@@ -1667,7 +1726,8 @@ func (m *mockServerInterface) GetSubscriptionRSS(ctx context.Context, _ backend.
 }
 
 // DeleteSubscription implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) DeleteSubscription(ctx context.Context,
 	_ backend.DeleteSubscriptionRequestObject) (
 	backend.DeleteSubscriptionResponseObject, error) {
@@ -1677,7 +1737,8 @@ func (m *mockServerInterface) DeleteSubscription(ctx context.Context,
 }
 
 // GetHealthcheckLiveness implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) GetHealthcheckLiveness(ctx context.Context,
 	_ backend.GetHealthcheckLivenessRequestObject) (
 	backend.GetHealthcheckLivenessResponseObject, error) {
@@ -1687,7 +1748,8 @@ func (m *mockServerInterface) GetHealthcheckLiveness(ctx context.Context,
 }
 
 // DeleteCodeSubscription implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) DeleteCodeSubscription(ctx context.Context,
 	_ backend.DeleteCodeSubscriptionRequestObject) (
 	backend.DeleteCodeSubscriptionResponseObject, error) {
@@ -1697,7 +1759,8 @@ func (m *mockServerInterface) DeleteCodeSubscription(ctx context.Context,
 }
 
 // HandleVCSWebhook implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) HandleVCSWebhook(_ context.Context,
 	_ backend.HandleVCSWebhookRequestObject) (
 	backend.HandleVCSWebhookResponseObject, error) {
@@ -1706,7 +1769,8 @@ func (m *mockServerInterface) HandleVCSWebhook(_ context.Context,
 }
 
 // ListCodeSubscriptions implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListCodeSubscriptions(ctx context.Context,
 	_ backend.ListCodeSubscriptionsRequestObject) (
 	backend.ListCodeSubscriptionsResponseObject, error) {
@@ -1716,7 +1780,8 @@ func (m *mockServerInterface) ListCodeSubscriptions(ctx context.Context,
 }
 
 // ListVCSInstallations implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListVCSInstallations(ctx context.Context,
 	_ backend.ListVCSInstallationsRequestObject) (
 	backend.ListVCSInstallationsResponseObject, error) {
@@ -1726,7 +1791,8 @@ func (m *mockServerInterface) ListVCSInstallations(ctx context.Context,
 }
 
 // ListVCSRepositories implements backend.StrictServerInterface.
-// nolint: ireturn // WONTFIX - generated method signature
+//
+//nolint:ireturn // WONTFIX - generated method signature
 func (m *mockServerInterface) ListVCSRepositories(ctx context.Context,
 	_ backend.ListVCSRepositoriesRequestObject) (
 	backend.ListVCSRepositoriesResponseObject, error) {

--- a/backend/pkg/httpserver/test_utils_test.go
+++ b/backend/pkg/httpserver/test_utils_test.go
@@ -21,12 +21,10 @@ import (
 // TestServerOption defines a function type to override Server fields in tests.
 type TestServerOption func(*Server)
 
-// setupTestServer creates a Server instance initialized with safe defaults for testing.
-func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
+func newDefaultMockWPTMetricsStorer(t *testing.T) *MockWPTMetricsStorer {
 	t.Helper()
 
-	// Default mock implementation
-	mockStorer := &MockWPTMetricsStorer{
+	return &MockWPTMetricsStorer{
 		t:                                                 t,
 		featureCfg:                                        nil,
 		aggregateCfg:                                      nil,
@@ -95,6 +93,13 @@ func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
 		callCountGetGlobalSavedSearch:                     0,
 		callCountGetSavedSearchSubscriptionPublic:         0,
 	}
+}
+
+// setupTestServer creates a Server instance initialized with safe defaults for testing.
+func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
+	t.Helper()
+
+	mockStorer := newDefaultMockWPTMetricsStorer(t)
 
 	srv := &Server{
 		metadataStorer:          nil,
@@ -104,6 +109,7 @@ func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
 		userGitHubClientFactory: nil,
 		eventPublisher:          nil,
 		rssRenderer:             NewRSSRenderer(),
+		webhookSecret:           nil,
 	}
 
 	// Apply Functional Options to override defaults
@@ -143,5 +149,11 @@ func withCustomCaches(c *operationResponseCaches) TestServerOption {
 func withCustomGitHubClientFactory(f UserGitHubClientFactory) TestServerOption {
 	return func(srv *Server) {
 		srv.userGitHubClientFactory = f
+	}
+}
+
+func withWebhookSecret(secret []byte) TestServerOption {
+	return func(srv *Server) {
+		srv.webhookSecret = secret
 	}
 }

--- a/backend/pkg/httpserver/update_notification_channel.go
+++ b/backend/pkg/httpserver/update_notification_channel.go
@@ -77,7 +77,8 @@ func validateUpdateNotificationChannel(request *backend.UpdateNotificationChanne
 }
 
 // UpdateNotificationChannel implements backend.StrictServerInterface.
-// nolint: ireturn // Name generated from openapi
+//
+//nolint:ireturn // Name generated from openapi
 func (s *Server) UpdateNotificationChannel(
 	ctx context.Context,
 	request backend.UpdateNotificationChannelRequestObject) (

--- a/backend/pkg/httpserver/update_saved_search.go
+++ b/backend/pkg/httpserver/update_saved_search.go
@@ -83,7 +83,8 @@ func validateSavedSearchUpdate(input *backend.UpdateSavedSearchJSONRequestBody) 
 }
 
 // UpdateSavedSearch implements backend.StrictServerInterface.
-// nolint: ireturn // Name generated from openapi
+//
+//nolint:ireturn // Name generated from openapi
 func (s *Server) UpdateSavedSearch(
 	ctx context.Context, request backend.UpdateSavedSearchRequestObject) (
 	backend.UpdateSavedSearchResponseObject, error) {
@@ -112,7 +113,7 @@ func (s *Server) UpdateSavedSearch(
 		err := s.wptMetricsStorer.ValidateQueryReferences(ctx, *request.Body.Query, &request.SearchId)
 		if err != nil {
 			if safeErr := sanitizeValidationError(err); safeErr != nil {
-				// nolint:nilerr // WONTFIX - false positive when returning structured 400 response instead of Go error.
+				//nolint:nilerr // WONTFIX - false positive when returning structured 400 response instead of Go error.
 				return backend.UpdateSavedSearch400JSONResponse{
 					Code:    http.StatusBadRequest,
 					Message: safeErr.Error(),

--- a/backend/pkg/httpserver/update_subscription.go
+++ b/backend/pkg/httpserver/update_subscription.go
@@ -86,7 +86,7 @@ func validateSubscriptionUpdate(input *backend.UpdateSubscriptionRequest) *field
 	return nil
 }
 
-// nolint:ireturn, revive // Expected ireturn for openapi generation.
+//nolint:ireturn, revive // Expected ireturn for openapi generation.
 func (s *Server) UpdateSubscription(
 	ctx context.Context,
 	request backend.UpdateSubscriptionRequestObject,

--- a/backend/pkg/httpserver/update_subscription_test.go
+++ b/backend/pkg/httpserver/update_subscription_test.go
@@ -217,7 +217,7 @@ func TestUpdateSubscription(t *testing.T) {
 	for _, tc := range testCases {
 
 		t.Run(tc.name, func(t *testing.T) {
-			// nolint:exhaustruct
+			//nolint:exhaustruct
 			mockStorer := &MockWPTMetricsStorer{
 				updateSavedSearchSubscriptionCfg: tc.cfg,
 				t:                                t,

--- a/infra/storage/spanner/migrations/000034.sql
+++ b/infra/storage/spanner/migrations/000034.sql
@@ -1,0 +1,31 @@
+-- Copyright 2026 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Migration: 000034.sql
+-- Description: Add VCSInstallations table for GitHub App and multi-VCS connections.
+
+CREATE TABLE IF NOT EXISTS VCSInstallations (
+    ID STRING(36) NOT NULL,
+    VCSProvider STRING(32) NOT NULL,
+    VCSInstallationID STRING(128) NOT NULL,
+    AccountLogin STRING(256) NOT NULL,
+    AccountType STRING(32) NOT NULL,
+    RepositorySelection STRING(32) NOT NULL,
+    Permissions JSON NOT NULL,
+    CreatedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+    UpdatedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+) PRIMARY KEY (ID);
+
+CREATE UNIQUE INDEX IF NOT EXISTS IDX_VCSInstallations_Provider_InstallationID ON VCSInstallations(VCSProvider, VCSInstallationID);
+CREATE INDEX IF NOT EXISTS IDX_VCSInstallations_Provider_AccountLogin ON VCSInstallations(VCSProvider, AccountLogin);

--- a/infra/storage/spanner/migrations/000035.sql
+++ b/infra/storage/spanner/migrations/000035.sql
@@ -1,0 +1,34 @@
+-- Copyright 2026 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Migration: 000035.sql
+-- Description: Add CodeSubscriptions table.
+
+CREATE TABLE IF NOT EXISTS CodeSubscriptions (
+    ID STRING(36) NOT NULL,
+    VCSProvider STRING(32) NOT NULL,
+    VCSInstallationID STRING(128) NOT NULL,
+    VCSRepositoryID STRING(128) NOT NULL,
+    RepositoryFullName STRING(256) NOT NULL,
+    TargetQuery STRING(2048) NOT NULL,
+    Triggers ARRAY<STRING(64)> NOT NULL,
+    Status STRING(32) NOT NULL,
+    Occurrences JSON NOT NULL,
+    CreatedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+    UpdatedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+) PRIMARY KEY (ID);
+
+CREATE UNIQUE INDEX IF NOT EXISTS IDX_CodeSubscriptions_Provider_Repo_Target ON CodeSubscriptions(VCSProvider, VCSRepositoryID, TargetQuery);
+CREATE INDEX IF NOT EXISTS IDX_CodeSubscriptions_Provider_Repo ON CodeSubscriptions(VCSProvider, VCSRepositoryID);
+CREATE INDEX IF NOT EXISTS IDX_CodeSubscriptions_TargetQuery ON CodeSubscriptions(TargetQuery);

--- a/infra/storage/spanner/migrations/000036.sql
+++ b/infra/storage/spanner/migrations/000036.sql
@@ -1,0 +1,35 @@
+-- Copyright 2026 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Migration: 000036.sql
+-- Description: Add CodeSubscriptionDeliveries table.
+
+CREATE TABLE IF NOT EXISTS CodeSubscriptionDeliveries (
+    ID STRING(36) NOT NULL,
+    SubscriptionID STRING(36) NOT NULL,
+    DeliveryStatus STRING(32) NOT NULL,
+    DeliveryChannel STRING(32) NOT NULL,
+    LockExpiresAt TIMESTAMP,
+    WorkerLockID STRING(64),
+    DeliveredAt TIMESTAMP,
+    ExternalIssueID STRING(128),
+    ExternalIssueURL STRING(1024),
+    ErrorMessage STRING(2048),
+    CreatedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+    UpdatedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+    CONSTRAINT FK_Deliveries_Subscription FOREIGN KEY (SubscriptionID) REFERENCES CodeSubscriptions(ID) ON DELETE CASCADE,
+) PRIMARY KEY (ID);
+
+CREATE INDEX IF NOT EXISTS IDX_Deliveries_SubscriptionID ON CodeSubscriptionDeliveries(SubscriptionID);
+CREATE INDEX IF NOT EXISTS IDX_Deliveries_LockStatus ON CodeSubscriptionDeliveries(DeliveryStatus, LockExpiresAt, CreatedAt);

--- a/infra/storage/spanner/migrations/000037.sql
+++ b/infra/storage/spanner/migrations/000037.sql
@@ -1,0 +1,43 @@
+-- Copyright 2026 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Migration: 000037.sql
+-- Description: Add CodeSubscriptionScanLogs and VCSWebhookDeliveries tables with native row deletion policies.
+
+CREATE TABLE IF NOT EXISTS CodeSubscriptionScanLogs (
+    ID STRING(36) NOT NULL,
+    VCSProvider STRING(32) NOT NULL,
+    VCSRepositoryID STRING(128) NOT NULL,
+    CommitSHA STRING(64) NOT NULL,
+    Branch STRING(256) NOT NULL,
+    ScanStatus STRING(32) NOT NULL,
+    FilesScanned INT64 NOT NULL,
+    DirectivesFound INT64 NOT NULL,
+    ErrorMessage STRING(2048),
+    ScannedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+) PRIMARY KEY (ID),
+ROW DELETION POLICY (OLDER_THAN(ScannedAt, INTERVAL 30 DAY));
+
+CREATE INDEX IF NOT EXISTS IDX_CodeSubscriptionScanLogs_Repo_ScannedAt ON CodeSubscriptionScanLogs(VCSProvider, VCSRepositoryID, ScannedAt DESC);
+
+CREATE TABLE IF NOT EXISTS VCSWebhookDeliveries (
+    VCSProvider STRING(32) NOT NULL,
+    DeliveryGUID STRING(128) NOT NULL,
+    EventType STRING(64) NOT NULL,
+    VCSRepositoryID STRING(128) NOT NULL,
+    ReceivedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+) PRIMARY KEY (VCSProvider, DeliveryGUID),
+ROW DELETION POLICY (OLDER_THAN(ReceivedAt, INTERVAL 7 DAY));
+
+CREATE INDEX IF NOT EXISTS IDX_VCSWebhookDeliveries_ReceivedAt ON VCSWebhookDeliveries(ReceivedAt);

--- a/lib/backendtypes/code_subscriptions.go
+++ b/lib/backendtypes/code_subscriptions.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backendtypes
+
+import (
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+// SubscriptionOccurrence represents an AST location where a directive was parsed.
+type SubscriptionOccurrence struct {
+	FilePath       string `json:"file_path"`
+	LineNumber     int64  `json:"line_number"`
+	CommentSnippet string `json:"comment_snippet"`
+}
+
+// CodeScanTaskMessage defines the Pub/Sub task payload for scanning a repository.
+type CodeScanTaskMessage struct {
+	VCSProvider        string   `json:"vcs_provider"`
+	VCSInstallationID  string   `json:"vcs_installation_id"`
+	VCSRepositoryID    string   `json:"vcs_repository_id"`
+	RepositoryFullName string   `json:"repository_full_name"`
+	CommitSHA          string   `json:"commit_sha"`
+	Branch             string   `json:"branch"`
+	IsDefaultBranch    bool     `json:"is_default_branch"`
+	ModifiedFiles      []string `json:"modified_files,omitempty"`
+}
+
+// IssueDeliveryTaskMessage defines the Pub/Sub task payload for delivering an issue.
+type IssueDeliveryTaskMessage struct {
+	DeliveryID         string                   `json:"delivery_id"`
+	SubscriptionID     string                   `json:"subscription_id"`
+	VCSProvider        string                   `json:"vcs_provider"`
+	VCSInstallationID  string                   `json:"vcs_installation_id"`
+	VCSRepositoryID    string                   `json:"vcs_repository_id"`
+	RepositoryFullName string                   `json:"repository_full_name"`
+	TargetQuery        string                   `json:"target_query"`
+	Trigger            string                   `json:"trigger"`
+	Occurrences        []SubscriptionOccurrence `json:"occurrences"`
+}
+
+// VCSInstallationSummary represents the summary of an installation for API responses.
+type VCSInstallationSummary struct {
+	ID                  string                    `json:"id"`
+	VCSProvider         string                    `json:"vcs_provider"`
+	VCSInstallationID   string                    `json:"vcs_installation_id"`
+	AccountLogin        string                    `json:"account_login"`
+	AccountType         string                    `json:"account_type"`
+	RepositorySelection string                    `json:"repository_selection"`
+	Permissions         gcpspanner.VCSPermissions `json:"permissions"`
+	CreatedAt           time.Time                 `json:"created_at"`
+	UpdatedAt           time.Time                 `json:"updated_at"`
+}
+
+// VCSInstallationToSummary converts a Spanner VCSInstallation to summary format.
+func VCSInstallationToSummary(in *gcpspanner.VCSInstallation) VCSInstallationSummary {
+	if in == nil {
+		return VCSInstallationSummary{
+			ID:                  "",
+			VCSProvider:         "",
+			VCSInstallationID:   "",
+			AccountLogin:        "",
+			AccountType:         "",
+			RepositorySelection: "",
+			Permissions:         gcpspanner.VCSPermissions{GitHub: nil},
+			CreatedAt:           time.Time{},
+			UpdatedAt:           time.Time{},
+		}
+	}
+
+	return VCSInstallationSummary{
+		ID:                  in.ID,
+		VCSProvider:         string(in.VCSProvider),
+		VCSInstallationID:   in.VCSInstallationID,
+		AccountLogin:        in.AccountLogin,
+		AccountType:         in.AccountType,
+		RepositorySelection: in.RepositorySelection,
+		Permissions:         in.Permissions,
+		CreatedAt:           in.CreatedAt,
+		UpdatedAt:           in.UpdatedAt,
+	}
+}
+
+// CodeSubscriptionsToResponse converts a slice of Spanner CodeSubscription to backend.CodeSubscriptionListResponse.
+func CodeSubscriptionsToResponse(subs []gcpspanner.CodeSubscription) backend.CodeSubscriptionListResponse {
+	results := make([]backend.CodeSubscriptionResponse, 0, len(subs))
+	for _, sub := range subs {
+		occurrences := make([]backend.SubscriptionOccurrence, 0, len(sub.Occurrences))
+		for _, occ := range sub.Occurrences {
+			occurrences = append(occurrences, backend.SubscriptionOccurrence{
+				CommentSnippet: occ.CommentSnippet,
+				FilePath:       occ.FilePath,
+				LineNumber:     occ.LineNumber,
+			})
+		}
+
+		triggers := make([]backend.SubscriptionTriggerWritable, 0, len(sub.Triggers))
+		for _, tr := range sub.Triggers {
+			triggers = append(triggers, backend.SubscriptionTriggerWritable(tr))
+		}
+
+		instID := sub.VCSInstallationID
+
+		results = append(results, backend.CodeSubscriptionResponse{
+			CreatedAt:          sub.CreatedAt,
+			FeatureId:          nil,
+			Id:                 sub.ID,
+			OccurrenceCount:    int64(len(occurrences)),
+			Occurrences:        occurrences,
+			RawDirective:       nil,
+			RepositoryFullName: sub.RepositoryFullName,
+			RepositoryName:     "",
+			RepositoryOwner:    "",
+			Status:             backend.CodeSubscriptionResponseStatus(sub.Status),
+			TargetQuery:        sub.TargetQuery,
+			Triggers:           triggers,
+			UpdatedAt:          sub.UpdatedAt,
+			VcsInstallationId:  &instID,
+			VcsProvider:        sub.VCSProvider,
+			VcsRepositoryId:    sub.VCSRepositoryID,
+		})
+	}
+
+	return backend.CodeSubscriptionListResponse{
+		Data: results,
+	}
+}

--- a/lib/backendtypes/code_subscriptions.go
+++ b/lib/backendtypes/code_subscriptions.go
@@ -130,7 +130,7 @@ func CodeSubscriptionsToResponse(subs []gcpspanner.CodeSubscription) backend.Cod
 			Triggers:           triggers,
 			UpdatedAt:          sub.UpdatedAt,
 			VcsInstallationId:  &instID,
-			VcsProvider:        sub.VCSProvider,
+			VcsProvider:        string(sub.VCSProvider),
 			VcsRepositoryId:    sub.VCSRepositoryID,
 		})
 	}

--- a/lib/backendtypes/code_subscriptions_test.go
+++ b/lib/backendtypes/code_subscriptions_test.go
@@ -60,7 +60,7 @@ func TestVCSInstallationToSummary(t *testing.T) {
 		t.Errorf("summary.ID = %s, want inst-uuid-1", summary.ID)
 	}
 	ghPerms := summary.Permissions.GitHub
-	if ghPerms == nil || ghPerms.Issues == nil || *ghPerms.Issues != "write" {
+	if ghPerms == nil || ghPerms.Issues == nil || *ghPerms.Issues != gcpspanner.GitHubPermissionLevelWrite {
 		t.Errorf("summary.Permissions.GitHub.Issues = %v, want write", ghPerms)
 	}
 }

--- a/lib/backendtypes/code_subscriptions_test.go
+++ b/lib/backendtypes/code_subscriptions_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backendtypes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestVCSInstallationToSummary(t *testing.T) {
+	t.Parallel()
+
+	// 1. Nil input
+	nilSummary := VCSInstallationToSummary(nil)
+	if nilSummary.ID != "" || nilSummary.VCSProvider != "" || nilSummary.Permissions.GitHub != nil {
+		t.Errorf("expected zero struct for nil installation, got %+v", nilSummary)
+	}
+
+	// 2. Populated input
+	now := time.Now().UTC()
+	writePerm := gcpspanner.GitHubPermissionLevelWrite
+	inst := &gcpspanner.VCSInstallation{
+		ID:                  "inst-uuid-1",
+		VCSProvider:         gcpspanner.VCSProviderGitHub,
+		VCSInstallationID:   "12345",
+		AccountLogin:        "GoogleChrome",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: gcpspanner.VCSPermissions{
+			GitHub: &gcpspanner.GitHubPermissions{
+				Issues:       &writePerm,
+				Contents:     nil,
+				Metadata:     nil,
+				PullRequests: nil,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	summary := VCSInstallationToSummary(inst)
+	if summary.ID != "inst-uuid-1" {
+		t.Errorf("summary.ID = %s, want inst-uuid-1", summary.ID)
+	}
+	ghPerms := summary.Permissions.GitHub
+	if ghPerms == nil || ghPerms.Issues == nil || *ghPerms.Issues != "write" {
+		t.Errorf("summary.Permissions.GitHub.Issues = %v, want write", ghPerms)
+	}
+}
+
+func TestCodeSubscriptionsToResponse(t *testing.T) {
+	t.Parallel()
+
+	// 1. Empty input
+	emptyResp := CodeSubscriptionsToResponse(nil)
+	if len(emptyResp.Data) != 0 {
+		t.Errorf("expected 0 data items for nil slice, got %d", len(emptyResp.Data))
+	}
+
+	// 2. Populated input
+	now := time.Now().UTC()
+	subs := []gcpspanner.CodeSubscription{
+		{
+			ID:                 "sub-uuid-1",
+			VCSProvider:        "github",
+			VCSInstallationID:  "12345",
+			VCSRepositoryID:    "67890",
+			RepositoryFullName: "GoogleChrome/webstatus.dev",
+			TargetQuery:        "id:subgrid",
+			Triggers:           []string{"feature_baseline_to_widely"},
+			Status:             gcpspanner.SubscriptionActive,
+			Occurrences: []gcpspanner.SubscriptionOccurrence{
+				{
+					FilePath:       "src/index.ts",
+					LineNumber:     42,
+					CommentSnippet: "// TODO(baseline/subgrid): grid",
+				},
+			},
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+	}
+
+	resp := CodeSubscriptionsToResponse(subs)
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 response item, got %d", len(resp.Data))
+	}
+
+	item := resp.Data[0]
+	if item.Id != "sub-uuid-1" {
+		t.Errorf("item.Id = %s, want sub-uuid-1", item.Id)
+	}
+	if item.Status != backend.CodeSubscriptionResponseStatus(gcpspanner.SubscriptionActive) {
+		t.Errorf("item.Status = %v, want ACTIVE", item.Status)
+	}
+	if item.OccurrenceCount != 1 {
+		t.Errorf("item.OccurrenceCount = %d, want 1", item.OccurrenceCount)
+	}
+}

--- a/lib/codescan/comment_parser.go
+++ b/lib/codescan/comment_parser.go
@@ -1,0 +1,273 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codescan
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// SubscriptionTrigger defines the baseline promotion trigger in the domain.
+type SubscriptionTrigger string
+
+const (
+	SubscriptionTriggerFeatureBaselinePromoteToWidely SubscriptionTrigger = "feature.baseline.promote_to_widely"
+	SubscriptionTriggerFeatureBaselinePromoteToNewly  SubscriptionTrigger = "feature.baseline.promote_to_newly"
+)
+
+// Directive represents a single parsed @webstatus AST comment directive.
+type Directive struct {
+	TargetQuery string
+	Trigger     SubscriptionTrigger
+	RawSnippet  string
+	LineNumber  int
+	FilePath    string
+}
+
+func emptyDirective() Directive {
+	return Directive{
+		TargetQuery: "",
+		Trigger:     "",
+		RawSnippet:  "",
+		LineNumber:  0,
+		FilePath:    "",
+	}
+}
+
+// Regex matching @webstatus comment directives.
+var webstatusDirectiveRegex = regexp.MustCompile(`(?i)^@webstatus:\s*(.*?)$`)
+
+// Regex matching idiomatic TODO(baseline/<id>) or TODO(baseline/<id>, newly) comments.
+var todoDirectiveRegex = regexp.MustCompile(
+	`(?i)^TODO\(` +
+		`(?:web-features?:\s*([\w-]+)|baseline(?:-(newly|widely))?/\s*([\w-]+)(?:\s*,\s*(newly|widely))?)\s*\)` +
+		`(?:\s*:\s*(.*?))?$`,
+)
+
+// ParseFileDirectives scans the lines of a source file and extracts all valid @webstatus directives.
+func ParseFileDirectives(content []byte, filePath string, defaultTarget string) []Directive {
+	var directives []Directive
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	lineNum := 0
+
+	inCBlock := false
+	inHTMLBlock := false
+
+	for scanner.Scan() {
+		lineNum++
+		rawLine := scanner.Text()
+
+		hasOpenC := strings.Contains(rawLine, "/*")
+		hasCloseC := strings.Contains(rawLine, "*/")
+		hasOpenHTML := strings.Contains(rawLine, "<!--")
+		hasCloseHTML := strings.Contains(rawLine, "-->")
+
+		if hasOpenC && !hasCloseC {
+			inCBlock = true
+		}
+		if hasOpenHTML && !hasCloseHTML {
+			inHTMLBlock = true
+		}
+
+		cleaned := cleanCommentLine(rawLine, inCBlock, inHTMLBlock)
+
+		if dir, ok := extractTodoDirective(cleaned, rawLine, lineNum, filePath); ok {
+			directives = append(directives, dir)
+		} else if dirs, ok := extractWebstatusDirective(cleaned, rawLine, lineNum, filePath, defaultTarget); ok {
+			directives = append(directives, dirs...)
+		}
+
+		if hasCloseC {
+			inCBlock = false
+		}
+		if hasCloseHTML {
+			inHTMLBlock = false
+		}
+	}
+
+	return directives
+}
+
+func cleanCommentLine(rawLine string, inCBlock, inHTMLBlock bool) string {
+	trimmed := strings.TrimSpace(rawLine)
+
+	prefixes := []string{"//", "#", "/*", "<!--"}
+	for _, p := range prefixes {
+		if after, ok := strings.CutPrefix(trimmed, p); ok {
+			trimmed = after
+
+			break
+		}
+	}
+
+	if inCBlock && strings.HasPrefix(trimmed, "*") {
+		trimmed = strings.TrimPrefix(trimmed, "*")
+	} else if inHTMLBlock && strings.HasPrefix(trimmed, "-->") {
+		return ""
+	}
+
+	trimmed = strings.TrimSuffix(trimmed, "*/")
+	trimmed = strings.TrimSuffix(trimmed, "-->")
+
+	return strings.TrimSpace(trimmed)
+}
+
+func extractTodoDirective(cleanedLine, rawLine string, lineNum int, filePath string) (Directive, bool) {
+	matches := todoDirectiveRegex.FindStringSubmatch(cleanedLine)
+	if len(matches) == 0 {
+		return emptyDirective(), false
+	}
+
+	var featureID string
+	var mod string
+
+	if matches[1] != "" {
+		featureID = matches[1]
+	} else {
+		prefixMod := strings.ToLower(matches[2])
+		featureID = matches[3]
+		suffixMod := strings.ToLower(matches[4])
+
+		if prefixMod != "" {
+			mod = prefixMod
+		} else if suffixMod != "" {
+			mod = suffixMod
+		}
+	}
+
+	trigger := SubscriptionTriggerFeatureBaselinePromoteToWidely
+	if mod == "newly" {
+		trigger = SubscriptionTriggerFeatureBaselinePromoteToNewly
+	}
+
+	return Directive{
+		TargetQuery: "id:" + featureID,
+		Trigger:     trigger,
+		RawSnippet:  strings.TrimSpace(rawLine),
+		LineNumber:  lineNum,
+		FilePath:    filePath,
+	}, true
+}
+
+func extractWebstatusDirective(
+	cleanedLine, rawLine string,
+	lineNum int,
+	filePath, defaultTarget string,
+) ([]Directive, bool) {
+	matches := webstatusDirectiveRegex.FindStringSubmatch(cleanedLine)
+	if len(matches) < 2 {
+		return nil, false
+	}
+
+	annotationBody := matches[1]
+	tokens := parseAnnotationTokens(annotationBody)
+
+	var ids []string
+	trigger := SubscriptionTriggerFeatureBaselinePromoteToWidely
+
+	if defaultTarget == "newly" || defaultTarget == "newly_available" {
+		trigger = SubscriptionTriggerFeatureBaselinePromoteToNewly
+	}
+
+	for _, token := range tokens {
+		parts := strings.SplitN(token, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		val := strings.TrimSpace(parts[1])
+
+		switch key {
+		case "id":
+			val = strings.TrimPrefix(val, "id:")
+			ids = append(ids, val)
+		case "trigger":
+			if strings.EqualFold(val, "newly_available") || strings.EqualFold(val, "newly") {
+				trigger = SubscriptionTriggerFeatureBaselinePromoteToNewly
+			} else if strings.EqualFold(val, "widely_available") || strings.EqualFold(val, "widely") {
+				trigger = SubscriptionTriggerFeatureBaselinePromoteToWidely
+			}
+		}
+	}
+
+	if len(ids) == 0 {
+		if defaultTarget != "" {
+			cleanID := strings.TrimPrefix(defaultTarget, "id:")
+			ids = append(ids, cleanID)
+		} else {
+			return nil, false
+		}
+	}
+
+	var results []Directive
+	for _, id := range ids {
+		targetQuery := id
+		if !strings.HasPrefix(id, "id:") && !strings.HasPrefix(id, "group:") {
+			targetQuery = "id:" + id
+		}
+		results = append(results, Directive{
+			TargetQuery: targetQuery,
+			Trigger:     trigger,
+			RawSnippet:  strings.TrimSpace(rawLine),
+			LineNumber:  lineNum,
+			FilePath:    filePath,
+		})
+	}
+
+	return results, true
+}
+
+func parseAnnotationTokens(body string) []string {
+	var tokens []string
+	fields := strings.FieldsSeq(body)
+	for field := range fields {
+		sub := strings.SplitSeq(field, ",")
+		for s := range sub {
+			trimmed := strings.TrimSpace(s)
+			if trimmed != "" {
+				tokens = append(tokens, trimmed)
+			}
+		}
+	}
+
+	return tokens
+}
+
+// ParseProjectDefaults extracts baseline target from .baseline.json or AGENTS.md.
+func ParseProjectDefaults(content []byte, fileName string) (string, error) {
+	if fileName == ".baseline.json" {
+		var cfg struct {
+			Target string `json:"target"`
+		}
+		if err := json.Unmarshal(content, &cfg); err != nil {
+			return "", err
+		}
+
+		return cfg.Target, nil
+	}
+
+	if fileName == "AGENTS.md" {
+		re := regexp.MustCompile(`(?i)(?:@webstatus:\s*target:|baseline\s*target\s*:\s*"?)\s*([\w-]+)"?`)
+		matches := re.FindSubmatch(content)
+		if len(matches) >= 2 {
+			return string(matches[1]), nil
+		}
+	}
+
+	return "", nil
+}

--- a/lib/codescan/comment_parser_test.go
+++ b/lib/codescan/comment_parser_test.go
@@ -1,0 +1,347 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codescan
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseFileDirectives(t *testing.T) {
+	t.Parallel()
+
+	sourceCode := `
+// Normal comment
+const x = 1;
+// TODO(baseline/popover): refactor modal to native popover
+// TODO(baseline-newly/view-transitions): progressive enhancement
+// TODO(web-feature: subgrid): upgrade layout
+/* TODO(baseline-widely/anchor-positioning): anchor tooltip */
+<!-- TODO(baseline/dialog): replace polyfill -->
+// @webstatus: id:view-transitions
+# @webstatus: id:subgrid trigger:newly_available
+/* @webstatus: id:anchor-positioning trigger:widely_available */
+<!-- @webstatus: id:backdrop-filter -->
+// @webstatus: id:compression-streams, id:badging
+// @webstatus: trigger:newly_available
+`
+
+	directives := ParseFileDirectives([]byte(sourceCode), "src/app.ts", "id:default-feature")
+
+	expected := []Directive{
+		{
+			TargetQuery: "id:popover",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "// TODO(baseline/popover): refactor modal to native popover",
+			LineNumber:  4,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:view-transitions",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
+			RawSnippet:  "// TODO(baseline-newly/view-transitions): progressive enhancement",
+			LineNumber:  5,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:subgrid",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "// TODO(web-feature: subgrid): upgrade layout",
+			LineNumber:  6,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:anchor-positioning",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "/* TODO(baseline-widely/anchor-positioning): anchor tooltip */",
+			LineNumber:  7,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:dialog",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "<!-- TODO(baseline/dialog): replace polyfill -->",
+			LineNumber:  8,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:view-transitions",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "// @webstatus: id:view-transitions",
+			LineNumber:  9,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:subgrid",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
+			RawSnippet:  "# @webstatus: id:subgrid trigger:newly_available",
+			LineNumber:  10,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:anchor-positioning",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "/* @webstatus: id:anchor-positioning trigger:widely_available */",
+			LineNumber:  11,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:backdrop-filter",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "<!-- @webstatus: id:backdrop-filter -->",
+			LineNumber:  12,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:compression-streams",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "// @webstatus: id:compression-streams, id:badging",
+			LineNumber:  13,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:badging",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToWidely,
+			RawSnippet:  "// @webstatus: id:compression-streams, id:badging",
+			LineNumber:  13,
+			FilePath:    "src/app.ts",
+		},
+		{
+			TargetQuery: "id:default-feature",
+			Trigger:     SubscriptionTriggerFeatureBaselinePromoteToNewly,
+			RawSnippet:  "// @webstatus: trigger:newly_available",
+			LineNumber:  14,
+			FilePath:    "src/app.ts",
+		},
+	}
+
+	if len(directives) != len(expected) {
+		t.Fatalf("got %d directives, want %d", len(directives), len(expected))
+	}
+
+	for i := range expected {
+		if !reflect.DeepEqual(directives[i], expected[i]) {
+			t.Errorf("directive[%d] mismatch:\ngot  %+v\nwant %+v", i, directives[i], expected[i])
+		}
+	}
+}
+
+func TestParseProjectDefaults(t *testing.T) {
+	t.Parallel()
+
+	// 1. .baseline.json
+	baselineJSON := []byte(`{"target": "group:css-anchor", "trigger": "newly_available"}`)
+	target, err := ParseProjectDefaults(baselineJSON, ".baseline.json")
+	if err != nil {
+		t.Fatalf("unexpected error parsing .baseline.json: %v", err)
+	}
+	if target != "group:css-anchor" {
+		t.Errorf("target = %q, want %q", target, "group:css-anchor")
+	}
+
+	// 2. AGENTS.md
+	agentsMD := []byte(`# AI Agent Guidelines
+<!-- @webstatus: target:widely_available -->
+`)
+	targetMD, err := ParseProjectDefaults(agentsMD, "AGENTS.md")
+	if err != nil {
+		t.Fatalf("unexpected error parsing AGENTS.md: %v", err)
+	}
+	if targetMD != "widely_available" {
+		t.Errorf("targetMD = %q, want %q", targetMD, "widely_available")
+	}
+
+	// 3. Invalid JSON error
+	invalidJSON := []byte(`{invalid-json-content}`)
+	_, err = ParseProjectDefaults(invalidJSON, ".baseline.json")
+	if err == nil {
+		t.Errorf("expected error parsing invalid .baseline.json, got nil")
+	}
+}
+
+func TestParseFileDirectivesEmptyAndBinary(t *testing.T) {
+	t.Parallel()
+
+	// 1. Empty buffer
+	emptyDirectives := ParseFileDirectives([]byte{}, "src/empty.ts", "id:default")
+	if len(emptyDirectives) != 0 {
+		t.Errorf("expected 0 directives for empty buffer, got %d", len(emptyDirectives))
+	}
+
+	// 2. Binary bytes (no matching comments)
+	binaryData := []byte{0x00, 0xFF, 0xFE, 0x01, 0x7F, 0x80}
+	binaryDirectives := ParseFileDirectives(binaryData, "assets/logo.png", "id:default")
+	if len(binaryDirectives) != 0 {
+		t.Errorf("expected 0 directives for binary data, got %d", len(binaryDirectives))
+	}
+}
+
+func TestParseFileDirectives_MultiLineComments(t *testing.T) {
+	t.Parallel()
+
+	sourceCode := `
+/*
+ * TODO(baseline/subgrid): Replace nested grid hack
+ * with native CSS subgrid once widely available.
+ */
+const y = 2;
+<!--
+  TODO(baseline/view-transitions): Multi-line
+  HTML block comment transition handler
+-->
+/*
+ * @webstatus: id:anchor-positioning trigger:newly_available
+ * Multiline webstatus comment
+ */
+`
+
+	directives := ParseFileDirectives([]byte(sourceCode), "src/multi.ts", "id:default")
+	if len(directives) != 3 {
+		t.Fatalf("got %d directives, want 3", len(directives))
+	}
+
+	if directives[0].TargetQuery != "id:subgrid" ||
+		directives[0].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely ||
+		directives[0].LineNumber != 3 {
+		t.Errorf("unexpected directive[0]: %+v", directives[0])
+	}
+	if directives[1].TargetQuery != "id:view-transitions" ||
+		directives[1].Trigger != SubscriptionTriggerFeatureBaselinePromoteToWidely ||
+		directives[1].LineNumber != 8 {
+		t.Errorf("unexpected directive[1]: %+v", directives[1])
+	}
+	if directives[2].TargetQuery != "id:anchor-positioning" ||
+		directives[2].Trigger != SubscriptionTriggerFeatureBaselinePromoteToNewly ||
+		directives[2].LineNumber != 12 {
+		t.Errorf("unexpected directive[2]: %+v", directives[2])
+	}
+}
+
+type expectedFixtureDirective struct {
+	FilePath    string              `json:"file_path"`
+	TargetQuery string              `json:"target_query"`
+	Trigger     SubscriptionTrigger `json:"trigger"`
+	LineNumber  int                 `json:"line_number"`
+	RawSnippet  string              `json:"raw_snippet"`
+}
+
+type archetypeFileExpectation struct {
+	Purpose            string                     `json:"purpose"`
+	ExpectedDirectives []expectedFixtureDirective `json:"expectedDirectives"`
+}
+
+type archetypeManifest struct {
+	Scenario    string                              `json:"scenario"`
+	Description string                              `json:"description"`
+	Files       map[string]archetypeFileExpectation `json:"files"`
+}
+
+func assertDirectiveMatch(t *testing.T, relPath string, idx int, got Directive, want expectedFixtureDirective) {
+	t.Helper()
+	if got.TargetQuery != want.TargetQuery {
+		t.Errorf("%s[%d] TargetQuery = %s, want %s", relPath, idx, got.TargetQuery, want.TargetQuery)
+	}
+	if got.Trigger != want.Trigger {
+		t.Errorf("%s[%d] Trigger = %s, want %s", relPath, idx, got.Trigger, want.Trigger)
+	}
+	if got.LineNumber != want.LineNumber {
+		t.Errorf("%s[%d] LineNumber = %d, want %d", relPath, idx, got.LineNumber, want.LineNumber)
+	}
+	if got.RawSnippet != want.RawSnippet {
+		t.Errorf("%s[%d] RawSnippet = %q, want %q", relPath, idx, got.RawSnippet, want.RawSnippet)
+	}
+}
+
+func verifyArchetypeDirectives(t *testing.T, arch string) {
+	t.Helper()
+	archDir := filepath.Join("testdata", "repos", arch)
+	expectedPath := filepath.Join(archDir, "expected.json")
+
+	expectedBytes, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("failed reading %s: %v", expectedPath, err)
+	}
+
+	var manifest archetypeManifest
+	if err := json.Unmarshal(expectedBytes, &manifest); err != nil {
+		t.Fatalf("failed parsing %s: %v", expectedPath, err)
+	}
+
+	// 1. Verify all manifested files match their expected directives
+	for relPath, fileExpectation := range manifest.Files {
+		cleanRelPath := filepath.Clean(relPath)
+		fullPath := filepath.Join(archDir, cleanRelPath)
+
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			t.Fatalf("failed reading manifested file %s: %v", fullPath, err)
+		}
+
+		got := ParseFileDirectives(content, cleanRelPath, "id:default")
+		if len(got) != len(fileExpectation.ExpectedDirectives) {
+			t.Errorf("%s: got %d directives, want %d", cleanRelPath, len(got), len(fileExpectation.ExpectedDirectives))
+
+			continue
+		}
+
+		for i, want := range fileExpectation.ExpectedDirectives {
+			assertDirectiveMatch(t, cleanRelPath, i, got[i], want)
+		}
+	}
+
+	// 2. Ensure every file in the directory is documented in manifest.Files
+	err = filepath.WalkDir(archDir, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return walkErr
+		}
+
+		relPath, err := filepath.Rel(archDir, path)
+		if err != nil {
+			return err
+		}
+		if relPath == "expected.json" {
+			return nil
+		}
+
+		if _, ok := manifest.Files[relPath]; !ok {
+			t.Errorf("unregistered fixture file found on disk: %s in archetype %s", relPath, arch)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed walking %s: %v", archDir, err)
+	}
+}
+
+func TestParseFileDirectives_ArchetypeFixtures(t *testing.T) {
+	t.Parallel()
+
+	archetypes := []string{
+		"standard-spa",
+		"monorepo-workspaces",
+		"sfc-components",
+	}
+
+	for _, arch := range archetypes {
+		t.Run(arch, func(t *testing.T) {
+			t.Parallel()
+			verifyArchetypeDirectives(t, arch)
+		})
+	}
+}

--- a/lib/codescan/testdata/repos/monorepo-workspaces/.baseline.json
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/.baseline.json
@@ -1,0 +1,4 @@
+{
+  "target": "group:css-anchor",
+  "trigger": "widely_available"
+}

--- a/lib/codescan/testdata/repos/monorepo-workspaces/apps/legacy-portal/src/table.css
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/apps/legacy-portal/src/table.css
@@ -1,0 +1,5 @@
+/* Legacy portal table */
+.table {
+  display: block;
+  /* TODO(baseline/subgrid): modernize nested table cells */
+}

--- a/lib/codescan/testdata/repos/monorepo-workspaces/apps/modern-pwa/.baseline.json
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/apps/modern-pwa/.baseline.json
@@ -1,0 +1,4 @@
+{
+  "target": "newly",
+  "trigger": "newly_available"
+}

--- a/lib/codescan/testdata/repos/monorepo-workspaces/apps/modern-pwa/src/camera.ts
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/apps/modern-pwa/src/camera.ts
@@ -1,0 +1,5 @@
+// Modern PWA camera integration
+export function initCamera() {
+  // TODO(baseline-newly/view-transitions): animate camera viewport
+  console.log('Camera ready');
+}

--- a/lib/codescan/testdata/repos/monorepo-workspaces/expected.json
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/expected.json
@@ -1,0 +1,50 @@
+{
+  "scenario": "Monorepo Workspaces with Hierarchical Overrides",
+  "description": "Demonstrates a multi-package monorepo where the root sets target=widely, legacy apps inherit it, modern sub-apps override with target=newly, and shared packages use explicit modifiers.",
+  "files": {
+    ".baseline.json": {
+      "purpose": "Root monorepo configuration setting target=widely",
+      "expectedDirectives": []
+    },
+    "apps/legacy-portal/src/table.css": {
+      "purpose": "Legacy portal application inheriting root target=widely with CSS block comment directive",
+      "expectedDirectives": [
+        {
+          "file_path": "apps/legacy-portal/src/table.css",
+          "target_query": "id:subgrid",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 4,
+          "raw_snippet": "/* TODO(baseline/subgrid): modernize nested table cells */"
+        }
+      ]
+    },
+    "apps/modern-pwa/.baseline.json": {
+      "purpose": "Sub-app workspace configuration overriding default target to newly",
+      "expectedDirectives": []
+    },
+    "apps/modern-pwa/src/camera.ts": {
+      "purpose": "Modern PWA app using explicit baseline-newly modifier",
+      "expectedDirectives": [
+        {
+          "file_path": "apps/modern-pwa/src/camera.ts",
+          "target_query": "id:view-transitions",
+          "trigger": "feature.baseline.promote_to_newly",
+          "line_number": 3,
+          "raw_snippet": "// TODO(baseline-newly/view-transitions): animate camera viewport"
+        }
+      ]
+    },
+    "packages/ui-components/src/dialog.ts": {
+      "purpose": "Shared component package with native dialog directive",
+      "expectedDirectives": [
+        {
+          "file_path": "packages/ui-components/src/dialog.ts",
+          "target_query": "id:dialog",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 2,
+          "raw_snippet": "// TODO(baseline/dialog): native dialog wrapper"
+        }
+      ]
+    }
+  }
+}

--- a/lib/codescan/testdata/repos/monorepo-workspaces/packages/ui-components/src/dialog.ts
+++ b/lib/codescan/testdata/repos/monorepo-workspaces/packages/ui-components/src/dialog.ts
@@ -1,0 +1,3 @@
+// Reusable UI components
+// TODO(baseline/dialog): native dialog wrapper
+export class DialogComponent {}

--- a/lib/codescan/testdata/repos/sfc-components/Modal.vue
+++ b/lib/codescan/testdata/repos/sfc-components/Modal.vue
@@ -1,0 +1,18 @@
+<template>
+  <!-- TODO(baseline/dialog): replace modal container with native dialog -->
+  <div class="modal-dialog">
+    <slot></slot>
+  </div>
+</template>
+
+<script setup lang="ts">
+// TODO(baseline/popover, newly): use popover for action menu
+import { ref } from 'vue';
+</script>
+
+<style scoped>
+/* TODO(baseline-widely/anchor-positioning): position modal anchored to trigger */
+.modal-dialog {
+  position: fixed;
+}
+</style>

--- a/lib/codescan/testdata/repos/sfc-components/Tooltip.svelte
+++ b/lib/codescan/testdata/repos/sfc-components/Tooltip.svelte
@@ -1,0 +1,15 @@
+<script>
+  // TODO(baseline/popover): use native popover
+  export let text = '';
+</script>
+
+<!-- TODO(baseline-widely/anchor-positioning): anchor tooltip -->
+<div class="tooltip-content">
+  {text}
+</div>
+
+<style>
+  .tooltip-content {
+    display: block;
+  }
+</style>

--- a/lib/codescan/testdata/repos/sfc-components/expected.json
+++ b/lib/codescan/testdata/repos/sfc-components/expected.json
@@ -1,0 +1,51 @@
+{
+  "scenario": "Single-File Components (Vue / Svelte)",
+  "description": "Demonstrates directives inside template, script, and style blocks of modern SFC formats (Vue .vue and Svelte .svelte).",
+  "files": {
+    "Modal.vue": {
+      "purpose": "Vue SFC with directives in <template>, <script>, and <style> blocks",
+      "expectedDirectives": [
+        {
+          "file_path": "Modal.vue",
+          "target_query": "id:dialog",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 2,
+          "raw_snippet": "<!-- TODO(baseline/dialog): replace modal container with native dialog -->"
+        },
+        {
+          "file_path": "Modal.vue",
+          "target_query": "id:popover",
+          "trigger": "feature.baseline.promote_to_newly",
+          "line_number": 9,
+          "raw_snippet": "// TODO(baseline/popover, newly): use popover for action menu"
+        },
+        {
+          "file_path": "Modal.vue",
+          "target_query": "id:anchor-positioning",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 14,
+          "raw_snippet": "/* TODO(baseline-widely/anchor-positioning): position modal anchored to trigger */"
+        }
+      ]
+    },
+    "Tooltip.svelte": {
+      "purpose": "Svelte SFC with directives in <script> and template sections",
+      "expectedDirectives": [
+        {
+          "file_path": "Tooltip.svelte",
+          "target_query": "id:popover",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 2,
+          "raw_snippet": "// TODO(baseline/popover): use native popover"
+        },
+        {
+          "file_path": "Tooltip.svelte",
+          "target_query": "id:anchor-positioning",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 6,
+          "raw_snippet": "<!-- TODO(baseline-widely/anchor-positioning): anchor tooltip -->"
+        }
+      ]
+    }
+  }
+}

--- a/lib/codescan/testdata/repos/standard-spa/.baseline.json
+++ b/lib/codescan/testdata/repos/standard-spa/.baseline.json
@@ -1,0 +1,4 @@
+{
+  "target": "2024",
+  "trigger": "widely_available"
+}

--- a/lib/codescan/testdata/repos/standard-spa/expected.json
+++ b/lib/codescan/testdata/repos/standard-spa/expected.json
@@ -1,0 +1,60 @@
+{
+  "scenario": "Standard Single-Page TypeScript/CSS Application",
+  "description": "Demonstrates a standard SPA with root .baseline.json configuration, inline TypeScript directives, CSS block directives, and HTML comment directives.",
+  "files": {
+    ".baseline.json": {
+      "purpose": "Repository root configuration establishing target=widely and issue label defaults",
+      "expectedDirectives": []
+    },
+    "src/app.ts": {
+      "purpose": "Main TypeScript application logic with inline TODO(baseline/popover) and TODO(baseline/view-transitions, newly) comments",
+      "expectedDirectives": [
+        {
+          "file_path": "src/app.ts",
+          "target_query": "id:popover",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 4,
+          "raw_snippet": "// TODO(baseline/popover): replace custom tooltip with native popover"
+        },
+        {
+          "file_path": "src/app.ts",
+          "target_query": "id:view-transitions",
+          "trigger": "feature.baseline.promote_to_newly",
+          "line_number": 7,
+          "raw_snippet": "// TODO(baseline/view-transitions, newly): smooth page transitions"
+        }
+      ]
+    },
+    "src/styles.css": {
+      "purpose": "Application styles with CSS block comment directives for subgrid and anchor-positioning",
+      "expectedDirectives": [
+        {
+          "file_path": "src/styles.css",
+          "target_query": "id:subgrid",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 5,
+          "raw_snippet": "/* TODO(baseline/subgrid): upgrade nested grid layout to subgrid */"
+        },
+        {
+          "file_path": "src/styles.css",
+          "target_query": "id:anchor-positioning",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 10,
+          "raw_snippet": "/* TODO(baseline-widely/anchor-positioning): anchor tooltip to button */"
+        }
+      ]
+    },
+    "index.html": {
+      "purpose": "HTML entrypoint with HTML comment directive for native dialog",
+      "expectedDirectives": [
+        {
+          "file_path": "index.html",
+          "target_query": "id:dialog",
+          "trigger": "feature.baseline.promote_to_widely",
+          "line_number": 9,
+          "raw_snippet": "<!-- TODO(baseline/dialog): replace third-party modal polyfill with native dialog -->"
+        }
+      ]
+    }
+  }
+}

--- a/lib/codescan/testdata/repos/standard-spa/index.html
+++ b/lib/codescan/testdata/repos/standard-spa/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Standard SPA</title>
+  <link rel="stylesheet" href="src/styles.css">
+</head>
+<body>
+  <!-- TODO(baseline/dialog): replace third-party modal polyfill with native dialog -->
+  <div id="modal-root"></div>
+  <script src="src/app.ts"></script>
+</body>
+</html>

--- a/lib/codescan/testdata/repos/standard-spa/src/app.ts
+++ b/lib/codescan/testdata/repos/standard-spa/src/app.ts
@@ -1,0 +1,11 @@
+// Standard SPA application entry point
+
+export function setupApp() {
+  // TODO(baseline/popover): replace custom tooltip with native popover
+  const tooltip = document.querySelector('.tooltip');
+
+  // TODO(baseline/view-transitions, newly): smooth page transitions
+  if (document.startViewTransition) {
+    document.startViewTransition();
+  }
+}

--- a/lib/codescan/testdata/repos/standard-spa/src/styles.css
+++ b/lib/codescan/testdata/repos/standard-spa/src/styles.css
@@ -1,0 +1,12 @@
+/* Application layout styles */
+
+.grid-container {
+  display: grid;
+  /* TODO(baseline/subgrid): upgrade nested grid layout to subgrid */
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.tooltip-box {
+  /* TODO(baseline-widely/anchor-positioning): anchor tooltip to button */
+  position: absolute;
+}

--- a/lib/codescan/tree_scanner.go
+++ b/lib/codescan/tree_scanner.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codescan
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	MaxBlobSizeBytes  int64 = 1024 * 1024       // 1MB per file
+	MaxScanTotalBytes int64 = 100 * 1024 * 1024 // 100MB total per repo
+	MaxScannedFiles   int   = 10000             // 10k files max per scan
+)
+
+// ScanStatus represents the final status of a git tree scan in the domain.
+type ScanStatus string
+
+const (
+	ScanStatusSuccess   ScanStatus = "SUCCESS"
+	ScanStatusTruncated ScanStatus = "TRUNCATED"
+	ScanStatusFailed    ScanStatus = "FAILED"
+)
+
+// SubscriptionOccurrence represents an individual location in code referencing a feature.
+type SubscriptionOccurrence struct {
+	FilePath       string
+	LineNumber     int64
+	CommentSnippet string
+}
+
+// ScannedSubscription represents an aggregated code subscription across occurrences.
+type ScannedSubscription struct {
+	ID                 string
+	VCSProvider        string
+	VCSInstallationID  string
+	VCSRepositoryID    string
+	RepositoryFullName string
+	TargetQuery        string
+	Triggers           []string
+	Occurrences        []SubscriptionOccurrence
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+// BlobReader abstracts content retrieval for git tree entries.
+type BlobReader interface {
+	GetBlob(ctx context.Context, repoFullName, sha string) ([]byte, error)
+}
+
+// GitTreeEntry represents a file entry in a VCS repository tree.
+type GitTreeEntry struct {
+	Path string
+	Type string
+	SHA  string
+	Size int64
+}
+
+// ScanResult contains all extracted subscriptions and execution statistics.
+type ScanResult struct {
+	Subscriptions   []ScannedSubscription
+	FilesScanned    int64
+	DirectivesFound int64
+	IsTruncated     bool
+	ScanStatus      ScanStatus
+}
+
+type subscriptionGroupKey struct {
+	TargetQuery string
+	Trigger     SubscriptionTrigger
+}
+
+// IsSupportedWebExtension reports whether the file extension is on the strict web allowlist.
+func IsSupportedWebExtension(ext string) bool {
+	switch strings.ToLower(ext) {
+	case ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs",
+		".css", ".scss",
+		".html", ".htm",
+		".vue", ".svelte", ".astro":
+		return true
+	default:
+		return false
+	}
+}
+
+// SupportedWebExtensions returns a slice of all supported web file extensions.
+func SupportedWebExtensions() []string {
+	return []string{
+		".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs",
+		".css", ".scss",
+		".html", ".htm",
+		".vue", ".svelte", ".astro",
+	}
+}
+
+func extractProjectDefaults(
+	ctx context.Context,
+	repoFullName string,
+	treeEntries []GitTreeEntry,
+	reader BlobReader,
+) string {
+	for _, entry := range treeEntries {
+		if entry.Type != "blob" {
+			continue
+		}
+		base := filepath.Base(entry.Path)
+		if base == ".baseline.json" || base == "AGENTS.md" {
+			content, err := reader.GetBlob(ctx, repoFullName, entry.SHA)
+			if err == nil {
+				defaultTarget, err := ParseProjectDefaults(content, base)
+				if err == nil && defaultTarget != "" {
+					return defaultTarget
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+func shouldSkipEntry(entry GitTreeEntry) bool {
+	if entry.Type != "blob" {
+		return true
+	}
+	ext := filepath.Ext(entry.Path)
+
+	return !IsSupportedWebExtension(ext) || entry.Size > MaxBlobSizeBytes
+}
+
+func buildSubscriptions(
+	vcsProvider, installationID, repoID, repoFullName string,
+	groups map[subscriptionGroupKey][]SubscriptionOccurrence,
+	now time.Time,
+) []ScannedSubscription {
+	if vcsProvider == "" {
+		vcsProvider = "github"
+	}
+	subscriptions := make([]ScannedSubscription, 0, len(groups))
+
+	for key, occurrences := range groups {
+		subID := uuid.New().String()
+		subscriptions = append(subscriptions, ScannedSubscription{
+			ID:                 subID,
+			VCSProvider:        vcsProvider,
+			VCSInstallationID:  installationID,
+			VCSRepositoryID:    repoID,
+			RepositoryFullName: repoFullName,
+			TargetQuery:        key.TargetQuery,
+			Triggers:           []string{string(key.Trigger)},
+			Occurrences:        occurrences,
+			CreatedAt:          now,
+			UpdatedAt:          now,
+		})
+	}
+
+	return subscriptions
+}
+
+// ScanGitTree walks tree entries, retrieves blobs, parses comment directives, and aggregates subscriptions.
+func ScanGitTree(
+	ctx context.Context,
+	vcsProvider, installationID, repoID, repoFullName string,
+	treeEntries []GitTreeEntry,
+	reader BlobReader,
+) (*ScanResult, error) {
+	now := time.Now().UTC()
+	var totalBytes int64
+	scannedCount := 0
+	isTruncated := false
+
+	defaultTarget := extractProjectDefaults(ctx, repoFullName, treeEntries, reader)
+	groups := make(map[subscriptionGroupKey][]SubscriptionOccurrence)
+
+	for _, entry := range treeEntries {
+		if shouldSkipEntry(entry) {
+			continue
+		}
+
+		if scannedCount >= MaxScannedFiles || (totalBytes+entry.Size) > MaxScanTotalBytes {
+			isTruncated = true
+
+			break
+		}
+
+		content, err := reader.GetBlob(ctx, repoFullName, entry.SHA)
+		if err != nil {
+			continue
+		}
+
+		scannedCount++
+		totalBytes += int64(len(content))
+
+		directives := ParseFileDirectives(content, entry.Path, defaultTarget)
+		for _, d := range directives {
+			key := subscriptionGroupKey{
+				TargetQuery: d.TargetQuery,
+				Trigger:     d.Trigger,
+			}
+			groups[key] = append(groups[key], SubscriptionOccurrence{
+				FilePath:       d.FilePath,
+				LineNumber:     int64(d.LineNumber),
+				CommentSnippet: d.RawSnippet,
+			})
+		}
+	}
+
+	subscriptions := buildSubscriptions(vcsProvider, installationID, repoID, repoFullName, groups, now)
+
+	scanStatus := ScanStatusSuccess
+	if isTruncated {
+		scanStatus = ScanStatusTruncated
+	}
+
+	var directivesCount int64
+	for _, sub := range subscriptions {
+		directivesCount += int64(len(sub.Occurrences))
+	}
+
+	return &ScanResult{
+		Subscriptions:   subscriptions,
+		FilesScanned:    int64(scannedCount),
+		DirectivesFound: directivesCount,
+		IsTruncated:     isTruncated,
+		ScanStatus:      scanStatus,
+	}, nil
+}

--- a/lib/codescan/tree_scanner_test.go
+++ b/lib/codescan/tree_scanner_test.go
@@ -1,0 +1,361 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codescan
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type mockBlobReader struct {
+	blobs map[string][]byte
+}
+
+func (m *mockBlobReader) GetBlob(_ context.Context, _, sha string) ([]byte, error) {
+	content, ok := m.blobs[sha]
+	if !ok {
+		return nil, fmt.Errorf("blob not found: %s", sha)
+	}
+
+	return content, nil
+}
+
+func TestScanGitTree(t *testing.T) {
+	t.Parallel()
+
+	reader := &mockBlobReader{
+		blobs: map[string][]byte{
+			"sha_file1": []byte("// TODO(baseline/view-transitions): transition\nconst a = 1;\n// TODO(baseline/subgrid): grid"),
+			"sha_file2": []byte("/* TODO(baseline/view-transitions): transition */\nconst b = 2;"),
+			"sha_file3": []byte("<!-- TODO(baseline/view-transitions, newly): anim -->"),
+		},
+	}
+
+	treeEntries := []GitTreeEntry{
+		{Path: "src/file1.ts", Type: "blob", SHA: "sha_file1", Size: 100},
+		{Path: "src/file2.js", Type: "blob", SHA: "sha_file2", Size: 100},
+		{Path: "public/index.html", Type: "blob", SHA: "sha_file3", Size: 100},
+		{Path: "ignored.png", Type: "blob", SHA: "sha_png", Size: 500},
+	}
+
+	res, err := ScanGitTree(
+		context.Background(),
+		"github",
+		"inst-123",
+		"12345",
+		"GoogleChrome/webstatus.dev",
+		treeEntries,
+		reader,
+	)
+	if err != nil {
+		t.Fatalf("ScanGitTree failed: %v", err)
+	}
+
+	if res.ScanStatus != ScanStatusSuccess {
+		t.Errorf("res.ScanStatus = %v, want Success", res.ScanStatus)
+	}
+	if res.FilesScanned != 3 {
+		t.Errorf("res.FilesScanned = %d, want 3", res.FilesScanned)
+	}
+	if res.DirectivesFound != 4 {
+		t.Errorf("res.DirectivesFound = %d, want 4", res.DirectivesFound)
+	}
+
+	if len(res.Subscriptions) != 3 {
+		t.Fatalf("expected 3 subscriptions, got %d", len(res.Subscriptions))
+	}
+}
+
+func TestScanGitTreeProjectDefaults(t *testing.T) {
+	t.Parallel()
+
+	reader := &mockBlobReader{
+		blobs: map[string][]byte{
+			"sha_config": []byte(`{"target": "2024"}`),
+			"sha_code":   []byte("// TODO(baseline/popover): use native popover"),
+		},
+	}
+
+	treeEntries := []GitTreeEntry{
+		{Path: ".baseline.json", Type: "blob", SHA: "sha_config", Size: 50},
+		{Path: "src/main.ts", Type: "blob", SHA: "sha_code", Size: 100},
+	}
+
+	res, err := ScanGitTree(
+		context.Background(),
+		"github",
+		"inst-123",
+		"12345",
+		"GoogleChrome/webstatus.dev",
+		treeEntries,
+		reader,
+	)
+	if err != nil {
+		t.Fatalf("ScanGitTree failed: %v", err)
+	}
+
+	if len(res.Subscriptions) != 1 {
+		t.Fatalf("expected 1 subscription, got %d", len(res.Subscriptions))
+	}
+
+	sub := res.Subscriptions[0]
+	if sub.TargetQuery != "id:popover" {
+		t.Errorf("sub.TargetQuery = %s, want id:popover", sub.TargetQuery)
+	}
+}
+
+func TestScanGitTreeLargeBlobSkipped(t *testing.T) {
+	t.Parallel()
+
+	reader := &mockBlobReader{
+		blobs: map[string][]byte{
+			"sha_large": []byte("// TODO(baseline/dialog): skipped"),
+		},
+	}
+
+	treeEntries := []GitTreeEntry{
+		{Path: "src/huge.ts", Type: "blob", SHA: "sha_large", Size: 2 * 1024 * 1024}, // 2MB > 1MB limit
+	}
+
+	res, err := ScanGitTree(
+		context.Background(),
+		"github",
+		"inst-123",
+		"12345",
+		"GoogleChrome/webstatus.dev",
+		treeEntries,
+		reader,
+	)
+	if err != nil {
+		t.Fatalf("ScanGitTree failed: %v", err)
+	}
+
+	if res.FilesScanned != 0 {
+		t.Errorf("res.FilesScanned = %d, want 0 (skipped due to size)", res.FilesScanned)
+	}
+	if len(res.Subscriptions) != 0 {
+		t.Errorf("expected 0 subscriptions for skipped file, got %d", len(res.Subscriptions))
+	}
+}
+
+func TestScanGitTreeMaxScannedFiles(t *testing.T) {
+	t.Parallel()
+
+	reader := &mockBlobReader{
+		blobs: map[string][]byte{},
+	}
+
+	// Create 10001 entries
+	treeEntries := make([]GitTreeEntry, MaxScannedFiles+1)
+	for i := range treeEntries {
+		treeEntries[i] = GitTreeEntry{
+			Path: fmt.Sprintf("src/file%d.ts", i),
+			Type: "blob",
+			SHA:  fmt.Sprintf("sha_%d", i),
+			Size: 50,
+		}
+		reader.blobs[fmt.Sprintf("sha_%d", i)] = []byte("const x = 1;")
+	}
+
+	res, err := ScanGitTree(
+		context.Background(),
+		"github",
+		"inst-123",
+		"12345",
+		"GoogleChrome/webstatus.dev",
+		treeEntries,
+		reader,
+	)
+	if err != nil {
+		t.Fatalf("ScanGitTree failed: %v", err)
+	}
+
+	if res.ScanStatus != ScanStatusTruncated {
+		t.Errorf("res.ScanStatus = %v, want ScanStatusTruncated", res.ScanStatus)
+	}
+	if res.FilesScanned != int64(MaxScannedFiles) {
+		t.Errorf("res.FilesScanned = %d, want %d", res.FilesScanned, MaxScannedFiles)
+	}
+}
+
+func TestScanGitTree_ArchetypeFixtures(t *testing.T) {
+	t.Parallel()
+
+	archDir := filepath.Join("testdata", "repos", "standard-spa")
+	expectedPath := filepath.Join(archDir, "expected.json")
+
+	expectedBytes, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("failed reading %s: %v", expectedPath, err)
+	}
+
+	var manifest archetypeManifest
+	if err := json.Unmarshal(expectedBytes, &manifest); err != nil {
+		t.Fatalf("failed parsing %s: %v", expectedPath, err)
+	}
+
+	totalExpectedDirectives := 0
+	for _, fileExp := range manifest.Files {
+		totalExpectedDirectives += len(fileExp.ExpectedDirectives)
+	}
+
+	files := []string{
+		".baseline.json",
+		"index.html",
+		"src/app.ts",
+		"src/styles.css",
+	}
+
+	reader := &mockBlobReader{blobs: make(map[string][]byte)}
+	treeEntries := make([]GitTreeEntry, 0, len(files))
+
+	for i, f := range files {
+		cleanF := filepath.Clean(f)
+		fullPath := filepath.Join(archDir, cleanF)
+		content, err := os.ReadFile(fullPath)
+		if err != nil {
+			t.Fatalf("failed reading %s: %v", fullPath, err)
+		}
+		sha := fmt.Sprintf("sha_%d", i)
+		reader.blobs[sha] = content
+		treeEntries = append(treeEntries, GitTreeEntry{
+			Path: cleanF,
+			Type: "blob",
+			SHA:  sha,
+			Size: int64(len(content)),
+		})
+	}
+
+	res, err := ScanGitTree(
+		context.Background(),
+		"github",
+		"inst-123",
+		"12345",
+		"GoogleChrome/webstatus.dev",
+		treeEntries,
+		reader,
+	)
+	if err != nil {
+		t.Fatalf("ScanGitTree failed: %v", err)
+	}
+
+	if res.ScanStatus != ScanStatusSuccess {
+		t.Errorf("res.ScanStatus = %v, want Success", res.ScanStatus)
+	}
+	if res.FilesScanned != 3 {
+		t.Errorf("res.FilesScanned = %d, want 3", res.FilesScanned)
+	}
+	if res.DirectivesFound != int64(totalExpectedDirectives) {
+		t.Errorf("res.DirectivesFound = %d, want %d", res.DirectivesFound, totalExpectedDirectives)
+	}
+}
+
+func TestIsSupportedWebExtension(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		ext  string
+		want bool
+	}{
+		// Web languages & components (allowed)
+		{ext: ".js", want: true},
+		{ext: ".JS", want: true},
+		{ext: ".jsx", want: true},
+		{ext: ".ts", want: true},
+		{ext: ".TSX", want: true},
+		{ext: ".mjs", want: true},
+		{ext: ".cjs", want: true},
+		{ext: ".css", want: true},
+		{ext: ".scss", want: true},
+		{ext: ".html", want: true},
+		{ext: ".htm", want: true},
+		{ext: ".vue", want: true},
+		{ext: ".svelte", want: true},
+		{ext: ".astro", want: true},
+
+		// Non-web / backend / binary extensions (rejected)
+		{ext: ".pas", want: false},
+		{ext: ".py", want: false},
+		{ext: ".go", want: false},
+		{ext: ".rs", want: false},
+		{ext: ".c", want: false},
+		{ext: ".cpp", want: false},
+		{ext: ".java", want: false},
+		{ext: ".md", want: false},
+		{ext: ".txt", want: false},
+		{ext: ".png", want: false},
+		{ext: ".exe", want: false},
+		{ext: "", want: false},
+	}
+
+	for _, tc := range tests {
+		got := IsSupportedWebExtension(tc.ext)
+		if got != tc.want {
+			t.Errorf("IsSupportedWebExtension(%q) = %v, want %v", tc.ext, got, tc.want)
+		}
+	}
+
+	exts := SupportedWebExtensions()
+	if len(exts) != 13 {
+		t.Errorf("SupportedWebExtensions() returned %d items, want 13", len(exts))
+	}
+}
+
+func TestScanGitTree_NonWebFilesSkipped(t *testing.T) {
+	t.Parallel()
+
+	reader := &mockBlobReader{
+		blobs: map[string][]byte{
+			"sha_ts":  []byte("// TODO(baseline/view-transitions): transition\nconst a = 1;"),
+			"sha_pas": []byte("{ TODO(baseline/popover): pascal comment }"),
+			"sha_py":  []byte("# TODO(baseline/subgrid): python comment"),
+			"sha_go":  []byte("// TODO(baseline/dialog): go comment"),
+		},
+	}
+
+	treeEntries := []GitTreeEntry{
+		{Path: "src/app.ts", Type: "blob", SHA: "sha_ts", Size: 100},
+		{Path: "legacy/calc.pas", Type: "blob", SHA: "sha_pas", Size: 100},
+		{Path: "server/backend.py", Type: "blob", SHA: "sha_py", Size: 100},
+		{Path: "cmd/main.go", Type: "blob", SHA: "sha_go", Size: 100},
+	}
+
+	res, err := ScanGitTree(
+		context.Background(),
+		"github",
+		"inst-123",
+		"12345",
+		"GoogleChrome/webstatus.dev",
+		treeEntries,
+		reader,
+	)
+	if err != nil {
+		t.Fatalf("ScanGitTree failed: %v", err)
+	}
+
+	if res.FilesScanned != 1 {
+		t.Errorf("res.FilesScanned = %d, want 1 (only .ts scanned, non-web files skipped)", res.FilesScanned)
+	}
+	if res.DirectivesFound != 1 {
+		t.Errorf("res.DirectivesFound = %d, want 1", res.DirectivesFound)
+	}
+	if len(res.Subscriptions) != 1 || res.Subscriptions[0].TargetQuery != "id:view-transitions" {
+		t.Errorf("unexpected subscriptions: %+v", res.Subscriptions)
+	}
+}

--- a/lib/gcppubsub/gcppubsubadapters/backend.go
+++ b/lib/gcppubsub/gcppubsubadapters/backend.go
@@ -16,9 +16,11 @@ package gcppubsubadapters
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/event"
 	searchconfigv1 "github.com/GoogleChrome/webstatus.dev/lib/event/searchconfigurationchanged/v1"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
@@ -63,6 +65,28 @@ func (p *BackendAdapter) PublishSearchConfigurationChanged(
 		"msgID", id,
 		"searchID", evt.SearchID,
 		"isCreation", evt.IsCreation)
+
+	return nil
+}
+
+func (p *BackendAdapter) PublishCodeScanTask(
+	ctx context.Context,
+	task backendtypes.CodeScanTaskMessage,
+) error {
+	data, err := json.Marshal(task)
+	if err != nil {
+		return fmt.Errorf("failed to marshal code scan task: %w", err)
+	}
+
+	id, err := p.client.Publish(ctx, p.topicID, data)
+	if err != nil {
+		return fmt.Errorf("failed to publish code scan task: %w", err)
+	}
+
+	slog.InfoContext(ctx, "published code scan task",
+		"msgID", id,
+		"repo", task.RepositoryFullName,
+		"commit", task.CommitSHA)
 
 	return nil
 }

--- a/lib/gcpspanner/code_subscription.go
+++ b/lib/gcpspanner/code_subscription.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+const codeSubscriptionTable = "CodeSubscriptions"
+
+var (
+	// ErrCodeSubscriptionNotFound indicates that the code subscription was not found.
+	ErrCodeSubscriptionNotFound = errors.New("code subscription not found")
+	// ErrUnknownSubscriptionStatus indicates an unrecognized subscription status.
+	ErrUnknownSubscriptionStatus = errors.New("unknown subscription status")
+)
+
+// SubscriptionStatus represents the lifecycle state of a code subscription.
+type SubscriptionStatus string
+
+const (
+	SubscriptionActive    SubscriptionStatus = "ACTIVE"
+	SubscriptionTriggered SubscriptionStatus = "TRIGGERED"
+	SubscriptionDelivered SubscriptionStatus = "DELIVERED"
+	SubscriptionResolved  SubscriptionStatus = "RESOLVED"
+	SubscriptionObsolete  SubscriptionStatus = "OBSOLETE"
+	SubscriptionDeleted   SubscriptionStatus = "DELETED"
+	SubscriptionError     SubscriptionStatus = "ERROR"
+)
+
+// SubscriptionOccurrence represents a code location where a directive is used.
+type SubscriptionOccurrence struct {
+	FilePath       string `json:"file_path"`
+	LineNumber     int64  `json:"line_number"`
+	CommentSnippet string `json:"comment_snippet"`
+}
+
+// CodeSubscription represents a subscription anchored to a code repository AST pattern.
+type CodeSubscription struct {
+	ID                 string
+	VCSProvider        VCSProvider
+	VCSInstallationID  string
+	VCSRepositoryID    string
+	RepositoryFullName string
+	TargetQuery        string
+	Triggers           []string
+	Status             SubscriptionStatus
+	Occurrences        []SubscriptionOccurrence
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+// spannerCodeSubscription is the internal struct for Spanner column mapping.
+type spannerCodeSubscription struct {
+	ID                 string           `spanner:"ID"`
+	VCSProvider        string           `spanner:"VCSProvider"`
+	VCSInstallationID  string           `spanner:"VCSInstallationID"`
+	VCSRepositoryID    string           `spanner:"VCSRepositoryID"`
+	RepositoryFullName string           `spanner:"RepositoryFullName"`
+	TargetQuery        string           `spanner:"TargetQuery"`
+	Triggers           []string         `spanner:"Triggers"`
+	Status             string           `spanner:"Status"`
+	Occurrences        spanner.NullJSON `spanner:"Occurrences"`
+	CreatedAt          time.Time        `spanner:"CreatedAt"`
+	UpdatedAt          time.Time        `spanner:"UpdatedAt"`
+}
+
+type codeSubscriptionMapper struct{}
+
+func (m codeSubscriptionMapper) Table() string { return codeSubscriptionTable }
+
+func (m codeSubscriptionMapper) SelectOne(id string) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSInstallationID, VCSRepositoryID, RepositoryFullName,
+			TargetQuery, Triggers, Status, Occurrences, CreatedAt, UpdatedAt
+		FROM CodeSubscriptions
+		WHERE ID = @id`,
+		Params: map[string]any{"id": id},
+	}
+}
+
+// ParseSubscriptionStatus parses and validates a raw subscription status string into a typed SubscriptionStatus.
+func ParseSubscriptionStatus(val string) (SubscriptionStatus, error) {
+	status := SubscriptionStatus(val)
+	switch status {
+	case SubscriptionActive,
+		SubscriptionTriggered,
+		SubscriptionDelivered,
+		SubscriptionResolved,
+		SubscriptionObsolete,
+		SubscriptionDeleted,
+		SubscriptionError:
+		return status, nil
+	}
+
+	return "", fmt.Errorf("%w: %q", ErrUnknownSubscriptionStatus, val)
+}
+
+func (s *spannerCodeSubscription) toCodeSubscription() (*CodeSubscription, error) {
+	provider, err := ParseVCSProvider(s.VCSProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	status, err := ParseSubscriptionStatus(s.Status)
+	if err != nil {
+		return nil, err
+	}
+
+	var occurrences []SubscriptionOccurrence
+	if s.Occurrences.Valid && s.Occurrences.Value != nil {
+		bytes, err := json.Marshal(s.Occurrences.Value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal occurrences: %w", err)
+		}
+		if err := json.Unmarshal(bytes, &occurrences); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal occurrences: %w", err)
+		}
+	} else {
+		occurrences = []SubscriptionOccurrence{}
+	}
+
+	return &CodeSubscription{
+		ID:                 s.ID,
+		VCSProvider:        provider,
+		VCSInstallationID:  s.VCSInstallationID,
+		VCSRepositoryID:    s.VCSRepositoryID,
+		RepositoryFullName: s.RepositoryFullName,
+		TargetQuery:        s.TargetQuery,
+		Triggers:           s.Triggers,
+		Status:             status,
+		Occurrences:        occurrences,
+		CreatedAt:          s.CreatedAt,
+		UpdatedAt:          s.UpdatedAt,
+	}, nil
+}
+
+func fromCodeSubscription(sub *CodeSubscription) *spannerCodeSubscription {
+	occurrences := sub.Occurrences
+	if occurrences == nil {
+		occurrences = []SubscriptionOccurrence{}
+	}
+
+	return &spannerCodeSubscription{
+		ID:                 sub.ID,
+		VCSProvider:        string(sub.VCSProvider),
+		VCSInstallationID:  sub.VCSInstallationID,
+		VCSRepositoryID:    sub.VCSRepositoryID,
+		RepositoryFullName: sub.RepositoryFullName,
+		TargetQuery:        sub.TargetQuery,
+		Triggers:           sub.Triggers,
+		Status:             string(sub.Status),
+		Occurrences: spanner.NullJSON{
+			Value: occurrences,
+			Valid: true,
+		},
+		CreatedAt: sub.CreatedAt,
+		UpdatedAt: sub.UpdatedAt,
+	}
+}
+
+// GetCodeSubscription retrieves a code subscription by ID.
+func (c *Client) GetCodeSubscription(ctx context.Context, id string) (*CodeSubscription, error) {
+	r := newEntityReader[
+		codeSubscriptionMapper, spannerCodeSubscription, CodeSubscription, string,
+	](c)
+	spannerSub, err := r.readRowByKey(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, ErrCodeSubscriptionNotFound
+		}
+
+		return nil, err
+	}
+
+	return spannerSub.toCodeSubscription()
+}

--- a/lib/gcpspanner/code_subscription_delivery.go
+++ b/lib/gcpspanner/code_subscription_delivery.go
@@ -1,0 +1,245 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+const codeSubscriptionDeliveryTable = "CodeSubscriptionDeliveries"
+
+var (
+	// ErrCodeSubscriptionDeliveryNotFound indicates that the delivery record was not found.
+	ErrCodeSubscriptionDeliveryNotFound = errors.New("code subscription delivery not found")
+	// ErrUnknownDeliveryStatus indicates an unrecognized delivery status.
+	ErrUnknownDeliveryStatus = errors.New("unknown delivery status")
+	// ErrUnknownDeliveryChannel indicates an unrecognized delivery channel.
+	ErrUnknownDeliveryChannel = errors.New("unknown delivery channel")
+)
+
+// DeliveryStatus represents the state of a notification delivery attempt.
+type DeliveryStatus string
+
+const (
+	DeliveryStatusPending   DeliveryStatus = "PENDING"
+	DeliveryStatusDelivered DeliveryStatus = "DELIVERED"
+	DeliveryStatusFailed    DeliveryStatus = "FAILED"
+)
+
+// DeliveryChannel represents the issue/notification delivery channel.
+type DeliveryChannel string
+
+const (
+	DeliveryChannelGitHubIssue DeliveryChannel = "github_issue"
+)
+
+// CodeSubscriptionDelivery tracks an issue notification delivery for a subscription.
+type CodeSubscriptionDelivery struct {
+	ID               string
+	SubscriptionID   string
+	DeliveryStatus   DeliveryStatus
+	DeliveryChannel  DeliveryChannel
+	LockExpiresAt    *time.Time
+	WorkerLockID     *string
+	DeliveredAt      *time.Time
+	ExternalIssueID  *string
+	ExternalIssueURL *string
+	ErrorMessage     *string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+// spannerCodeSubscriptionDelivery is the internal struct for Spanner column mapping.
+type spannerCodeSubscriptionDelivery struct {
+	ID               string             `spanner:"ID"`
+	SubscriptionID   string             `spanner:"SubscriptionID"`
+	DeliveryStatus   string             `spanner:"DeliveryStatus"`
+	DeliveryChannel  string             `spanner:"DeliveryChannel"`
+	LockExpiresAt    spanner.NullTime   `spanner:"LockExpiresAt"`
+	WorkerLockID     spanner.NullString `spanner:"WorkerLockID"`
+	DeliveredAt      spanner.NullTime   `spanner:"DeliveredAt"`
+	ExternalIssueID  spanner.NullString `spanner:"ExternalIssueID"`
+	ExternalIssueURL spanner.NullString `spanner:"ExternalIssueURL"`
+	ErrorMessage     spanner.NullString `spanner:"ErrorMessage"`
+	CreatedAt        time.Time          `spanner:"CreatedAt"`
+	UpdatedAt        time.Time          `spanner:"UpdatedAt"`
+}
+
+type codeSubscriptionDeliveryMapper struct{}
+
+func (m codeSubscriptionDeliveryMapper) Table() string { return codeSubscriptionDeliveryTable }
+
+func (m codeSubscriptionDeliveryMapper) SelectOne(id string) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID, SubscriptionID, DeliveryStatus, DeliveryChannel, LockExpiresAt,
+			WorkerLockID, DeliveredAt, ExternalIssueID, ExternalIssueURL, ErrorMessage,
+			CreatedAt, UpdatedAt
+		FROM CodeSubscriptionDeliveries
+		WHERE ID = @id`,
+		Params: map[string]any{"id": id},
+	}
+}
+
+// ParseDeliveryStatus parses and validates a raw delivery status string into a typed DeliveryStatus.
+func ParseDeliveryStatus(val string) (DeliveryStatus, error) {
+	status := DeliveryStatus(val)
+	switch status {
+	case DeliveryStatusPending,
+		DeliveryStatusDelivered,
+		DeliveryStatusFailed:
+		return status, nil
+	}
+
+	return "", fmt.Errorf("%w: %q", ErrUnknownDeliveryStatus, val)
+}
+
+// ParseDeliveryChannel parses and validates a raw delivery channel string into a typed DeliveryChannel.
+func ParseDeliveryChannel(val string) (DeliveryChannel, error) {
+	channel := DeliveryChannel(val)
+	switch channel {
+	case DeliveryChannelGitHubIssue:
+		return channel, nil
+	}
+
+	return "", fmt.Errorf("%w: %q", ErrUnknownDeliveryChannel, val)
+}
+
+func (s *spannerCodeSubscriptionDelivery) toCodeSubscriptionDelivery() (*CodeSubscriptionDelivery, error) {
+	status, err := ParseDeliveryStatus(s.DeliveryStatus)
+	if err != nil {
+		return nil, err
+	}
+	channel, err := ParseDeliveryChannel(s.DeliveryChannel)
+	if err != nil {
+		return nil, err
+	}
+
+	var lockExpiresAt *time.Time
+	if s.LockExpiresAt.Valid {
+		lockExpiresAt = &s.LockExpiresAt.Time
+	}
+
+	var workerLockID *string
+	if s.WorkerLockID.Valid {
+		workerLockID = &s.WorkerLockID.StringVal
+	}
+
+	var deliveredAt *time.Time
+	if s.DeliveredAt.Valid {
+		deliveredAt = &s.DeliveredAt.Time
+	}
+
+	var extIssueID *string
+	if s.ExternalIssueID.Valid {
+		extIssueID = &s.ExternalIssueID.StringVal
+	}
+
+	var extIssueURL *string
+	if s.ExternalIssueURL.Valid {
+		extIssueURL = &s.ExternalIssueURL.StringVal
+	}
+
+	var errMsg *string
+	if s.ErrorMessage.Valid {
+		errMsg = &s.ErrorMessage.StringVal
+	}
+
+	return &CodeSubscriptionDelivery{
+		ID:               s.ID,
+		SubscriptionID:   s.SubscriptionID,
+		DeliveryStatus:   status,
+		DeliveryChannel:  channel,
+		LockExpiresAt:    lockExpiresAt,
+		WorkerLockID:     workerLockID,
+		DeliveredAt:      deliveredAt,
+		ExternalIssueID:  extIssueID,
+		ExternalIssueURL: extIssueURL,
+		ErrorMessage:     errMsg,
+		CreatedAt:        s.CreatedAt,
+		UpdatedAt:        s.UpdatedAt,
+	}, nil
+}
+
+func fromCodeSubscriptionDelivery(d *CodeSubscriptionDelivery) *spannerCodeSubscriptionDelivery {
+	var lockExpiresAt spanner.NullTime
+	if d.LockExpiresAt != nil {
+		lockExpiresAt = spanner.NullTime{Time: *d.LockExpiresAt, Valid: true}
+	}
+
+	var workerLockID spanner.NullString
+	if d.WorkerLockID != nil {
+		workerLockID = spanner.NullString{StringVal: *d.WorkerLockID, Valid: true}
+	}
+
+	var deliveredAt spanner.NullTime
+	if d.DeliveredAt != nil {
+		deliveredAt = spanner.NullTime{Time: *d.DeliveredAt, Valid: true}
+	}
+
+	var extIssueID spanner.NullString
+	if d.ExternalIssueID != nil {
+		extIssueID = spanner.NullString{StringVal: *d.ExternalIssueID, Valid: true}
+	}
+
+	var extIssueURL spanner.NullString
+	if d.ExternalIssueURL != nil {
+		extIssueURL = spanner.NullString{StringVal: *d.ExternalIssueURL, Valid: true}
+	}
+
+	var errMsg spanner.NullString
+	if d.ErrorMessage != nil {
+		errMsg = spanner.NullString{StringVal: *d.ErrorMessage, Valid: true}
+	}
+
+	return &spannerCodeSubscriptionDelivery{
+		ID:               d.ID,
+		SubscriptionID:   d.SubscriptionID,
+		DeliveryStatus:   string(d.DeliveryStatus),
+		DeliveryChannel:  string(d.DeliveryChannel),
+		LockExpiresAt:    lockExpiresAt,
+		WorkerLockID:     workerLockID,
+		DeliveredAt:      deliveredAt,
+		ExternalIssueID:  extIssueID,
+		ExternalIssueURL: extIssueURL,
+		ErrorMessage:     errMsg,
+		CreatedAt:        d.CreatedAt,
+		UpdatedAt:        d.UpdatedAt,
+	}
+}
+
+// GetCodeSubscriptionDelivery retrieves a delivery record by ID.
+func (c *Client) GetCodeSubscriptionDelivery(
+	ctx context.Context,
+	id string,
+) (*CodeSubscriptionDelivery, error) {
+	r := newEntityReader[
+		codeSubscriptionDeliveryMapper, spannerCodeSubscriptionDelivery, CodeSubscriptionDelivery, string,
+	](c)
+	spannerDel, err := r.readRowByKey(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, ErrCodeSubscriptionDeliveryNotFound
+		}
+
+		return nil, err
+	}
+
+	return spannerDel.toCodeSubscriptionDelivery()
+}

--- a/lib/gcpspanner/code_subscription_delivery_test.go
+++ b/lib/gcpspanner/code_subscription_delivery_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+)
+
+func TestCodeSubscriptionDeliveryConversion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	lockExp := now.Add(30 * time.Second)
+	lockID := "worker-1"
+	issueID := "issue-123"
+	issueURL := "https://github.com/owner/repo/issues/123"
+	errMsg := "rate limited"
+
+	testCases := []struct {
+		name     string
+		original CodeSubscriptionDelivery
+	}{
+		{
+			name: "Populated nullable fields roundtrip",
+			original: CodeSubscriptionDelivery{
+				ID:               "del-uuid-1",
+				SubscriptionID:   "sub-uuid-1",
+				DeliveryStatus:   DeliveryStatusDelivered,
+				DeliveryChannel:  DeliveryChannelGitHubIssue,
+				LockExpiresAt:    &lockExp,
+				WorkerLockID:     &lockID,
+				DeliveredAt:      &now,
+				ExternalIssueID:  &issueID,
+				ExternalIssueURL: &issueURL,
+				ErrorMessage:     &errMsg,
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			},
+		},
+		{
+			name: "Nil nullable fields roundtrip",
+			original: CodeSubscriptionDelivery{
+				ID:               "del-uuid-nil-fields",
+				SubscriptionID:   "sub-uuid-1",
+				DeliveryStatus:   DeliveryStatusPending,
+				DeliveryChannel:  DeliveryChannelGitHubIssue,
+				LockExpiresAt:    nil,
+				WorkerLockID:     nil,
+				DeliveredAt:      nil,
+				ExternalIssueID:  nil,
+				ExternalIssueURL: nil,
+				ErrorMessage:     nil,
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			scsd := fromCodeSubscriptionDelivery(&tc.original)
+			converted, err := scsd.toCodeSubscriptionDelivery()
+			if err != nil {
+				t.Fatalf("unexpected toCodeSubscriptionDelivery error: %v", err)
+			}
+
+			if diff := cmp.Diff(&tc.original, converted); diff != "" {
+				t.Errorf("CodeSubscriptionDelivery conversion mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCodeSubscriptionDelivery_InvalidEnums(t *testing.T) {
+	t.Parallel()
+
+	invalidStatus := spannerCodeSubscriptionDelivery{
+		ID:               "del-1",
+		SubscriptionID:   "sub-1",
+		DeliveryStatus:   "INVALID_STATUS",
+		DeliveryChannel:  "github_issue",
+		LockExpiresAt:    spanner.NullTime{Time: time.Time{}, Valid: false},
+		WorkerLockID:     spanner.NullString{StringVal: "", Valid: false},
+		DeliveredAt:      spanner.NullTime{Time: time.Time{}, Valid: false},
+		ExternalIssueID:  spanner.NullString{StringVal: "", Valid: false},
+		ExternalIssueURL: spanner.NullString{StringVal: "", Valid: false},
+		ErrorMessage:     spanner.NullString{StringVal: "", Valid: false},
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	_, err := invalidStatus.toCodeSubscriptionDelivery()
+	if err == nil {
+		t.Fatalf("expected error for invalid delivery status, got nil")
+	}
+	if !errors.Is(err, ErrUnknownDeliveryStatus) {
+		t.Fatalf("expected ErrUnknownDeliveryStatus, got %v", err)
+	}
+
+	invalidChannel := spannerCodeSubscriptionDelivery{
+		ID:               "del-2",
+		SubscriptionID:   "sub-1",
+		DeliveryStatus:   "PENDING",
+		DeliveryChannel:  "unsupported_channel",
+		LockExpiresAt:    spanner.NullTime{Time: time.Time{}, Valid: false},
+		WorkerLockID:     spanner.NullString{StringVal: "", Valid: false},
+		DeliveredAt:      spanner.NullTime{Time: time.Time{}, Valid: false},
+		ExternalIssueID:  spanner.NullString{StringVal: "", Valid: false},
+		ExternalIssueURL: spanner.NullString{StringVal: "", Valid: false},
+		ErrorMessage:     spanner.NullString{StringVal: "", Valid: false},
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	_, err = invalidChannel.toCodeSubscriptionDelivery()
+	if err == nil {
+		t.Fatalf("expected error for invalid delivery channel, got nil")
+	}
+	if !errors.Is(err, ErrUnknownDeliveryChannel) {
+		t.Fatalf("expected ErrUnknownDeliveryChannel, got %v", err)
+	}
+}
+
+func testCodeSubscriptionDeliveryNotFound(ctx context.Context, t *testing.T) {
+	_, err := spannerClient.GetCodeSubscriptionDelivery(ctx, "non-existent-del-id")
+	if !errors.Is(err, ErrCodeSubscriptionDeliveryNotFound) {
+		t.Fatalf("expected ErrCodeSubscriptionDeliveryNotFound, got %v", err)
+	}
+}
+
+func testCodeSubscriptionDeliveryInsertAndGet(ctx context.Context, t *testing.T, subID string) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	delID := uuid.NewString()
+	del := CodeSubscriptionDelivery{
+		ID:               delID,
+		SubscriptionID:   subID,
+		DeliveryStatus:   DeliveryStatusPending,
+		DeliveryChannel:  DeliveryChannelGitHubIssue,
+		LockExpiresAt:    nil,
+		WorkerLockID:     nil,
+		DeliveredAt:      nil,
+		ExternalIssueID:  nil,
+		ExternalIssueURL: nil,
+		ErrorMessage:     nil,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	spannerDel := fromCodeSubscriptionDelivery(&del)
+	delMut, err := spanner.InsertStruct(codeSubscriptionDeliveryTable, spannerDel)
+	if err != nil {
+		t.Fatalf("InsertStruct delivery failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{delMut}); err != nil {
+		t.Fatalf("Apply delivery mutation failed: %v", err)
+	}
+
+	retrieved, err := spannerClient.GetCodeSubscriptionDelivery(ctx, delID)
+	if err != nil {
+		t.Fatalf("GetCodeSubscriptionDelivery failed: %v", err)
+	}
+	if retrieved.ID != delID || retrieved.SubscriptionID != subID {
+		t.Fatalf("retrieved delivery mismatch: %+v", retrieved)
+	}
+	if retrieved.DeliveryStatus != DeliveryStatusPending {
+		t.Errorf("expected status %s, got %s", DeliveryStatusPending, retrieved.DeliveryStatus)
+	}
+}
+
+func testCodeSubscriptionDeliveryNullableFields(ctx context.Context, t *testing.T, subID string) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	delID := uuid.NewString()
+	lockExp := now.Add(30 * time.Second)
+	workerID := "worker-lock-42"
+	issueID := "gh-issue-99"
+	issueURL := "https://github.com/GoogleChrome/webstatus.dev/issues/99"
+	errMsg := "rate limited by github"
+
+	del := CodeSubscriptionDelivery{
+		ID:               delID,
+		SubscriptionID:   subID,
+		DeliveryStatus:   DeliveryStatusFailed,
+		DeliveryChannel:  DeliveryChannelGitHubIssue,
+		LockExpiresAt:    &lockExp,
+		WorkerLockID:     &workerID,
+		DeliveredAt:      &now,
+		ExternalIssueID:  &issueID,
+		ExternalIssueURL: &issueURL,
+		ErrorMessage:     &errMsg,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	spannerDel := fromCodeSubscriptionDelivery(&del)
+	delMut, err := spanner.InsertStruct(codeSubscriptionDeliveryTable, spannerDel)
+	if err != nil {
+		t.Fatalf("InsertStruct delivery failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{delMut}); err != nil {
+		t.Fatalf("Apply delivery mutation failed: %v", err)
+	}
+
+	retrieved, err := spannerClient.GetCodeSubscriptionDelivery(ctx, delID)
+	if err != nil {
+		t.Fatalf("GetCodeSubscriptionDelivery failed: %v", err)
+	}
+	if retrieved.WorkerLockID == nil || *retrieved.WorkerLockID != workerID {
+		t.Errorf("expected WorkerLockID %s, got %v", workerID, retrieved.WorkerLockID)
+	}
+	if retrieved.ExternalIssueID == nil || *retrieved.ExternalIssueID != issueID {
+		t.Errorf("expected ExternalIssueID %s, got %v", issueID, retrieved.ExternalIssueID)
+	}
+	if retrieved.ErrorMessage == nil || *retrieved.ErrorMessage != errMsg {
+		t.Errorf("expected ErrorMessage %s, got %v", errMsg, retrieved.ErrorMessage)
+	}
+}
+
+func TestClient_GetCodeSubscriptionDelivery(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	subID := uuid.NewString()
+
+	// Create parent installation
+	writeLevel := GitHubPermissionLevelWrite
+	inst := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   "12345678",
+		AccountLogin:        "GoogleChrome",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       &writeLevel,
+				Contents:     nil,
+				Metadata:     nil,
+				PullRequests: nil,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+	instIDPtr, err := spannerClient.UpsertVCSInstallation(ctx, inst)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation failed: %v", err)
+	}
+	instID := *instIDPtr
+
+	// Insert CodeSubscription via mutation
+	sub := CodeSubscription{
+		ID:                 subID,
+		VCSProvider:        VCSProviderGitHub,
+		VCSInstallationID:  instID,
+		VCSRepositoryID:    "repo-123",
+		RepositoryFullName: "GoogleChrome/webstatus.dev",
+		TargetQuery:        "id:view-transitions",
+		Triggers:           []string{"feature_baseline_to_widely"},
+		Status:             SubscriptionActive,
+		Occurrences: []SubscriptionOccurrence{
+			{
+				FilePath:       "src/app.ts",
+				LineNumber:     10,
+				CommentSnippet: "// TODO(baseline/view-transitions)",
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	spannerSub := fromCodeSubscription(&sub)
+	subMut, err := spanner.InsertStruct(codeSubscriptionTable, spannerSub)
+	if err != nil {
+		t.Fatalf("InsertStruct failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{subMut}); err != nil {
+		t.Fatalf("Apply subscription mutation failed: %v", err)
+	}
+
+	t.Run("NotFound returns ErrCodeSubscriptionDeliveryNotFound", func(t *testing.T) {
+		testCodeSubscriptionDeliveryNotFound(ctx, t)
+	})
+	t.Run("Insert and retrieve delivery record", func(t *testing.T) {
+		testCodeSubscriptionDeliveryInsertAndGet(ctx, t, subID)
+	})
+	t.Run("Handles populated nullable fields", func(t *testing.T) {
+		testCodeSubscriptionDeliveryNullableFields(ctx, t, subID)
+	})
+}

--- a/lib/gcpspanner/code_subscription_test.go
+++ b/lib/gcpspanner/code_subscription_test.go
@@ -1,0 +1,266 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/uuid"
+)
+
+func TestCodeSubscriptionConversion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	testCases := []struct {
+		name        string
+		input       CodeSubscription
+		checkOutput func(t *testing.T, converted *CodeSubscription)
+	}{
+		{
+			name: "Populated occurrences roundtrip",
+			input: CodeSubscription{
+				ID:                 "sub-uuid-1",
+				VCSProvider:        VCSProviderGitHub,
+				VCSInstallationID:  "123456",
+				VCSRepositoryID:    "987654",
+				RepositoryFullName: "owner/repo",
+				TargetQuery:        "id:css-subgrid AND baseline_status:widely",
+				Triggers:           []string{"feature_baseline_to_widely"},
+				Status:             SubscriptionActive,
+				Occurrences: []SubscriptionOccurrence{
+					{
+						FilePath:       "src/styles.css",
+						LineNumber:     42,
+						CommentSnippet: "// TODO(baseline/subgrid): remove flex fallback",
+					},
+				},
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			checkOutput: func(t *testing.T, converted *CodeSubscription) {
+				if len(converted.Occurrences) != 1 {
+					t.Fatalf("expected 1 occurrence, got %d", len(converted.Occurrences))
+				}
+				if converted.Occurrences[0].LineNumber != 42 {
+					t.Errorf("expected line 42, got %d", converted.Occurrences[0].LineNumber)
+				}
+			},
+		},
+		{
+			name: "Nil occurrences deserializes as non-nil empty slice",
+			input: CodeSubscription{
+				ID:                 "sub-uuid-nil-occ",
+				VCSProvider:        VCSProviderGitHub,
+				VCSInstallationID:  "123456",
+				VCSRepositoryID:    "987654",
+				RepositoryFullName: "owner/repo",
+				TargetQuery:        "id:css-subgrid",
+				Triggers:           []string{"feature_baseline_to_widely"},
+				Status:             SubscriptionActive,
+				Occurrences:        nil,
+				CreatedAt:          now,
+				UpdatedAt:          now,
+			},
+			checkOutput: func(t *testing.T, converted *CodeSubscription) {
+				if converted.Occurrences == nil {
+					t.Errorf("expected non-nil empty slice for occurrences, got nil")
+				}
+				if len(converted.Occurrences) != 0 {
+					t.Errorf("expected 0 occurrences, got %d", len(converted.Occurrences))
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			scs := fromCodeSubscription(&tc.input)
+			converted, err := scs.toCodeSubscription()
+			if err != nil {
+				t.Fatalf("unexpected toCodeSubscription error: %v", err)
+			}
+			tc.checkOutput(t, converted)
+		})
+	}
+}
+
+func TestCodeSubscription_InvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	invalid := spannerCodeSubscription{
+		ID:                 "sub-invalid-status",
+		VCSProvider:        "github",
+		VCSInstallationID:  "123",
+		VCSRepositoryID:    "456",
+		RepositoryFullName: "owner/repo",
+		TargetQuery:        "query",
+		Triggers:           []string{"trigger"},
+		Status:             "INVALID_STATUS",
+		Occurrences:        spanner.NullJSON{Value: nil, Valid: false},
+		CreatedAt:          time.Now(),
+		UpdatedAt:          time.Now(),
+	}
+
+	_, err := invalid.toCodeSubscription()
+	if err == nil {
+		t.Fatalf("expected error for invalid status, got nil")
+	}
+	if !errors.Is(err, ErrUnknownSubscriptionStatus) {
+		t.Fatalf("expected ErrUnknownSubscriptionStatus, got %v", err)
+	}
+}
+
+func testCodeSubscriptionNotFound(ctx context.Context, t *testing.T) {
+	_, err := spannerClient.GetCodeSubscription(ctx, "non-existent-sub-id")
+	if !errors.Is(err, ErrCodeSubscriptionNotFound) {
+		t.Fatalf("expected ErrCodeSubscriptionNotFound, got: %v", err)
+	}
+}
+
+func testCodeSubscriptionInsertWithOccurrences(ctx context.Context, t *testing.T, instID string) {
+	subID := uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	sub := CodeSubscription{
+		ID:                 subID,
+		VCSProvider:        VCSProviderGitHub,
+		VCSInstallationID:  instID,
+		VCSRepositoryID:    "repo-123",
+		RepositoryFullName: "GoogleChrome/webstatus.dev",
+		TargetQuery:        "id:view-transitions",
+		Triggers:           []string{"feature_baseline_to_widely"},
+		Status:             SubscriptionActive,
+		Occurrences: []SubscriptionOccurrence{
+			{
+				FilePath:       "src/app.ts",
+				LineNumber:     10,
+				CommentSnippet: "// TODO(baseline/view-transitions)",
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	spannerSub := fromCodeSubscription(&sub)
+	subMut, err := spanner.InsertStruct(codeSubscriptionTable, spannerSub)
+	if err != nil {
+		t.Fatalf("InsertStruct failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{subMut}); err != nil {
+		t.Fatalf("Apply subscription mutation failed: %v", err)
+	}
+
+	retrievedSub, err := spannerClient.GetCodeSubscription(ctx, subID)
+	if err != nil {
+		t.Fatalf("GetCodeSubscription failed: %v", err)
+	}
+	if retrievedSub.ID != subID || len(retrievedSub.Occurrences) != 1 {
+		t.Fatalf("retrieved subscription mismatch: %+v", retrievedSub)
+	}
+	if retrievedSub.VCSProvider != VCSProviderGitHub {
+		t.Errorf("expected VCSProvider %s, got %s", VCSProviderGitHub, retrievedSub.VCSProvider)
+	}
+	if retrievedSub.Status != SubscriptionActive {
+		t.Errorf("expected Status %s, got %s", SubscriptionActive, retrievedSub.Status)
+	}
+	if retrievedSub.Occurrences[0].FilePath != "src/app.ts" || retrievedSub.Occurrences[0].LineNumber != 10 {
+		t.Errorf("unexpected occurrence data: %+v", retrievedSub.Occurrences[0])
+	}
+}
+
+func testCodeSubscriptionEmptyOccurrences(ctx context.Context, t *testing.T, instID string) {
+	emptySubID := uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	emptySub := CodeSubscription{
+		ID:                 emptySubID,
+		VCSProvider:        VCSProviderGitHub,
+		VCSInstallationID:  instID,
+		VCSRepositoryID:    "repo-empty-occ",
+		RepositoryFullName: "GoogleChrome/webstatus.dev",
+		TargetQuery:        "id:subgrid",
+		Triggers:           []string{"feature_baseline_to_widely"},
+		Status:             SubscriptionActive,
+		Occurrences:        []SubscriptionOccurrence{},
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	spannerEmptySub := fromCodeSubscription(&emptySub)
+	emptyMut, err := spanner.InsertStruct(codeSubscriptionTable, spannerEmptySub)
+	if err != nil {
+		t.Fatalf("InsertStruct failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{emptyMut}); err != nil {
+		t.Fatalf("Apply empty subscription mutation failed: %v", err)
+	}
+
+	retrieved, err := spannerClient.GetCodeSubscription(ctx, emptySubID)
+	if err != nil {
+		t.Fatalf("GetCodeSubscription failed: %v", err)
+	}
+	if retrieved.Occurrences == nil {
+		t.Errorf("expected non-nil empty occurrences slice, got nil")
+	}
+	if len(retrieved.Occurrences) != 0 {
+		t.Errorf("expected 0 occurrences, got %d", len(retrieved.Occurrences))
+	}
+}
+
+func TestClient_GetCodeSubscription(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	// Create parent installation for foreign key / relationship
+	writeLevel := GitHubPermissionLevelWrite
+	inst := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   "12345678",
+		AccountLogin:        "GoogleChrome",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       &writeLevel,
+				Contents:     nil,
+				Metadata:     nil,
+				PullRequests: nil,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+	instIDPtr, err := spannerClient.UpsertVCSInstallation(ctx, inst)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation failed: %v", err)
+	}
+	instID := *instIDPtr
+
+	t.Run("NotFound returns ErrCodeSubscriptionNotFound", func(t *testing.T) {
+		testCodeSubscriptionNotFound(ctx, t)
+	})
+	t.Run("Insert and retrieve with occurrences", func(t *testing.T) {
+		testCodeSubscriptionInsertWithOccurrences(ctx, t, instID)
+	})
+	t.Run("Roundtrip with empty occurrences", func(t *testing.T) {
+		testCodeSubscriptionEmptyOccurrences(ctx, t, instID)
+	})
+}

--- a/lib/gcpspanner/code_subscriptions.go
+++ b/lib/gcpspanner/code_subscriptions.go
@@ -1,0 +1,442 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/uuid"
+	"google.golang.org/api/iterator"
+)
+
+var (
+	// ErrDeliveryAlreadyDelivered indicates the delivery task is already completed.
+	ErrDeliveryAlreadyDelivered = errors.New("delivery already delivered")
+	// ErrDeliveryAlreadyLocked indicates the delivery task is currently leased by another worker.
+	ErrDeliveryAlreadyLocked = errors.New("delivery already locked by another worker")
+	// ErrWebhookAlreadyDelivered indicates the webhook delivery GUID was already processed.
+	ErrWebhookAlreadyDelivered = errors.New("webhook delivery already recorded")
+)
+
+func readExistingRepositorySubscriptions(
+	ctx context.Context,
+	tx *spanner.ReadWriteTransaction,
+	vcsProvider VCSProvider,
+	repoID string,
+) (map[string]CodeSubscription, error) {
+	stmt := spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSInstallationID, VCSRepositoryID, RepositoryFullName,
+			TargetQuery, Triggers, Status, Occurrences, CreatedAt, UpdatedAt
+		FROM CodeSubscriptions
+		WHERE VCSProvider = @vcsProvider AND VCSRepositoryID = @repoID`,
+		Params: map[string]any{
+			"vcsProvider": string(vcsProvider),
+			"repoID":      repoID,
+		},
+	}
+
+	iter := tx.Query(ctx, stmt)
+	defer iter.Stop()
+
+	existingMap := make(map[string]CodeSubscription)
+	for {
+		row, iterErr := iter.Next()
+		if errors.Is(iterErr, iterator.Done) {
+			break
+		}
+		if iterErr != nil {
+			return nil, fmt.Errorf("failed to read existing code subscriptions: %w", iterErr)
+		}
+
+		var scs spannerCodeSubscription
+		if err := row.ToStruct(&scs); err != nil {
+			return nil, fmt.Errorf("failed to decode code subscription row: %w", err)
+		}
+		sub, err := scs.toCodeSubscription()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse code subscription: %w", err)
+		}
+		existingMap[sub.TargetQuery] = *sub
+	}
+
+	return existingMap, nil
+}
+
+func computeSyncMutations(
+	incoming []CodeSubscription,
+	existingMap map[string]CodeSubscription,
+	now time.Time,
+) ([]*spanner.Mutation, error) {
+	var mutations []*spanner.Mutation
+	incomingMatched := make(map[string]bool)
+
+	for _, in := range incoming {
+		incomingMatched[in.TargetQuery] = true
+		if existing, found := existingMap[in.TargetQuery]; found {
+			in.ID = existing.ID
+			in.CreatedAt = existing.CreatedAt
+			in.Status = SubscriptionActive
+		} else {
+			in.CreatedAt = now
+			in.Status = SubscriptionActive
+		}
+		in.UpdatedAt = now
+
+		scs := fromCodeSubscription(&in)
+		mut, mutErr := spanner.InsertOrUpdateStruct(codeSubscriptionTable, scs)
+		if mutErr != nil {
+			return nil, fmt.Errorf("failed to create code subscription mutation: %w", mutErr)
+		}
+		mutations = append(mutations, mut)
+	}
+
+	for targetQuery, existing := range existingMap {
+		if !incomingMatched[targetQuery] && existing.Status == SubscriptionActive {
+			existing.Status = SubscriptionObsolete
+			existing.UpdatedAt = now
+			scs := fromCodeSubscription(&existing)
+			mut, mutErr := spanner.InsertOrUpdateStruct(codeSubscriptionTable, scs)
+			if mutErr != nil {
+				return nil, fmt.Errorf("failed to create obsolete mutation: %w", mutErr)
+			}
+			mutations = append(mutations, mut)
+		}
+	}
+
+	return mutations, nil
+}
+
+// SynchronizeRepositoryCodeSubscriptions transactionally updates the active code subscriptions
+// for a specific repository, inserting new subscriptions, updating modified occurrences, and
+// marking missing ones as obsolete.
+func (c *Client) SynchronizeRepositoryCodeSubscriptions(
+	ctx context.Context,
+	vcsProvider VCSProvider,
+	repoID string,
+	incoming []CodeSubscription,
+) error {
+	now := time.Now().UTC()
+
+	_, err := c.ReadWriteTransaction(ctx, func(ctx context.Context, tx *spanner.ReadWriteTransaction) error {
+		existingMap, err := readExistingRepositorySubscriptions(ctx, tx, vcsProvider, repoID)
+		if err != nil {
+			return err
+		}
+
+		mutations, err := computeSyncMutations(incoming, existingMap, now)
+		if err != nil {
+			return err
+		}
+
+		if len(mutations) > 0 {
+			if err := tx.BufferWrite(mutations); err != nil {
+				return fmt.Errorf("failed to buffer write mutations: %w", err)
+			}
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+// ListCodeSubscriptionsByRepository returns active code subscriptions for a repository.
+func (c *Client) ListCodeSubscriptionsByRepository(
+	ctx context.Context,
+	vcsProvider VCSProvider,
+	repoID string,
+) ([]CodeSubscription, error) {
+	stmt := spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSInstallationID, VCSRepositoryID, RepositoryFullName,
+			TargetQuery, Triggers, Status, Occurrences, CreatedAt, UpdatedAt
+		FROM CodeSubscriptions
+		WHERE VCSProvider = @vcsProvider AND VCSRepositoryID = @repoID AND Status = 'ACTIVE'
+		ORDER BY CreatedAt DESC, ID DESC`,
+		Params: map[string]any{
+			"vcsProvider": string(vcsProvider),
+			"repoID":      repoID,
+		},
+	}
+
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var results []CodeSubscription
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to query code subscriptions: %w", err)
+		}
+
+		var scs spannerCodeSubscription
+		if err := row.ToStruct(&scs); err != nil {
+			return nil, fmt.Errorf("failed to decode code subscription: %w", err)
+		}
+		sub, err := scs.toCodeSubscription()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse code subscription: %w", err)
+		}
+		results = append(results, *sub)
+	}
+
+	return results, nil
+}
+
+// ListCodeSubscriptionsByTargetQuery returns all active subscriptions matching targetQuery and trigger.
+func (c *Client) ListCodeSubscriptionsByTargetQuery(
+	ctx context.Context,
+	targetQuery, trigger string,
+) ([]CodeSubscription, error) {
+	stmt := spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSInstallationID, VCSRepositoryID, RepositoryFullName,
+			TargetQuery, Triggers, Status, Occurrences, CreatedAt, UpdatedAt
+		FROM CodeSubscriptions
+		WHERE TargetQuery = @targetQuery AND Status = 'ACTIVE'`,
+		Params: map[string]any{
+			"targetQuery": targetQuery,
+		},
+	}
+
+	iter := c.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	var results []CodeSubscription
+	for {
+		row, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to query code subscriptions by target: %w", err)
+		}
+
+		var scs spannerCodeSubscription
+		if err := row.ToStruct(&scs); err != nil {
+			return nil, fmt.Errorf("failed to decode code subscription: %w", err)
+		}
+		sub, err := scs.toCodeSubscription()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse code subscription: %w", err)
+		}
+
+		if slices.Contains(sub.Triggers, trigger) {
+			results = append(results, *sub)
+		}
+	}
+
+	return results, nil
+}
+
+// DeleteCodeSubscription marks a code subscription as deleted.
+func (c *Client) DeleteCodeSubscription(ctx context.Context, id string) error {
+	now := time.Now().UTC()
+	mut := spanner.UpdateMap(codeSubscriptionTable, map[string]any{
+		"ID":        id,
+		"Status":    string(SubscriptionDeleted),
+		"UpdatedAt": now,
+	})
+
+	_, err := c.Apply(ctx, []*spanner.Mutation{mut})
+
+	return err
+}
+
+// RecordVCSWebhookDelivery checks and inserts a webhook delivery GUID for replay protection.
+// Returns true if new delivery recorded, false if already processed.
+func (c *Client) RecordVCSWebhookDelivery(
+	ctx context.Context,
+	delivery VCSWebhookDelivery,
+) (bool, error) {
+	mutator := newEntityMutator[vcsWebhookDeliveryMapper, spannerVCSWebhookDelivery, vcsWebhookDeliveryKey](c)
+
+	key := vcsWebhookDeliveryKey{
+		VCSProvider:  delivery.VCSProvider,
+		DeliveryGUID: delivery.DeliveryGUID,
+	}
+
+	err := mutator.readInspectMutate(
+		ctx,
+		key,
+		func(_ context.Context, existing *spannerVCSWebhookDelivery) (*spanner.Mutation, error) {
+			if existing != nil {
+				return nil, ErrWebhookAlreadyDelivered
+			}
+
+			spannerWebhook := fromVCSWebhookDelivery(&delivery)
+
+			mut, mutErr := spanner.InsertOrUpdateStruct(vcsWebhookDeliveryTable, spannerWebhook)
+			if mutErr != nil {
+				return nil, fmt.Errorf("failed to create webhook delivery mutation: %w", mutErr)
+			}
+
+			return mut, nil
+		},
+	)
+
+	if errors.Is(err, ErrWebhookAlreadyDelivered) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// InsertCodeSubscriptionScanLog stores an AST scan audit log entry using entityWriter.
+func (c *Client) InsertCodeSubscriptionScanLog(
+	ctx context.Context,
+	scanLog CodeSubscriptionScanLog,
+) error {
+	if scanLog.ID == "" {
+		scanLog.ID = uuid.NewString()
+	}
+	if scanLog.ScannedAt.IsZero() {
+		scanLog.ScannedAt = c.timeNow()
+	}
+
+	return newEntityWriter[
+		codeSubscriptionScanLogMapper,
+		CodeSubscriptionScanLog,
+		spannerCodeSubscriptionScanLog,
+		string,
+	](c).upsert(ctx, scanLog)
+}
+
+// AcquireDeliveryLock attempts to atomically lease a delivery task for a worker.
+func (c *Client) AcquireDeliveryLock(
+	ctx context.Context,
+	subscriptionID, deliveryID, workerID string,
+	ttl time.Duration,
+) (bool, error) {
+	mutator := newEntityMutator[codeSubscriptionDeliveryMapper, spannerCodeSubscriptionDelivery, string](c)
+
+	err := mutator.readInspectMutate(
+		ctx,
+		deliveryID,
+		func(_ context.Context, existing *spannerCodeSubscriptionDelivery) (*spanner.Mutation, error) {
+			now := c.timeNow()
+			lockExpires := now.Add(ttl)
+
+			if existing == nil {
+				// Delivery record does not exist yet; insert a new locked delivery
+				return spanner.InsertOrUpdateMap(codeSubscriptionDeliveryTable, map[string]any{
+					"ID":              deliveryID,
+					"SubscriptionID":  subscriptionID,
+					"DeliveryStatus":  string(DeliveryStatusPending),
+					"DeliveryChannel": string(DeliveryChannelGitHubIssue),
+					"LockExpiresAt":   lockExpires,
+					"WorkerLockID":    workerID,
+					"CreatedAt":       now,
+					"UpdatedAt":       now,
+				}), nil
+			}
+
+			if existing.DeliveryStatus == string(DeliveryStatusDelivered) {
+				return nil, ErrDeliveryAlreadyDelivered
+			}
+
+			if existing.LockExpiresAt.Valid && existing.LockExpiresAt.Time.After(now) {
+				// Lock still active by another worker
+				return nil, ErrDeliveryAlreadyLocked
+			}
+
+			// Lock acquired / renewed
+			return spanner.UpdateMap(codeSubscriptionDeliveryTable, map[string]any{
+				"ID":             deliveryID,
+				"DeliveryStatus": string(DeliveryStatusPending),
+				"LockExpiresAt":  lockExpires,
+				"WorkerLockID":   workerID,
+				"UpdatedAt":      now,
+			}), nil
+		},
+	)
+
+	if errors.Is(err, ErrDeliveryAlreadyDelivered) || errors.Is(err, ErrDeliveryAlreadyLocked) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// RecordDeliverySuccess records successful issue delivery.
+func (c *Client) RecordDeliverySuccess(
+	ctx context.Context,
+	deliveryID, issueID, issueURL string,
+) error {
+	mutator := newEntityMutator[codeSubscriptionDeliveryMapper, spannerCodeSubscriptionDelivery, string](c)
+
+	return mutator.readInspectMutate(
+		ctx,
+		deliveryID,
+		func(_ context.Context, existing *spannerCodeSubscriptionDelivery) (*spanner.Mutation, error) {
+			if existing == nil {
+				return nil, ErrCodeSubscriptionDeliveryNotFound
+			}
+
+			now := c.timeNow()
+
+			return spanner.UpdateMap(codeSubscriptionDeliveryTable, map[string]any{
+				"ID":               deliveryID,
+				"DeliveryStatus":   string(DeliveryStatusDelivered),
+				"DeliveredAt":      now,
+				"ExternalIssueID":  issueID,
+				"ExternalIssueURL": issueURL,
+				"LockExpiresAt":    nil,
+				"WorkerLockID":     nil,
+				"UpdatedAt":        now,
+			}), nil
+		},
+	)
+}
+
+// ReleaseDeliveryLock clears worker lock lease on transient errors.
+func (c *Client) ReleaseDeliveryLock(ctx context.Context, deliveryID string) error {
+	mutator := newEntityMutator[codeSubscriptionDeliveryMapper, spannerCodeSubscriptionDelivery, string](c)
+
+	err := mutator.readInspectMutate(
+		ctx,
+		deliveryID,
+		func(_ context.Context, existing *spannerCodeSubscriptionDelivery) (*spanner.Mutation, error) {
+			if existing == nil {
+				return nil, ErrCodeSubscriptionDeliveryNotFound
+			}
+
+			return spanner.UpdateMap(codeSubscriptionDeliveryTable, map[string]any{
+				"ID":             deliveryID,
+				"DeliveryStatus": string(DeliveryStatusPending),
+				"LockExpiresAt":  nil,
+				"WorkerLockID":   nil,
+				"UpdatedAt":      c.timeNow(),
+			}), nil
+		},
+	)
+	if errors.Is(err, ErrCodeSubscriptionDeliveryNotFound) {
+		return nil
+	}
+
+	return err
+}

--- a/lib/gcpspanner/code_subscriptions_test.go
+++ b/lib/gcpspanner/code_subscriptions_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestCodeSubscriptions(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	installationID := "inst-" + uuid.NewString()
+	repoID := "repo-" + uuid.NewString()
+	repoFullName := "GoogleChrome/webstatus.dev"
+
+	// 1. Create installation record
+	writeLevel := GitHubPermissionLevelWrite
+	readLevel := GitHubPermissionLevelRead
+	inst := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   installationID,
+		AccountLogin:        "GoogleChrome",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       &writeLevel,
+				Contents:     &readLevel,
+				Metadata:     nil,
+				PullRequests: nil,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+	if _, err := spannerClient.UpsertVCSInstallation(ctx, inst); err != nil {
+		t.Fatalf("UpsertVCSInstallation failed: %v", err)
+	}
+
+	// 2. Test SynchronizeRepositoryCodeSubscriptions (Initial Ingestion)
+	sub1 := CodeSubscription{
+		ID:                 uuid.NewString(),
+		VCSProvider:        VCSProviderGitHub,
+		VCSInstallationID:  installationID,
+		VCSRepositoryID:    repoID,
+		RepositoryFullName: repoFullName,
+		TargetQuery:        "id:view-transitions",
+		Triggers:           []string{"feature_baseline_to_widely"},
+		Status:             SubscriptionActive,
+		Occurrences: []SubscriptionOccurrence{
+			{FilePath: "src/app.ts", LineNumber: 10, CommentSnippet: "// TODO(baseline/view-transitions): transition"},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	sub2 := CodeSubscription{
+		ID:                 uuid.NewString(),
+		VCSProvider:        VCSProviderGitHub,
+		VCSInstallationID:  installationID,
+		VCSRepositoryID:    repoID,
+		RepositoryFullName: repoFullName,
+		TargetQuery:        "id:subgrid",
+		Triggers:           []string{"feature_baseline_to_widely"},
+		Status:             SubscriptionActive,
+		Occurrences: []SubscriptionOccurrence{
+			{FilePath: "src/grid.css", LineNumber: 5, CommentSnippet: "// TODO(baseline/subgrid): grid"},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := spannerClient.SynchronizeRepositoryCodeSubscriptions(
+		ctx, VCSProviderGitHub, repoID, []CodeSubscription{sub1, sub2}); err != nil {
+		t.Fatalf("SynchronizeRepositoryCodeSubscriptions failed: %v", err)
+	}
+
+	// 3. Test ListCodeSubscriptionsByRepository
+	list, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, VCSProviderGitHub, repoID)
+	if err != nil {
+		t.Fatalf("ListCodeSubscriptionsByRepository failed: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 active subscriptions, got %d", len(list))
+	}
+
+	// 4. Test ListCodeSubscriptionsByTargetQuery
+	targetList, err := spannerClient.ListCodeSubscriptionsByTargetQuery(
+		ctx, "id:view-transitions", "feature_baseline_to_widely")
+	if err != nil {
+		t.Fatalf("ListCodeSubscriptionsByTargetQuery failed: %v", err)
+	}
+	if len(targetList) != 1 {
+		t.Fatalf("expected 1 subscription for targetQuery, got %d", len(targetList))
+	}
+
+	// 5. Test GetCodeSubscription
+	retrieved, err := spannerClient.GetCodeSubscription(ctx, list[0].ID)
+	if err != nil {
+		t.Fatalf("GetCodeSubscription failed: %v", err)
+	}
+	if retrieved.ID != list[0].ID {
+		t.Errorf("retrieved.ID = %s, want %s", retrieved.ID, list[0].ID)
+	}
+
+	// 6. Test AcquireDeliveryLock, RecordDeliverySuccess, ReleaseDeliveryLock
+	delID1 := uuid.NewString()
+	lockAcquired, err := spannerClient.AcquireDeliveryLock(ctx, list[0].ID, delID1, "worker-1", 30*time.Second)
+	if err != nil {
+		t.Fatalf("AcquireDeliveryLock failed: %v", err)
+	}
+	if !lockAcquired {
+		t.Errorf("expected lock acquisition to succeed")
+	}
+
+	// Duplicate lock acquisition while active should fail
+	secondLock, err := spannerClient.AcquireDeliveryLock(ctx, list[0].ID, delID1, "worker-2", 30*time.Second)
+	if err != nil {
+		t.Fatalf("AcquireDeliveryLock 2 failed: %v", err)
+	}
+	if secondLock {
+		t.Errorf("expected second lock acquisition to fail")
+	}
+
+	// Record success
+	err = spannerClient.RecordDeliverySuccess(
+		ctx, delID1, "issue-123", "https://github.com/owner/repo/issues/123")
+	if err != nil {
+		t.Fatalf("RecordDeliverySuccess failed: %v", err)
+	}
+
+	// Test ReleaseDeliveryLock on list[1] and reacquire
+	delID2 := uuid.NewString()
+	acquired2, err := spannerClient.AcquireDeliveryLock(ctx, list[1].ID, delID2, "worker-temp", 30*time.Second)
+	if err != nil || !acquired2 {
+		t.Fatalf("failed to acquire initial lock for delivery 2: %v", err)
+	}
+
+	if err := spannerClient.ReleaseDeliveryLock(ctx, delID2); err != nil {
+		t.Fatalf("ReleaseDeliveryLock failed: %v", err)
+	}
+
+	reacquired, err := spannerClient.AcquireDeliveryLock(ctx, list[1].ID, delID2, "worker-next", 30*time.Second)
+	if err != nil || !reacquired {
+		t.Fatalf("failed to reacquire lock after release: %v", err)
+	}
+
+	// 7. Test DeleteCodeSubscription (Soft Delete) and subsequent revival on resync
+	if err := spannerClient.DeleteCodeSubscription(ctx, list[0].ID); err != nil {
+		t.Fatalf("DeleteCodeSubscription failed: %v", err)
+	}
+
+	// Resync with the same directives must revive the soft-deleted subscription without unique index error
+	if err := spannerClient.SynchronizeRepositoryCodeSubscriptions(
+		ctx, VCSProviderGitHub, repoID, []CodeSubscription{sub1, sub2}); err != nil {
+		t.Fatalf("SynchronizeRepositoryCodeSubscriptions (revival) failed: %v", err)
+	}
+	revivedList, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, VCSProviderGitHub, repoID)
+	if err != nil {
+		t.Fatalf("ListCodeSubscriptionsByRepository after revival failed: %v", err)
+	}
+	if len(revivedList) != 2 {
+		t.Fatalf("expected 2 active subscriptions after revival, got %d", len(revivedList))
+	}
+
+	// 8. Test Webhook Replay Protection
+	delivery := VCSWebhookDelivery{
+		VCSProvider:     VCSProviderGitHub,
+		DeliveryGUID:    "guid-unique-12345",
+		EventType:       "push",
+		VCSRepositoryID: repoID,
+		ReceivedAt:      now,
+	}
+	isNew, err := spannerClient.RecordVCSWebhookDelivery(ctx, delivery)
+	if err != nil {
+		t.Fatalf("RecordVCSWebhookDelivery failed: %v", err)
+	}
+	if !isNew {
+		t.Errorf("expected isNew=true for first delivery")
+	}
+
+	isDuplicate, err := spannerClient.RecordVCSWebhookDelivery(ctx, delivery)
+	if err != nil {
+		t.Fatalf("RecordVCSWebhookDelivery second attempt failed: %v", err)
+	}
+	if isDuplicate {
+		t.Errorf("expected isDuplicate=false for replay delivery")
+	}
+
+	// 9. Test InsertCodeSubscriptionScanLog
+	scanLog := CodeSubscriptionScanLog{
+		ID:              uuid.NewString(),
+		VCSProvider:     VCSProviderGitHub,
+		VCSRepositoryID: repoID,
+		CommitSHA:       "abcdef123456",
+		Branch:          "main",
+		ScanStatus:      ScanStatusSuccess,
+		FilesScanned:    12,
+		DirectivesFound: 2,
+		ErrorMessage:    nil,
+		ScannedAt:       now,
+	}
+	if err := spannerClient.InsertCodeSubscriptionScanLog(ctx, scanLog); err != nil {
+		t.Fatalf("InsertCodeSubscriptionScanLog failed: %v", err)
+	}
+}

--- a/lib/gcpspanner/scan_log_and_webhook.go
+++ b/lib/gcpspanner/scan_log_and_webhook.go
@@ -1,0 +1,315 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+const (
+	codeSubscriptionScanLogTable = "CodeSubscriptionScanLogs"
+	vcsWebhookDeliveryTable      = "VCSWebhookDeliveries"
+)
+
+var (
+	// ErrScanLogNotFound indicates that the scan log record was not found.
+	ErrScanLogNotFound = errors.New("scan log not found")
+	// ErrVCSWebhookDeliveryNotFound indicates that the webhook delivery record was not found.
+	ErrVCSWebhookDeliveryNotFound = errors.New("vcs webhook delivery not found")
+	// ErrUnknownScanStatus indicates an unrecognized scan status.
+	ErrUnknownScanStatus = errors.New("unknown scan status")
+)
+
+// ScanStatus represents the completion status of an AST repository scan.
+type ScanStatus string
+
+const (
+	ScanStatusSuccess   ScanStatus = "SUCCESS"
+	ScanStatusTruncated ScanStatus = "TRUNCATED"
+	ScanStatusFailed    ScanStatus = "FAILED"
+)
+
+// CodeSubscriptionScanLog stores the audit log of an AST repository scan for a commit.
+type CodeSubscriptionScanLog struct {
+	ID              string
+	VCSProvider     VCSProvider
+	VCSRepositoryID string
+	CommitSHA       string
+	Branch          string
+	ScanStatus      ScanStatus
+	FilesScanned    int64
+	DirectivesFound int64
+	ErrorMessage    *string
+	ScannedAt       time.Time
+}
+
+// spannerCodeSubscriptionScanLog is the internal struct for Spanner column mapping.
+type spannerCodeSubscriptionScanLog struct {
+	ID              string             `spanner:"ID"`
+	VCSProvider     string             `spanner:"VCSProvider"`
+	VCSRepositoryID string             `spanner:"VCSRepositoryID"`
+	CommitSHA       string             `spanner:"CommitSHA"`
+	Branch          string             `spanner:"Branch"`
+	ScanStatus      string             `spanner:"ScanStatus"`
+	FilesScanned    int64              `spanner:"FilesScanned"`
+	DirectivesFound int64              `spanner:"DirectivesFound"`
+	ErrorMessage    spanner.NullString `spanner:"ErrorMessage"`
+	ScannedAt       time.Time          `spanner:"ScannedAt"`
+}
+
+type codeSubscriptionScanLogMapper struct{}
+
+func (m codeSubscriptionScanLogMapper) Table() string { return codeSubscriptionScanLogTable }
+
+func (m codeSubscriptionScanLogMapper) SelectOne(id string) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSRepositoryID, CommitSHA, Branch, ScanStatus,
+			FilesScanned, DirectivesFound, ErrorMessage, ScannedAt
+		FROM CodeSubscriptionScanLogs
+		WHERE ID = @id`,
+		Params: map[string]any{"id": id},
+	}
+}
+
+func (m codeSubscriptionScanLogMapper) GetKeyFromExternal(in CodeSubscriptionScanLog) string {
+	return in.ID
+}
+
+func (m codeSubscriptionScanLogMapper) NewEntity(
+	id string,
+	in CodeSubscriptionScanLog,
+) (spannerCodeSubscriptionScanLog, error) {
+	var errMsg spanner.NullString
+	if in.ErrorMessage != nil {
+		errMsg = spanner.NullString{StringVal: *in.ErrorMessage, Valid: true}
+	}
+
+	entityID := id
+	if in.ID != "" {
+		entityID = in.ID
+	}
+
+	return spannerCodeSubscriptionScanLog{
+		ID:              entityID,
+		VCSProvider:     string(in.VCSProvider),
+		VCSRepositoryID: in.VCSRepositoryID,
+		CommitSHA:       in.CommitSHA,
+		Branch:          in.Branch,
+		ScanStatus:      string(in.ScanStatus),
+		FilesScanned:    in.FilesScanned,
+		DirectivesFound: in.DirectivesFound,
+		ErrorMessage:    errMsg,
+		ScannedAt:       in.ScannedAt,
+	}, nil
+}
+
+func (m codeSubscriptionScanLogMapper) Merge(
+	in CodeSubscriptionScanLog,
+	existing spannerCodeSubscriptionScanLog,
+) spannerCodeSubscriptionScanLog {
+	var errMsg spanner.NullString
+	if in.ErrorMessage != nil {
+		errMsg = spanner.NullString{StringVal: *in.ErrorMessage, Valid: true}
+	}
+
+	return spannerCodeSubscriptionScanLog{
+		ID:              existing.ID,
+		VCSProvider:     string(in.VCSProvider),
+		VCSRepositoryID: in.VCSRepositoryID,
+		CommitSHA:       in.CommitSHA,
+		Branch:          in.Branch,
+		ScanStatus:      string(in.ScanStatus),
+		FilesScanned:    in.FilesScanned,
+		DirectivesFound: in.DirectivesFound,
+		ErrorMessage:    errMsg,
+		ScannedAt:       in.ScannedAt,
+	}
+}
+
+// ParseScanStatus parses and validates a raw scan status string into a typed ScanStatus.
+func ParseScanStatus(val string) (ScanStatus, error) {
+	status := ScanStatus(val)
+	switch status {
+	case ScanStatusSuccess,
+		ScanStatusTruncated,
+		ScanStatusFailed:
+		return status, nil
+	}
+
+	return "", fmt.Errorf("%w: %q", ErrUnknownScanStatus, val)
+}
+
+func (s *spannerCodeSubscriptionScanLog) toCodeSubscriptionScanLog() (*CodeSubscriptionScanLog, error) {
+	provider, err := ParseVCSProvider(s.VCSProvider)
+	if err != nil {
+		return nil, err
+	}
+	status, err := ParseScanStatus(s.ScanStatus)
+	if err != nil {
+		return nil, err
+	}
+
+	var errMsg *string
+	if s.ErrorMessage.Valid {
+		errMsg = &s.ErrorMessage.StringVal
+	}
+
+	return &CodeSubscriptionScanLog{
+		ID:              s.ID,
+		VCSProvider:     provider,
+		VCSRepositoryID: s.VCSRepositoryID,
+		CommitSHA:       s.CommitSHA,
+		Branch:          s.Branch,
+		ScanStatus:      status,
+		FilesScanned:    s.FilesScanned,
+		DirectivesFound: s.DirectivesFound,
+		ErrorMessage:    errMsg,
+		ScannedAt:       s.ScannedAt,
+	}, nil
+}
+
+func fromCodeSubscriptionScanLog(log *CodeSubscriptionScanLog) *spannerCodeSubscriptionScanLog {
+	var errMsg spanner.NullString
+	if log.ErrorMessage != nil {
+		errMsg = spanner.NullString{StringVal: *log.ErrorMessage, Valid: true}
+	}
+
+	return &spannerCodeSubscriptionScanLog{
+		ID:              log.ID,
+		VCSProvider:     string(log.VCSProvider),
+		VCSRepositoryID: log.VCSRepositoryID,
+		CommitSHA:       log.CommitSHA,
+		Branch:          log.Branch,
+		ScanStatus:      string(log.ScanStatus),
+		FilesScanned:    log.FilesScanned,
+		DirectivesFound: log.DirectivesFound,
+		ErrorMessage:    errMsg,
+		ScannedAt:       log.ScannedAt,
+	}
+}
+
+// VCSWebhookDelivery represents an idempotency record for a received webhook delivery.
+type VCSWebhookDelivery struct {
+	VCSProvider     VCSProvider
+	DeliveryGUID    string
+	EventType       string
+	VCSRepositoryID string
+	ReceivedAt      time.Time
+}
+
+// spannerVCSWebhookDelivery is the internal struct for Spanner column mapping.
+type spannerVCSWebhookDelivery struct {
+	VCSProvider     string    `spanner:"VCSProvider"`
+	DeliveryGUID    string    `spanner:"DeliveryGUID"`
+	EventType       string    `spanner:"EventType"`
+	VCSRepositoryID string    `spanner:"VCSRepositoryID"`
+	ReceivedAt      time.Time `spanner:"ReceivedAt"`
+}
+
+type vcsWebhookDeliveryKey struct {
+	VCSProvider  VCSProvider
+	DeliveryGUID string
+}
+
+type vcsWebhookDeliveryMapper struct{}
+
+func (m vcsWebhookDeliveryMapper) Table() string { return vcsWebhookDeliveryTable }
+
+func (m vcsWebhookDeliveryMapper) SelectOne(key vcsWebhookDeliveryKey) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT VCSProvider, DeliveryGUID, EventType, VCSRepositoryID, ReceivedAt
+		FROM VCSWebhookDeliveries
+		WHERE VCSProvider = @vcsProvider AND DeliveryGUID = @deliveryGUID`,
+		Params: map[string]any{
+			"vcsProvider":  string(key.VCSProvider),
+			"deliveryGUID": key.DeliveryGUID,
+		},
+	}
+}
+
+func (s *spannerVCSWebhookDelivery) toVCSWebhookDelivery() (*VCSWebhookDelivery, error) {
+	provider, err := ParseVCSProvider(s.VCSProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VCSWebhookDelivery{
+		VCSProvider:     provider,
+		DeliveryGUID:    s.DeliveryGUID,
+		EventType:       s.EventType,
+		VCSRepositoryID: s.VCSRepositoryID,
+		ReceivedAt:      s.ReceivedAt,
+	}, nil
+}
+
+func fromVCSWebhookDelivery(d *VCSWebhookDelivery) *spannerVCSWebhookDelivery {
+	return &spannerVCSWebhookDelivery{
+		VCSProvider:     string(d.VCSProvider),
+		DeliveryGUID:    d.DeliveryGUID,
+		EventType:       d.EventType,
+		VCSRepositoryID: d.VCSRepositoryID,
+		ReceivedAt:      d.ReceivedAt,
+	}
+}
+
+// GetCodeSubscriptionScanLog retrieves a scan log record by ID.
+func (c *Client) GetCodeSubscriptionScanLog(
+	ctx context.Context,
+	id string,
+) (*CodeSubscriptionScanLog, error) {
+	r := newEntityReader[
+		codeSubscriptionScanLogMapper, spannerCodeSubscriptionScanLog, CodeSubscriptionScanLog, string,
+	](c)
+	spannerLog, err := r.readRowByKey(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, ErrScanLogNotFound
+		}
+
+		return nil, err
+	}
+
+	return spannerLog.toCodeSubscriptionScanLog()
+}
+
+// GetVCSWebhookDelivery retrieves a webhook delivery idempotency record by provider and delivery GUID.
+func (c *Client) GetVCSWebhookDelivery(
+	ctx context.Context,
+	provider VCSProvider,
+	deliveryGUID string,
+) (*VCSWebhookDelivery, error) {
+	key := vcsWebhookDeliveryKey{
+		VCSProvider:  provider,
+		DeliveryGUID: deliveryGUID,
+	}
+	r := newEntityReader[
+		vcsWebhookDeliveryMapper, spannerVCSWebhookDelivery, VCSWebhookDelivery, vcsWebhookDeliveryKey,
+	](c)
+	spannerDel, err := r.readRowByKey(ctx, key)
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, ErrVCSWebhookDeliveryNotFound
+		}
+
+		return nil, err
+	}
+
+	return spannerDel.toVCSWebhookDelivery()
+}

--- a/lib/gcpspanner/scan_log_and_webhook_test.go
+++ b/lib/gcpspanner/scan_log_and_webhook_test.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+)
+
+func TestCodeSubscriptionScanLogConversion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	errMsg := "rate limited by GitHub API"
+
+	testCases := []struct {
+		name     string
+		original CodeSubscriptionScanLog
+	}{
+		{
+			name: "Populated error message roundtrip",
+			original: CodeSubscriptionScanLog{
+				ID:              "scan-uuid-1",
+				VCSProvider:     VCSProviderGitHub,
+				VCSRepositoryID: "repo-999",
+				CommitSHA:       "abcdef123456",
+				Branch:          "main",
+				ScanStatus:      ScanStatusFailed,
+				FilesScanned:    42,
+				DirectivesFound: 3,
+				ErrorMessage:    &errMsg,
+				ScannedAt:       now,
+			},
+		},
+		{
+			name: "Nil error message roundtrip",
+			original: CodeSubscriptionScanLog{
+				ID:              "scan-uuid-nil-err",
+				VCSProvider:     VCSProviderGitHub,
+				VCSRepositoryID: "repo-999",
+				CommitSHA:       "abcdef123456",
+				Branch:          "main",
+				ScanStatus:      ScanStatusSuccess,
+				FilesScanned:    100,
+				DirectivesFound: 5,
+				ErrorMessage:    nil,
+				ScannedAt:       now,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			scsl := fromCodeSubscriptionScanLog(&tc.original)
+			converted, err := scsl.toCodeSubscriptionScanLog()
+			if err != nil {
+				t.Fatalf("unexpected toCodeSubscriptionScanLog error: %v", err)
+			}
+
+			if diff := cmp.Diff(&tc.original, converted); diff != "" {
+				t.Errorf("CodeSubscriptionScanLog conversion mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCodeSubscriptionScanLog_InvalidEnums(t *testing.T) {
+	t.Parallel()
+
+	invalidProvider := spannerCodeSubscriptionScanLog{
+		ID:              "scan-1",
+		VCSProvider:     "invalid_provider",
+		VCSRepositoryID: "repo-1",
+		CommitSHA:       "sha-1",
+		Branch:          "main",
+		ScanStatus:      "SUCCESS",
+		FilesScanned:    10,
+		DirectivesFound: 1,
+		ErrorMessage:    spanner.NullString{StringVal: "", Valid: false},
+		ScannedAt:       time.Now(),
+	}
+	_, err := invalidProvider.toCodeSubscriptionScanLog()
+	if err == nil {
+		t.Fatalf("expected error for invalid vcs provider, got nil")
+	}
+	if !errors.Is(err, ErrUnknownVCSProvider) {
+		t.Fatalf("expected ErrUnknownVCSProvider, got %v", err)
+	}
+
+	invalidStatus := spannerCodeSubscriptionScanLog{
+		ID:              "scan-2",
+		VCSProvider:     "github",
+		VCSRepositoryID: "repo-1",
+		CommitSHA:       "sha-1",
+		Branch:          "main",
+		ScanStatus:      "INVALID_SCAN_STATUS",
+		FilesScanned:    10,
+		DirectivesFound: 1,
+		ErrorMessage:    spanner.NullString{StringVal: "", Valid: false},
+		ScannedAt:       time.Now(),
+	}
+	_, err = invalidStatus.toCodeSubscriptionScanLog()
+	if err == nil {
+		t.Fatalf("expected error for invalid scan status, got nil")
+	}
+	if !errors.Is(err, ErrUnknownScanStatus) {
+		t.Fatalf("expected ErrUnknownScanStatus, got %v", err)
+	}
+}
+
+func testScanLogAndWebhookDeliveryNotFound(ctx context.Context, t *testing.T) {
+	_, err := spannerClient.GetCodeSubscriptionScanLog(ctx, "non-existent-scan-id")
+	if !errors.Is(err, ErrScanLogNotFound) {
+		t.Fatalf("expected ErrScanLogNotFound, got: %v", err)
+	}
+
+	_, err = spannerClient.GetVCSWebhookDelivery(ctx, VCSProviderGitHub, "non-existent-guid")
+	if !errors.Is(err, ErrVCSWebhookDeliveryNotFound) {
+		t.Fatalf("expected ErrVCSWebhookDeliveryNotFound, got: %v", err)
+	}
+}
+
+func testScanLogInsertAndGet(ctx context.Context, t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	scanID := uuid.NewString()
+	errMsg := "rate limit backoff"
+
+	log := CodeSubscriptionScanLog{
+		ID:              scanID,
+		VCSProvider:     VCSProviderGitHub,
+		VCSRepositoryID: "repo-123",
+		CommitSHA:       "sha-abc",
+		Branch:          "main",
+		ScanStatus:      ScanStatusFailed,
+		FilesScanned:    15,
+		DirectivesFound: 2,
+		ErrorMessage:    &errMsg,
+		ScannedAt:       now,
+	}
+
+	spannerLog := fromCodeSubscriptionScanLog(&log)
+	logMut, err := spanner.InsertStruct(codeSubscriptionScanLogTable, spannerLog)
+	if err != nil {
+		t.Fatalf("InsertStruct scan log failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{logMut}); err != nil {
+		t.Fatalf("Apply scan log mutation failed: %v", err)
+	}
+
+	retrievedLog, err := spannerClient.GetCodeSubscriptionScanLog(ctx, scanID)
+	if err != nil {
+		t.Fatalf("GetCodeSubscriptionScanLog failed: %v", err)
+	}
+	if retrievedLog.ID != scanID || *retrievedLog.ErrorMessage != errMsg {
+		t.Fatalf("retrieved scan log mismatch: %+v", retrievedLog)
+	}
+	if retrievedLog.ScanStatus != ScanStatusFailed {
+		t.Errorf("expected ScanStatus %s, got %s", ScanStatusFailed, retrievedLog.ScanStatus)
+	}
+}
+
+func testWebhookDeliveryInsertAndGet(ctx context.Context, t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	guid := uuid.NewString()
+
+	delivery := VCSWebhookDelivery{
+		VCSProvider:     VCSProviderGitHub,
+		DeliveryGUID:    guid,
+		EventType:       "push",
+		VCSRepositoryID: "repo-123",
+		ReceivedAt:      now,
+	}
+
+	spannerDelivery := fromVCSWebhookDelivery(&delivery)
+	deliveryMut, err := spanner.InsertStruct(vcsWebhookDeliveryTable, spannerDelivery)
+	if err != nil {
+		t.Fatalf("InsertStruct webhook delivery failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{deliveryMut}); err != nil {
+		t.Fatalf("Apply webhook delivery mutation failed: %v", err)
+	}
+
+	retrievedDelivery, err := spannerClient.GetVCSWebhookDelivery(ctx, VCSProviderGitHub, guid)
+	if err != nil {
+		t.Fatalf("GetVCSWebhookDelivery failed: %v", err)
+	}
+	if retrievedDelivery.DeliveryGUID != guid || retrievedDelivery.EventType != "push" {
+		t.Fatalf("retrieved webhook delivery mismatch: %+v", retrievedDelivery)
+	}
+}
+
+func TestClient_GetScanLogAndWebhookDelivery(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	t.Run("NotFound returns expected sentinel errors", func(t *testing.T) {
+		testScanLogAndWebhookDeliveryNotFound(ctx, t)
+	})
+	t.Run("Insert and retrieve scan log", func(t *testing.T) {
+		testScanLogInsertAndGet(ctx, t)
+	})
+	t.Run("Insert and retrieve webhook delivery idempotency record", func(t *testing.T) {
+		testWebhookDeliveryInsertAndGet(ctx, t)
+	})
+}

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -187,7 +187,8 @@ type BackendSpannerClient interface {
 	) ([]gcpspanner.SavedSearchNotificationEvent, *string, error)
 	ListCodeSubscriptionsByRepository(
 		ctx context.Context,
-		vcsProvider, repoID string,
+		vcsProvider gcpspanner.VCSProvider,
+		repoID string,
 	) ([]gcpspanner.CodeSubscription, error)
 	DeleteCodeSubscription(
 		ctx context.Context,
@@ -2228,7 +2229,11 @@ func (s *Backend) ListCodeSubscriptions(
 	ctx context.Context,
 	vcsProvider, repoID string,
 ) ([]backend.CodeSubscriptionResponse, error) {
-	subs, err := s.client.ListCodeSubscriptionsByRepository(ctx, vcsProvider, repoID)
+	provider, err := gcpspanner.ParseVCSProvider(vcsProvider)
+	if err != nil {
+		return nil, err
+	}
+	subs, err := s.client.ListCodeSubscriptionsByRepository(ctx, provider, repoID)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -185,6 +185,18 @@ type BackendSpannerClient interface {
 		pageSize int,
 		pageToken *string,
 	) ([]gcpspanner.SavedSearchNotificationEvent, *string, error)
+	ListCodeSubscriptionsByRepository(
+		ctx context.Context,
+		vcsProvider, repoID string,
+	) ([]gcpspanner.CodeSubscription, error)
+	DeleteCodeSubscription(
+		ctx context.Context,
+		id string,
+	) error
+	RecordVCSWebhookDelivery(
+		ctx context.Context,
+		delivery gcpspanner.VCSWebhookDelivery,
+	) (bool, error)
 }
 
 // Backend converts queries to spanner to usable entities for the backend
@@ -2210,4 +2222,31 @@ func (s *Backend) GetGlobalSavedSearch(
 		CreatedAt:    &savedSearch.CreatedAt,
 		UpdatedAt:    &savedSearch.UpdatedAt,
 	}, nil
+}
+
+func (s *Backend) ListCodeSubscriptions(
+	ctx context.Context,
+	vcsProvider, repoID string,
+) ([]backend.CodeSubscriptionResponse, error) {
+	subs, err := s.client.ListCodeSubscriptionsByRepository(ctx, vcsProvider, repoID)
+	if err != nil {
+		return nil, err
+	}
+	resp := backendtypes.CodeSubscriptionsToResponse(subs)
+
+	return resp.Data, nil
+}
+
+func (s *Backend) DeleteCodeSubscription(
+	ctx context.Context,
+	id string,
+) error {
+	return s.client.DeleteCodeSubscription(ctx, id)
+}
+
+func (s *Backend) RecordVCSWebhookDelivery(
+	ctx context.Context,
+	delivery gcpspanner.VCSWebhookDelivery,
+) (bool, error) {
+	return s.client.RecordVCSWebhookDelivery(ctx, delivery)
 }

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -782,6 +782,28 @@ func (c mockBackendSpannerClient) UpdateSavedSearchSubscription(
 	return c.mockUpdateSavedSearchSubscriptionCfg.returnedError
 }
 
+func (c mockBackendSpannerClient) ListCodeSubscriptionsByRepository(
+	_ context.Context,
+	_ string,
+	_ string,
+) ([]gcpspanner.CodeSubscription, error) {
+	return nil, nil
+}
+
+func (c mockBackendSpannerClient) DeleteCodeSubscription(
+	_ context.Context,
+	_ string,
+) error {
+	return nil
+}
+
+func (c mockBackendSpannerClient) RecordVCSWebhookDelivery(
+	_ context.Context,
+	_ gcpspanner.VCSWebhookDelivery,
+) (bool, error) {
+	return true, nil
+}
+
 func TestCreateSavedSearchSubscriptionMapsLimitError(t *testing.T) {
 	mock := new(mockBackendSpannerClient)
 	mock.t = t

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -784,7 +784,7 @@ func (c mockBackendSpannerClient) UpdateSavedSearchSubscription(
 
 func (c mockBackendSpannerClient) ListCodeSubscriptionsByRepository(
 	_ context.Context,
-	_ string,
+	_ gcpspanner.VCSProvider,
 	_ string,
 ) ([]gcpspanner.CodeSubscription, error) {
 	return nil, nil

--- a/lib/gcpspanner/spanneradapters/vcs_scanner.go
+++ b/lib/gcpspanner/spanneradapters/vcs_scanner.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/codescan"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+)
+
+// VCSScannerSpannerClient defines the database interface required by the VCS scanner adapter.
+type VCSScannerSpannerClient interface {
+	SynchronizeRepositoryCodeSubscriptions(
+		ctx context.Context,
+		vcsProvider, vcsInstallationID, vcsRepositoryID string,
+		subscriptions []gcpspanner.CodeSubscription,
+		now time.Time,
+	) error
+	InsertCodeSubscriptionScanLog(ctx context.Context, scanLog gcpspanner.CodeSubscriptionScanLog) error
+}
+
+// VCSScannerAdapter adapts domain scan results to Spanner mutations.
+type VCSScannerAdapter struct {
+	client VCSScannerSpannerClient
+}
+
+// NewVCSScannerAdapter creates a new VCSScannerAdapter.
+func NewVCSScannerAdapter(client VCSScannerSpannerClient) *VCSScannerAdapter {
+	return &VCSScannerAdapter{client: client}
+}
+
+// SynchronizeScanResult adapts and persists a domain ScanResult into Spanner.
+func (a *VCSScannerAdapter) SynchronizeScanResult(
+	ctx context.Context,
+	vcsProvider, vcsInstallationID, vcsRepositoryID string,
+	result *codescan.ScanResult,
+	now time.Time,
+) error {
+	spannerSubs := make([]gcpspanner.CodeSubscription, 0, len(result.Subscriptions))
+	for _, sub := range result.Subscriptions {
+		occurrences := make([]gcpspanner.SubscriptionOccurrence, 0, len(sub.Occurrences))
+		for _, occ := range sub.Occurrences {
+			occurrences = append(occurrences, gcpspanner.SubscriptionOccurrence{
+				FilePath:       occ.FilePath,
+				LineNumber:     occ.LineNumber,
+				CommentSnippet: occ.CommentSnippet,
+			})
+		}
+
+		spannerSubs = append(spannerSubs, gcpspanner.CodeSubscription{
+			ID:                 sub.ID,
+			VCSProvider:        gcpspanner.VCSProvider(sub.VCSProvider),
+			VCSInstallationID:  sub.VCSInstallationID,
+			VCSRepositoryID:    sub.VCSRepositoryID,
+			RepositoryFullName: sub.RepositoryFullName,
+			TargetQuery:        sub.TargetQuery,
+			Triggers:           sub.Triggers,
+			Status:             gcpspanner.SubscriptionActive,
+			Occurrences:        occurrences,
+			CreatedAt:          sub.CreatedAt,
+			UpdatedAt:          sub.UpdatedAt,
+		})
+	}
+
+	return a.client.SynchronizeRepositoryCodeSubscriptions(
+		ctx,
+		vcsProvider,
+		vcsInstallationID,
+		vcsRepositoryID,
+		spannerSubs,
+		now,
+	)
+}
+
+// RecordScanLog adapts and persists a commit scan log into Spanner.
+func (a *VCSScannerAdapter) RecordScanLog(
+	ctx context.Context,
+	log gcpspanner.CodeSubscriptionScanLog,
+) error {
+	return a.client.InsertCodeSubscriptionScanLog(ctx, log)
+}

--- a/lib/gcpspanner/spanneradapters/vcs_scanner_test.go
+++ b/lib/gcpspanner/spanneradapters/vcs_scanner_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanneradapters
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/codescan"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
+)
+
+type mockVCSScannerSpannerClient struct {
+	syncCalled bool
+	logCalled  bool
+	passedSubs []gcpspanner.CodeSubscription
+	passedLog  gcpspanner.CodeSubscriptionScanLog
+}
+
+func (m *mockVCSScannerSpannerClient) SynchronizeRepositoryCodeSubscriptions(
+	_ context.Context,
+	_, _, _ string,
+	subscriptions []gcpspanner.CodeSubscription,
+	_ time.Time,
+) error {
+	m.syncCalled = true
+	m.passedSubs = subscriptions
+
+	return nil
+}
+
+func (m *mockVCSScannerSpannerClient) InsertCodeSubscriptionScanLog(
+	_ context.Context,
+	log gcpspanner.CodeSubscriptionScanLog,
+) error {
+	m.logCalled = true
+	m.passedLog = log
+
+	return nil
+}
+
+func TestVCSScannerAdapter_SynchronizeScanResult(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	mockClient := &mockVCSScannerSpannerClient{
+		syncCalled: false,
+		logCalled:  false,
+		passedSubs: nil,
+		passedLog: gcpspanner.CodeSubscriptionScanLog{
+			ID:              "",
+			VCSProvider:     "",
+			VCSRepositoryID: "",
+			CommitSHA:       "",
+			Branch:          "",
+			ScanStatus:      "",
+			FilesScanned:    0,
+			DirectivesFound: 0,
+			ErrorMessage:    nil,
+			ScannedAt:       time.Time{},
+		},
+	}
+	adapter := NewVCSScannerAdapter(mockClient)
+
+	scanResult := &codescan.ScanResult{
+		Subscriptions: []codescan.ScannedSubscription{
+			{
+				ID:                 "sub-1",
+				VCSProvider:        "github",
+				VCSInstallationID:  "inst-1",
+				VCSRepositoryID:    "repo-1",
+				RepositoryFullName: "owner/repo",
+				TargetQuery:        "id:view-transitions",
+				Triggers:           []string{"feature.baseline.promote_to_widely"},
+				Occurrences: []codescan.SubscriptionOccurrence{
+					{
+						FilePath:       "src/app.ts",
+						LineNumber:     10,
+						CommentSnippet: "// TODO(baseline/view-transitions)",
+					},
+				},
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+		},
+		FilesScanned:    1,
+		DirectivesFound: 1,
+		IsTruncated:     false,
+		ScanStatus:      codescan.ScanStatusSuccess,
+	}
+
+	err := adapter.SynchronizeScanResult(
+		context.Background(),
+		"github",
+		"inst-1",
+		"repo-1",
+		scanResult,
+		now,
+	)
+	if err != nil {
+		t.Fatalf("SynchronizeScanResult returned error: %v", err)
+	}
+
+	if !mockClient.syncCalled {
+		t.Errorf("expected SynchronizeRepositoryCodeSubscriptions to be called")
+	}
+	if len(mockClient.passedSubs) != 1 {
+		t.Fatalf("expected 1 subscription passed, got %d", len(mockClient.passedSubs))
+	}
+
+	sub := mockClient.passedSubs[0]
+	if sub.ID != "sub-1" || sub.TargetQuery != "id:view-transitions" {
+		t.Errorf("unexpected subscription fields: %+v", sub)
+	}
+	if len(sub.Occurrences) != 1 || sub.Occurrences[0].LineNumber != 10 {
+		t.Errorf("unexpected occurrences: %+v", sub.Occurrences)
+	}
+}
+
+func TestVCSScannerAdapter_RecordScanLog(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 18, 12, 0, 0, 0, time.UTC)
+	mockClient := &mockVCSScannerSpannerClient{
+		syncCalled: false,
+		logCalled:  false,
+		passedSubs: nil,
+		passedLog: gcpspanner.CodeSubscriptionScanLog{
+			ID:              "",
+			VCSProvider:     "",
+			VCSRepositoryID: "",
+			CommitSHA:       "",
+			Branch:          "",
+			ScanStatus:      "",
+			FilesScanned:    0,
+			DirectivesFound: 0,
+			ErrorMessage:    nil,
+			ScannedAt:       time.Time{},
+		},
+	}
+	adapter := NewVCSScannerAdapter(mockClient)
+
+	log := gcpspanner.CodeSubscriptionScanLog{
+		ID:              "log-1",
+		VCSProvider:     "github",
+		VCSRepositoryID: "repo-1",
+		CommitSHA:       "sha-123",
+		Branch:          "main",
+		ScanStatus:      gcpspanner.ScanStatusSuccess,
+		FilesScanned:    5,
+		DirectivesFound: 2,
+		ErrorMessage:    nil,
+		ScannedAt:       now,
+	}
+
+	err := adapter.RecordScanLog(context.Background(), log)
+	if err != nil {
+		t.Fatalf("RecordScanLog returned error: %v", err)
+	}
+
+	if !mockClient.logCalled {
+		t.Errorf("expected InsertCodeSubscriptionScanLog to be called")
+	}
+	if mockClient.passedLog.ID != "log-1" {
+		t.Errorf("unexpected log passed: %+v", mockClient.passedLog)
+	}
+}

--- a/lib/gcpspanner/vcs_installation.go
+++ b/lib/gcpspanner/vcs_installation.go
@@ -1,0 +1,308 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/uuid"
+)
+
+const vcsInstallationTable = "VCSInstallations"
+
+var (
+	// ErrVCSInstallationNotFound indicates that the installation record does not exist.
+	ErrVCSInstallationNotFound = errors.New("vcs installation not found")
+	// ErrUnknownVCSProvider indicates an unrecognized VCS provider.
+	ErrUnknownVCSProvider = errors.New("unknown vcs provider")
+)
+
+// VCSProvider represents a supported version control system provider.
+type VCSProvider string
+
+const (
+	VCSProviderGitHub VCSProvider = "github"
+)
+
+// GitHubPermissionLevel represents a GitHub App permission level.
+type GitHubPermissionLevel string
+
+const (
+	GitHubPermissionLevelRead  GitHubPermissionLevel = "read"
+	GitHubPermissionLevelWrite GitHubPermissionLevel = "write"
+	GitHubPermissionLevelAdmin GitHubPermissionLevel = "admin"
+)
+
+// GitHubPermissions represents GitHub App permission levels for an installation.
+type GitHubPermissions struct {
+	Issues       *GitHubPermissionLevel `json:"issues,omitempty"`
+	Contents     *GitHubPermissionLevel `json:"contents,omitempty"`
+	Metadata     *GitHubPermissionLevel `json:"metadata,omitempty"`
+	PullRequests *GitHubPermissionLevel `json:"pull_requests,omitempty"`
+	Workflows    *GitHubPermissionLevel `json:"workflows,omitempty"`
+	Actions      *GitHubPermissionLevel `json:"actions,omitempty"`
+}
+
+// VCSPermissions encapsulates provider-specific permissions.
+type VCSPermissions struct {
+	GitHub *GitHubPermissions `json:"github,omitempty"`
+}
+
+// VCSInstallation represents an installed GitHub App instance for an account.
+type VCSInstallation struct {
+	ID                  string
+	VCSProvider         VCSProvider
+	VCSInstallationID   string
+	AccountLogin        string
+	AccountType         string
+	RepositorySelection string
+	Permissions         VCSPermissions
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+type spannerVCSInstallation struct {
+	ID                  string           `spanner:"ID"`
+	VCSProvider         string           `spanner:"VCSProvider"`
+	VCSInstallationID   string           `spanner:"VCSInstallationID"`
+	AccountLogin        string           `spanner:"AccountLogin"`
+	AccountType         string           `spanner:"AccountType"`
+	RepositorySelection string           `spanner:"RepositorySelection"`
+	Permissions         spanner.NullJSON `spanner:"Permissions"`
+	CreatedAt           time.Time        `spanner:"CreatedAt"`
+	UpdatedAt           time.Time        `spanner:"UpdatedAt"`
+}
+
+type vcsInstallationKey struct {
+	VCSProvider       VCSProvider
+	VCSInstallationID string
+}
+
+type vcsInstallationMapper struct{}
+
+func (m vcsInstallationMapper) Table() string { return vcsInstallationTable }
+
+func (m vcsInstallationMapper) GetKeyFromExternal(in VCSInstallation) vcsInstallationKey {
+	return vcsInstallationKey{
+		VCSProvider:       in.VCSProvider,
+		VCSInstallationID: in.VCSInstallationID,
+	}
+}
+
+func (m vcsInstallationMapper) SelectOne(key vcsInstallationKey) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSInstallationID, AccountLogin, AccountType,
+			RepositorySelection, Permissions, CreatedAt, UpdatedAt
+		FROM VCSInstallations
+		WHERE VCSProvider = @vcsProvider AND VCSInstallationID = @vcsInstallationID`,
+		Params: map[string]any{
+			"vcsProvider":       string(key.VCSProvider),
+			"vcsInstallationID": key.VCSInstallationID,
+		},
+	}
+}
+
+func (m vcsInstallationMapper) GetID(key vcsInstallationKey) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID
+		FROM VCSInstallations
+		WHERE VCSProvider = @vcsProvider AND VCSInstallationID = @vcsInstallationID
+		LIMIT 1`,
+		Params: map[string]any{
+			"vcsProvider":       string(key.VCSProvider),
+			"vcsInstallationID": key.VCSInstallationID,
+		},
+	}
+}
+
+func (m vcsInstallationMapper) GetIDFromInternal(s spannerVCSInstallation) string {
+	return s.ID
+}
+
+func extractPermissionsValue(in VCSInstallation) any {
+	switch in.VCSProvider {
+	case VCSProviderGitHub:
+		if in.Permissions.GitHub != nil {
+			return in.Permissions.GitHub
+		}
+	}
+
+	return map[string]any{}
+}
+
+func (m vcsInstallationMapper) NewEntityWithID(in VCSInstallation) (spannerVCSInstallation, string, error) {
+	id := in.ID
+	if id == "" {
+		id = uuid.NewString()
+	}
+
+	return spannerVCSInstallation{
+		ID:                  id,
+		VCSProvider:         string(in.VCSProvider),
+		VCSInstallationID:   in.VCSInstallationID,
+		AccountLogin:        in.AccountLogin,
+		AccountType:         in.AccountType,
+		RepositorySelection: in.RepositorySelection,
+		Permissions: spanner.NullJSON{
+			Value: extractPermissionsValue(in),
+			Valid: true,
+		},
+		CreatedAt: spanner.CommitTimestamp,
+		UpdatedAt: spanner.CommitTimestamp,
+	}, id, nil
+}
+
+func (m vcsInstallationMapper) Merge(
+	in VCSInstallation,
+	existing spannerVCSInstallation,
+) spannerVCSInstallation {
+	return spannerVCSInstallation{
+		ID:                  existing.ID,
+		VCSProvider:         string(in.VCSProvider),
+		VCSInstallationID:   in.VCSInstallationID,
+		AccountLogin:        in.AccountLogin,
+		AccountType:         in.AccountType,
+		RepositorySelection: in.RepositorySelection,
+		Permissions: spanner.NullJSON{
+			Value: extractPermissionsValue(in),
+			Valid: true,
+		},
+		CreatedAt: existing.CreatedAt,
+		UpdatedAt: spanner.CommitTimestamp,
+	}
+}
+
+// ParseVCSProvider parses and validates a raw provider string into a typed VCSProvider.
+func ParseVCSProvider(provider string) (VCSProvider, error) {
+	p := VCSProvider(provider)
+	switch p {
+	case VCSProviderGitHub:
+		return p, nil
+	}
+
+	return "", fmt.Errorf("%w: %q", ErrUnknownVCSProvider, provider)
+}
+
+func loadVCSPermissions(provider VCSProvider, permissionsJSON spanner.NullJSON) (VCSPermissions, error) {
+	var ret VCSPermissions
+	if !permissionsJSON.Valid || permissionsJSON.Value == nil {
+		return ret, nil
+	}
+
+	bytes, err := json.Marshal(permissionsJSON.Value)
+	if err != nil {
+		return ret, fmt.Errorf("failed to marshal permissions json: %w", err)
+	}
+
+	switch provider {
+	case VCSProviderGitHub:
+		var gh GitHubPermissions
+		if err := json.Unmarshal(bytes, &gh); err != nil {
+			return ret, fmt.Errorf("failed to unmarshal github permissions: %w", err)
+		}
+		if gh.Issues != nil || gh.Contents != nil || gh.Metadata != nil ||
+			gh.PullRequests != nil || gh.Workflows != nil || gh.Actions != nil {
+			ret.GitHub = &gh
+		}
+	}
+
+	return ret, nil
+}
+
+func (s *spannerVCSInstallation) toVCSInstallation() (*VCSInstallation, error) {
+	provider, err := ParseVCSProvider(s.VCSProvider)
+	if err != nil {
+		return nil, err
+	}
+	permissions, err := loadVCSPermissions(provider, s.Permissions)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VCSInstallation{
+		ID:                  s.ID,
+		VCSProvider:         provider,
+		VCSInstallationID:   s.VCSInstallationID,
+		AccountLogin:        s.AccountLogin,
+		AccountType:         s.AccountType,
+		RepositorySelection: s.RepositorySelection,
+		Permissions:         permissions,
+		CreatedAt:           s.CreatedAt,
+		UpdatedAt:           s.UpdatedAt,
+	}, nil
+}
+
+type vcsInstallationByIDMapper struct{}
+
+func (m vcsInstallationByIDMapper) SelectOne(id string) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID, VCSProvider, VCSInstallationID, AccountLogin, AccountType,
+			RepositorySelection, Permissions, CreatedAt, UpdatedAt
+		FROM VCSInstallations
+		WHERE ID = @id`,
+		Params: map[string]any{"id": id},
+	}
+}
+
+// GetVCSInstallation retrieves a VCS installation by internal ID.
+func (c *Client) GetVCSInstallation(ctx context.Context, id string) (*VCSInstallation, error) {
+	r := newEntityReader[vcsInstallationByIDMapper, spannerVCSInstallation, VCSInstallation, string](c)
+	spannerInst, err := r.readRowByKey(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, ErrVCSInstallationNotFound
+		}
+
+		return nil, err
+	}
+
+	return spannerInst.toVCSInstallation()
+}
+
+// GetVCSInstallationByProviderID retrieves a VCS installation by provider and installation ID.
+func (c *Client) GetVCSInstallationByProviderID(
+	ctx context.Context,
+	provider VCSProvider,
+	vcsInstallationID string,
+) (*VCSInstallation, error) {
+	key := vcsInstallationKey{
+		VCSProvider:       provider,
+		VCSInstallationID: vcsInstallationID,
+	}
+	r := newEntityReader[vcsInstallationMapper, spannerVCSInstallation, VCSInstallation, vcsInstallationKey](c)
+	spannerInst, err := r.readRowByKey(ctx, key)
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, ErrVCSInstallationNotFound
+		}
+
+		return nil, err
+	}
+
+	return spannerInst.toVCSInstallation()
+}
+
+// UpsertVCSInstallation creates or updates a VCS installation in Spanner atomically using entityWriterWithIDRetrieval.
+// It returns the ID of the installation.
+func (c *Client) UpsertVCSInstallation(ctx context.Context, in VCSInstallation) (*string, error) {
+	return newEntityWriterWithIDRetrieval[
+		vcsInstallationMapper, string, VCSInstallation, spannerVCSInstallation, vcsInstallationKey,
+	](c).upsertAndGetID(ctx, in)
+}

--- a/lib/gcpspanner/vcs_installation_test.go
+++ b/lib/gcpspanner/vcs_installation_test.go
@@ -1,0 +1,433 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+)
+
+func TestVCSInstallation_PermissionsMapping(t *testing.T) {
+	t.Parallel()
+
+	writeLevel := GitHubPermissionLevelWrite
+	readLevel := GitHubPermissionLevelRead
+
+	testCases := []struct {
+		name        string
+		input       VCSInstallation
+		checkOutput func(t *testing.T, converted *VCSInstallation)
+	}{
+		{
+			name: "Populated GitHub permissions roundtrip",
+			input: VCSInstallation{
+				ID:                  "test-inst-1",
+				VCSProvider:         VCSProviderGitHub,
+				VCSInstallationID:   "12345678",
+				AccountLogin:        "GoogleChrome",
+				AccountType:         "Organization",
+				RepositorySelection: "selected",
+				Permissions: VCSPermissions{
+					GitHub: &GitHubPermissions{
+						Issues:       &writeLevel,
+						Contents:     &readLevel,
+						Metadata:     nil,
+						PullRequests: nil,
+						Workflows:    nil,
+						Actions:      nil,
+					},
+				},
+				CreatedAt: time.Unix(100, 0).UTC(),
+				UpdatedAt: time.Unix(100, 0).UTC(),
+			},
+			checkOutput: func(t *testing.T, converted *VCSInstallation) {
+				if converted.Permissions.GitHub == nil ||
+					converted.Permissions.GitHub.Issues == nil ||
+					*converted.Permissions.GitHub.Issues != writeLevel {
+					t.Errorf("unexpected issues permission: %v", converted.Permissions.GitHub)
+				}
+			},
+		},
+		{
+			name: "Nil GitHub permissions handled cleanly",
+			input: VCSInstallation{
+				ID:                  "test-inst-nil-perm",
+				VCSProvider:         VCSProviderGitHub,
+				VCSInstallationID:   "87654321",
+				AccountLogin:        "GoogleChrome",
+				AccountType:         "Organization",
+				RepositorySelection: "all",
+				Permissions:         VCSPermissions{GitHub: nil},
+				CreatedAt:           time.Unix(100, 0).UTC(),
+				UpdatedAt:           time.Unix(100, 0).UTC(),
+			},
+			checkOutput: func(t *testing.T, converted *VCSInstallation) {
+				if converted.Permissions.GitHub != nil {
+					t.Errorf("expected nil GitHub permissions, got %+v", converted.Permissions.GitHub)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mapper := vcsInstallationMapper{}
+			wrapper, _, err := mapper.NewEntityWithID(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected NewEntityWithID error: %v", err)
+			}
+			converted, err := wrapper.toVCSInstallation()
+			if err != nil {
+				t.Fatalf("unexpected toVCSInstallation error: %v", err)
+			}
+			tc.checkOutput(t, converted)
+		})
+	}
+}
+
+func TestVCSInstallation_InvalidProvider(t *testing.T) {
+	t.Parallel()
+
+	invalidWrapper := spannerVCSInstallation{
+		ID:                  "test-id",
+		VCSProvider:         "unsupported-provider",
+		VCSInstallationID:   "123",
+		AccountLogin:        "user",
+		AccountType:         "User",
+		RepositorySelection: "all",
+		Permissions:         spanner.NullJSON{Value: nil, Valid: false},
+		CreatedAt:           time.Now(),
+		UpdatedAt:           time.Now(),
+	}
+
+	_, err := invalidWrapper.toVCSInstallation()
+	if err == nil {
+		t.Fatalf("expected error for invalid provider, got nil")
+	}
+	if !errors.Is(err, ErrUnknownVCSProvider) {
+		t.Fatalf("expected ErrUnknownVCSProvider, got %v", err)
+	}
+}
+
+func testVCSInstallationNotFound(ctx context.Context, t *testing.T) {
+	_, err := spannerClient.GetVCSInstallation(ctx, "non-existent-id")
+	if !errors.Is(err, ErrVCSInstallationNotFound) {
+		t.Fatalf("expected ErrVCSInstallationNotFound, got %v", err)
+	}
+
+	_, err = spannerClient.GetVCSInstallationByProviderID(ctx, VCSProviderGitHub, "non-existent-external-id")
+	if !errors.Is(err, ErrVCSInstallationNotFound) {
+		t.Fatalf("expected ErrVCSInstallationNotFound, got %v", err)
+	}
+}
+
+func testVCSInstallationInsertAndGet(ctx context.Context, t *testing.T) {
+	instID := uuid.NewString()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	writeLevel := GitHubPermissionLevelWrite
+	readLevel := GitHubPermissionLevelRead
+	inst := VCSInstallation{
+		ID:                  instID,
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   "inst-insert-1",
+		AccountLogin:        "GoogleChrome",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       &writeLevel,
+				Contents:     &readLevel,
+				Metadata:     nil,
+				PullRequests: nil,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	insertedID, err := spannerClient.UpsertVCSInstallation(ctx, inst)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation failed: %v", err)
+	}
+	if insertedID == nil || *insertedID != instID {
+		t.Fatalf("expected inserted ID %s, got %v", instID, insertedID)
+	}
+
+	retrieved, err := spannerClient.GetVCSInstallation(ctx, instID)
+	if err != nil {
+		t.Fatalf("GetVCSInstallation failed: %v", err)
+	}
+
+	//nolint:exhaustruct // Ignore CreatedAt and UpdatedAt
+	ignoreFields := cmpopts.IgnoreFields(VCSInstallation{}, "CreatedAt", "UpdatedAt")
+	if diff := cmp.Diff(&inst, retrieved, ignoreFields); diff != "" {
+		t.Errorf("GetVCSInstallation mismatch (-want +got):\n%s", diff)
+	}
+	if retrieved.CreatedAt.IsZero() || retrieved.UpdatedAt.IsZero() {
+		t.Errorf("expected non-zero commit timestamps")
+	}
+}
+
+func testVCSInstallationGetByProviderID(ctx context.Context, t *testing.T) {
+	extID := "ext-inst-query-2"
+	inst := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   extID,
+		AccountLogin:        "GoogleChrome-Ext",
+		AccountType:         "User",
+		RepositorySelection: "all",
+		Permissions:         VCSPermissions{GitHub: nil},
+		CreatedAt:           time.Time{},
+		UpdatedAt:           time.Time{},
+	}
+
+	idPtr, err := spannerClient.UpsertVCSInstallation(ctx, inst)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation failed: %v", err)
+	}
+
+	byProvider, err := spannerClient.GetVCSInstallationByProviderID(ctx, VCSProviderGitHub, extID)
+	if err != nil {
+		t.Fatalf("GetVCSInstallationByProviderID failed: %v", err)
+	}
+	if byProvider.ID != *idPtr {
+		t.Errorf("expected ID %s, got %s", *idPtr, byProvider.ID)
+	}
+	if byProvider.Permissions.GitHub != nil {
+		t.Errorf("expected nil GitHub permissions, got %+v", byProvider.Permissions.GitHub)
+	}
+}
+
+func testVCSInstallationPartialPermissions(ctx context.Context, t *testing.T) {
+	writeLevel := GitHubPermissionLevelWrite
+	extID := "ext-inst-partial-3"
+	inst := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   extID,
+		AccountLogin:        "GoogleChrome-Partial",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       nil,
+				Contents:     nil,
+				Metadata:     nil,
+				PullRequests: &writeLevel,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+
+	idPtr, err := spannerClient.UpsertVCSInstallation(ctx, inst)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation (partial permissions) failed: %v", err)
+	}
+
+	retrieved, err := spannerClient.GetVCSInstallation(ctx, *idPtr)
+	if err != nil {
+		t.Fatalf("GetVCSInstallation failed: %v", err)
+	}
+	if retrieved.Permissions.GitHub == nil {
+		t.Fatalf("expected non-nil GitHub permissions")
+	}
+	if retrieved.Permissions.GitHub.PullRequests == nil ||
+		*retrieved.Permissions.GitHub.PullRequests != writeLevel {
+		t.Errorf("expected PullRequests write, got %+v", retrieved.Permissions.GitHub.PullRequests)
+	}
+	if retrieved.Permissions.GitHub.Issues != nil ||
+		retrieved.Permissions.GitHub.Contents != nil ||
+		retrieved.Permissions.GitHub.Metadata != nil ||
+		retrieved.Permissions.GitHub.Workflows != nil ||
+		retrieved.Permissions.GitHub.Actions != nil {
+		t.Errorf("expected all other permission fields to remain nil, got %+v", retrieved.Permissions.GitHub)
+	}
+}
+
+func testVCSInstallationMergeSemantics(ctx context.Context, t *testing.T) {
+	writeLevel := GitHubPermissionLevelWrite
+	readLevel := GitHubPermissionLevelRead
+	extID := "ext-inst-merge-4"
+	now := time.Now().UTC().Add(-10 * time.Minute).Truncate(time.Microsecond)
+	initial := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   extID,
+		AccountLogin:        "GoogleChrome-Initial",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       &writeLevel,
+				Contents:     &readLevel,
+				Metadata:     nil,
+				PullRequests: nil,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	idPtr, err := spannerClient.UpsertVCSInstallation(ctx, initial)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation (initial) failed: %v", err)
+	}
+	retrievedInitial, err := spannerClient.GetVCSInstallation(ctx, *idPtr)
+	if err != nil {
+		t.Fatalf("GetVCSInstallation (initial) failed: %v", err)
+	}
+	initialCreatedAt := retrievedInitial.CreatedAt
+
+	updateTime := now.Add(5 * time.Minute)
+	spannerClient.setTimeNowForTesting(func() time.Time { return updateTime })
+	defer spannerClient.setTimeNowForTesting(time.Now)
+
+	updated := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   extID,
+		AccountLogin:        "GoogleChrome-Updated",
+		AccountType:         "Organization",
+		RepositorySelection: "all",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       &writeLevel,
+				Contents:     nil,
+				Metadata:     nil,
+				PullRequests: &writeLevel,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+
+	updatedID, err := spannerClient.UpsertVCSInstallation(ctx, updated)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation (update) failed: %v", err)
+	}
+	if updatedID == nil || *updatedID != *idPtr {
+		t.Fatalf("expected preserved ID %s, got %v", *idPtr, updatedID)
+	}
+
+	retrievedUpdated, err := spannerClient.GetVCSInstallation(ctx, *idPtr)
+	if err != nil {
+		t.Fatalf("GetVCSInstallation after update failed: %v", err)
+	}
+	if retrievedUpdated.AccountLogin != "GoogleChrome-Updated" {
+		t.Errorf("expected AccountLogin GoogleChrome-Updated, got %s", retrievedUpdated.AccountLogin)
+	}
+	if retrievedUpdated.RepositorySelection != "all" {
+		t.Errorf("expected RepositorySelection all, got %s", retrievedUpdated.RepositorySelection)
+	}
+	if retrievedUpdated.Permissions.GitHub == nil ||
+		retrievedUpdated.Permissions.GitHub.PullRequests == nil ||
+		*retrievedUpdated.Permissions.GitHub.PullRequests != writeLevel {
+		t.Errorf("unexpected permissions after update: %+v", retrievedUpdated.Permissions.GitHub)
+	}
+	if !retrievedUpdated.CreatedAt.Equal(initialCreatedAt) {
+		t.Errorf("CreatedAt was not preserved: got %v, want %v", retrievedUpdated.CreatedAt, initialCreatedAt)
+	}
+}
+
+func testVCSInstallationUniqueIndex(ctx context.Context, t *testing.T) {
+	instA := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   "ext-inst-distinct-A",
+		AccountLogin:        "AccountA",
+		AccountType:         "Organization",
+		RepositorySelection: "all",
+		Permissions:         VCSPermissions{GitHub: nil},
+		CreatedAt:           time.Time{},
+		UpdatedAt:           time.Time{},
+	}
+	instB := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   "ext-inst-distinct-B",
+		AccountLogin:        "AccountB",
+		AccountType:         "Organization",
+		RepositorySelection: "all",
+		Permissions:         VCSPermissions{GitHub: nil},
+		CreatedAt:           time.Time{},
+		UpdatedAt:           time.Time{},
+	}
+
+	idAPtr, err := spannerClient.UpsertVCSInstallation(ctx, instA)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation instA failed: %v", err)
+	}
+	idBPtr, err := spannerClient.UpsertVCSInstallation(ctx, instB)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation instB failed: %v", err)
+	}
+	if *idAPtr == *idBPtr {
+		t.Fatalf("expected distinct IDs for distinct installations, got identical: %s", *idAPtr)
+	}
+
+	retrievedA, err := spannerClient.GetVCSInstallation(ctx, *idAPtr)
+	if err != nil {
+		t.Fatalf("GetVCSInstallation A failed: %v", err)
+	}
+	retrievedB, err := spannerClient.GetVCSInstallation(ctx, *idBPtr)
+	if err != nil {
+		t.Fatalf("GetVCSInstallation B failed: %v", err)
+	}
+	if retrievedA.AccountLogin != "AccountA" || retrievedB.AccountLogin != "AccountB" {
+		t.Errorf("account logins mismatch: A=%s B=%s", retrievedA.AccountLogin, retrievedB.AccountLogin)
+	}
+}
+
+func TestClient_VCSInstallation(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	t.Run("NotFound returns ErrVCSInstallationNotFound", func(t *testing.T) {
+		testVCSInstallationNotFound(ctx, t)
+	})
+	t.Run("Insert and retrieve by ID", func(t *testing.T) {
+		testVCSInstallationInsertAndGet(ctx, t)
+	})
+	t.Run("Retrieve by provider and external installation ID", func(t *testing.T) {
+		testVCSInstallationGetByProviderID(ctx, t)
+	})
+	t.Run("Partial permissions payload (only pull_requests)", func(t *testing.T) {
+		testVCSInstallationPartialPermissions(ctx, t)
+	})
+	t.Run("Merge semantics update mutable fields and preserve CreatedAt", func(t *testing.T) {
+		testVCSInstallationMergeSemantics(ctx, t)
+	})
+	t.Run("Unique index allows distinct installations per provider", func(t *testing.T) {
+		testVCSInstallationUniqueIndex(ctx, t)
+	})
+}

--- a/lib/gen/openapi/backend/server.gen.go
+++ b/lib/gen/openapi/backend/server.gen.go
@@ -26,6 +26,9 @@ import (
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// Delete a code subscription
+	// (DELETE /v1/code-subscriptions/{id})
+	DeleteCodeSubscription(w http.ResponseWriter, r *http.Request, id string)
 	// List features
 	// (GET /v1/features)
 	ListFeatures(w http.ResponseWriter, r *http.Request, params ListFeaturesParams)
@@ -119,6 +122,18 @@ type ServerInterface interface {
 	// Update a subscription for a saved search
 	// (PATCH /v1/users/me/subscriptions/{subscription_id})
 	UpdateSubscription(w http.ResponseWriter, r *http.Request, subscriptionId string)
+	// List VCS installations accessible to the authenticated user
+	// (GET /v1/vcs/{provider}/installations)
+	ListVCSInstallations(w http.ResponseWriter, r *http.Request, provider string)
+	// List VCS repositories accessible to the authenticated user
+	// (GET /v1/vcs/{provider}/repositories)
+	ListVCSRepositories(w http.ResponseWriter, r *http.Request, provider string)
+	// List active code subscriptions for a repository
+	// (GET /v1/vcs/{provider}/repositories/{repository_id}/code-subscriptions)
+	ListCodeSubscriptions(w http.ResponseWriter, r *http.Request, provider string, repositoryId string)
+	// VCS Webhook Ingress
+	// (POST /v1/webhooks/{provider})
+	HandleVCSWebhook(w http.ResponseWriter, r *http.Request, provider string, params HandleVCSWebhookParams)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -129,6 +144,38 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// DeleteCodeSubscription operation middleware
+func (siw *ServerInterfaceWrapper) DeleteCodeSubscription(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteCodeSubscription(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // ListFeatures operation middleware
 func (siw *ServerInterfaceWrapper) ListFeatures(w http.ResponseWriter, r *http.Request) {
@@ -1658,6 +1705,199 @@ func (siw *ServerInterfaceWrapper) UpdateSubscription(w http.ResponseWriter, r *
 	handler.ServeHTTP(w, r)
 }
 
+// ListVCSInstallations operation middleware
+func (siw *ServerInterfaceWrapper) ListVCSInstallations(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "provider" -------------
+	var provider string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "provider", r.PathValue("provider"), &provider, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "provider", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListVCSInstallations(w, r, provider)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListVCSRepositories operation middleware
+func (siw *ServerInterfaceWrapper) ListVCSRepositories(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "provider" -------------
+	var provider string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "provider", r.PathValue("provider"), &provider, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "provider", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListVCSRepositories(w, r, provider)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListCodeSubscriptions operation middleware
+func (siw *ServerInterfaceWrapper) ListCodeSubscriptions(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "provider" -------------
+	var provider string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "provider", r.PathValue("provider"), &provider, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "provider", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "repository_id" -------------
+	var repositoryId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "repository_id", r.PathValue("repository_id"), &repositoryId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "repository_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListCodeSubscriptions(w, r, provider, repositoryId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// HandleVCSWebhook operation middleware
+func (siw *ServerInterfaceWrapper) HandleVCSWebhook(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "provider" -------------
+	var provider string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "provider", r.PathValue("provider"), &provider, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "provider", Err: err})
+		return
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params HandleVCSWebhookParams
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "X-Hub-Signature-256" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Hub-Signature-256")]; found {
+		var XHubSignature256 string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Hub-Signature-256", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Hub-Signature-256", valueList[0], &XHubSignature256, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Hub-Signature-256", Err: err})
+			return
+		}
+
+		params.XHubSignature256 = &XHubSignature256
+
+	}
+
+	// ------------- Optional header parameter "X-GitHub-Delivery" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-GitHub-Delivery")]; found {
+		var XGitHubDelivery string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-GitHub-Delivery", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-GitHub-Delivery", valueList[0], &XGitHubDelivery, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-GitHub-Delivery", Err: err})
+			return
+		}
+
+		params.XGitHubDelivery = &XGitHubDelivery
+
+	}
+
+	// ------------- Optional header parameter "X-GitHub-Event" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-GitHub-Event")]; found {
+		var XGitHubEvent string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-GitHub-Event", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-GitHub-Event", valueList[0], &XGitHubEvent, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-GitHub-Event", Err: err})
+			return
+		}
+
+		params.XGitHubEvent = &XGitHubEvent
+
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.HandleVCSWebhook(w, r, provider, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 type UnescapedCookieParamError struct {
 	ParamName string
 	Err       error
@@ -1778,6 +2018,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 		ErrorHandlerFunc:   options.ErrorHandlerFunc,
 	}
 
+	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/v1/code-subscriptions/{id}", wrapper.DeleteCodeSubscription)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/features", wrapper.ListFeatures)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/features/{feature_id}", wrapper.GetFeature)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/features/{feature_id}/feature-metadata", wrapper.GetFeatureMetadata)
@@ -1809,8 +2050,70 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/v1/users/me/subscriptions/{subscription_id}", wrapper.DeleteSubscription)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/users/me/subscriptions/{subscription_id}", wrapper.GetSubscription)
 	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/v1/users/me/subscriptions/{subscription_id}", wrapper.UpdateSubscription)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/vcs/{provider}/installations", wrapper.ListVCSInstallations)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/vcs/{provider}/repositories", wrapper.ListVCSRepositories)
+	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/v1/vcs/{provider}/repositories/{repository_id}/code-subscriptions", wrapper.ListCodeSubscriptions)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/v1/webhooks/{provider}", wrapper.HandleVCSWebhook)
 
 	return m
+}
+
+type DeleteCodeSubscriptionRequestObject struct {
+	Id string `json:"id"`
+}
+
+type DeleteCodeSubscriptionResponseObject interface {
+	VisitDeleteCodeSubscriptionResponse(w http.ResponseWriter) error
+}
+
+type DeleteCodeSubscription204Response struct {
+}
+
+func (response DeleteCodeSubscription204Response) VisitDeleteCodeSubscriptionResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
+}
+
+type DeleteCodeSubscription401JSONResponse BasicErrorModel
+
+func (response DeleteCodeSubscription401JSONResponse) VisitDeleteCodeSubscriptionResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteCodeSubscription404JSONResponse BasicErrorModel
+
+func (response DeleteCodeSubscription404JSONResponse) VisitDeleteCodeSubscriptionResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type DeleteCodeSubscription500JSONResponse BasicErrorModel
+
+func (response DeleteCodeSubscription500JSONResponse) VisitDeleteCodeSubscriptionResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+	_, err := buf.WriteTo(w)
+	return err
 }
 
 type ListFeaturesRequestObject struct {
@@ -4233,8 +4536,236 @@ func (response UpdateSubscription500JSONResponse) VisitUpdateSubscriptionRespons
 	return err
 }
 
+type ListVCSInstallationsRequestObject struct {
+	Provider string `json:"provider"`
+}
+
+type ListVCSInstallationsResponseObject interface {
+	VisitListVCSInstallationsResponse(w http.ResponseWriter) error
+}
+
+type ListVCSInstallations200JSONResponse VCSInstallationListResponse
+
+func (response ListVCSInstallations200JSONResponse) VisitListVCSInstallationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListVCSInstallations401JSONResponse BasicErrorModel
+
+func (response ListVCSInstallations401JSONResponse) VisitListVCSInstallationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListVCSInstallations500JSONResponse BasicErrorModel
+
+func (response ListVCSInstallations500JSONResponse) VisitListVCSInstallationsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListVCSRepositoriesRequestObject struct {
+	Provider string `json:"provider"`
+}
+
+type ListVCSRepositoriesResponseObject interface {
+	VisitListVCSRepositoriesResponse(w http.ResponseWriter) error
+}
+
+type ListVCSRepositories200JSONResponse VCSRepositoryListResponse
+
+func (response ListVCSRepositories200JSONResponse) VisitListVCSRepositoriesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListVCSRepositories401JSONResponse BasicErrorModel
+
+func (response ListVCSRepositories401JSONResponse) VisitListVCSRepositoriesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListVCSRepositories500JSONResponse BasicErrorModel
+
+func (response ListVCSRepositories500JSONResponse) VisitListVCSRepositoriesResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListCodeSubscriptionsRequestObject struct {
+	Provider     string `json:"provider"`
+	RepositoryId string `json:"repository_id"`
+}
+
+type ListCodeSubscriptionsResponseObject interface {
+	VisitListCodeSubscriptionsResponse(w http.ResponseWriter) error
+}
+
+type ListCodeSubscriptions200JSONResponse CodeSubscriptionListResponse
+
+func (response ListCodeSubscriptions200JSONResponse) VisitListCodeSubscriptionsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListCodeSubscriptions401JSONResponse BasicErrorModel
+
+func (response ListCodeSubscriptions401JSONResponse) VisitListCodeSubscriptionsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListCodeSubscriptions404JSONResponse BasicErrorModel
+
+func (response ListCodeSubscriptions404JSONResponse) VisitListCodeSubscriptionsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type ListCodeSubscriptions500JSONResponse BasicErrorModel
+
+func (response ListCodeSubscriptions500JSONResponse) VisitListCodeSubscriptionsResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type HandleVCSWebhookRequestObject struct {
+	Provider string `json:"provider"`
+	Params   HandleVCSWebhookParams
+	Body     *HandleVCSWebhookJSONRequestBody
+}
+
+type HandleVCSWebhookResponseObject interface {
+	VisitHandleVCSWebhookResponse(w http.ResponseWriter) error
+}
+
+type HandleVCSWebhook202Response struct {
+}
+
+func (response HandleVCSWebhook202Response) VisitHandleVCSWebhookResponse(w http.ResponseWriter) error {
+	w.WriteHeader(202)
+	return nil
+}
+
+type HandleVCSWebhook400JSONResponse BasicErrorModel
+
+func (response HandleVCSWebhook400JSONResponse) VisitHandleVCSWebhookResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type HandleVCSWebhook401JSONResponse BasicErrorModel
+
+func (response HandleVCSWebhook401JSONResponse) VisitHandleVCSWebhookResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+type HandleVCSWebhook500JSONResponse BasicErrorModel
+
+func (response HandleVCSWebhook500JSONResponse) VisitHandleVCSWebhookResponse(w http.ResponseWriter) error {
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(response); err != nil {
+		return err
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+	_, err := buf.WriteTo(w)
+	return err
+}
+
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
+	// Delete a code subscription
+	// (DELETE /v1/code-subscriptions/{id})
+	DeleteCodeSubscription(ctx context.Context, request DeleteCodeSubscriptionRequestObject) (DeleteCodeSubscriptionResponseObject, error)
 	// List features
 	// (GET /v1/features)
 	ListFeatures(ctx context.Context, request ListFeaturesRequestObject) (ListFeaturesResponseObject, error)
@@ -4328,6 +4859,18 @@ type StrictServerInterface interface {
 	// Update a subscription for a saved search
 	// (PATCH /v1/users/me/subscriptions/{subscription_id})
 	UpdateSubscription(ctx context.Context, request UpdateSubscriptionRequestObject) (UpdateSubscriptionResponseObject, error)
+	// List VCS installations accessible to the authenticated user
+	// (GET /v1/vcs/{provider}/installations)
+	ListVCSInstallations(ctx context.Context, request ListVCSInstallationsRequestObject) (ListVCSInstallationsResponseObject, error)
+	// List VCS repositories accessible to the authenticated user
+	// (GET /v1/vcs/{provider}/repositories)
+	ListVCSRepositories(ctx context.Context, request ListVCSRepositoriesRequestObject) (ListVCSRepositoriesResponseObject, error)
+	// List active code subscriptions for a repository
+	// (GET /v1/vcs/{provider}/repositories/{repository_id}/code-subscriptions)
+	ListCodeSubscriptions(ctx context.Context, request ListCodeSubscriptionsRequestObject) (ListCodeSubscriptionsResponseObject, error)
+	// VCS Webhook Ingress
+	// (POST /v1/webhooks/{provider})
+	HandleVCSWebhook(ctx context.Context, request HandleVCSWebhookRequestObject) (HandleVCSWebhookResponseObject, error)
 }
 
 type StrictHandlerFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, request any) (any, error)
@@ -4357,6 +4900,32 @@ type strictHandler struct {
 	ssi         StrictServerInterface
 	middlewares []StrictMiddlewareFunc
 	options     StrictHTTPServerOptions
+}
+
+// DeleteCodeSubscription operation middleware
+func (sh *strictHandler) DeleteCodeSubscription(w http.ResponseWriter, r *http.Request, id string) {
+	var request DeleteCodeSubscriptionRequestObject
+
+	request.Id = id
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteCodeSubscription(ctx, request.(DeleteCodeSubscriptionRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteCodeSubscription")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteCodeSubscriptionResponseObject); ok {
+		if err := validResponse.VisitDeleteCodeSubscriptionResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
 }
 
 // ListFeatures operation middleware
@@ -5218,142 +5787,268 @@ func (sh *strictHandler) UpdateSubscription(w http.ResponseWriter, r *http.Reque
 	}
 }
 
+// ListVCSInstallations operation middleware
+func (sh *strictHandler) ListVCSInstallations(w http.ResponseWriter, r *http.Request, provider string) {
+	var request ListVCSInstallationsRequestObject
+
+	request.Provider = provider
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListVCSInstallations(ctx, request.(ListVCSInstallationsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListVCSInstallations")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListVCSInstallationsResponseObject); ok {
+		if err := validResponse.VisitListVCSInstallationsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListVCSRepositories operation middleware
+func (sh *strictHandler) ListVCSRepositories(w http.ResponseWriter, r *http.Request, provider string) {
+	var request ListVCSRepositoriesRequestObject
+
+	request.Provider = provider
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListVCSRepositories(ctx, request.(ListVCSRepositoriesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListVCSRepositories")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListVCSRepositoriesResponseObject); ok {
+		if err := validResponse.VisitListVCSRepositoriesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListCodeSubscriptions operation middleware
+func (sh *strictHandler) ListCodeSubscriptions(w http.ResponseWriter, r *http.Request, provider string, repositoryId string) {
+	var request ListCodeSubscriptionsRequestObject
+
+	request.Provider = provider
+	request.RepositoryId = repositoryId
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListCodeSubscriptions(ctx, request.(ListCodeSubscriptionsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListCodeSubscriptions")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListCodeSubscriptionsResponseObject); ok {
+		if err := validResponse.VisitListCodeSubscriptionsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// HandleVCSWebhook operation middleware
+func (sh *strictHandler) HandleVCSWebhook(w http.ResponseWriter, r *http.Request, provider string, params HandleVCSWebhookParams) {
+	var request HandleVCSWebhookRequestObject
+
+	request.Provider = provider
+	request.Params = params
+
+	var body HandleVCSWebhookJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.HandleVCSWebhook(ctx, request.(HandleVCSWebhookRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "HandleVCSWebhook")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(HandleVCSWebhookResponseObject); ok {
+		if err := validResponse.VisitHandleVCSWebhookResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // Base64 encoded, compressed with deflate, json marshaled OpenAPI spec.
 // Stored as a slice of fixed-width chunks rather than one concatenated
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7H35c9s2t+i/guH3ZpLMkyXbcdN+nrnzJk2aXL8vi5+X5s00GQUijyTUJMACoGQ14//9DjYSJEGJdrwk",
-	"qX5pYxHrwTkHZ8eXKGZZzihQKaLDL1GOOc5AAtd/TThbCuDHWM6P1Qf1WwIi5iSXhNHoMPrVtEAUZxAN",
-	"IqJ+y7GcR4NI/3ToxogGEYe/CsIhiQ4lL2AQiXgOGVZj/i8O0+gw+teoWszIfBWj0yLPGZeQ2KlEdHU1",
-	"iOI5phTSr1qZHWPtyoAWWXT4RyQknqRqHLjMgZMMqMRp9GkQyVWuxhKSEzrTSwOaPJcdi/qNJijBEtDj",
-	"k1cv0NOnT/89QAJi9RX9NHw2QFPGEVziLE9hgPZ3937e2f15Z3/vyRCdzcF0JQLBZZwWgixg6Hb2VwF8",
-	"VW1Nr2HtxqaMZ1hGh5EaMwrtg9A4LRL4FQtICYW3bEJScIfQsb8j0wdNbCeU6V7IIoFAhCI5B8RB5IwK",
-	"UNsiQm2J0XSFcJ6nJFaQ1oBIQFxIlle9l0TOEUYx42aAhNBZY4rhR9oBE7ufsVvb2HQcu9EjHzwWHBPG",
-	"UsBUwyMDyUn8O4HlGqw7zSEmUwIJMs3RgsASsane9YfjM3WEeBjGR9NjrHrcmFo+HJ+9Ldepl53jGaFY",
-	"Le+U/A0dy35XZBPgap0cRJFKgSRDHGTBu6CZ4xmMBfkbamBLYIqLVEaHe4Mow5ckU9Szt7s7iDJC7V8l",
-	"rhEqYQa8scozdgG0Y5nHZSskVbN1a3MNWmfqobiQmMtOYj1VX2+DXDXmrSNXu46vItgr11hzbke1R3TK",
-	"2jt7wajEhIqKTgk146udqU1hNAUsC66XnHOWA5cE9NBzMpuP9SI2r2oQpWzZv7GQWBbC57spyYiERIEK",
-	"lqkC2ZIkkK7CrNf+wiZ/QizVgA4Mp3pgQxn6mqvtKGYFlW0onTGJU6Q/KsqwABEKIuVOCJXPDqI2Sg8i",
-	"STIQEmd5a+c76lOQ5Van/4fX/1PPjYljPIP27hTHUf8nEjKxiX8EAVZBFnOOV5FhhtgNvG48taS3rm1z",
-	"i/rHjt2R+DfOGX/LEkhDJ5bonZY85lmdx6i/2keSgRAWROth7xoOzETBJZpb40iRvpYGDNIEgA8BzHLM",
-	"gVG0nJN4rq8Hi2BoiQUiblxI1J2Jy+vt2qzIx9b+dFdQvMAktUJP9e8W2Q2iyx3VaWeBueJmQvU+r/V+",
-	"XvW+GkQL4MKCqg0Uu0tkG6mtt+EzgRhngMophlE/XmDGPoEUsIBXZrCHYwntzZefkZxjaaScFEvQlzGm",
-	"CBZApfmW4ZVi2WkBNAYNnNaaLBsv8UYLWqrfBKwIpuHgZBMHeSIFpFP0eDkHD+10R2EkcYQRhSUSUJvu",
-	"yQAx3hwYUybnwMtR7KiNX+24orp00KSQiBUciVKcKtcnEGVLlOLZTAl/E5gTmjjBUK3LDvFkiE5gClzB",
-	"Tq2K0IQsSFLgFAFNckao1BDKGFfAoxIupSJH1bZwYCEClTzNCJa3z8i7sfJW+PkapL9/tm4Wcy6C+4rn",
-	"nGWwaeYXupUeQss2QVJ/genRuSiFn/o8Jdx6AdANJSFrA2zd3KpDe+4kdPmoXnpbLzFJV+rqvY2j9yCl",
-	"hrz/424eVWA7JF21eeEbxfMkEhTnYs6k41CFGsipVVPLbGZkAbSUVRskygpzAXVoIpWMQLX603GeDTC2",
-	"drGBq5tlV4368ZBBVDgqaSgl14bKLQClPzt7wQFLeMckmZJYy0QvjJXlBP4qQMjQTUunZBbUUaZkVnCj",
-	"k9iLIHbs3NpukFqAun0TovpmSjtk3EiGea4gefgl4kJ0IfbJ6amZRykWMJkzdtGpWZvPtvlVqRWt3hkd",
-	"ToPiahAxCu+n0eEfG/T0xmjrW1fLvFIilNEamwB7ru4tvpPAlFBItN2rRAgLruHGy8pay+yhhE74twyT",
-	"9EV5aPXDxEnCQYgwJYDqiWyTmsikv4SIwPxQiaWm4aeNV676OihXE9wGLbJzekHZMiCKnkDOQagjUHJX",
-	"YZoNUEGFM0ZqaSdRzWKsZHS1QLTAaaGxsZKizQSdUvM7JzF7y/ldjaJF5d8uJdAEkromhNO0B4I1VSiF",
-	"YvWzAvXRnRpRO8fpcZ2zhY+jhGID6nbANrTVXqzo0UYZZ4Loq5maW3/g7MpjUtPA1u6nh6DU0OeuBg3M",
-	"eKn/miiZXAmVtdbIqFGOM7tLSZuCLmAlSmo0cFGiJaApZxmaS5mLw9FoRuS8mAxjlo2WMNnJUywVjewk",
-	"l/pvJ2uPJimbjKbPnu7C7u4u3vsJ8HS6/3R6sJc8m/wSH+CDgzjGzw7wAf4ZDsotatOj+WP4p2D0X2/2",
-	"n+3tvNn/5d/6imiRSAILSBX8xoLMKE43wtCe8UvX79R2uzL8mRUczyDpO0rVwx253f84KEV1scXTudJZ",
-	"NDfUqpO2xxm6UpfJBNC8yDBFU06AJulqiF6wTKlP6mDcWrDEjwR6pEZ5hKYEUq2V3+jYMkxo55H4B+Gp",
-	"5znEPaF2mkPswCVWQkI2zjBVQBwLvFD/BczjuQVhm0cfvXToa3rv2N5I90amt0VkInwjIS1So+RbyyUH",
-	"nLynSr4zf3cLOD3I0qgM2npAE8bHOROkJPcO26aQmCaYJwKVrc2hLjAnrBDIjCWsx6CPSP277nFshwtJ",
-	"1Mtc9jypD8dnTpYTLVbqYfrA3cml38Jaa0K3WhcFtrhuSuhFQPIm9KJUmIUoAEmO4wulaJfMABlm0LYS",
-	"tw84XzAJwSOytgpzMAvFKyGZ4PiiPmofq8rVGihUHOR5HDOeEDo7Y92wWC9T6Faf+s2WSuAUq531VQHr",
-	"c5Gk50xhvQq73Y4l660urgdaANVxtUvxNbN4wOqlYNshXjMKWr65TZmIwnLs2HVIwk6J8K1e6OilMLfK",
-	"HC9A24pSkJCuEIc8xbG6YtR9z8mMUJwOEGXLnRmjpXAwQFggbJ1u2mKGpkWaIpGnRF6DMZXcPyXSsf/m",
-	"eTlZuumxTZSiZgUa3wTNIWOK5yeKDTCE7aI88Vb/0Fsar8F2rZCojlZvZXu0P9rRvvUsTg07AKZjMi4E",
-	"9LXIWVjU9vyljyPALuUWTGxOqbkl09oHIufawxC2sXmDrrkdSgkweM/159RqHCUPXIspV1jace91SZyV",
-	"6V/TnKEaSIzA5uHn19ybNYmrtb5aYM8NlcgPx2eextDWHivZtGHF8yevwkTWao5WmFW/JmQ6BQ5UohgL",
-	"EH1UEwlCitEyl8Ppilh9cvLTBMPP8bNk9+CnZ09/eXYA0714/xe8/+wp3sW/JM+ePf05PoCRmGMOySjn",
-	"LCliOVbayXDG/vXm572dN3u7B2Fl0gZQ3TdgzbQ/IkhDVPgaKHASn+dqr5MUzin5q4AuH7o21SZjY9Pu",
-	"Z5Tu0LwLNeG1hmoT7sBfUG3IEEm/TtkEp6dKKT3VOml/UcHv1BYTbgKVhIg8xasx4wnwMJc7P0KCcak0",
-	"Kd3KxLeZfupHGxcnSAITzHv6k0Ms1Rw5MotDJAEqyZTYCfUUniLfobbd4DCbN/6gJV8ZewKa6YOrmxO0",
-	"95ZIoaBkYWKgNAwe9XHQMfIc5Xim/baBKYyL/itu+ja+3aY7rYXe/w04lfN4DvHFiQ2VDFmpzRft246x",
-	"Ri51wnPduWGNFMAXJIYWFLzQDxM8Eh1GZoDVRqpdY4h4S4QgdPaewlGWp53G37pFb6Nw0DPSIzj5bbhU",
-	"w7u6d8dqwL32EH4144zp2JnvJhp8ky44f4WbHHB34K5T6K2t0pZAu110XW6wCl4GwL21tY0+vgCC3QL1",
-	"BL3ClrndKTddN3FvsWGdbLUJIUIE2xY92lF4QNVMiaFD88/NrsTAZCaa87dytM4mL8tpevN6heG1Izhs",
-	"W14u5diLye6npYcV4xsMPoik69rHmlwjGFbP8qhWV5F4Ox6kQaz9STM0UUPE7fZTB0QqbBgMpgnCSIec",
-	"Dz/SX5mco8/qw2f95bP+8BlhDsitCOk4PS0KK6HCBvz5gqPWSBq8oG6IyfDlG6AzOY8O93b3D3SISfnD",
-	"oNt75/V7ur+xlwmkr3fb3z34ZUPHcNSDGWzDKayzbnRuqof2o5tumPt+udZ6RWnC2EWG+cW4YlvrBjsX",
-	"wL0Bf7W99S0OPFOClXXnXWOUY69nSAupQ08DAbxApE5ikiY+G1cEIRkyelGD0IYf6XuaroyFlUCaWKMx",
-	"hdK9nLHEhLB6v9lcpKTKh9KLGn6kZwzFKWDtBVPjDVzbagrV6bNZzTjD4sLQsQBpA4H95CgdkqImpUWa",
-	"usXahWoe4dy2pj9DkheAYkzVKvVCIPl6Ym/6hh+W+J2Kq4G31hVgD9Sd/RCdWHwYoudpypaQGAALxT0P",
-	"LVcdoM/egOpPw2EbNn93PVje46+hzYm67vou7H6LxcU7M/C6Ji9rk65r+f/Mgq40aI/MHvYaMtsgKjR3",
-	"sZ/VUTc5nQ/4IK9zRudrOGnbgxSTGnI2w4y1vBNUOX+7zFMSE4kUgzxEx5wtSKJJ3qlJTj86elkhg4kj",
-	"x7TAqfsu0GOrMhg148kQvS1kgdN0VSVvGgJ85Bak9vHIIMlGevH7BBw/Wcc2atodOhd27Y1Qj2oPMJwN",
-	"B+gRF+LREyUTcPBCQxAuJMuwJLHeFgfB0gUIxLiRHKzfyek1mwFAErv9huS0ERpTzT5pvNqcS1xhxquy",
-	"09UgCsTGtKVITmYzmxjdz4PizXZmOn/gxNjBQ06VmrjdWJC/SW8pnzag/ysfMm39sxzTxl0Ir6vvDSRZ",
-	"BgkxyUNLgAudiJcxKudpLy4VWtGRN2awwQc3UfDrWzd7Y8e3oKf6w92PghqccQPnuiZPOIV0umN+mmhD",
-	"4So3vl91j2lCPT9Sf1uLsZFoEkjJAvhKyTCGWlkh0RRkPHfGxoImwFNtw3aUXqPhvqaKwY0s719P+R3A",
-	"tJQwcU6rnnJy6aC/BV7hECGcenLXThdvD3XeU4PMwEfKBgpu4k2hbW7QcAmdpYDswkxepM+yyrICA98k",
-	"TqSwtvC2D4Dj5VhLcGH+WEV3cLy0snTlIlQaFRYwRFqotutExJjzHunWjxAR6JENA380MNSmaSUlRtPw",
-	"KE5J8eYO9iPL3TEMw7Gh5epviF0m2ryJGmbUa57g72FA1o/QPy53kCZuHtniER7A9LU0xzRJTQhiB1D6",
-	"2XvXX8cbbMVetsDVpzAYysGCqGTTJRc4JcnAZGoISCE2/mm3nw33sHOXlKGgko1dXnzom82V9z4Gg+bH",
-	"mK7GLsIpNBSHGQetZ6tRXU7+9S5+CyXrNHHR/GfsnV1/n7Yf3H7WNA7F8T+nqxfV9jbPdFLu94y9cbvV",
-	"p96sRRMIoTW6Y5kpUlUv0YaBJUwsM0pggeKCc6AyXSFCZyCk8A7b5kMOoinhMGWXivfiKeZEtUlMdrpu",
-	"MsY04cwIiaap94vpMiYsfOkaRW+br3Uv+Vr3bocwZ7XB8tDyA3VR8yZc8YwOfZpaCN25TcGspS5id+D2",
-	"14uTd6sk3h3GuHUrrCmh0IU4QcmwL/4EDkJhw1k15tp2FbTvHnE6TNaH3Y67G1jAjePtOrEV6wcK19Ww",
-	"bVxQiBUzmjk9WAsmdQWutPNTRnUaivsbxzpmP3irNMz0t6CTB5wgd6qSr/E0tHbC2WYlsTHeierSZ+IT",
-	"O3YZmO0bhtiSAg+eQCNTqTPs0ljUWmyEMQHpCrlcYhsjyZ0kb5yCVh0zaVSPQglXJtzSgKBMvDOLSFeI",
-	"5UB3TCLe48+h5R1qb8TnJ9pOEccsy5h2weiI2QVLF2odQvIi1pHDLiM+F5IDzpCfe7dj5Qth/DqCFTyG",
-	"YThUtRFs2jpuH8n6Q7UMUWW56YDcOAhPWGGcNyaP3xZruYDVjtE5c0x05RPjPIoZFSQBDgkqqA1wVbpj",
-	"jKmWs2aAsESYrlDGlAg8REdT505C2og7ARPumtlMhaVx+eAkQUQ6kS3DhKI6LAxCmKPtCPONGW/U+nIF",
-	"B3rUWqhXrwuXTQKhbe7NunovTYR8eUWBkGNdE0cYm4X/Q4hgPhyfnRS0qxwQL+h4Q50HXcPNq+Fj18YL",
-	"Ouxd80EvMsdCjDvqD1V1+lQrbYOzWkOf8kNM4nSsO4zX1jei5Sy9R2/cXnV4fQofdQnv2wjNq53fvUfk",
-	"1dWDjSEhTnUJIWLB0zCC2U7o/OTNEL1wiuPAVM48TXGsP2mBrtI+a7hXaN2xV4yYWsWnUMy5gLjgRK5O",
-	"FbxsJABgDvx5IefVX6/cnP/3w5krwqgLauqv1SrmUubaAcxc/wbCM4QLOVe3htEjSpe89l9xzbdYLpHi",
-	"oIostK/L3E9mLlMpsqy8OAec6AXY0ov/f+cd29FzVziTk//AytTlIcH6ic+RZCxVjDJjlEglOdHE5Mq6",
-	"rAMbeovTFH2ACTq2WQJVeS4ccyYESkgGVMsVxj5gwnBSY+VirsgZSYk0BsJGyYG/Cmw+mdGcrWFggn4S",
-	"c9egyUphT5XD64yJROp437pN4vnxUeSVaYt2h3vDXa0p50BxTqLD6Olwd6i4QI7lXKPAaLE38pPrZqCZ",
-	"i5pLr/MosaYRF4yrO1elhju076rJKFggtEsPD/aryp+qbqEynMtcjutFWG9YdLWNL3omF5Wva6s6e7EJ",
-	"60ilthAxXQJ3VdqXhWQc0HJOdICGkvkInRmpyoyYFUKiKSudOM/fnb05QTOOswzzITo2pdg4YJOuaDqp",
-	"PzMrJMiUlymGJqIlS1oTTAAVPEUCT6G7vu5fNXhtCL9qQuiVFk4k01kSaLIaWN8wFrGxAmMRgwlpUZj9",
-	"SPV+5IoEuy8mZwC9NEVohRtO14lbueoNhHpjmVwM5+dWDcZqxifdu1QDRqEK0a6zbTpW62pn7dsWzV9t",
-	"YyPMjZ1ZL/BbvaE17uHAb/WGkMwa4+lf6o1K42Hox/AKjZkxuFL3rWOOUM/mx+BmCRPBDavfbQc/m64O",
-	"zNCXUKcaYENfQp08ILd/D3WoAzz4ad2OaiBc12Lt3N2jdBxHCBzVoXR9tZ3tynTtD9uj9pNt1iw9M7a1",
-	"JGyXzs+2u39r1hEg9CXUyTvL9u+hDvWzDH4KdashWujLuh3Vjm5di7UL7h6lAwFCy6wQoOur7hyIg/6k",
-	"5E9j0dGiw/7urnUzSDAqiq0Kr26K0Z/CWDP6Xcx+prcW5+qXzvv/KLHm4BYnbJUhaE/6K07QEc0LaeY+",
-	"uM+53zGJXrGCJnru/X/f59wnWALSzjQ1+U/3C/QjqouMpOjUpMEhUzlEKzSFEpVWznVXSrHqmy/Wjr5U",
-	"yWpXnTLua3AibnT3eN2N009399pay1td8+EYeIap1h2jgVWH9ALfsLgsYh1IYD1540waFJYDlLthUGr7",
-	"lRmmXrJeoHx9WAm9+icT4t6tY0ZVHCcwufqIHtuWpqAyShmdAa9qaivlQFf4Oj85cmVCYMHSQo3xZMs+",
-	"AuzjNUjkpYQ21NuGulMWmQk/BVKr/9X9JkRArbpLvfbTOpboft3xLW0beGRpaLt7XunZ9LZywFYO2ETI",
-	"pW/GuEVrBZVNCGDPoo8PxQrW06qQWIqRVrlGRlcY6WLc2h6x3oLnVSovi2Jf35xXe3mnhxnPe1TrWka/",
-	"WzAW3qWCEiz7vuVQWw61mUMZ1EGabGtV4EWIZ33LbGiZy5FzXIy+2H9djVwa0uiL/dfV6IsnxVz18TOU",
-	"EsyWQ90QZdt+2i172rKn9ezpRGELLEygzjKX2h/q2FKOuSRxkWJeGQoeTl3aQG6tB1B79Gk9TdqjT+ht",
-	"yZJ3mnpWOzrya8fVs1rL/VrVqh7a4XqXHCpcH+yb5FLfrNUzWDKtNIHOq2pkYpQqscK+8WERsJnvIwtO",
-	"BcJof3cXvf+Pi4aQzGVl2SKfXlkylHMWg9AvwWI1g/byWpSxD2e2jAhekbQ3blF3iGehmmwdWFYDsAO+",
-	"A5yrz6ZHigaRxDMdHu2NL0z9HQX7NtXnTATI3jy845fsMJwQhPyVJatbg0KtKEg9eEjHWLcOYO8upl53",
-	"AAYSyW3TeuAxls1Cyd59kvs5xYWcM07+drt/ep/Tv2J8QpIE6DfG6WzAmr7z/FC1Pz6pa6miU4M3jbD4",
-	"KEyHoy9lav6V4YA6t6xFlSe60HaTKmv0cRAMenthAIceiyJWjHFapEhPUprfH1TY/sfi9UPpGehxLVkj",
-	"YSAQZRLBJRHyyXdEcVeDTqfAWjLZve9rxEmLD6dXfh8nOvhSBu82OeprkA1mukHP00eDzNl0Knt+UZRr",
-	"GKJ0tKopolfHPJtudp+SU70SWS8x6sHwfytB/bNumu/pLnGymTYjN2JqRylbjnWCp7MO2eyfdYaT57MZ",
-	"h5lSH+oP4b9wmURbG/LNUMCD5daWvLUlX8uWrK1J4Tfuqyob1VNNHHA8hwQ5foDK59BcZmP1qrxJJ13l",
-	"gB5XpTh0QpXjHjoVoM5oqvcc206rG/Eal39hNvMjc5nN3Wy1U8cy3rIJSV1RF3EfvGrTe/xblrVlWbfD",
-	"smwRhpIZWSaC2AK4TiQ2eVhlHm31ZhGhCVmQpDBJ5NrnX08o4wZ9q9c/mpNornZdRtP2hn3qzRgz83TG",
-	"mFFoVp/qwSvrD29UfX98uex2OOagu1RMVZ6KGZcEIlNUnhsiAqV4NtM5dDAnNEGsDCoRBkH1SETY3FuF",
-	"YyuLcLosJIfc1pE3GYXV0ofoN/PmzCH6P3bC/5oyZtf+sdjd3X/mfp/gv93vXal5tulas0DPmjzNMl/t",
-	"cq3bO2h7B323d1CZae5VqVvpXPXWfaHWiDkRjFacYlJIbXyu9a53k5jPQLou+i1UNkVKMne/PRLocb2V",
-	"rhzdmu6Ju8y0sP7t3VujL2pdV/3S37vusRunxQcDVAJVUxTCKulhOSfx3CSgezE63pu3w7DRNTGFmrsZ",
-	"a63ASTS4QazN9tq89rW5vTU3Pc62vS+39+V178vOl8CXwO1tCom60ezdgBiFZl0WRv1XI0r2q4Y3cdm+",
-	"Hla7jO4iGroyNf0zAqIHPZ93Z7byin1vWjHmW1No7ERHyX+RZM9wZf+n/U6GXLaKgiy443HAe2Gx22Dw",
-	"LWe9Qa6KQLhkQLpYnwQhDSMVnVYwXdHQvR3zPi+rRlqKnaxqUuvtqAUPENztl3oXoy/+nzpFhotASdfj",
-	"YpKSGJ2cnqIpNC2Jcat8fGfAjV9i9/T0ewoR50L878ssraNzq6jAtxfTs2UPbbf+uvChJor7T3ttjCby",
-	"35rojCaqE9yNktsKYch8RL2C5ztOYlsrmQVKpP/AqRpd7wp/o1LENnr7+4ne1mksihCRT4TlW3aaWaxJ",
-	"nAi90Hw3YYCd810rHHDvLmnym86usGByRRsJ1U/qoPOTNwMdyTEy71ko5TzDMp4/+QfTsgOSC4nJ8CXJ",
-	"iswr8Ozo42FL+rh1SsZQhumqvqzvOZeEwjLIkEqjz3rZobT2bEo0eal/7+Ji24STbRjwtRNO3JNN9VwT",
-	"xLi5Zsuf2ZIiIr9XSjWE00Gj3apzL0rbfahLeis8byn2h6XY1yCD5IomK6Xlb7IK+KSEXpTPeYetA7XX",
-	"TW8v2ej+tI2N7/vdc/LRgzOybRLSlpd9O7zMkGdPDcG9j+nsGA1rp66ELlyOwwTHF0BtXoR51w3NsUB/",
-	"FkL6T6pAMvxI9XNT+m1iUe/MUA5cv1sisbgQKCUXYF73N68nmOcFy7fATVhXztmUpPCR6icctEcda48P",
-	"oSZKSBcLds8om+eP5cp5W3mltE45CPfQOOFIPyWOcJJwEOLJ8CO1Cwea5IxQicScFWmin8jCaWr8tu6h",
-	"ZUZjGKDyIft0hfBUgrEplwpPymbEvmxVZ9vHhM7OqyiZm3Dp+otApnrkWL9NEy64/JrI/y4m6L1CHIT1",
-	"Es1TNohNJNbPstmouynXa0hQUujnRYhCTPM6HxJkRncI1Y/llB0Cx4sRo+ZdKiRWNEZsalDGnqV5Ne2x",
-	"Pn59DE9QQjjEMl2ZkzSrtQ+XmWUSQ6D6CZPm1MHHrNsvggUuBPd4Wo5XKcMJis2zahpLOKaCmBB4wpOd",
-	"HHO5Mosxbka3GbVDQmfDaPPNt1ZZ3lqJvzd+a5ikQW1N7LbOkOY0Dj/anPcapbcazzf+yIW3Qq98bpXR",
-	"LY3emienoxxZB1n6NXlG5Su1wnsVd12Nnq7Hfm9yI2wxfVuZ5/urzFMPh1U00fFstFfB09/68KHLuxSB",
-	"K/m4kL0pe7dN2du7a0vRPwZFP0+Sa5Nz6771YxUDxOIoz4ycYYp1Aoy5y/2++mXG2uXeGaaopIHT2rw/",
-	"rDztb3MrTG+F6VsTpuu0ZyMpm3XZ1lWV9aMu76g4Wi2w857ryvph0NvCslsavLPCsn5AcogM11647eSA",
-	"zQFBLcrdGje35ffuMIymB44PekqNXj5LS4Dsm9QS3ZO01seFvaWkLSX1DW/pRUYPnPuyqZ7u3cuM7Yke",
-	"qqLuNVnBVnbccqLvJzilj9yqh+WLMC865iwpYssICp5Gh9FcylwcjkY4J8MlTIw9apjAIrr6dPU/AQAA",
-	"//8=",
+	"7H17bxu39uBXIeYu4AQrS7bjpr0GflikjpvrvU7itZ3kAq2hUDNHEq9nyCnJkaIa/u4LvubJkUaObCep",
+	"/mljDZ+H5xyeN2+DkCUpo0ClCI5ugxRznIAErv8acTYXwM+xnJ6rD+q3CETISSoJo8FR8KtpgShOIOgF",
+	"RP2WYjkNeoH+6ciNEfQCDn9mhEMUHEmeQS8Q4RQSrMb8XxzGwVHwj0GxmIH5KgaXWZoyLiGyU4ng7q4X",
+	"hFNMKcRftTI7xtKVAc2S4Oj3QEg8itU48CUFThKgEsfBdS+Qi1SNJSQndKKXBjR6JVsWdUIjFGEJ6NnF",
+	"b8foxYsX/+whAaH6in7qv+yhMeMIvuAkjaGHDvb2f97d+3n3YP95H11NwXQlAsGXMM4EmUHf7ezPDPii",
+	"2Jpew9KNjRlPsAyOAjVm4NsHoWGcRfArFhATCm/ZiMTgDqFlf6emDxrZTijRvZBFAoEIRXIKiINIGRWg",
+	"tkWE2hKj8QLhNI1JqCCtARGBuJEsLXrPiZwijELGzQARoZPaFP0/aAtM7H6Gbm1D03HoRg/K4LHgGDEW",
+	"A6YaHglITsKPBOZLsO4yhZCMCUTINEczAnPExnrXn86v1BHivh8fTY+h6nFvavl0fvU2X6dedoonhGK1",
+	"vEvyF7Qs+12WjICrdXIQWSwFkgxxkBlvg2aKJzAU5C+ogC2CMc5iGRzt94IEfyGJop79vb1ekBBq/8px",
+	"jVAJE+C1VV6xG6AtyzzPWyGpmi1bm2vQONMSiguJuWwl1kv1dRPkqjFvGbnadXwVwd65xppzO6o9pWPW",
+	"3NkxoxITKgo6JdSMr3amNoXRGLDMuF5yylkKXBLQQ0/JZDrUi1i9ql4Qs3n3xkJimYky341JQiREClQw",
+	"jxXI5iSCeOFnvfYXNvovhFIN6MBwqQc2lKGvucqOQpZR2YTSFZM4RvqjogwLEKEgku+EUPnyMGiidC+Q",
+	"JAEhcZI2dr6rPnlZbnH6v5f6X3fcmDjHE2juTnEc9X8iIRGr+IcXYAVkMed4ERhmiN3Ay8ZTS3rr2ta3",
+	"qH9s2R0JTzhn/C2LIPadWKR3mvOYl1Ueo/5qHkkCQlgQLYe9a9gzE3mXaG6NU0X6WhowSOMBPngwyzEH",
+	"RtF8SsKpvh4sgqE5Foi4cSFSdybOr7e1WVEZW7vTXUbxDJPYCj3Fvxtk1wu+7KpOuzPMFTcTqveHSu9X",
+	"Re+7XjADLiyomkCxu0S2kdp6Ez4jCHECKJ+iH3TjBWbsC4gBC/jNDPZ0LKG5+fwzklMsjZQTYwn6MsYU",
+	"wQyoNN8SvFAsO86AhqCB01iTZeM53mhBS/UbgRXBNBycbOIgT6SAeIyezadQQjvdURhJHGFEYY4EVKZ7",
+	"3kOM1wfGlMkp8HwUO2rtVzuuKC4dNMokYhlHIhen8vUJRNkcxXgyUcLfCKaERk4wVOuyQzzvowsYA1ew",
+	"U6siNCIzEmU4RkCjlBEqNYQSxhXwqIQvUpGjaps5sBCBcp5mBMvNM/J2rNwIP1+C9I/P1s1iPgjvvsIp",
+	"ZwmsmvlYt9JDaNnGS+rHmJ5+ELnwU50nh1snALqhJCRNgC2bW3Vozh35Lh/VS2/rNSbxQl29mzj6EqTU",
+	"kI9/3PWj8myHxIsmLzxTPE8iQXEqpkw6DpWpgZxaNbbMZkJmQHNZtUaiLDMXUIsmUsgIVKs/LedZA2Nj",
+	"Fyu4ull20agbD+kFmaOSmlKyNlQ2AJTu7OyYRXCZjfIVnxEhL6yy/7X4XBs6H9ZHlt0QtG3EJm/igCVE",
+	"Q3P+3Q7Qgn/opfle0PIzC8OMc3WtD3MZpINoUXTrztrKW3+f9/fxCY7nw4hwJW7OwLtsDikTRDK+GI6z",
+	"OB4axXZ5wy5t2JwC9zZqyqyvjq9OP54EveDq4vTNm5OLk9dBL3h9cnb60f774uTy/dlH/c/3v16+Pzu5",
+	"OjEtTq70jycXF+8vPJplL5CYT0AOjdruW43kZDKxVtO1gX9lOn/ixFgZPSeQpdHaCDgLxZBQIXEca+2k",
+	"DRNVu5SzGYlaQK0alM7Ef4lVaY4olb0ysG8Yz1E3MaQFuWqHUjqCHDeqZOGhrV6ZsCtA9rIL3fYdk2RM",
+	"Qg3RY2NBvoA/MxDSp0XQMZl47S9jMsm4sbdYITd0oqq1SyO1AKVZRET1TQjFknGj9aapAvrRbcCFaMOw",
+	"i8tLM0/QC+YwmjJ202o1NJ9t87vc4rN4Z+xTGhSKy1B4Pw6Ofl9hg6yNtrx1scw7pR46plAF2Cslk/Pd",
+	"CMaEQqRt+vllZ8HVXymIW7Sxh+I74ZMEk/g4P7TqYeIo4iCE/5YH1RPZJhV1UH/xkaf5oWBfpuH1SnVC",
+	"fe3lq/Fug2bJB3pD2dyjZl9AykGoI1A6ZWaa9VBGhXO0aE0uUs1CRQ5ILRDNcJxpbCwsBGaCVovAO2cN",
+	"KC3noxpFmwFOvkigEURVKw+O4w4IVjcPKRSrnhWoj+7UiNo5js+rUpv/OHIo1qBuB2xCW+3FqlVNlHHm",
+	"1a5WN6PR9JzPbEgq1qWl++mgBNZsVXe9Gma81n+NQBiFudIaGZbqpE4ncGsz9w0sRE6NBi5KbQY05ixB",
+	"UylTcTQYTIicZqN+yJLBHEa7aYylopHd6Iv+29kRBqOYjQbjly/2YG9vD+//BHg8PngxPtyPXo5+CQ/x",
+	"4WEY4peH+BD/DIf5FrVbxfzR/69g9B9nBy/3d88OfvmnFn8bJBLBDGIFv6EgE4rjlTC0Z/za9bu03e4M",
+	"f2YZxxOIuo5S9HBHvkJa9LPFyynj0nBDbRbSvgZDV+oyGQGaZgmmaMwJ0Che9NExS0CYg3FrwRLvCLSj",
+	"RtlBYwKxtjje69gSTGjrkZQPoiTGpRB2hNplCqEDl1gICckwwVQBcSjwTP0XMA+nFoRNHn362qGv6b1r",
+	"eyPdG5neFpGJKDtAaBYbA6b1ynDA0XuqdFfzd7vy1oEsjTlEW0ZpxPhQyzqO3Fv8NkJiGmEeCZS3Noc6",
+	"w5ywTCAzlrDe0C4C6Ufd49wO55NB56nseFKfzq+cnioarLSE6T13J+c+WSu5+W61NgpscN2Y0BuPVYHQ",
+	"m9wYKEQGSHIc3hA6QTkzQIYZND1gzQNOZ0yC94isHdYczEzxSohGOLypjtrFYny3BAoFB3kVhoxHhE6u",
+	"WDsslssUutV1t9liCZxipwh2MW81NINuM/ltRtjtdihZZ2VrOdA8qI6LXYqvmaUErE7GQzvEG0ZByzeb",
+	"lIkozIeOXfsk7JiIskUfnb4W5laZ4hloO3gMEuIF4pDGOFRXjLrvOZkQiuMeomy+O2E0Fw56CAuEbUCB",
+	"9gYgpb0hkcZErsGYcu4fE+nYf/28nCxdj0aJlKJmBZqye41DwhTPjxQbYAjbRZXEW/1DZ2m8AtulQqI6",
+	"Wr2V7dH+aEf7tmRNr9kBMB2SYSagq7fBwqKy59suTk67lA24D5xSsyG3wScip9p76jfPlgZdcjvkEqD3",
+	"nlvD+JZCqOSBtZhygaUt916bxFm4NTXNGaqByAhsJfz8mnuzInE11lcJWrynEvnp/KqkMTS1x0I2rXko",
+	"ypMXIXBLNUcrzKpfIzIeAwcqUYgFiC6qiQQhxWCeyv54Qaw+OfpphOHn8GW0d/jTyxe/vDyE8X548As+",
+	"ePkC7+FfopcvX/wcHsJATDGHaJByFmWhHCrtpD9h/zj7eX/3bH/v0K9M2uDQxwasmfZHBKmPCt8ABU7C",
+	"D6na6yiGD5T8mUFbfNA9/DUtmvf6lnefKXwdO/ObmI1wfKmU0kutk3YXFcqdmmLCfaASEZHGeDFk3HoH",
+	"mlzuwykSjEulSelWJnbX9FM/2phfQSIYYd4xVsbHUs2RI7M4RCKgkoyJnVBPUVLkW9S2exxm/cbvNeQr",
+	"Y09AE31wVXOCjkwhUigoWZgYKPW9R33udfq+Qime6JgUzxQm/Ogrbvomvm0yVKCB3v8CHMtpOIXwpuxw",
+	"rVupzRcdtxNijVzqhKe6c80aKYDPSAgNKJRchCYwLjgKzACLlVS7xBDxlghB6OQ9hdMkjVuNv1WL3krh",
+	"oGMUm3fyTYSL+Hf16EEjHvfaU/jVjDOmZWdlN1Hvm3TBlVe4ygH3AO46hd7aKm0JtN1F1+YGK+BlANxZ",
+	"W1vp4/Mg2Aaox+sVbotP2SQ3XTZxZ7FhmWy1CiF8BNsUPZrRGkDVTJGhQ/PP1a5Ez2QmUv0kH621yet8",
+	"ms68XmF45QiOmpaXL3JYyjfppqX7FeN7DN4LpOvaxZpcIRhWzWArVleQeDPWrUas3UnTN1FNxG33U3tE",
+	"KmwYDKYRwkiHgPT/oL8yOUWf1YfP+stn/eEzwhyQWxHSMchaFFZChQ1mLguOWiOp8YKqISbBX86ATuQ0",
+	"ONrfOzjU4XP5D712712p34uDlb3yaKNSt4O9w19WdPRHPZjBVpzCMutG66Y6aD+66Yq5H5drLVeURozd",
+	"JJjfDAu2tWywDwJ4acBfbW99iwNPlGBl3XlrjHJe6unTQqrQ00CAUiBSKzFJk3uCC4KQDBm9qEZo/T/o",
+	"exovjIWVQBxZozGF3L2csMiE55d+s3mWUZHrqRfV/4NeMRTGgLUXTI3Xc22LKVSnz2Y1wwSLG0PHAqRN",
+	"cignfuqQFDUpzeLYLdYuVPMI57Y1/RmSPAMUYqpWqRcC0dcTe903/LTE71RcDbylrgB7oO7s++jC4kMf",
+	"vYpjNofIAFgo7nlkuWoPfS4NqP40HLZm83fXg+U95TU0OVHbXd+G3W+xuHlnBl7W5HVl0mUt/59Z0J0G",
+	"7anZw35NZusFmeYu9rM66jqnKwPey+uc0XkNJ21zkFLYqC+FQss7XpXz5Esak5BIpBjkETo3cZna/mzV",
+	"JKcfnb4ukMHkyGCa4dh9F+iZVRmMmvG8j95mMsNxvCgS0w0B7rgFqX3sGCRZSS/lPh7HT9KyjYp2hz4I",
+	"u/ZaqEexB+hP+j20w4XYea5kAg6l0BCEM8kSLEmot8VBsHgGAjFuJAfrd3J6zWoAkMhuvyY5rYTGWLNP",
+	"Gi7WCSj+Le901ws8sTGPHL5cF7drCypvsrSU6xXo/1sZMk39Mx/Txl2IUteyN5AkCUTEJEbOAW50knHC",
+	"qJzGnbiUb0WnpTG9DT65ibxf37rZazsuBel7TCJJAlQOBSVpCtJ7ymMSw1DXHPB91fE3NunjHvpEMXh1",
+	"qF5jaasOdgPqeLc8kU3q4R3zSCoMek3WdwnxeNf8NNL20EVqXNzqutb86MOp+tsaxo3gFkFMZsAXSlQz",
+	"TIllEo1BhlNnU81oBDzWpnrH0CqsqqtFpne/NJmvZnAtwLQEP3K+uY7qQB6HsAGW6BDBnz340L6lSkpE",
+	"mcVWINMrI2UNBVdRqm+bKxR5QicxILswk9pe5sx5ZZhe2fJPpLAm/6arg+P5UAuq/mugCGLheG5VhsIT",
+	"qhRHLKCPtO5g14mIsVru6NY7iAi0Y6Pdd3qG2jStxMQoVCWKU8qKETXKAfTuGPr+ENh89ffELhNUX0cN",
+	"M+qaJ/jRD8jqEZaPyx2kSQ9Atv5PCWD69p1iGsUm0rIFKN3M2suljhUm8VJSxN21Hwz5YF5UshnvMxyT",
+	"qGcSUgTEEBo3vNvPCnHDeYXyiFfJhq60ie+bLXdS+ujNDRhiuhi6QC7fUBwmHLQ5QY3qyqqsJ99YKFnf",
+	"kEtauGLv7Pq7tP3k9rOksS9d4RVdHBfbWz3TRb7fK3bmdqtPvV5OzBMpbFTkPCGmKECl7R9zGFlmFMEM",
+	"GZFMxgtE6ASEFKXDtintSvLiMGZfFO/FY8yJahOZAiO6yRDTiDMjC5umpV9MlyFh/kvX6LPbtLRHSUt7",
+	"dHOLOasVBpaGu6uNmlfhSsm20qWphdCDm07MWqoidgtuf704+TipvJvHGLduhTU5FNoQxysZdsUfz0Eo",
+	"bLgqxlzaroD2wyNOi2X+qN0/eQ9Dv/EvrhNCsnwgf2kk28bFvlgxo566hLVgUlXgcncGZVRn27i/sUno",
+	"994qNW/EBnRyj6/nQVXyJQ6Vxk44W60k1sa7UF26THxhx87jz8v2L5P17juBj8eXp6Xs/Q1W0qiNfJkl",
+	"CeaL+9fRaBnPm7uTUTmM2YT4vdmuhTOAdA3S3FCpg45FDOoz9Wo7q+2jBWQXeVWDzR5tMe4mDrY5WvPK",
+	"XVrwYz3vcS9or/iRcjKz5fTq5VkrNSK+URypl75w9S6sDFeubOF22nImVpI9x4uY4ag97rziUiiNUM30",
+	"XNG9IZ8wJiBeIFeLwcaYc2ciMEEV1s5j0lB3fAmrJlzd4G2euGwWES8QS4HumkTmZ599yzvS3tzPz7UB",
+	"NAxZkjDtwtYZBzMWz9Q6hORZqDMvXLWkVEgOOEHl3OVdq7gI4xcXLOMh9P2h/rVg/QYtlG+v7lDNQ/xZ",
+	"ajogNw7CI5YZ57ep8WQL+d3AYtcYs1JMdFU843wPGRUKCyFCGbUJAphG2uutFLgJICwRpguUMKVb99Hp",
+	"2LnjkXaCjcCkCyQ202tuXOY4ihCRThdMMKGoCguDEOZoW9IkQsZrdWBdMaoOdbiqlY39JTVBaJ9lveby",
+	"a5NhlMu+IKQpACOMMbT8g+8m/nR+dZHRtlKRPKPDFTXAdH3fUn1Huzae0X7nemB6kSkWYthSm7Ko4axa",
+	"aeO+NUd0KU3JJI6HusNwae1Lms/SefQax6zC69p/1Dm8NxHaXDm/R49ortodVobUOZuIDxEzHvsRzHZC",
+	"Hy7O+ujYWaR6pqr6ZYxD/UlrioVZq4J7mTZKdYqxVau49uXsCAgzTuTiUsHLRlIB5sBfZcbnaP76zc35",
+	"fz9duQLd+jbXX4tVTKVMtajAXP8awjOEMzlVt4YxUOQhTdr/zzXfYqlEioMqstA3tLmfzFyminhelXsK",
+	"OCqu5KPgP7vv2K6eu8CZlPwbFqZmI/HW1n6FJGOxYpQJo+q61/xX1xpwWVs2dQHHMfoEI3Rus6yK0q04",
+	"5EwIFJEEqFZYjOHRhDHGxnzOXAFcEhNpPA+1ki1/Zth8MqM5I2bPBE1G5q5Bo4XCnqIGgvNSEKnzJarG",
+	"zlfnp0GphG+w19/v72mpLQWKUxIcBS/6e33FBVIspxoFBrP9Qcgi2C2bxMXglkR3Bnrapnt0q8YwpsfT",
+	"SFejUb/XS/RpOcpIynrwg71DL2KoGxWopr/DvX1r9NS/qIvZPDOgWg/+K4wI1K28fiMV+66RrveBKqRk",
+	"nPwFkZn+8DGnf8ck+o1lVM/9097eY859SnW5gxiZ2gVllqCts2Vm8Pv13bW6fK1OYY9bP+4QQcV7okX/",
+	"0rMkv9/6Hk+wInZb9fw6Y7u+62nELGfNT0zYRBUNlW7msmyCxkJ8ACuaDLyvGrRZnr39ijcbVDff2wHz",
+	"VA6rL0fc86WIJiPTM7l0O/0ghPOQmnjNWGqfCNPvdixyj6qQjAOaT4mOvMRcRxoYcd+MmGRCojHLwxZe",
+	"vbs6u0ATjhUy9NG5qR/NAZs6BKaT+jOx0quMeV47wISqJlFjghGgjMdI4DG0PwryZwVeK+Kq6xD6TUvN",
+	"kun0RzRa9GzQFxah8XtiEYKJVVUsd0f13nEvm7gvJhkQvTYvZwg3nC5uvXBlmQgtjWWSLF0Am2owVDM+",
+	"b9+lGjDwPWvjOtumQ7WuZjke26L+q21stIyhc2R5fqs2tO4s7Pmt2hCiSW08/Uu1Ue4u8/3oX6FxrHlX",
+	"6r61zOHrWf/o3Sxhwrth9bvtUE6TrwLT98XXqQJY3xdfpxKQm7/7OlQB7v20bEcVEC5rsXTu9lFajsMH",
+	"juJQ2r7aznZluqiX7VH5yTar15Qb2iJRtkvrZ9u9LM5VEcD3xdepdJbN330dqmfp/eTrVkE035dlO6oc",
+	"3bIWSxfcPkoLAviWWSBA21fd2ZPgdN0QQzcnaJVLuHiErPf/NlLlo0p2v+IIndI0k08t0R4e/PMx577A",
+	"EpAOH3lKcfrS5LeXxepcbtbBKrkUe1cTawe3RRb6XauM+waciBs8PF634/QLo6hVP73VxZzOgSeYaqNG",
+	"0LN6ul7gGQvzl3c8lSkuzpytjcK8h1I3DIptv7x0RCkL3/Pmlt86cvd3JsT9jWNGUfXOM7n6iJ7ZluYV",
+	"GBQzOgFePASklANduvPDxamr/wUzFmdqjOdb9uFhH29AolKth5p6W1N38upx/vcLK4U9u6viD6zXXi9j",
+	"ie7X3bIJeAWPzC3AD88rS8bmrRywlQNWEXLuNDSBQJVXYEzQe8dqzk/FCpbTqpBYioFWuQZGVxjoF4S0",
+	"PWK5Ba/0vFL+ks/65rzKc6EdzHill4DXMvptwFj4kAqK962qLYfacqjVHMqgDtJkW3m6Svh41rfMhuap",
+	"HDiP2uDW/utu4PKLB7f2X3eD25IUc9fFz5BLMFsOdU+UbQYQbNnTlj0tZ08XCltgZiLI5qnUjnrHllLM",
+	"JQmzGPPCUPB06tIKcrPMqHilvkOf0FVCW6OP70H8nHeaQpW7OtZ51xWqXMr9GmUon9rh+pAcyl/485vk",
+	"Ut+s1dNbCzU3gU6LMqNiECuxwj7eZRGwnuEqM04Fwuhgbw+9/7cL05HM5SHb6t2leqMo5SwEIRARCKsZ",
+	"tJfXoox97b9hRChVPz1zi3pAPPMVW23BsgqAHfAd4FzhVT2SfntvohOCSuMLU1hPwb5J9SkTHrI3L+qV",
+	"a3EZTghC/sqixcagUKn2VY1q01lFjQPYf4iplx2AgUS0aVr3vLK2Wih54nCpF485/W+Mj0gUAf3GOF3X",
+	"sCmDN7VEsMBPh4PbvObO0si7C/2CRp0quwfdoWciCxVjHGcx0pPk5vcnFbb/tnj9VHoGelZJT4wYCESZ",
+	"RPCFCPn8O6K4u16rU2Apmew99jXipMW/X8jpeifau82jyusc9Q3IGjNdoefpo0HmbFqVvXK1szUMUTqM",
+	"2lTHrWKeTbB+TMmpWmK0kxj1ZPi/laD+XjfN93SXONlMm5FrMbWDmM2HuqSBsw7ZtLRlhpNXkwmHiVIf",
+	"XPEbU0fg2KW4bW3I90OBEiy3tuStLXktW7K2Jpma1fZB2Dy7q6grVbzByAGHU4iQ4wcof+fUpdzackwQ",
+	"IZPnvEgBPSuKT+lMP8c9dCpAldEUDzU3nVb34jUu/8Js5kfmMqu72TLmjmW8ZSMSuzJm4jF4lZnqAnTm",
+	"TBE8tGVZW5a1YZZlyw7lzMgyEcRmwHWGu8nDyhO8i8cICY3IjESZqW6gff7VhDJu0Ld41qs+ieZq6zKa",
+	"pjfsujNjTMybWENGoV5vsQOvrL6oVfT98eWyzXDMXntxtKIgIzMuCUTGKD83RASK8WSic+hgSmiEWB5U",
+	"IgyC6pGIsEnhCscWFuF0IWQOqX0gxmQUFkvvoxPzmNwR+j92wv8ZM2bX/ke2t3fw0v0+wn+539tS82zT",
+	"pWaBjlXo6oUtm2V/tnfQ9g76bu+gvARCqS7rQhdRaNwXao2YE8FowSlGmdTG50rvajeJ+QSk66IfOWdj",
+	"pCRz99uOQM+qrfSTEI3pnrvLTAvr3969NbhV67rrlv7edo/dOy3eG6DiKeejEFZJD/MpCacmAb0Uo1N6",
+	"zL7vN7pG5gWGdsZaqbwT9O4Ra7O9Nte+Nre35qpXV7f35fa+XPe+zMsGF1zRVSvn9jaFSN1o9m5AjEK9",
+	"YBCj5eegcvarhjdx2WU9rHIZPUQ0dGFq+nsERC/h25VDZbbyCuIgslgqxrwxhcZOdBr9D4n2DVcu/3TQ",
+	"ypDzVoGXBbe8+vsoLHYbDL7lrPfIVREI5wxIV5GUIKRhpKLVCqZLbbpH4d6neTlTS7GjRUVq3Yxa8ATB",
+	"3bVKbuU/dYoMF54i5ufZKCYhuri8RGOoWxLDxoMprQE35aLyl5ffU4g4F+J/f0niKjo3igp8ezE9W/bQ",
+	"dOsvCx+qo/jyYna1aKLy60qt0URVgrtXclsmDJkPaOmJj10nsS2VzDyPgvzAqRqe3X7LUsQ2evv7id7W",
+	"aSyKEFGZCPNHajWzWJI44cHMBwoDbJ1vrXDA/YekyW86u8KCyRVtJFQ/Ioc+XJz1dCTHwLzgpJTzBMtw",
+	"+vxvTMsOSC4kJsFfSJIlpcrjjj6etqSPW6dkDCWYLqrL+p5zSSjMvQwpN/oslx1ya8+wU4nnNi62TTjZ",
+	"hgGvnXDiHims5pogxs01m//M5hQR+b1Sqi2W7afRdtW5E6XtPdUlvRWetxT7w1LsG5BeckWjhdLyV1kF",
+	"yqSELC21Wgcq73lvLtno8bSNlS/aPnLy0ZMzsm0S0paXfTu8zJBnRw3BvQjt7Bg1a6euhC5cjsMIhzdA",
+	"bV6EeckUTbFA/82ELL/1A1H/D6rfQdOv8YtqZ4ZS4PpBHYnFjUAxuQEUcuv+VIehNqBTK6agJ9nRbtMx",
+	"ieEPqp9w0B51rD0+hJooIV0smLPExDLrB//lwnlbeaG0jjmIqR2ccAQJJjHCUcRBiOf9P6hdONAoZYRK",
+	"JKYsiyP9dhuOY+O3DWOiH9tnNIQeIkkCEcES4gXCYwnGppwrPPrNSfuKfoVtnxM6+VBEydyHS1efqjLV",
+	"I4f60SR/weU3RP4rG6H3CnEQ1ks0bywhNpJYvxdoo+7GXK8hQlGmnxchCjHNe7RIkAndJVS/4pR38Bwv",
+	"RoyaB9OQWNAQsbFBGXuW5jm/Z/r49TE8RxHhEMp4YU7SrNa+qGeWSQyB6idM6lNXnrUrPZFVfwireSG4",
+	"V/1S82IjCs17fxpLOKaCmBB4wqPdFHO5MIsxbka3GbVDQif9YPXN9+0/ibS1Eq/Bbw2TNKitid3WGdKc",
+	"xuFHk/OuUXqr9mDxj1x4y/eu9VYZ3dLoxjw5LeXIWsiyXJNnkL/LLkrvwC+r0dP2vP19boQtpm8r83x/",
+	"lXmq4bCKJpCjIlfCr1HBs7z1/lOXd8k8V/J5JjtT9l6Tsrd315aifwyKfhVFa5Nz474txyp6iMVRnhk5",
+	"wRTrBBhzl5f76pcZK5d7a5iikgYuK/P+sPJ0eZtbYXorTG9MmK7Sno2krNdlW1ZVtv5q9AMUR6sEdj5y",
+	"XdlyGPS2sOyWBh+ssGw5INlHhksv3GZywOqAoO/9vfdt+b3vK4ymA473OkqNpXyWhgDZNakleCRprYsL",
+	"e0tJW0rqGt7SiYyeOPdlVT3dh5cZmxM9VUXdNVnBVnbccqLvJzilu9w6C8Xg1oVx3A0IFRLHMc7NRa0G",
+	"no/Hl6eVxg9IrLW51PTf/PX9VMhzX4PDx+NLVDl9G8BCRjG4AKVKDJIW8TyXmufScvi19LYCmiXB0e82",
+	"zCa47rXmbtZwlkPKBJGME1iJshfltg+LsflUiy2+PhC+lk/+u0TXwW3+10L7wEMWwW7DZt/+sC+LoG5p",
+	"f7iHb2uTfRdo/XeUH+5LUjb+UOGg1/5c4Oqj0lHPO3iFcO5VAmAOoyljN2Xi1EGfj8Yf2iz4/8I0iuHj",
+	"8eUns8LAD+wpYLMIu6z/7P4rG+3qcDn9qP/BTy+DFU9ptoxjIkN3X0NMZqbO0VeMcjJTyL9CL30IXbMA",
+	"4LkJPO2mYx40LayvwhDSB3AjdPTj5SryVkgosSwlANjzRad0wkEIM4YAPvNbWM45i7LQmjcyHiu0lTIV",
+	"R4MBTkl/DiPjZe9HMAvuru/+fwAAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/lib/gen/openapi/backend/types.gen.go
+++ b/lib/gen/openapi/backend/types.gen.go
@@ -56,6 +56,39 @@ func (e BrowserImplementationStatus) Valid() bool {
 	}
 }
 
+// Defines values for CodeSubscriptionResponseStatus.
+const (
+	ACTIVE    CodeSubscriptionResponseStatus = "ACTIVE"
+	DELETED   CodeSubscriptionResponseStatus = "DELETED"
+	DELIVERED CodeSubscriptionResponseStatus = "DELIVERED"
+	ERROR     CodeSubscriptionResponseStatus = "ERROR"
+	OBSOLETE  CodeSubscriptionResponseStatus = "OBSOLETE"
+	RESOLVED  CodeSubscriptionResponseStatus = "RESOLVED"
+	TRIGGERED CodeSubscriptionResponseStatus = "TRIGGERED"
+)
+
+// Valid indicates whether the value is a known member of the CodeSubscriptionResponseStatus enum.
+func (e CodeSubscriptionResponseStatus) Valid() bool {
+	switch e {
+	case ACTIVE:
+		return true
+	case DELETED:
+		return true
+	case DELIVERED:
+		return true
+	case ERROR:
+		return true
+	case OBSOLETE:
+		return true
+	case RESOLVED:
+		return true
+	case TRIGGERED:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for EmailConfigType.
 const (
 	EmailConfigTypeEmail EmailConfigType = "email"
@@ -686,6 +719,34 @@ type ChromeUsageStat struct {
 	Usage *float64 `json:"usage,omitempty"`
 }
 
+// CodeSubscriptionListResponse defines model for CodeSubscriptionListResponse.
+type CodeSubscriptionListResponse struct {
+	Data []CodeSubscriptionResponse `json:"data"`
+}
+
+// CodeSubscriptionResponse defines model for CodeSubscriptionResponse.
+type CodeSubscriptionResponse struct {
+	CreatedAt          time.Time                      `json:"created_at"`
+	FeatureId          *string                        `json:"feature_id,omitempty"`
+	Id                 string                         `json:"id"`
+	OccurrenceCount    int64                          `json:"occurrence_count"`
+	Occurrences        []SubscriptionOccurrence       `json:"occurrences"`
+	RawDirective       *string                        `json:"raw_directive,omitempty"`
+	RepositoryFullName string                         `json:"repository_full_name"`
+	RepositoryName     string                         `json:"repository_name"`
+	RepositoryOwner    string                         `json:"repository_owner"`
+	Status             CodeSubscriptionResponseStatus `json:"status"`
+	TargetQuery        string                         `json:"target_query"`
+	Triggers           []SubscriptionTriggerWritable  `json:"triggers"`
+	UpdatedAt          time.Time                      `json:"updated_at"`
+	VcsInstallationId  *string                        `json:"vcs_installation_id,omitempty"`
+	VcsProvider        string                         `json:"vcs_provider"`
+	VcsRepositoryId    string                         `json:"vcs_repository_id"`
+}
+
+// CodeSubscriptionResponseStatus defines model for CodeSubscriptionResponse.Status.
+type CodeSubscriptionResponseStatus string
+
 // CreateNotificationChannelRequest defines model for CreateNotificationChannelRequest.
 type CreateNotificationChannelRequest struct {
 	// Config Configuration specific to the channel type.
@@ -1004,6 +1065,13 @@ type SubscriptionChannelType string
 // SubscriptionFrequency The frequency for a subscription.
 type SubscriptionFrequency string
 
+// SubscriptionOccurrence defines model for SubscriptionOccurrence.
+type SubscriptionOccurrence struct {
+	CommentSnippet string `json:"comment_snippet"`
+	FilePath       string `json:"file_path"`
+	LineNumber     int64  `json:"line_number"`
+}
+
 // SubscriptionPage defines model for SubscriptionPage.
 type SubscriptionPage struct {
 	Data     *[]SubscriptionResponse `json:"data,omitempty"`
@@ -1102,6 +1170,40 @@ type UserSavedSearchPermissions struct {
 
 // UserSavedSearchRole defines model for UserSavedSearchRole.
 type UserSavedSearchRole string
+
+// VCSInstallationListResponse defines model for VCSInstallationListResponse.
+type VCSInstallationListResponse struct {
+	Data []VCSInstallationSummary `json:"data"`
+}
+
+// VCSInstallationSummary defines model for VCSInstallationSummary.
+type VCSInstallationSummary struct {
+	AccountLogin      string `json:"account_login"`
+	AccountType       string `json:"account_type"`
+	Id                string `json:"id"`
+	VcsInstallationId string `json:"vcs_installation_id"`
+	VcsProvider       string `json:"vcs_provider"`
+}
+
+// VCSRepositoryListResponse defines model for VCSRepositoryListResponse.
+type VCSRepositoryListResponse struct {
+	Data []VCSRepositorySummary `json:"data"`
+}
+
+// VCSRepositorySummary defines model for VCSRepositorySummary.
+type VCSRepositorySummary struct {
+	FullName          string `json:"full_name"`
+	Id                string `json:"id"`
+	Name              string `json:"name"`
+	Owner             string `json:"owner"`
+	Private           bool   `json:"private"`
+	RepositoryId      string `json:"repository_id"`
+	VcsInstallationId string `json:"vcs_installation_id"`
+	VcsProvider       string `json:"vcs_provider"`
+}
+
+// VCSWebhookPayload defines model for VCSWebhookPayload.
+type VCSWebhookPayload map[string]interface{}
 
 // VendorPosition A loosely defined object representing a single vendor's standards position. The schema is intentionally open-ended (`additionalProperties: true`) to accommodate the evolving structure of the upstream web-features-mappings data source.
 type VendorPosition map[string]interface{}
@@ -1367,6 +1469,13 @@ type ListSubscriptionsParams struct {
 	PageSize *PaginationSizeParam `form:"page_size,omitempty" json:"page_size,omitempty"`
 }
 
+// HandleVCSWebhookParams defines parameters for HandleVCSWebhook.
+type HandleVCSWebhookParams struct {
+	XHubSignature256 *string `json:"X-Hub-Signature-256,omitempty"`
+	XGitHubDelivery  *string `json:"X-GitHub-Delivery,omitempty"`
+	XGitHubEvent     *string `json:"X-GitHub-Event,omitempty"`
+}
+
 // CreateSavedSearchJSONRequestBody defines body for CreateSavedSearch for application/json ContentType.
 type CreateSavedSearchJSONRequestBody = SavedSearch
 
@@ -1387,6 +1496,9 @@ type CreateSubscriptionJSONRequestBody = Subscription
 
 // UpdateSubscriptionJSONRequestBody defines body for UpdateSubscription for application/json ContentType.
 type UpdateSubscriptionJSONRequestBody = UpdateSubscriptionRequest
+
+// HandleVCSWebhookJSONRequestBody defines body for HandleVCSWebhook for application/json ContentType.
+type HandleVCSWebhookJSONRequestBody = VCSWebhookPayload
 
 // AsWebhookConfig returns the union data inside the CreateNotificationChannelRequest_Config as a WebhookConfig
 func (t CreateNotificationChannelRequest_Config) AsWebhookConfig() (WebhookConfig, error) {

--- a/lib/gen/openapi/ts-webstatus.dev-backend-types/types.d.ts
+++ b/lib/gen/openapi/ts-webstatus.dev-backend-types/types.d.ts
@@ -443,6 +443,102 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/vcs/{provider}/installations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: "github";
+            };
+            cookie?: never;
+        };
+        /** List VCS installations accessible to the authenticated user */
+        get: operations["listVCSInstallations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/vcs/{provider}/repositories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: "github";
+            };
+            cookie?: never;
+        };
+        /** List VCS repositories accessible to the authenticated user */
+        get: operations["listVCSRepositories"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/vcs/{provider}/repositories/{repository_id}/code-subscriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: "github";
+                repository_id: string;
+            };
+            cookie?: never;
+        };
+        /** List active code subscriptions for a repository */
+        get: operations["listCodeSubscriptions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/code-subscriptions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a code subscription */
+        delete: operations["deleteCodeSubscription"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/webhooks/{provider}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: "github";
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** VCS Webhook Ingress */
+        post: operations["handleVCSWebhook"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -879,6 +975,63 @@ export interface components {
         MissingOneImplFeaturesPage: {
             metadata?: components["schemas"]["PageMetadata"];
             data: components["schemas"]["MissingOneImplFeature"][];
+        };
+        VCSInstallationSummary: {
+            id: string;
+            vcs_provider: string;
+            vcs_installation_id: string;
+            account_login: string;
+            account_type: string;
+        };
+        VCSInstallationListResponse: {
+            data: components["schemas"]["VCSInstallationSummary"][];
+        };
+        VCSRepositorySummary: {
+            id: string;
+            vcs_provider: string;
+            vcs_installation_id: string;
+            repository_id: string;
+            owner: string;
+            name: string;
+            full_name: string;
+            private: boolean;
+        };
+        VCSRepositoryListResponse: {
+            data: components["schemas"]["VCSRepositorySummary"][];
+        };
+        SubscriptionOccurrence: {
+            file_path: string;
+            /** Format: int64 */
+            line_number: number;
+            comment_snippet: string;
+        };
+        CodeSubscriptionResponse: {
+            id: string;
+            vcs_provider: string;
+            vcs_installation_id?: string;
+            vcs_repository_id: string;
+            repository_owner: string;
+            repository_name: string;
+            repository_full_name: string;
+            feature_id?: string;
+            target_query: string;
+            triggers: components["schemas"]["SubscriptionTriggerWritable"][];
+            raw_directive?: string;
+            occurrences: components["schemas"]["SubscriptionOccurrence"][];
+            /** Format: int64 */
+            occurrence_count: number;
+            /** @enum {string} */
+            status: "ACTIVE" | "TRIGGERED" | "DELIVERED" | "RESOLVED" | "OBSOLETE" | "DELETED" | "ERROR";
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        CodeSubscriptionListResponse: {
+            data: components["schemas"]["CodeSubscriptionResponse"][];
+        };
+        VCSWebhookPayload: {
+            [key: string]: unknown;
         };
     };
     responses: never;
@@ -2841,6 +2994,238 @@ export interface operations {
                 };
             };
             /** @description Internal Service Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+        };
+    };
+    listVCSInstallations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: "github";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VCSInstallationListResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+            /** @description Internal Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+        };
+    };
+    listVCSRepositories: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: "github";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VCSRepositoryListResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+            /** @description Internal Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+        };
+    };
+    listCodeSubscriptions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: "github";
+                repository_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CodeSubscriptionListResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+            /** @description Internal Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+        };
+    };
+    deleteCodeSubscription: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+            /** @description Internal Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+        };
+    };
+    handleVCSWebhook: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Hub-Signature-256"?: string;
+                "X-GitHub-Delivery"?: string;
+                "X-GitHub-Event"?: string;
+            };
+            path: {
+                provider: "github";
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["VCSWebhookPayload"];
+            };
+        };
+        responses: {
+            /** @description Accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BasicErrorModel"];
+                };
+            };
+            /** @description Internal Error */
             500: {
                 headers: {
                     [name: string]: unknown;

--- a/lib/gh/jwt.go
+++ b/lib/gh/jwt.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+var (
+	// ErrInvalidPrivateKey is returned when the PEM block cannot be parsed as an RSA private key.
+	ErrInvalidPrivateKey = errors.New("invalid rsa private key")
+
+	// ErrEmptyAppID is returned when app ID is empty.
+	ErrEmptyAppID = errors.New("app id must not be empty")
+)
+
+type jwtHeader struct {
+	Alg string `json:"alg"`
+	Typ string `json:"typ"`
+}
+
+type jwtClaims struct {
+	IssuedAt  int64  `json:"iat"`
+	ExpiresAt int64  `json:"exp"`
+	Issuer    string `json:"iss"`
+}
+
+// MintAppJWT generates an RS256-signed JSON Web Token for authenticating as a GitHub App.
+// Claims:
+// - iat: now - 60s (handles clock skew)
+// - exp: now + 10m (GitHub maximum validity)
+// - iss: appID.
+func MintAppJWT(appID string, privateKeyPEM []byte) (string, error) {
+	if appID == "" {
+		return "", ErrEmptyAppID
+	}
+
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyPEM)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalidPrivateKey, err)
+	}
+
+	now := time.Now().UTC()
+	header := jwtHeader{
+		Alg: "RS256",
+		Typ: "JWT",
+	}
+	claims := jwtClaims{
+		IssuedAt:  now.Add(-60 * time.Second).Unix(),
+		ExpiresAt: now.Add(10 * time.Minute).Unix(),
+		Issuer:    appID,
+	}
+
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal jwt header: %w", err)
+	}
+
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal jwt claims: %w", err)
+	}
+
+	headerB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	claimsB64 := base64.RawURLEncoding.EncodeToString(claimsJSON)
+	signingInput := headerB64 + "." + claimsB64
+
+	hashed := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, hashed[:])
+	if err != nil {
+		return "", fmt.Errorf("failed to sign jwt with rsa private key: %w", err)
+	}
+
+	sigB64 := base64.RawURLEncoding.EncodeToString(signature)
+
+	return signingInput + "." + sigB64, nil
+}

--- a/lib/gh/jwt_test.go
+++ b/lib/gh/jwt_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func generateTestRSAPEM(t *testing.T) (*rsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey failed: %v", err)
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	return key, pemBytes
+}
+
+func TestMintAppJWT(t *testing.T) {
+	t.Parallel()
+
+	privKey, pemBytes := generateTestRSAPEM(t)
+	appID := "webstatus-github-app-123"
+
+	tokenStr, err := MintAppJWT(appID, pemBytes)
+	if err != nil {
+		t.Fatalf("MintAppJWT failed: %v", err)
+	}
+
+	parts := strings.Split(tokenStr, ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 JWT parts, got %d", len(parts))
+	}
+
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("failed to decode header: %v", err)
+	}
+	var header map[string]string
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		t.Fatalf("failed to unmarshal header: %v", err)
+	}
+	if header["alg"] != "RS256" || header["typ"] != "JWT" {
+		t.Errorf("unexpected header: %v", header)
+	}
+
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("failed to decode payload: %v", err)
+	}
+	var claims struct {
+		Iss string `json:"iss"`
+		Iat int64  `json:"iat"`
+		Exp int64  `json:"exp"`
+	}
+	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+	if claims.Iss != appID {
+		t.Errorf("iss = %s, want %s", claims.Iss, appID)
+	}
+	now := time.Now().Unix()
+	if claims.Exp-claims.Iat != 660 {
+		t.Errorf("token lifespan = %d, want 660s", claims.Exp-claims.Iat)
+	}
+	if claims.Iat > now || claims.Exp < now {
+		t.Errorf("invalid token timestamps: iat=%d, exp=%d, now=%d", claims.Iat, claims.Exp, now)
+	}
+
+	sigBytes, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("failed to decode signature: %v", err)
+	}
+	signedContent := parts[0] + "." + parts[1]
+	hasher := sha256.New()
+	hasher.Write([]byte(signedContent))
+	hashed := hasher.Sum(nil)
+
+	if err := rsa.VerifyPKCS1v15(&privKey.PublicKey, crypto.SHA256, hashed, sigBytes); err != nil {
+		t.Errorf("RSA PKCS1v15 signature verification failed: %v", err)
+	}
+}
+
+func TestMintAppJWTErrors(t *testing.T) {
+	t.Parallel()
+
+	_, validPEM := generateTestRSAPEM(t)
+
+	tests := []struct {
+		name      string
+		appID     string
+		pemData   []byte
+		targetErr error
+	}{
+		{
+			name:      "empty app ID",
+			appID:     "",
+			pemData:   validPEM,
+			targetErr: ErrEmptyAppID,
+		},
+		{
+			name:      "invalid PEM format",
+			appID:     "123",
+			pemData:   []byte("not a pem block"),
+			targetErr: ErrInvalidPrivateKey,
+		},
+		{
+			name:  "corrupted PEM block bytes",
+			appID: "123",
+			pemData: pem.EncodeToMemory(&pem.Block{
+				Type:    "RSA PRIVATE KEY",
+				Headers: nil,
+				Bytes:   []byte("garbage"),
+			}),
+			targetErr: ErrInvalidPrivateKey,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := MintAppJWT(tc.appID, tc.pemData)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !errors.Is(err, tc.targetErr) {
+				t.Errorf("expected error %v, got %v", tc.targetErr, err)
+			}
+		})
+	}
+}

--- a/lib/gh/token_provider.go
+++ b/lib/gh/token_provider.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrEmptyInstallationID is returned when an installation ID is empty.
+	ErrEmptyInstallationID = errors.New("installation id must not be empty")
+)
+
+type cachedToken struct {
+	token     string
+	expiresAt time.Time
+}
+
+// TokenProvider manages RS256 JWT minting and cached GitHub App installation access tokens.
+type TokenProvider struct {
+	appID         string
+	privateKeyPEM []byte
+	httpClient    *http.Client
+	baseURL       string
+	cacheMu       sync.RWMutex
+	cachedTokens  map[string]cachedToken
+}
+
+// TokenProviderOption configures a TokenProvider.
+type TokenProviderOption func(*TokenProvider)
+
+// WithTokenProviderHTTPClient sets a custom HTTP client for the TokenProvider.
+func WithTokenProviderHTTPClient(client *http.Client) TokenProviderOption {
+	return func(tp *TokenProvider) {
+		if client != nil {
+			tp.httpClient = client
+		}
+	}
+}
+
+// WithTokenProviderBaseURL sets a custom base URL for testing against WireMock or mock servers.
+func WithTokenProviderBaseURL(baseURL string) TokenProviderOption {
+	return func(tp *TokenProvider) {
+		tp.baseURL = strings.TrimRight(baseURL, "/")
+	}
+}
+
+// NewTokenProvider returns a new TokenProvider configured with standard HTTP transport.
+func NewTokenProvider(appID string, privateKeyPEM []byte, opts ...TokenProviderOption) *TokenProvider {
+	tp := &TokenProvider{
+		appID:         appID,
+		privateKeyPEM: privateKeyPEM,
+		httpClient: &http.Client{
+			Transport:     nil,
+			CheckRedirect: nil,
+			Jar:           nil,
+			Timeout:       10 * time.Second,
+		},
+		baseURL:      "https://api.github.com",
+		cacheMu:      sync.RWMutex{},
+		cachedTokens: make(map[string]cachedToken),
+	}
+
+	for _, opt := range opts {
+		opt(tp)
+	}
+
+	return tp
+}
+
+type installationTokenResponse struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// GetInstallationToken returns a valid GitHub App installation access token.
+// Caches tokens in memory with a 5-minute expiry safety buffer.
+func (tp *TokenProvider) GetInstallationToken(ctx context.Context, installationID string) (string, error) {
+	if installationID == "" {
+		return "", ErrEmptyInstallationID
+	}
+
+	// 1. Fast path: check memory cache under read lock
+	tp.cacheMu.RLock()
+	c, ok := tp.cachedTokens[installationID]
+	if ok && time.Now().UTC().Before(c.expiresAt) {
+		tp.cacheMu.RUnlock()
+
+		return c.token, nil
+	}
+	tp.cacheMu.RUnlock()
+
+	// 2. Slow path: fetch fresh token under write lock
+	tp.cacheMu.Lock()
+	defer tp.cacheMu.Unlock()
+
+	// Double-check cache under write lock
+	c, ok = tp.cachedTokens[installationID]
+	if ok && time.Now().UTC().Before(c.expiresAt) {
+		return c.token, nil
+	}
+
+	jwtToken, mintErr := MintAppJWT(tp.appID, tp.privateKeyPEM)
+	if mintErr != nil {
+		return "", fmt.Errorf("failed to mint app jwt: %w", mintErr)
+	}
+
+	// Detach background context with 10s timeout to prevent cache poison on client ctx cancel
+	reqCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+
+	reqURL := fmt.Sprintf("%s/app/installations/%s/access_tokens", tp.baseURL, installationID)
+	req, reqErr := http.NewRequestWithContext(reqCtx, http.MethodPost, reqURL, nil)
+	if reqErr != nil {
+		return "", fmt.Errorf("failed to create access token request: %w", reqErr)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+jwtToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, doErr := tp.httpClient.Do(req)
+	if doErr != nil {
+		return "", fmt.Errorf("access token request failed: %w", doErr)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+
+		return "", fmt.Errorf("unexpected status %d from github access tokens API: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp installationTokenResponse
+	if decodeErr := json.NewDecoder(resp.Body).Decode(&tokenResp); decodeErr != nil {
+		return "", fmt.Errorf("failed to decode access token response: %w", decodeErr)
+	}
+
+	if tokenResp.Token == "" {
+		return "", errors.New("empty installation access token received from github")
+	}
+
+	// 5-minute safety buffer before token true expiration
+	cacheExpiry := tokenResp.ExpiresAt.UTC().Add(-5 * time.Minute)
+	if cacheExpiry.Before(time.Now().UTC()) {
+		cacheExpiry = tokenResp.ExpiresAt.UTC()
+	}
+
+	tp.cachedTokens[installationID] = cachedToken{
+		token:     tokenResp.Token,
+		expiresAt: cacheExpiry,
+	}
+
+	return tokenResp.Token, nil
+}

--- a/lib/gh/token_provider_test.go
+++ b/lib/gh/token_provider_test.go
@@ -1,0 +1,213 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+//nolint:gosec // Mock test tokens for unit testing
+const (
+	mockInstToken1 = "mock_val_sample_123"
+	mockInstToken2 = "mock_val_coalesce_456"
+	mockInstToken3 = "mock_val_detached_789"
+	mockInstToken4 = "mock_val_recovered_000"
+)
+
+func TestTokenProvider_GetInstallationToken(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+	var requestCount int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/app/installations/inst-123/access_tokens" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") == "" {
+			t.Errorf("missing Authorization header")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(installationTokenResponse{
+			Token:     mockInstToken1,
+			ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+		})
+	}))
+	defer server.Close()
+
+	tp := NewTokenProvider("app-99", privPEM,
+		WithTokenProviderBaseURL(server.URL),
+		WithTokenProviderHTTPClient(server.Client()))
+
+	// 1. Initial token fetch
+	token, err := tp.GetInstallationToken(context.Background(), "inst-123")
+	if err != nil {
+		t.Fatalf("GetInstallationToken failed: %v", err)
+	}
+	if token != mockInstToken1 {
+		t.Errorf("unexpected token: %s", token)
+	}
+
+	// 2. Cache hit (no additional network call)
+	token2, err := tp.GetInstallationToken(context.Background(), "inst-123")
+	if err != nil {
+		t.Fatalf("second GetInstallationToken failed: %v", err)
+	}
+	if token2 != token {
+		t.Errorf("cached token mismatch: %s != %s", token2, token)
+	}
+
+	if count := atomic.LoadInt64(&requestCount); count != 1 {
+		t.Errorf("expected 1 HTTP request, got %d", count)
+	}
+}
+
+func TestTokenProviderSingleflight(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+	var requestCount int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt64(&requestCount, 1)
+		time.Sleep(20 * time.Millisecond) // Simulate network delay
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(installationTokenResponse{
+			Token:     mockInstToken2,
+			ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+		})
+	}))
+	defer server.Close()
+
+	tp := NewTokenProvider("app-99", privPEM,
+		WithTokenProviderBaseURL(server.URL),
+		WithTokenProviderHTTPClient(server.Client()))
+
+	const numGoroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for range numGoroutines {
+		go func() {
+			defer wg.Done()
+			token, err := tp.GetInstallationToken(context.Background(), "inst-concurrent")
+			if err != nil {
+				t.Errorf("concurrent GetInstallationToken failed: %v", err)
+			}
+			if token != mockInstToken2 {
+				t.Errorf("unexpected token: %s", token)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if count := atomic.LoadInt64(&requestCount); count != 1 {
+		t.Errorf("singleflight failed: expected 1 request, got %d", count)
+	}
+}
+
+func TestTokenProviderDetachedContext(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(30 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(installationTokenResponse{
+			Token:     mockInstToken3,
+			ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+		})
+	}))
+	defer server.Close()
+
+	tp := NewTokenProvider("app-99", privPEM,
+		WithTokenProviderBaseURL(server.URL),
+		WithTokenProviderHTTPClient(server.Client()))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	// Calling with short timeout context that cancels before server responds
+	token, err := tp.GetInstallationToken(ctx, "inst-detached")
+	if err != nil {
+		t.Fatalf("expected token acquisition to succeed despite caller cancel, got: %v", err)
+	}
+	if token != mockInstToken3 {
+		t.Errorf("unexpected token: %s", token)
+	}
+}
+
+func TestTokenProviderErrorRecovery(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+	var callCount int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := atomic.AddInt64(&callCount, 1)
+		if count == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("internal github error"))
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(installationTokenResponse{
+			Token:     mockInstToken4,
+			ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+		})
+	}))
+	defer server.Close()
+
+	tp := NewTokenProvider("app-99", privPEM,
+		WithTokenProviderBaseURL(server.URL),
+		WithTokenProviderHTTPClient(server.Client()))
+
+	// First call fails
+	_, err := tp.GetInstallationToken(context.Background(), "inst-retry")
+	if err == nil {
+		t.Fatalf("expected error on first call, got nil")
+	}
+
+	// Second call should NOT be blocked by cached failure in singleflight
+	token, err := tp.GetInstallationToken(context.Background(), "inst-retry")
+	if err != nil {
+		t.Fatalf("expected second call to succeed, got: %v", err)
+	}
+	if token != mockInstToken4 {
+		t.Errorf("unexpected token: %s", token)
+	}
+}

--- a/lib/gh/webhook_verifier.go
+++ b/lib/gh/webhook_verifier.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/google/go-github/v79/github"
+)
+
+// MinWebhookSecretLength is the minimum secret length required to prevent empty/trivial secret bypass.
+const MinWebhookSecretLength = 16
+
+// VerifyWebhookSignature verifies a GitHub HMAC SHA-256 webhook signature header (e.g. "sha256=...")
+// using the official go-github SDK (github.ValidatePayloadFromBody).
+func VerifyWebhookSignature(payload []byte, headerSig string, secret []byte) bool {
+	if len(secret) < MinWebhookSecretLength {
+		return false
+	}
+	cleanSig := strings.TrimSpace(headerSig)
+	if cleanSig == "" {
+		return false
+	}
+	if strings.HasPrefix(cleanSig, "sha256=") {
+		cleanSig = "sha256=" + strings.TrimSpace(strings.TrimPrefix(cleanSig, "sha256="))
+	}
+
+	_, err := github.ValidatePayloadFromBody("application/json", bytes.NewReader(payload), cleanSig, secret)
+
+	return err == nil
+}

--- a/lib/gh/webhook_verifier.go
+++ b/lib/gh/webhook_verifier.go
@@ -34,8 +34,8 @@ func VerifyWebhookSignature(payload []byte, headerSig string, secret []byte) boo
 	if cleanSig == "" {
 		return false
 	}
-	if strings.HasPrefix(cleanSig, "sha256=") {
-		cleanSig = "sha256=" + strings.TrimSpace(strings.TrimPrefix(cleanSig, "sha256="))
+	if after, ok := strings.CutPrefix(cleanSig, "sha256="); ok {
+		cleanSig = "sha256=" + strings.TrimSpace(after)
 	}
 
 	_, err := github.ValidatePayloadFromBody("application/json", bytes.NewReader(payload), cleanSig, secret)

--- a/lib/gh/webhook_verifier_test.go
+++ b/lib/gh/webhook_verifier_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+)
+
+func TestVerifyWebhookSignature(t *testing.T) {
+	t.Parallel()
+
+	validSecret := []byte("this-is-a-secure-webhook-secret-1234")
+	payload := []byte(`{"action":"push","repository":{"id":12345,"full_name":"org/repo"}}`)
+
+	mac := hmac.New(sha256.New, validSecret)
+	mac.Write(payload)
+	validSig := fmt.Sprintf("sha256=%s", hex.EncodeToString(mac.Sum(nil)))
+
+	tests := []struct {
+		name      string
+		payload   []byte
+		headerSig string
+		secret    []byte
+		wantValid bool
+	}{
+		{
+			name:      "valid signature",
+			payload:   payload,
+			headerSig: validSig,
+			secret:    validSecret,
+			wantValid: true,
+		},
+		{
+			name:      "valid signature with whitespace",
+			payload:   payload,
+			headerSig: "sha256= " + hex.EncodeToString(mac.Sum(nil)) + " ",
+			secret:    validSecret,
+			wantValid: true,
+		},
+		{
+			name:      "tampered payload",
+			payload:   []byte(`{"action":"tampered"}`),
+			headerSig: validSig,
+			secret:    validSecret,
+			wantValid: false,
+		},
+		{
+			name:      "wrong secret",
+			payload:   payload,
+			headerSig: validSig,
+			secret:    []byte("different-secret-key-1234567890"),
+			wantValid: false,
+		},
+		{
+			name:      "too short secret (<16 bytes)",
+			payload:   payload,
+			headerSig: validSig,
+			secret:    []byte("short-secret"),
+			wantValid: false,
+		},
+		{
+			name:      "nil secret",
+			payload:   payload,
+			headerSig: validSig,
+			secret:    nil,
+			wantValid: false,
+		},
+		{
+			name:      "missing sha256 prefix",
+			payload:   payload,
+			headerSig: hex.EncodeToString(mac.Sum(nil)),
+			secret:    validSecret,
+			wantValid: false,
+		},
+		{
+			name:      "sha1 prefix instead of sha256",
+			payload:   payload,
+			headerSig: "sha1=abcdef123456",
+			secret:    validSecret,
+			wantValid: false,
+		},
+		{
+			name:      "invalid hex in signature",
+			payload:   payload,
+			headerSig: "sha256=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			secret:    validSecret,
+			wantValid: false,
+		},
+		{
+			name:      "truncated hex signature",
+			payload:   payload,
+			headerSig: "sha256=abcdef",
+			secret:    validSecret,
+			wantValid: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := VerifyWebhookSignature(tc.payload, tc.headerSig, tc.secret)
+			if got != tc.wantValid {
+				t.Errorf("VerifyWebhookSignature() = %v, want %v", got, tc.wantValid)
+			}
+		})
+	}
+}
+
+func FuzzVerifyWebhookSignature(f *testing.F) {
+	f.Add([]byte("sample payload"), "sha256=abcdef0123456789", []byte("a-secret-longer-than-16-bytes"))
+	f.Add([]byte(""), "invalid", []byte(""))
+
+	f.Fuzz(func(_ *testing.T, payload []byte, header string, secret []byte) {
+		// Verify function never panics on arbitrary input
+		_ = VerifyWebhookSignature(payload, header, secret)
+	})
+}

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/getkin/kin-openapi v0.146.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-openapi/jsonpointer v1.0.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-github/v89 v89.0.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -155,7 +156,7 @@ require (
 	golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0
-	golang.org/x/sync v0.22.0 // indirect
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -135,6 +135,9 @@ github.com/go-openapi/jsonpointer v1.0.0 h1:kR9tHqY0CtZaOPVFm622dPVNhrvYpwr4uCxg
 github.com/go-openapi/jsonpointer v1.0.0/go.mod h1:Z3rw7dWu1p9IgitXCFamSlA5lmDiklEB6vkaxcNZW5Y=
 github.com/go-openapi/testify/v2 v2.6.0 h1:5PKH2HE7YJ/LuRPQGvSxBRlFXNQhSetBLlGAgUEu3ug=
 github.com/go-openapi/testify/v2 v2.6.0/go.mod h1:SgsVHtfooshd0tublTtJ50FPKhujf47YRqauXXOUxfw=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/openapi/backend/openapi.yaml
+++ b/openapi/backend/openapi.yaml
@@ -1454,6 +1454,200 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasicErrorModel'
+  /v1/vcs/{provider}/installations:
+    parameters:
+      - name: provider
+        in: path
+        required: true
+        schema:
+          type: string
+          enum: [github]
+    get:
+      summary: List VCS installations accessible to the authenticated user
+      operationId: listVCSInstallations
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VCSInstallationListResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+  /v1/vcs/{provider}/repositories:
+    parameters:
+      - name: provider
+        in: path
+        required: true
+        schema:
+          type: string
+          enum: [github]
+    get:
+      summary: List VCS repositories accessible to the authenticated user
+      operationId: listVCSRepositories
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VCSRepositoryListResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+  /v1/vcs/{provider}/repositories/{repository_id}/code-subscriptions:
+    parameters:
+      - name: provider
+        in: path
+        required: true
+        schema:
+          type: string
+          enum: [github]
+      - name: repository_id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: List active code subscriptions for a repository
+      operationId: listCodeSubscriptions
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CodeSubscriptionListResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+  /v1/code-subscriptions/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    delete:
+      summary: Delete a code subscription
+      operationId: deleteCodeSubscription
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: No Content
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+  /v1/webhooks/{provider}:
+    parameters:
+      - name: provider
+        in: path
+        required: true
+        schema:
+          type: string
+          enum: [github]
+    post:
+      summary: VCS Webhook Ingress
+      operationId: handleVCSWebhook
+      parameters:
+        - name: X-Hub-Signature-256
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: X-GitHub-Delivery
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: X-GitHub-Event
+          in: header
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VCSWebhookPayload'
+      responses:
+        '202':
+          description: Accepted
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
+        '500':
+          description: Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasicErrorModel'
 components:
   parameters:
     browserPathParam:
@@ -2435,6 +2629,155 @@ components:
             $ref: '#/components/schemas/MissingOneImplFeature'
       required:
         - data
+    VCSInstallationSummary:
+      type: object
+      required:
+        - id
+        - vcs_provider
+        - vcs_installation_id
+        - account_login
+        - account_type
+      properties:
+        id:
+          type: string
+        vcs_provider:
+          type: string
+        vcs_installation_id:
+          type: string
+        account_login:
+          type: string
+        account_type:
+          type: string
+    VCSInstallationListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/VCSInstallationSummary'
+    VCSRepositorySummary:
+      type: object
+      required:
+        - id
+        - vcs_provider
+        - vcs_installation_id
+        - repository_id
+        - owner
+        - name
+        - full_name
+        - private
+      properties:
+        id:
+          type: string
+        vcs_provider:
+          type: string
+        vcs_installation_id:
+          type: string
+        repository_id:
+          type: string
+        owner:
+          type: string
+        name:
+          type: string
+        full_name:
+          type: string
+        private:
+          type: boolean
+    VCSRepositoryListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/VCSRepositorySummary'
+    SubscriptionOccurrence:
+      type: object
+      required:
+        - file_path
+        - line_number
+        - comment_snippet
+      properties:
+        file_path:
+          type: string
+        line_number:
+          type: integer
+          format: int64
+        comment_snippet:
+          type: string
+    CodeSubscriptionResponse:
+      type: object
+      required:
+        - id
+        - vcs_provider
+        - vcs_repository_id
+        - repository_owner
+        - repository_name
+        - repository_full_name
+        - target_query
+        - triggers
+        - status
+        - occurrences
+        - occurrence_count
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+        vcs_provider:
+          type: string
+        vcs_installation_id:
+          type: string
+        vcs_repository_id:
+          type: string
+        repository_owner:
+          type: string
+        repository_name:
+          type: string
+        repository_full_name:
+          type: string
+        feature_id:
+          type: string
+        target_query:
+          type: string
+        triggers:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubscriptionTriggerWritable'
+        raw_directive:
+          type: string
+        occurrences:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubscriptionOccurrence'
+        occurrence_count:
+          type: integer
+          format: int64
+        status:
+          type: string
+          enum:
+            [ACTIVE, TRIGGERED, DELIVERED, RESOLVED, OBSOLETE, DELETED, ERROR]
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    CodeSubscriptionListResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/CodeSubscriptionResponse'
+    VCSWebhookPayload:
+      type: object
+      additionalProperties: true
   securitySchemes:
     bearerAuth:
       type: http


### PR DESCRIPTION
Refs #2712, #2722

Adds HTTP route handlers for code subscriptions and webhook ingestion.

- `backend/pkg/httpserver/code_subscriptions_handlers.go`: REST handlers for listing installations, querying subscriptions, and deleting subscriptions with BOLA authorization checks.
- `backend/pkg/httpserver/handle_vcs_webhook.go`: Ingress webhook handler verifying HMAC signatures, recording deduplication, and publishing scan tasks to Pub/Sub.
- HTTP handler unit tests using standard test server helpers.