### PR TITLE
[API] Implement GET /v1/vcs/{provider}/installations HTTP Handler

### DIFF
--- a/backend/pkg/httpserver/list_vcs_installations.go
+++ b/backend/pkg/httpserver/list_vcs_installations.go
@@ -12,20 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:dupl // Similar structure across listing handlers
 package httpserver
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-// ListVCSInstallations handles GET /v1/users/me/vcs-installations.
+// ListVCSInstallations handles GET /v1/vcs/{provider}/installations.
 //
-//nolint:ireturn, revive // Expected ireturn for openapi generation.
+//nolint:ireturn, revive, dupl // Expected ireturn for openapi generation.
 func (s *Server) ListVCSInstallations(
 	ctx context.Context,
-	_ backend.ListVCSInstallationsRequestObject,
+	request backend.ListVCSInstallationsRequestObject,
 ) (backend.ListVCSInstallationsResponseObject, error) {
 	userCheck := CheckAuthenticatedUser[backend.ListVCSInstallationsResponseObject](
 		ctx, "ListVCSInstallations",
@@ -37,10 +43,35 @@ func (s *Server) ListVCSInstallations(
 		return userCheck.Response, nil
 	}
 
-	data := []backend.VCSInstallationSummary{}
+	pageSize := getPageSizeOrDefault(request.Params.PageSize)
 
-	return backend.ListVCSInstallations200JSONResponse{
-		Data:     &data,
-		Metadata: nil,
-	}, nil
+	page, err := s.wptMetricsStorer.ListVCSInstallations(
+		ctx, request.Provider, pageSize, request.Params.PageToken)
+	if err != nil {
+		if errors.Is(err, backendtypes.ErrInvalidPageToken) {
+			return backend.ListVCSInstallations400JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusBadRequest,
+					Message: errMsgInvalidPageToken,
+				}), nil
+		}
+		if errors.Is(err, backendtypes.ErrUnsupportedVCSProvider) {
+			return backend.ListVCSInstallations400JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusBadRequest,
+					Message: fmt.Sprintf("unsupported VCS provider: %s", request.Provider),
+				}), nil
+		}
+
+		slog.ErrorContext(ctx, "failed to list VCS installations", "error", err,
+			"provider", request.Provider)
+
+		return backend.ListVCSInstallations500JSONResponse(
+			backend.BasicErrorModel{
+				Code:    http.StatusInternalServerError,
+				Message: "failed to list VCS installations",
+			}), nil
+	}
+
+	return backend.ListVCSInstallations200JSONResponse(*page), nil
 }

--- a/backend/pkg/httpserver/list_vcs_installations.go
+++ b/backend/pkg/httpserver/list_vcs_installations.go
@@ -24,8 +24,23 @@ import (
 //
 //nolint:ireturn, revive // Expected ireturn for openapi generation.
 func (s *Server) ListVCSInstallations(
-	_ context.Context,
+	ctx context.Context,
 	_ backend.ListVCSInstallationsRequestObject,
 ) (backend.ListVCSInstallationsResponseObject, error) {
-	return nil, errNotImplemented
+	userCheck := CheckAuthenticatedUser[backend.ListVCSInstallationsResponseObject](
+		ctx, "ListVCSInstallations",
+		func(code int, message string) backend.ListVCSInstallationsResponseObject {
+			return backend.ListVCSInstallations500JSONResponse(
+				backend.BasicErrorModel{Code: code, Message: message})
+		})
+	if userCheck.User == nil {
+		return userCheck.Response, nil
+	}
+
+	data := []backend.VCSInstallationSummary{}
+
+	return backend.ListVCSInstallations200JSONResponse{
+		Data:     &data,
+		Metadata: nil,
+	}, nil
 }

--- a/backend/pkg/httpserver/list_vcs_installations_test.go
+++ b/backend/pkg/httpserver/list_vcs_installations_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httpserver tests for VCS installations handler.
+//
+//nolint:dupl // Similar structure across simple listing handlers
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+)
+
+func TestListVCSInstallations(t *testing.T) {
+	testUser := &auth.User{ID: "user-123", GitHubUserID: new("12345")}
+
+	testCases := []struct {
+		name                 string
+		authMiddlewareOption testServerOption
+		request              *http.Request
+		expectedResponse     *http.Response
+	}{
+		{
+			name:                 "Success",
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/installations", nil),
+			expectedResponse: testJSONResponse(http.StatusOK, `{
+				"data": []
+			}`),
+		},
+		{
+			name:                 "Unauthenticated",
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(nil)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/installations", nil),
+			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
+				"code": 500,
+				"message": "internal server error"
+			}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := setupTestServer(t)
+			assertTestServerRequest(t, server, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
+		})
+	}
+}

--- a/backend/pkg/httpserver/list_vcs_installations_test.go
+++ b/backend/pkg/httpserver/list_vcs_installations_test.go
@@ -14,38 +14,124 @@
 
 // Package httpserver tests for VCS installations handler.
 //
-//nolint:dupl // Similar structure across simple listing handlers
+//nolint:dupl // Similar structure across listing handlers
 package httpserver
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
 func TestListVCSInstallations(t *testing.T) {
-	testUser := &auth.User{ID: "user-123", GitHubUserID: new("12345")}
+	githubUserID := "12345"
+	testUser := &auth.User{ID: "user-123", GitHubUserID: &githubUserID}
+	invalidPageToken := "invalid-token"
+
+	mockInstallations := []backend.VCSInstallationSummary{
+		{
+			AccountLogin:      "GoogleChrome",
+			AccountType:       "Organization",
+			Id:                "inst-123",
+			VcsInstallationId: "12345",
+			VcsProvider:       "github",
+		},
+	}
 
 	testCases := []struct {
 		name                 string
 		authMiddlewareOption testServerOption
+		cfg                  *MockListVCSInstallationsConfig
 		request              *http.Request
 		expectedResponse     *http.Response
 	}{
 		{
-			name:                 "Success",
+			name:                 "Success with Data",
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			cfg: &MockListVCSInstallationsConfig{
+				expectedProvider:  "github",
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				result: &backend.VCSInstallationPage{
+					Data:     &mockInstallations,
+					Metadata: nil,
+				},
+				err: nil,
+			},
 			request: httptest.NewRequestWithContext(t.Context(),
 				http.MethodGet, "/v1/vcs/github/installations", nil),
 			expectedResponse: testJSONResponse(http.StatusOK, `{
-				"data": []
+				"data": [
+					{
+						"account_login": "GoogleChrome",
+						"account_type": "Organization",
+						"id": "inst-123",
+						"vcs_installation_id": "12345",
+						"vcs_provider": "github"
+					}
+				]
+			}`),
+		},
+		{
+			name:                 "Invalid Page Token",
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			cfg: &MockListVCSInstallationsConfig{
+				expectedProvider:  "github",
+				expectedPageSize:  100,
+				expectedPageToken: &invalidPageToken,
+				result:            nil,
+				err:               backendtypes.ErrInvalidPageToken,
+			},
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/installations?page_token=invalid-token", nil),
+			expectedResponse: testJSONResponse(http.StatusBadRequest, `{
+				"code": 400,
+				"message": "invalid page token"
+			}`),
+		},
+		{
+			name:                 "Unsupported Provider",
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			cfg: &MockListVCSInstallationsConfig{
+				expectedProvider:  "unknown",
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				result:            nil,
+				err:               backendtypes.ErrUnsupportedVCSProvider,
+			},
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/unknown/installations", nil),
+			expectedResponse: testJSONResponse(http.StatusBadRequest, `{
+				"code": 400,
+				"message": "unsupported VCS provider: unknown"
+			}`),
+		},
+		{
+			name:                 "Database Error",
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			cfg: &MockListVCSInstallationsConfig{
+				expectedProvider:  "github",
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				result:            nil,
+				err:               errors.New("db error"),
+			},
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/installations", nil),
+			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
+				"code": 500,
+				"message": "failed to list VCS installations"
 			}`),
 		},
 		{
 			name:                 "Unauthenticated",
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(nil)),
+			cfg:                  nil,
 			request: httptest.NewRequestWithContext(t.Context(),
 				http.MethodGet, "/v1/vcs/github/installations", nil),
 			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
@@ -57,8 +143,21 @@ func TestListVCSInstallations(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			server := setupTestServer(t)
-			assertTestServerRequest(t, server, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
+			var opts []TestServerOption
+			if tc.cfg != nil {
+				//nolint:exhaustruct
+				mockStorer := &MockWPTMetricsStorer{
+					listVCSInstallationsCfg: tc.cfg,
+					t:                       t,
+				}
+				opts = append(opts, withCustomStorer(mockStorer))
+			}
+			server := setupTestServer(t, opts...)
+			var authOpts []testServerOption
+			if tc.authMiddlewareOption != nil {
+				authOpts = append(authOpts, tc.authMiddlewareOption)
+			}
+			assertTestServerRequest(t, server, tc.request, tc.expectedResponse, authOpts...)
 		})
 	}
 }

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -193,6 +193,12 @@ type WPTMetricsStorer interface {
 		userID, subscriptionID string,
 		req backend.UpdateSubscriptionRequest,
 	) (*backend.SubscriptionResponse, error)
+	ListVCSInstallations(
+		ctx context.Context,
+		provider string,
+		pageSize int,
+		pageToken *string,
+	) (*backend.VCSInstallationPage, error)
 }
 
 type Server struct {

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -329,6 +329,14 @@ type MockUpdateSavedSearchSubscriptionConfig struct {
 	err                    error
 }
 
+type MockListVCSInstallationsConfig struct {
+	expectedProvider  string
+	expectedPageSize  int
+	expectedPageToken *string
+	result            *backend.VCSInstallationPage
+	err               error
+}
+
 type basicHTTPTestCase[T any] struct {
 	name             string
 	cfg              *T
@@ -370,6 +378,7 @@ type MockWPTMetricsStorer struct {
 	updateSavedSearchSubscriptionCfg                  *MockUpdateSavedSearchSubscriptionConfig
 	validateQueryReferencesCfg                        *MockValidateQueryReferencesConfig
 	listGlobalSavedSearchesCfg                        *MockListGlobalSavedSearchesConfig
+	listVCSInstallationsCfg                           *MockListVCSInstallationsConfig
 	t                                                 *testing.T
 	callCountListMissingOneImplCounts                 int
 	callCountListMissingOneImplFeatures               int
@@ -993,6 +1002,28 @@ func (m *MockWPTMetricsStorer) ListNotificationChannels(
 	}
 
 	return m.listNotificationChannelsCfg.output, m.listNotificationChannelsCfg.err
+}
+
+func (m *MockWPTMetricsStorer) ListVCSInstallations(
+	_ context.Context,
+	provider string,
+	pageSize int,
+	pageToken *string,
+) (*backend.VCSInstallationPage, error) {
+	if provider != m.listVCSInstallationsCfg.expectedProvider {
+		m.t.Errorf("provider mismatch: got %s, want %s",
+			provider, m.listVCSInstallationsCfg.expectedProvider)
+	}
+	if pageSize != m.listVCSInstallationsCfg.expectedPageSize {
+		m.t.Errorf("pageSize mismatch: got %d, want %d",
+			pageSize, m.listVCSInstallationsCfg.expectedPageSize)
+	}
+	if !reflect.DeepEqual(pageToken, m.listVCSInstallationsCfg.expectedPageToken) {
+		m.t.Errorf("pageToken mismatch: got %v, want %v",
+			pageToken, m.listVCSInstallationsCfg.expectedPageToken)
+	}
+
+	return m.listVCSInstallationsCfg.result, m.listVCSInstallationsCfg.err
 }
 
 func (m *MockWPTMetricsStorer) DeleteNotificationChannel(

--- a/backend/pkg/httpserver/test_utils_test.go
+++ b/backend/pkg/httpserver/test_utils_test.go
@@ -61,6 +61,7 @@ func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
 		updateSavedSearchSubscriptionCfg:                  nil,
 		validateQueryReferencesCfg:                        nil,
 		listGlobalSavedSearchesCfg:                        nil,
+		listVCSInstallationsCfg:                           nil,
 		callCountListMetricsForFeatureIDBrowserAndChannel: 0,
 		callCountListMetricsOverTimeWithAggregatedTotals:  0,
 		callCountListChromeDailyUsageStats:                0,


### PR DESCRIPTION
Part of Epic #2712.
Refs #2722

### Context & Purpose
Implements the backend HTTP handler for `GET /v1/vcs/{provider}/installations`, returning active VCS app installations for the authenticated user.

### Implementation Details
- `backend/pkg/httpserver/list_vcs_installations.go`: Extracts authenticated user from context and returns installation summaries.
- `backend/pkg/httpserver/list_vcs_installations_test.go`: Framework-agnostic HTTP test suite testing success, unauthenticated, and error payloads via `assertTestServerRequest`.