### PR TITLE
feat(spanner): add migration 000036.sql for CodeSubscriptionDeliveries

### DIFF
--- a/infra/storage/spanner/migrations/000036.sql
+++ b/infra/storage/spanner/migrations/000036.sql
@@ -1,0 +1,35 @@
+-- Copyright 2026 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Migration: 000036.sql
+-- Description: Add CodeSubscriptionDeliveries table.
+
+CREATE TABLE IF NOT EXISTS CodeSubscriptionDeliveries (
+    ID STRING(36) NOT NULL,
+    SubscriptionID STRING(36) NOT NULL,
+    DeliveryStatus STRING(32) NOT NULL,
+    DeliveryChannel STRING(32) NOT NULL,
+    LockExpiresAt TIMESTAMP,
+    WorkerLockID STRING(64),
+    DeliveredAt TIMESTAMP,
+    ExternalIssueID STRING(128),
+    ExternalIssueURL STRING(1024),
+    ErrorMessage STRING(2048),
+    CreatedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+    UpdatedAt TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),
+    CONSTRAINT FK_Deliveries_Subscription FOREIGN KEY (SubscriptionID) REFERENCES CodeSubscriptions(ID) ON DELETE CASCADE,
+) PRIMARY KEY (ID);
+
+CREATE INDEX IF NOT EXISTS IDX_Deliveries_SubscriptionID ON CodeSubscriptionDeliveries(SubscriptionID);
+CREATE INDEX IF NOT EXISTS IDX_Deliveries_LockStatus ON CodeSubscriptionDeliveries(DeliveryStatus, LockExpiresAt, CreatedAt);

--- a/lib/gcpspanner/code_subscription_delivery.go
+++ b/lib/gcpspanner/code_subscription_delivery.go
@@ -1,0 +1,245 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+const codeSubscriptionDeliveryTable = "CodeSubscriptionDeliveries"
+
+var (
+	// ErrCodeSubscriptionDeliveryNotFound indicates that the delivery record was not found.
+	ErrCodeSubscriptionDeliveryNotFound = errors.New("code subscription delivery not found")
+	// ErrUnknownDeliveryStatus indicates an unrecognized delivery status.
+	ErrUnknownDeliveryStatus = errors.New("unknown delivery status")
+	// ErrUnknownDeliveryChannel indicates an unrecognized delivery channel.
+	ErrUnknownDeliveryChannel = errors.New("unknown delivery channel")
+)
+
+// DeliveryStatus represents the state of a notification delivery attempt.
+type DeliveryStatus string
+
+const (
+	DeliveryStatusPending   DeliveryStatus = "PENDING"
+	DeliveryStatusDelivered DeliveryStatus = "DELIVERED"
+	DeliveryStatusFailed    DeliveryStatus = "FAILED"
+)
+
+// DeliveryChannel represents the issue/notification delivery channel.
+type DeliveryChannel string
+
+const (
+	DeliveryChannelGitHubIssue DeliveryChannel = "github_issue"
+)
+
+// CodeSubscriptionDelivery tracks an issue notification delivery for a subscription.
+type CodeSubscriptionDelivery struct {
+	ID               string
+	SubscriptionID   string
+	DeliveryStatus   DeliveryStatus
+	DeliveryChannel  DeliveryChannel
+	LockExpiresAt    *time.Time
+	WorkerLockID     *string
+	DeliveredAt      *time.Time
+	ExternalIssueID  *string
+	ExternalIssueURL *string
+	ErrorMessage     *string
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+// spannerCodeSubscriptionDelivery is the internal struct for Spanner column mapping.
+type spannerCodeSubscriptionDelivery struct {
+	ID               string             `spanner:"ID"`
+	SubscriptionID   string             `spanner:"SubscriptionID"`
+	DeliveryStatus   string             `spanner:"DeliveryStatus"`
+	DeliveryChannel  string             `spanner:"DeliveryChannel"`
+	LockExpiresAt    spanner.NullTime   `spanner:"LockExpiresAt"`
+	WorkerLockID     spanner.NullString `spanner:"WorkerLockID"`
+	DeliveredAt      spanner.NullTime   `spanner:"DeliveredAt"`
+	ExternalIssueID  spanner.NullString `spanner:"ExternalIssueID"`
+	ExternalIssueURL spanner.NullString `spanner:"ExternalIssueURL"`
+	ErrorMessage     spanner.NullString `spanner:"ErrorMessage"`
+	CreatedAt        time.Time          `spanner:"CreatedAt"`
+	UpdatedAt        time.Time          `spanner:"UpdatedAt"`
+}
+
+type codeSubscriptionDeliveryMapper struct{}
+
+func (m codeSubscriptionDeliveryMapper) Table() string { return codeSubscriptionDeliveryTable }
+
+func (m codeSubscriptionDeliveryMapper) SelectOne(id string) spanner.Statement {
+	return spanner.Statement{
+		SQL: `SELECT ID, SubscriptionID, DeliveryStatus, DeliveryChannel, LockExpiresAt,
+			WorkerLockID, DeliveredAt, ExternalIssueID, ExternalIssueURL, ErrorMessage,
+			CreatedAt, UpdatedAt
+		FROM CodeSubscriptionDeliveries
+		WHERE ID = @id`,
+		Params: map[string]any{"id": id},
+	}
+}
+
+// ParseDeliveryStatus parses and validates a raw delivery status string into a typed DeliveryStatus.
+func ParseDeliveryStatus(val string) (DeliveryStatus, error) {
+	status := DeliveryStatus(val)
+	switch status {
+	case DeliveryStatusPending,
+		DeliveryStatusDelivered,
+		DeliveryStatusFailed:
+		return status, nil
+	}
+
+	return "", fmt.Errorf("%w: %q", ErrUnknownDeliveryStatus, val)
+}
+
+// ParseDeliveryChannel parses and validates a raw delivery channel string into a typed DeliveryChannel.
+func ParseDeliveryChannel(val string) (DeliveryChannel, error) {
+	channel := DeliveryChannel(val)
+	switch channel {
+	case DeliveryChannelGitHubIssue:
+		return channel, nil
+	}
+
+	return "", fmt.Errorf("%w: %q", ErrUnknownDeliveryChannel, val)
+}
+
+func (s *spannerCodeSubscriptionDelivery) toCodeSubscriptionDelivery() (*CodeSubscriptionDelivery, error) {
+	status, err := ParseDeliveryStatus(s.DeliveryStatus)
+	if err != nil {
+		return nil, err
+	}
+	channel, err := ParseDeliveryChannel(s.DeliveryChannel)
+	if err != nil {
+		return nil, err
+	}
+
+	var lockExpiresAt *time.Time
+	if s.LockExpiresAt.Valid {
+		lockExpiresAt = &s.LockExpiresAt.Time
+	}
+
+	var workerLockID *string
+	if s.WorkerLockID.Valid {
+		workerLockID = &s.WorkerLockID.StringVal
+	}
+
+	var deliveredAt *time.Time
+	if s.DeliveredAt.Valid {
+		deliveredAt = &s.DeliveredAt.Time
+	}
+
+	var extIssueID *string
+	if s.ExternalIssueID.Valid {
+		extIssueID = &s.ExternalIssueID.StringVal
+	}
+
+	var extIssueURL *string
+	if s.ExternalIssueURL.Valid {
+		extIssueURL = &s.ExternalIssueURL.StringVal
+	}
+
+	var errMsg *string
+	if s.ErrorMessage.Valid {
+		errMsg = &s.ErrorMessage.StringVal
+	}
+
+	return &CodeSubscriptionDelivery{
+		ID:               s.ID,
+		SubscriptionID:   s.SubscriptionID,
+		DeliveryStatus:   status,
+		DeliveryChannel:  channel,
+		LockExpiresAt:    lockExpiresAt,
+		WorkerLockID:     workerLockID,
+		DeliveredAt:      deliveredAt,
+		ExternalIssueID:  extIssueID,
+		ExternalIssueURL: extIssueURL,
+		ErrorMessage:     errMsg,
+		CreatedAt:        s.CreatedAt,
+		UpdatedAt:        s.UpdatedAt,
+	}, nil
+}
+
+func fromCodeSubscriptionDelivery(d *CodeSubscriptionDelivery) *spannerCodeSubscriptionDelivery {
+	var lockExpiresAt spanner.NullTime
+	if d.LockExpiresAt != nil {
+		lockExpiresAt = spanner.NullTime{Time: *d.LockExpiresAt, Valid: true}
+	}
+
+	var workerLockID spanner.NullString
+	if d.WorkerLockID != nil {
+		workerLockID = spanner.NullString{StringVal: *d.WorkerLockID, Valid: true}
+	}
+
+	var deliveredAt spanner.NullTime
+	if d.DeliveredAt != nil {
+		deliveredAt = spanner.NullTime{Time: *d.DeliveredAt, Valid: true}
+	}
+
+	var extIssueID spanner.NullString
+	if d.ExternalIssueID != nil {
+		extIssueID = spanner.NullString{StringVal: *d.ExternalIssueID, Valid: true}
+	}
+
+	var extIssueURL spanner.NullString
+	if d.ExternalIssueURL != nil {
+		extIssueURL = spanner.NullString{StringVal: *d.ExternalIssueURL, Valid: true}
+	}
+
+	var errMsg spanner.NullString
+	if d.ErrorMessage != nil {
+		errMsg = spanner.NullString{StringVal: *d.ErrorMessage, Valid: true}
+	}
+
+	return &spannerCodeSubscriptionDelivery{
+		ID:               d.ID,
+		SubscriptionID:   d.SubscriptionID,
+		DeliveryStatus:   string(d.DeliveryStatus),
+		DeliveryChannel:  string(d.DeliveryChannel),
+		LockExpiresAt:    lockExpiresAt,
+		WorkerLockID:     workerLockID,
+		DeliveredAt:      deliveredAt,
+		ExternalIssueID:  extIssueID,
+		ExternalIssueURL: extIssueURL,
+		ErrorMessage:     errMsg,
+		CreatedAt:        d.CreatedAt,
+		UpdatedAt:        d.UpdatedAt,
+	}
+}
+
+// GetCodeSubscriptionDelivery retrieves a delivery record by ID.
+func (c *Client) GetCodeSubscriptionDelivery(
+	ctx context.Context,
+	id string,
+) (*CodeSubscriptionDelivery, error) {
+	r := newEntityReader[
+		codeSubscriptionDeliveryMapper, spannerCodeSubscriptionDelivery, CodeSubscriptionDelivery, string,
+	](c)
+	spannerDel, err := r.readRowByKey(ctx, id)
+	if err != nil {
+		if errors.Is(err, ErrQueryReturnedNoResults) {
+			return nil, ErrCodeSubscriptionDeliveryNotFound
+		}
+
+		return nil, err
+	}
+
+	return spannerDel.toCodeSubscriptionDelivery()
+}

--- a/lib/gcpspanner/code_subscription_delivery_test.go
+++ b/lib/gcpspanner/code_subscription_delivery_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+)
+
+func TestCodeSubscriptionDeliveryConversion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	lockExp := now.Add(30 * time.Second)
+	lockID := "worker-1"
+	issueID := "issue-123"
+	issueURL := "https://github.com/owner/repo/issues/123"
+	errMsg := "rate limited"
+
+	testCases := []struct {
+		name     string
+		original CodeSubscriptionDelivery
+	}{
+		{
+			name: "Populated nullable fields roundtrip",
+			original: CodeSubscriptionDelivery{
+				ID:               "del-uuid-1",
+				SubscriptionID:   "sub-uuid-1",
+				DeliveryStatus:   DeliveryStatusDelivered,
+				DeliveryChannel:  DeliveryChannelGitHubIssue,
+				LockExpiresAt:    &lockExp,
+				WorkerLockID:     &lockID,
+				DeliveredAt:      &now,
+				ExternalIssueID:  &issueID,
+				ExternalIssueURL: &issueURL,
+				ErrorMessage:     &errMsg,
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			},
+		},
+		{
+			name: "Nil nullable fields roundtrip",
+			original: CodeSubscriptionDelivery{
+				ID:               "del-uuid-nil-fields",
+				SubscriptionID:   "sub-uuid-1",
+				DeliveryStatus:   DeliveryStatusPending,
+				DeliveryChannel:  DeliveryChannelGitHubIssue,
+				LockExpiresAt:    nil,
+				WorkerLockID:     nil,
+				DeliveredAt:      nil,
+				ExternalIssueID:  nil,
+				ExternalIssueURL: nil,
+				ErrorMessage:     nil,
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			scsd := fromCodeSubscriptionDelivery(&tc.original)
+			converted, err := scsd.toCodeSubscriptionDelivery()
+			if err != nil {
+				t.Fatalf("unexpected toCodeSubscriptionDelivery error: %v", err)
+			}
+
+			if diff := cmp.Diff(&tc.original, converted); diff != "" {
+				t.Errorf("CodeSubscriptionDelivery conversion mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCodeSubscriptionDelivery_InvalidEnums(t *testing.T) {
+	t.Parallel()
+
+	invalidStatus := spannerCodeSubscriptionDelivery{
+		ID:               "del-1",
+		SubscriptionID:   "sub-1",
+		DeliveryStatus:   "INVALID_STATUS",
+		DeliveryChannel:  "github_issue",
+		LockExpiresAt:    spanner.NullTime{Time: time.Time{}, Valid: false},
+		WorkerLockID:     spanner.NullString{StringVal: "", Valid: false},
+		DeliveredAt:      spanner.NullTime{Time: time.Time{}, Valid: false},
+		ExternalIssueID:  spanner.NullString{StringVal: "", Valid: false},
+		ExternalIssueURL: spanner.NullString{StringVal: "", Valid: false},
+		ErrorMessage:     spanner.NullString{StringVal: "", Valid: false},
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	_, err := invalidStatus.toCodeSubscriptionDelivery()
+	if err == nil {
+		t.Fatalf("expected error for invalid delivery status, got nil")
+	}
+	if !errors.Is(err, ErrUnknownDeliveryStatus) {
+		t.Fatalf("expected ErrUnknownDeliveryStatus, got %v", err)
+	}
+
+	invalidChannel := spannerCodeSubscriptionDelivery{
+		ID:               "del-2",
+		SubscriptionID:   "sub-1",
+		DeliveryStatus:   "PENDING",
+		DeliveryChannel:  "unsupported_channel",
+		LockExpiresAt:    spanner.NullTime{Time: time.Time{}, Valid: false},
+		WorkerLockID:     spanner.NullString{StringVal: "", Valid: false},
+		DeliveredAt:      spanner.NullTime{Time: time.Time{}, Valid: false},
+		ExternalIssueID:  spanner.NullString{StringVal: "", Valid: false},
+		ExternalIssueURL: spanner.NullString{StringVal: "", Valid: false},
+		ErrorMessage:     spanner.NullString{StringVal: "", Valid: false},
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+
+	_, err = invalidChannel.toCodeSubscriptionDelivery()
+	if err == nil {
+		t.Fatalf("expected error for invalid delivery channel, got nil")
+	}
+	if !errors.Is(err, ErrUnknownDeliveryChannel) {
+		t.Fatalf("expected ErrUnknownDeliveryChannel, got %v", err)
+	}
+}
+
+func testCodeSubscriptionDeliveryNotFound(ctx context.Context, t *testing.T) {
+	_, err := spannerClient.GetCodeSubscriptionDelivery(ctx, "non-existent-del-id")
+	if !errors.Is(err, ErrCodeSubscriptionDeliveryNotFound) {
+		t.Fatalf("expected ErrCodeSubscriptionDeliveryNotFound, got %v", err)
+	}
+}
+
+func testCodeSubscriptionDeliveryInsertAndGet(ctx context.Context, t *testing.T, subID string) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	delID := uuid.NewString()
+	del := CodeSubscriptionDelivery{
+		ID:               delID,
+		SubscriptionID:   subID,
+		DeliveryStatus:   DeliveryStatusPending,
+		DeliveryChannel:  DeliveryChannelGitHubIssue,
+		LockExpiresAt:    nil,
+		WorkerLockID:     nil,
+		DeliveredAt:      nil,
+		ExternalIssueID:  nil,
+		ExternalIssueURL: nil,
+		ErrorMessage:     nil,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	spannerDel := fromCodeSubscriptionDelivery(&del)
+	delMut, err := spanner.InsertStruct(codeSubscriptionDeliveryTable, spannerDel)
+	if err != nil {
+		t.Fatalf("InsertStruct delivery failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{delMut}); err != nil {
+		t.Fatalf("Apply delivery mutation failed: %v", err)
+	}
+
+	retrieved, err := spannerClient.GetCodeSubscriptionDelivery(ctx, delID)
+	if err != nil {
+		t.Fatalf("GetCodeSubscriptionDelivery failed: %v", err)
+	}
+	if retrieved.ID != delID || retrieved.SubscriptionID != subID {
+		t.Fatalf("retrieved delivery mismatch: %+v", retrieved)
+	}
+	if retrieved.DeliveryStatus != DeliveryStatusPending {
+		t.Errorf("expected status %s, got %s", DeliveryStatusPending, retrieved.DeliveryStatus)
+	}
+}
+
+func testCodeSubscriptionDeliveryNullableFields(ctx context.Context, t *testing.T, subID string) {
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	delID := uuid.NewString()
+	lockExp := now.Add(30 * time.Second)
+	workerID := "worker-lock-42"
+	issueID := "gh-issue-99"
+	issueURL := "https://github.com/GoogleChrome/webstatus.dev/issues/99"
+	errMsg := "rate limited by github"
+
+	del := CodeSubscriptionDelivery{
+		ID:               delID,
+		SubscriptionID:   subID,
+		DeliveryStatus:   DeliveryStatusFailed,
+		DeliveryChannel:  DeliveryChannelGitHubIssue,
+		LockExpiresAt:    &lockExp,
+		WorkerLockID:     &workerID,
+		DeliveredAt:      &now,
+		ExternalIssueID:  &issueID,
+		ExternalIssueURL: &issueURL,
+		ErrorMessage:     &errMsg,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	spannerDel := fromCodeSubscriptionDelivery(&del)
+	delMut, err := spanner.InsertStruct(codeSubscriptionDeliveryTable, spannerDel)
+	if err != nil {
+		t.Fatalf("InsertStruct delivery failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{delMut}); err != nil {
+		t.Fatalf("Apply delivery mutation failed: %v", err)
+	}
+
+	retrieved, err := spannerClient.GetCodeSubscriptionDelivery(ctx, delID)
+	if err != nil {
+		t.Fatalf("GetCodeSubscriptionDelivery failed: %v", err)
+	}
+	if retrieved.WorkerLockID == nil || *retrieved.WorkerLockID != workerID {
+		t.Errorf("expected WorkerLockID %s, got %v", workerID, retrieved.WorkerLockID)
+	}
+	if retrieved.ExternalIssueID == nil || *retrieved.ExternalIssueID != issueID {
+		t.Errorf("expected ExternalIssueID %s, got %v", issueID, retrieved.ExternalIssueID)
+	}
+	if retrieved.ErrorMessage == nil || *retrieved.ErrorMessage != errMsg {
+		t.Errorf("expected ErrorMessage %s, got %v", errMsg, retrieved.ErrorMessage)
+	}
+}
+
+func TestClient_GetCodeSubscriptionDelivery(t *testing.T) {
+	ctx := context.Background()
+	restartDatabaseContainer(t)
+
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	subID := uuid.NewString()
+
+	// Create parent installation
+	writeLevel := GitHubPermissionLevelWrite
+	inst := VCSInstallation{
+		ID:                  "",
+		VCSProvider:         VCSProviderGitHub,
+		VCSInstallationID:   "12345678",
+		AccountLogin:        "GoogleChrome",
+		AccountType:         "Organization",
+		RepositorySelection: "selected",
+		Permissions: VCSPermissions{
+			GitHub: &GitHubPermissions{
+				Issues:       &writeLevel,
+				Contents:     nil,
+				Metadata:     nil,
+				PullRequests: nil,
+				Workflows:    nil,
+				Actions:      nil,
+			},
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+	instIDPtr, err := spannerClient.UpsertVCSInstallation(ctx, inst)
+	if err != nil {
+		t.Fatalf("UpsertVCSInstallation failed: %v", err)
+	}
+	instID := *instIDPtr
+
+	// Insert CodeSubscription via mutation
+	sub := CodeSubscription{
+		ID:                 subID,
+		VCSProvider:        VCSProviderGitHub,
+		VCSInstallationID:  instID,
+		VCSRepositoryID:    "repo-123",
+		RepositoryFullName: "GoogleChrome/webstatus.dev",
+		TargetQuery:        "id:view-transitions",
+		Triggers:           []string{"feature_baseline_to_widely"},
+		Status:             SubscriptionActive,
+		Occurrences: []SubscriptionOccurrence{
+			{
+				FilePath:       "src/app.ts",
+				LineNumber:     10,
+				CommentSnippet: "// TODO(baseline/view-transitions)",
+			},
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	spannerSub := fromCodeSubscription(&sub)
+	subMut, err := spanner.InsertStruct(codeSubscriptionTable, spannerSub)
+	if err != nil {
+		t.Fatalf("InsertStruct failed: %v", err)
+	}
+	if _, err := spannerClient.Apply(ctx, []*spanner.Mutation{subMut}); err != nil {
+		t.Fatalf("Apply subscription mutation failed: %v", err)
+	}
+
+	t.Run("NotFound returns ErrCodeSubscriptionDeliveryNotFound", func(t *testing.T) {
+		testCodeSubscriptionDeliveryNotFound(ctx, t)
+	})
+	t.Run("Insert and retrieve delivery record", func(t *testing.T) {
+		testCodeSubscriptionDeliveryInsertAndGet(ctx, t, subID)
+	})
+	t.Run("Handles populated nullable fields", func(t *testing.T) {
+		testCodeSubscriptionDeliveryNullableFields(ctx, t, subID)
+	})
+}


### PR DESCRIPTION
Refs #2712, #2714

Adds Spanner migration `000036.sql` and Go models for delivery attempt tracking and worker locks.

- `infra/storage/spanner/migrations/000036.sql`: `CodeSubscriptionDeliveries` table (foreign key cascade to `CodeSubscriptions`).
- `lib/gcpspanner/code_subscription_delivery.go`: Models and `GetCodeSubscriptionDelivery` reader.
- `lib/gcpspanner/code_subscription_delivery_test.go`: Unit and emulator integration tests.