### PR TITLE
fix(workflows): resolve wpt consumer race condition and streamline ingestion alerts

### DIFF
--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -95,10 +95,10 @@ uma_region_schedules = {
   "europe-west1" = "30 3,9,15,21 * * *"
 }
 
-# 5. WPT - Takes a while. It runs once daily.
+# 5. WPT - Runs every 6 hours
 wpt_region_schedules = {
-  "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
-  "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
+  "us-central1"  = "0 4,10,16,22 * * *"
+  "europe-west1" = "30 4,10,16,22 * * *"
 }
 
 firebase_api_key_location = "prod-firebase-app-api-key"

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -96,10 +96,10 @@ uma_region_schedules = {
   "europe-west1" = "30 3,9,15,21 * * *"
 }
 
-# 5. WPT - Takes a while. It runs once daily.
+# 5. WPT - Runs every 6 hours
 wpt_region_schedules = {
-  "us-central1"  = "0 21 * * *" # Daily at 9:00 PM
-  "europe-west1" = "0 9 * * *"  # Daily at 9:00 AM
+  "us-central1"  = "0 4,10,16,22 * * *"
+  "europe-west1" = "30 4,10,16,22 * * *"
 }
 
 

--- a/infra/ingestion/workflows.tf
+++ b/infra/ingestion/workflows.tf
@@ -77,7 +77,7 @@ module "wpt_workflow" {
   full_name                       = "WPT Workflow"
   deletion_protection             = var.deletion_protection
   project_id                      = var.spanner_datails.project_id
-  timeout_seconds                 = 86400 # 24 hours
+  timeout_seconds                 = 7200 # 2 hours
   image_name                      = "wpt_consumer_image"
   spanner_details                 = var.spanner_datails
   notification_channel_ids        = var.notification_channel_ids

--- a/infra/modules/single_stage_go_workflow/main.tf
+++ b/infra/modules/single_stage_go_workflow/main.tf
@@ -110,48 +110,44 @@ resource "google_project_iam_member" "invoker" {
   member   = google_service_account.service_account.member
 }
 
-# This alert fires when a job has failed at least once in the last 23 hours,
-# and has not had any successful runs in that same period.
-# The alert will automatically resolve when the job succeeds on a subsequent run.
-# We use a 23-hour alignment period because of a GCP limitation where alignment
-# periods must be at least 5 minutes shorter than the 24-hour duration.
+# This alert fires when no successful job execution has completed across any region
+# in the last 23 hours.
+# It uses a single condition_absent combining all regional instances of this workflow,
+# ensuring exactly one notification is sent and preventing false alarms when one region fails
+# but another succeeds.
+# The alert will automatically resolve when any regional job succeeds on a subsequent run.
 resource "google_monitoring_alert_policy" "job_failed_alert" {
-  for_each = { for r in var.regions : r => r if length(var.notification_channel_ids) > 0 }
+  count = length(var.notification_channel_ids) > 0 ? 1 : 0
 
-  display_name          = "${var.full_name}/${each.key} - Job Not Succeeded in 23 Hours (Error)"
-  combiner              = "AND"
+  display_name          = "${var.full_name} - Ingestion Stalled (No Success in 23 Hours)"
+  combiner              = "OR"
   notification_channels = var.notification_channel_ids
   severity              = "ERROR"
 
   conditions {
-    display_name = "No successful job executions in 23 hours"
+    display_name = "No successful job executions in any region in 23 hours"
     condition_absent {
-      filter   = "metric.type=\"run.googleapis.com/job/completed_execution_count\" AND resource.type=\"cloud_run_job\" AND metric.labels.result=\"succeeded\" AND resource.labels.job_name=\"${module.job.regional_job_map[each.key].name}\""
+      filter = join(" AND ", [
+        "resource.type=\"cloud_run_job\"",
+        "metric.type=\"run.googleapis.com/job/completed_execution_count\"",
+        "metric.labels.result=\"succeeded\"",
+        "resource.labels.job_name = one_of(${join(", ", [for k, v in module.job.regional_job_map : "\"${v.name}\""])})"
+      ])
       duration = "120s"
       trigger {
         count = 1
       }
       aggregations {
-        alignment_period   = "82800s" # 23 hours
-        per_series_aligner = "ALIGN_SUM"
+        alignment_period     = "82800s" # 23 hours
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+        group_by_fields      = []
       }
     }
   }
 
-  conditions {
-    display_name = "Job has failed at least once in the last 23 hours"
-    condition_threshold {
-      filter          = "metric.type=\"run.googleapis.com/job/completed_execution_count\" AND resource.type=\"cloud_run_job\" AND metric.labels.result=\"failed\" AND resource.labels.job_name=\"${module.job.regional_job_map[each.key].name}\""
-      duration        = "120s"
-      comparison      = "COMPARISON_GT"
-      threshold_value = 0
-      trigger {
-        count = 1
-      }
-      aggregations {
-        alignment_period   = "82800s" # 23 hours
-        per_series_aligner = "ALIGN_SUM"
-      }
-    }
+  documentation {
+    content   = "No successful ${var.full_name} execution has completed across any region in the last 23 hours (7-8 consecutive runs failed). Check Cloud Run job logs for errors or panics."
+    mime_type = "text/markdown"
   }
 }

--- a/lib/localcache/cache.go
+++ b/lib/localcache/cache.go
@@ -16,6 +16,7 @@ package localcache
 
 import (
 	"context"
+	"maps"
 	"sync"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
@@ -25,6 +26,41 @@ import (
 // This is necessary for cache implementations that store reference types (e.g., maps, slices, pointers)
 // to prevent race conditions when multiple goroutines access and modify cached data.
 type Copier[V any] func(V) V
+
+// MapCopier returns a reusable Copier function for single-level maps: map[K]V.
+func MapCopier[M ~map[K]V, K comparable, V any]() Copier[M] {
+	return func(in M) M {
+		if in == nil {
+			return nil
+		}
+		out := make(M, len(in))
+		maps.Copy(out, in)
+
+		return out
+	}
+}
+
+// NestedMapCopier returns a reusable Copier function for two-level nested maps: map[K1]map[K2]V.
+func NestedMapCopier[M ~map[K1]map[K2]V, K1 comparable, K2 comparable, V any]() Copier[M] {
+	return func(in M) M {
+		if in == nil {
+			return nil
+		}
+		out := make(M, len(in))
+		for k, inner := range in {
+			if inner == nil {
+				out[k] = nil
+
+				continue
+			}
+			newInner := make(map[K2]V, len(inner))
+			maps.Copy(newInner, inner)
+			out[k] = newInner
+		}
+
+		return out
+	}
+}
 
 // LocalDataCache is an in-memory thread safe cache.
 // It uses generics so that users of it can uses any type of data they want.
@@ -53,6 +89,9 @@ func NewLocalDataCache[K comparable, V any](copier Copier[V]) *LocalDataCache[K,
 }
 
 // Cache stores a value in the cache.
+// If a copier function was provided to NewLocalDataCache, this method stores a
+// deep copy of the value to ensure thread safety and prevent mutations by the caller
+// from corrupting cached data.
 func (c *LocalDataCache[K, V]) Cache(
 	_ context.Context,
 	key K,
@@ -60,7 +99,11 @@ func (c *LocalDataCache[K, V]) Cache(
 ) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.data[key] = in
+	if c.copier != nil {
+		c.data[key] = c.copier(in)
+	} else {
+		c.data[key] = in
+	}
 
 	return nil
 }

--- a/lib/localcache/cache_test.go
+++ b/lib/localcache/cache_test.go
@@ -17,7 +17,6 @@ package localcache
 import (
 	"context"
 	"errors"
-	"maps"
 	"reflect"
 	"sync"
 	"testing"
@@ -116,20 +115,8 @@ func TestLocalDataCache(t *testing.T) {
 // This test is designed to fail under the Go race detector if the cache's Get
 // method does not return a proper copy, leading to a data race.
 func TestLocalDataCache_ConcurrentMapAccess(t *testing.T) {
-	// Define a copier function for our test map type. This is what a consumer
-	// of the cache would provide for their specific reference type.
-	copier := func(in map[string]int) map[string]int {
-		if in == nil {
-			return nil
-		}
-		out := make(map[string]int, len(in))
-		maps.Copy(out, in)
-
-		return out
-	}
-
-	// Create a new cache instance with the copier function.
-	cache := NewLocalDataCache[string, map[string]int](copier)
+	// Create a new cache instance with the generic MapCopier function.
+	cache := NewLocalDataCache[string, map[string]int](MapCopier[map[string]int]())
 	initialMap := map[string]int{"a": 1}
 	// Seed the cache with an initial value.
 	err := cache.Cache(context.Background(), "test-map", initialMap)
@@ -160,4 +147,115 @@ func TestLocalDataCache_ConcurrentMapAccess(t *testing.T) {
 	// Wait for all goroutines to complete. If there was a race condition,
 	// the test will have already failed when run with the -race flag.
 	wg.Wait()
+}
+
+// TestLocalDataCache_CopyOnWrite tests that mutating the original map passed to Cache
+// does not modify the cached data when a copier is provided.
+func TestLocalDataCache_CopyOnWrite(t *testing.T) {
+	cache := NewLocalDataCache[string, map[string]int](MapCopier[map[string]int]())
+	inputMap := map[string]int{"a": 1}
+
+	err := cache.Cache(context.Background(), "test-key", inputMap)
+	if err != nil {
+		t.Fatalf("unexpected error caching: %v", err)
+	}
+
+	// Mutate the original map after caching.
+	inputMap["a"] = 999
+	inputMap["b"] = 123
+
+	// Retrieve from cache and verify it still has the original value.
+	cached, err := cache.Get(context.Background(), "test-key")
+	if err != nil {
+		t.Fatalf("unexpected error getting: %v", err)
+	}
+
+	expected := map[string]int{"a": 1}
+	if !reflect.DeepEqual(cached, expected) {
+		t.Errorf("expected cached map %v, got %v", expected, cached)
+	}
+}
+
+// TestLocalDataCache_ConcurrentNestedMapAccess tests that NestedMapCopier provides
+// complete thread safety and mutation isolation across 100 concurrent workers modifying
+// both inner and outer maps simultaneously.
+func TestLocalDataCache_ConcurrentNestedMapAccess(t *testing.T) {
+	type NestedMap map[string]map[string]any
+
+	cache := NewLocalDataCache[string, NestedMap](NestedMapCopier[NestedMap]())
+	initialData := NestedMap{
+		"test1.html": {"feat1": 100, "feat2": 200},
+		"test2.html": {"feat3": 300},
+	}
+
+	err := cache.Cache(context.Background(), "nested-key", initialData)
+	if err != nil {
+		t.Fatalf("unexpected error caching: %v", err)
+	}
+
+	// Mutate original map to ensure copy-on-store holds
+	initialData["test1.html"]["feat1"] = 999
+	initialData["test3.html"] = map[string]any{"feat4": 400}
+
+	var wg sync.WaitGroup
+	numGoroutines := 100
+
+	for i := range numGoroutines {
+		wg.Go(func() {
+			m, err := cache.Get(context.Background(), "nested-key")
+			if err != nil {
+				t.Error(err)
+			}
+			// Verify original values are untouched
+			if m["test1.html"]["feat1"] != 100 {
+				t.Errorf("expected feat1=100, got %v", m["test1.html"]["feat1"])
+			}
+			if _, exists := m["test3.html"]; exists {
+				t.Errorf("expected test3.html to not exist in cached copy")
+			}
+
+			// Perform concurrent mutations on both outer and inner maps
+			m["test1.html"]["feat1"] = i
+			delete(m["test1.html"], "feat2")
+			m["test1.html"]["new_feat"] = "concurrent_value"
+			m["new_test.html"] = map[string]any{"custom": i}
+		})
+	}
+
+	wg.Wait()
+
+	// Verify the cached state remains completely pristine after all workers finish
+	finalCached, err := cache.Get(context.Background(), "nested-key")
+	if err != nil {
+		t.Fatalf("unexpected error getting: %v", err)
+	}
+
+	expectedFinal := NestedMap{
+		"test1.html": {"feat1": 100, "feat2": 200},
+		"test2.html": {"feat3": 300},
+	}
+	if !reflect.DeepEqual(finalCached, expectedFinal) {
+		t.Errorf("cache corrupted! expected %v, got %v", expectedFinal, finalCached)
+	}
+}
+
+func TestNestedMapCopier_NilHandling(t *testing.T) {
+	type NestedMap map[string]map[string]int
+	copier := NestedMapCopier[NestedMap]()
+
+	if copier(nil) != nil {
+		t.Errorf("expected nil for nil input")
+	}
+
+	inputWithNilInner := NestedMap{
+		"test1": nil,
+		"test2": {"a": 1},
+	}
+	copied := copier(inputWithNilInner)
+	if copied["test1"] != nil {
+		t.Errorf("expected nil inner map for test1, got %v", copied["test1"])
+	}
+	if copied["test2"]["a"] != 1 {
+		t.Errorf("expected 1, got %v", copied["test2"]["a"])
+	}
 }

--- a/workflows/steps/services/wpt_consumer/cmd/job/main.go
+++ b/workflows/steps/services/wpt_consumer/cmd/job/main.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"maps"
 	"os"
 	"strconv"
 	"time"
@@ -107,17 +106,6 @@ func main() {
 	// Worker Pool Setup
 	pool := workerpool.Pool[workflow.JobArguments]{}
 
-	webFeaturesDataCopier := func(in shared.WebFeaturesData) shared.WebFeaturesData {
-		dataCopy := make(shared.WebFeaturesData, len(in))
-		for testName, featuresMap := range in {
-			newFeaturesMap := make(map[string]any, len(featuresMap))
-			maps.Copy(newFeaturesMap, featuresMap)
-			dataCopy[testName] = newFeaturesMap
-		}
-
-		return dataCopy
-	}
-
 	processor := workflow.NewWPTJobProcessor(
 		wptfyi.NewHTTPClient(wptFyiHostname),
 		workflow.NewWPTRunsProcessor(
@@ -125,7 +113,9 @@ func main() {
 				workflow.NewHTTPResultsGetter(),
 				workflow.NewCacheableWebFeaturesDataGetter(
 					shared.NewGitHubWebFeaturesClient(ghClient),
-					localcache.NewLocalDataCache[string, shared.WebFeaturesData](webFeaturesDataCopier),
+					localcache.NewLocalDataCache[string, shared.WebFeaturesData](
+						localcache.NestedMapCopier[shared.WebFeaturesData](),
+					),
 				),
 				spanneradapters.NewWPTWorkflowConsumer(spannerClient),
 			),

--- a/workflows/steps/services/wpt_consumer/pkg/workflow/get_web_feature_map.go
+++ b/workflows/steps/services/wpt_consumer/pkg/workflow/get_web_feature_map.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -38,12 +39,14 @@ func NewCacheableWebFeaturesDataGetter(
 	return &CacheableWebFeaturesDataGetter{
 		client: client,
 		cache:  cache,
+		loadMu: &sync.Mutex{},
 	}
 }
 
 type CacheableWebFeaturesDataGetter struct {
 	client WebFeatureDataGetter
 	cache  DataCacher[string, shared.WebFeaturesData]
+	loadMu *sync.Mutex
 }
 
 const (
@@ -59,10 +62,6 @@ type WebFeatureDataGetter interface {
 func (g *CacheableWebFeaturesDataGetter) GetWebFeaturesData(
 	ctx context.Context, _ string) (shared.WebFeaturesData, error) {
 	// 1. Attempts to retrieve data from the cache.
-	// 2. If not found or an unexpected cache error occurs, falls back to fetching data directly.
-	// 3. Caches freshly fetched data for future requests.
-
-	// Step 1.
 	cachedData, err := g.cache.Get(ctx, cacheKeyLatest)
 	if err == nil {
 		return cachedData, nil
@@ -70,16 +69,29 @@ func (g *CacheableWebFeaturesDataGetter) GetWebFeaturesData(
 		slog.WarnContext(ctx, "unexpected error when trying to get cache data", "err", err)
 	}
 
-	// Step 2.
+	// 2. Slow path: Acquire mutex so only 1 worker fetches on cold start.
+	g.loadMu.Lock()
+	defer g.loadMu.Unlock()
+
+	// Double-check cache in case another worker already populated it while we waited.
+	cachedData, err = g.cache.Get(ctx, cacheKeyLatest)
+	if err == nil {
+		return cachedData, nil
+	} else if !errors.Is(err, cachetypes.ErrCachedDataNotFound) {
+		slog.WarnContext(ctx, "unexpected error when trying to get cache data", "err", err)
+	}
+
+	// 3. Fetch data directly.
 	data, err := g.client.Get(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Step 3.
+	// 4. Cache freshly fetched data for future requests.
 	if err := g.cache.Cache(ctx, cacheKeyLatest, data); err != nil {
 		slog.WarnContext(ctx, "unable to cache web features data", "err", err)
 	}
 
-	return data, nil
+	// Return isolated copy from cache.
+	return g.cache.Get(ctx, cacheKeyLatest)
 }

--- a/workflows/steps/services/wpt_consumer/pkg/workflow/get_web_feature_map_test.go
+++ b/workflows/steps/services/wpt_consumer/pkg/workflow/get_web_feature_map_test.go
@@ -18,9 +18,12 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/cachetypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/localcache"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
@@ -47,6 +50,7 @@ type mockCacheCacheConfig struct {
 type MockDataCacher struct {
 	mockCacheGetConfig   *mockCacheGetConfig
 	mockCacheCacheConfig *mockCacheCacheConfig
+	cachedData           shared.WebFeaturesData
 	t                    *testing.T
 }
 
@@ -55,11 +59,15 @@ func (m *MockDataCacher) Cache(_ context.Context, key string, value shared.WebFe
 		!reflect.DeepEqual(value, m.mockCacheCacheConfig.expectedData) {
 		m.t.Error("unexpected input to Cache")
 	}
+	m.cachedData = value
 
 	return m.mockCacheCacheConfig.err
 }
 
 func (m *MockDataCacher) Get(_ context.Context, key string) (shared.WebFeaturesData, error) {
+	if m.cachedData != nil {
+		return m.cachedData, nil
+	}
 	if key != m.mockCacheGetConfig.expectedKey {
 		m.t.Error("unexpected input to Get")
 	}
@@ -129,6 +137,7 @@ func TestGetWebFeaturesData(t *testing.T) {
 				t:                    t,
 				mockCacheGetConfig:   tt.mockCacheGetConfig,
 				mockCacheCacheConfig: tt.mockCacheCacheConfig,
+				cachedData:           nil,
 			}
 			getter := NewCacheableWebFeaturesDataGetter(
 				tt.mockWebFeatureDataGetter,
@@ -144,5 +153,59 @@ func TestGetWebFeaturesData(t *testing.T) {
 				t.Error("unexpected data")
 			}
 		})
+	}
+}
+
+type countingGetter struct {
+	mu    sync.Mutex
+	calls int
+	data  shared.WebFeaturesData
+}
+
+func (g *countingGetter) Get(_ context.Context) (shared.WebFeaturesData, error) {
+	time.Sleep(10 * time.Millisecond)
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.calls++
+
+	return g.data, nil
+}
+
+func TestGetWebFeaturesData_Concurrent(t *testing.T) {
+	cache := localcache.NewLocalDataCache[string, shared.WebFeaturesData](
+		localcache.NestedMapCopier[shared.WebFeaturesData](),
+	)
+	getterImpl := &countingGetter{
+		mu:    sync.Mutex{},
+		calls: 0,
+		data: shared.WebFeaturesData{
+			"test1.html": {"feature1": nil},
+			"test2.html": {"feature2": nil},
+		},
+	}
+
+	getter := NewCacheableWebFeaturesDataGetter(getterImpl, cache)
+
+	numGoroutines := 30
+	var wg sync.WaitGroup
+
+	for range numGoroutines {
+		wg.Go(func() {
+			data, err := getter.GetWebFeaturesData(context.Background(), "test-rev")
+			if err != nil {
+				t.Error(err)
+			}
+			// Simulate mutation/read by worker
+			if len(data) == 0 {
+				t.Error("expected non-empty data")
+			}
+			data["mutated_test.html"] = map[string]any{"mutated": nil}
+		})
+	}
+
+	wg.Wait()
+
+	if getterImpl.calls != 1 {
+		t.Errorf("expected exactly 1 call to client.Get, got %d", getterImpl.calls)
 	}
 }


### PR DESCRIPTION
Fixes #2757

### Overview
Fixes intermittent `fatal error: concurrent map iteration and map write` crashes in the WPT consumer job and reduces false-alarm alert noise across ingestion workflows.

### Changes
1. **Thread Safety & Deduplication (`lib/localcache` & `wpt_consumer`)**:
   - **Copy-on-Store**: `LocalDataCache.Cache()` now clones inputs via `c.copier` on write, isolating cache state from caller mutations.
   - **Single-Flight Fetch**: `CacheableWebFeaturesDataGetter` uses double-checked locking (`sync.Mutex`) to prevent cold-start thundering herds against the GitHub API.
   - **Architecture Note**: In-memory `LocalDataCache` is retained over `ValkeyDataCache` to eliminate network round-trip overhead during high-frequency lookups in batch jobs.
   - **Tests**: Added copy-on-write and 30-worker concurrent race tests.

2. **Ingestion Schedules & Timeouts**:
   - Updated WPT schedule in staging/prod to run every 6 hours (`0 4,10,16,22 * * *` US / `30 4,10,16,22 * * *` EU), matching the other ingestion workflows.
   - Lowered WPT job timeout from 24h to 2h based on ~50m observed execution time. (previously, we consumed a lot more data to do a backfill. We don't do that anymore)

3. **Global 23-Hour Absence Alerting**:
   - Replaced 12 regional dual-condition alert policies with 6 global single-condition policies (`condition_absent` with 23h lookback) in `infra/modules/single_stage_go_workflow/main.tf`.
   - Eliminates duplicate GCP incidents/emails while ensuring alerts only trigger when all regional runs fail for 23 hours.
