### PR TITLE
perf(ci): configure MINIKUBE_HOME cache and partition DevContainer caching

### DIFF
--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -1,2 +1,4 @@
 MINIKUBE_PROFILE=webstatus-dev
 DOCKER_BUILDKIT=1
+MINIKUBE_HOME=/workspaces/webstatus.dev/.devcontainer/cache/minikube_home
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,14 +63,6 @@ jobs:
           sudo df -h
           echo "Docker Root Dir:"
           sudo docker info | grep "Docker Root Dir"
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: ${{ env.GO_CACHE_DEPENDENCY_PATH }}
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
       - name: Get Repo Owner
         id: get_repo_owner
         run: echo "REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" > $GITHUB_ENV
@@ -81,15 +73,17 @@ jobs:
             .devcontainer/cache/go/go-build
             .devcontainer/cache/go/pkg
             .devcontainer/cache/node/.npm
-          key: ${{ runner.os }}-devcontainer-cache-${{ hashFiles('**/*.sum') }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-devcontainer-precommit-${{ hashFiles('**/*.sum') }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('.devcontainer/devcontainer.json') }}
           restore-keys: |
-            ${{ runner.os }}-devcontainer-cache-${{ hashFiles('**/*.sum') }}-
-            ${{ runner.os }}-devcontainer-cache-
+            ${{ runner.os }}-devcontainer-precommit-${{ hashFiles('**/*.sum') }}-${{ hashFiles('package-lock.json') }}-
+            ${{ runner.os }}-devcontainer-precommit-${{ hashFiles('**/*.sum') }}-
+            ${{ runner.os }}-devcontainer-precommit-
+            ${{ runner.os }}-devcontainer-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ env.REPO_OWNER }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run precommit target for CI
         uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3
@@ -150,33 +144,29 @@ jobs:
           sudo df -h
           echo "Docker Root Dir:"
           sudo docker info | grep "Docker Root Dir"
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: ${{ env.GO_CACHE_DEPENDENCY_PATH }}
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
       - name: Get Repo Owner
         id: get_repo_owner
         run: echo "REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" > $GITHUB_ENV
-      - name: Cache DevContainer Dependencies (Go & Node)
+      - name: Cache DevContainer Dependencies (Go, Node, Minikube)
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: |
             .devcontainer/cache/go/go-build
             .devcontainer/cache/go/pkg
             .devcontainer/cache/node/.npm
-          key: ${{ runner.os }}-devcontainer-cache-${{ hashFiles('**/*.sum') }}-${{ hashFiles('package-lock.json') }}
+            .devcontainer/cache/minikube_home
+          key: ${{ runner.os }}-devcontainer-playwright-${{ hashFiles('**/*.sum') }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('.devcontainer/devcontainer.json') }}
           restore-keys: |
-            ${{ runner.os }}-devcontainer-cache-${{ hashFiles('**/*.sum') }}-
-            ${{ runner.os }}-devcontainer-cache-
+            ${{ runner.os }}-devcontainer-playwright-${{ hashFiles('**/*.sum') }}-${{ hashFiles('package-lock.json') }}-
+            ${{ runner.os }}-devcontainer-playwright-${{ hashFiles('**/*.sum') }}-
+            ${{ runner.os }}-devcontainer-playwright-
+            ${{ runner.os }}-devcontainer-precommit-
+            ${{ runner.os }}-devcontainer-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ env.REPO_OWNER }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run playwright target for CI
         uses: devcontainers/ci@513af61f4de4f75d37e4438f184ba4358f0fc1ca # v0.3

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -101,17 +101,22 @@ jobs:
           sudo df -h
           echo "Docker Root Dir:"
           sudo docker info | grep "Docker Root Dir"
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: ${{ env.GO_CACHE_DEPENDENCY_PATH }}
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
       - name: Get Repo Owner
         id: get_repo_owner
         run: echo "REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" > $GITHUB_ENV
+      - name: Cache DevContainer Dependencies (Go & Node)
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: |
+            .devcontainer/cache/go/go-build
+            .devcontainer/cache/go/pkg
+            .devcontainer/cache/node/.npm
+          key: ${{ runner.os }}-devcontainer-precommit-${{ hashFiles('**/*.sum') }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('.devcontainer/devcontainer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-devcontainer-precommit-${{ hashFiles('**/*.sum') }}-${{ hashFiles('package-lock.json') }}-
+            ${{ runner.os }}-devcontainer-precommit-${{ hashFiles('**/*.sum') }}-
+            ${{ runner.os }}-devcontainer-precommit-
+            ${{ runner.os }}-devcontainer-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -130,7 +135,7 @@ jobs:
   # is not broken.
   test-playwright-action:
     runs-on: ubuntu-latest
-    needs: build-base-image
+    needs: [build-base-image, warm-up-precommit-action]
     steps:
       - name: Maximize build space
         uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c
@@ -164,17 +169,24 @@ jobs:
           sudo df -h
           echo "Docker Root Dir:"
           sudo docker info | grep "Docker Root Dir"
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: ${{ env.GO_CACHE_DEPENDENCY_PATH }}
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
       - name: Get Repo Owner
         id: get_repo_owner
         run: echo "REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" > $GITHUB_ENV
+      - name: Cache DevContainer Dependencies (Go, Node, Minikube)
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: |
+            .devcontainer/cache/go/go-build
+            .devcontainer/cache/go/pkg
+            .devcontainer/cache/node/.npm
+            .devcontainer/cache/minikube_home
+          key: ${{ runner.os }}-devcontainer-playwright-${{ hashFiles('**/*.sum') }}-${{ hashFiles('package-lock.json') }}-${{ hashFiles('.devcontainer/devcontainer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-devcontainer-playwright-${{ hashFiles('**/*.sum') }}-${{ hashFiles('package-lock.json') }}-
+            ${{ runner.os }}-devcontainer-playwright-${{ hashFiles('**/*.sum') }}-
+            ${{ runner.os }}-devcontainer-playwright-
+            ${{ runner.os }}-devcontainer-precommit-
+            ${{ runner.os }}-devcontainer-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -65,9 +65,11 @@ go.work.sum
 .devcontainer/cache/go/go-build/*
 .devcontainer/cache/go/pkg/*
 .devcontainer/cache/node/.npm/*
+.devcontainer/cache/minikube_home/*
 !.devcontainer/cache/go/go-build/.gitkeep
 !.devcontainer/cache/go/pkg/.gitkeep
 !.devcontainer/cache/node/.npm/.gitkeep
+!.devcontainer/cache/minikube_home/.gitkeep
 
 # TypeScript
 tsconfig.tsbuildinfo


### PR DESCRIPTION
### Summary
- Remove redundant `actions/setup-go` and `actions/setup-node` steps from host runner jobs (everything runs inside DevContainer; host toolchains were never used).
- Set `MINIKUBE_HOME=/workspaces/webstatus.dev/.devcontainer/cache/minikube_home` in `devcontainer.env` so Minikube stores configuration, ISOs, and image layers on the workspace filesystem without Docker named volume collisions.
- Partition cache keys into `devcontainer-precommit` (Go + Node) and `devcontainer-playwright` (Go + Node + Minikube) to eliminate cache key reservation conflicts between concurrent jobs.
- Make `test-playwright-action` in `devcontainer.yml` depend on `warm-up-precommit-action` to populate the combined Playwright cache on `main`.
- Standardize `docker/login-action` on `REPO_OWNER` for GHCR cache layer authentication.