### PR TITLE
[API] Implement GET /v1/vcs/{provider}/repositories HTTP Handler

### DIFF
--- a/backend/pkg/httpserver/list_vcs_repositories.go
+++ b/backend/pkg/httpserver/list_vcs_repositories.go
@@ -12,20 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:dupl // Similar structure across listing handlers
 package httpserver
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-// ListVCSRepositories handles GET /v1/users/me/vcs-installations/{id}/repositories.
+// ListVCSRepositories handles GET /v1/vcs/{provider}/repositories.
 //
-//nolint:ireturn, revive // Expected ireturn for openapi generation.
+//nolint:ireturn, revive, dupl // Expected ireturn for openapi generation.
 func (s *Server) ListVCSRepositories(
 	ctx context.Context,
-	_ backend.ListVCSRepositoriesRequestObject,
+	request backend.ListVCSRepositoriesRequestObject,
 ) (backend.ListVCSRepositoriesResponseObject, error) {
 	userCheck := CheckAuthenticatedUser[backend.ListVCSRepositoriesResponseObject](
 		ctx, "ListVCSRepositories",
@@ -37,10 +43,35 @@ func (s *Server) ListVCSRepositories(
 		return userCheck.Response, nil
 	}
 
-	data := []backend.VCSRepositorySummary{}
+	pageSize := getPageSizeOrDefault(request.Params.PageSize)
 
-	return backend.ListVCSRepositories200JSONResponse{
-		Data:     &data,
-		Metadata: nil,
-	}, nil
+	page, err := s.wptMetricsStorer.ListVCSRepositories(
+		ctx, request.Provider, pageSize, request.Params.PageToken)
+	if err != nil {
+		if errors.Is(err, backendtypes.ErrInvalidPageToken) {
+			return backend.ListVCSRepositories400JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusBadRequest,
+					Message: errMsgInvalidPageToken,
+				}), nil
+		}
+		if errors.Is(err, backendtypes.ErrUnsupportedVCSProvider) {
+			return backend.ListVCSRepositories400JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusBadRequest,
+					Message: fmt.Sprintf("unsupported VCS provider: %s", request.Provider),
+				}), nil
+		}
+
+		slog.ErrorContext(ctx, "failed to list VCS repositories", "error", err,
+			"provider", request.Provider)
+
+		return backend.ListVCSRepositories500JSONResponse(
+			backend.BasicErrorModel{
+				Code:    http.StatusInternalServerError,
+				Message: "failed to list VCS repositories",
+			}), nil
+	}
+
+	return backend.ListVCSRepositories200JSONResponse(*page), nil
 }

--- a/backend/pkg/httpserver/list_vcs_repositories.go
+++ b/backend/pkg/httpserver/list_vcs_repositories.go
@@ -24,8 +24,23 @@ import (
 //
 //nolint:ireturn, revive // Expected ireturn for openapi generation.
 func (s *Server) ListVCSRepositories(
-	_ context.Context,
+	ctx context.Context,
 	_ backend.ListVCSRepositoriesRequestObject,
 ) (backend.ListVCSRepositoriesResponseObject, error) {
-	return nil, errNotImplemented
+	userCheck := CheckAuthenticatedUser[backend.ListVCSRepositoriesResponseObject](
+		ctx, "ListVCSRepositories",
+		func(code int, message string) backend.ListVCSRepositoriesResponseObject {
+			return backend.ListVCSRepositories500JSONResponse(
+				backend.BasicErrorModel{Code: code, Message: message})
+		})
+	if userCheck.User == nil {
+		return userCheck.Response, nil
+	}
+
+	data := []backend.VCSRepositorySummary{}
+
+	return backend.ListVCSRepositories200JSONResponse{
+		Data:     &data,
+		Metadata: nil,
+	}, nil
 }

--- a/backend/pkg/httpserver/list_vcs_repositories_test.go
+++ b/backend/pkg/httpserver/list_vcs_repositories_test.go
@@ -14,38 +14,130 @@
 
 // Package httpserver tests for VCS repositories handler.
 //
-//nolint:dupl // Similar structure across simple listing handlers
+//nolint:dupl // Similar structure across listing handlers
 package httpserver
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
 func TestListVCSRepositories(t *testing.T) {
-	testUser := &auth.User{ID: "user-123", GitHubUserID: new("12345")}
+	githubUserID := "12345"
+	testUser := &auth.User{ID: "user-123", GitHubUserID: &githubUserID}
+	invalidPageToken := "invalid-token"
+
+	mockRepositories := []backend.VCSRepositorySummary{
+		{
+			FullName:          "GoogleChrome/webstatus.dev",
+			Id:                "repo-123",
+			Name:              "webstatus.dev",
+			Owner:             "GoogleChrome",
+			Private:           false,
+			RepositoryId:      "repo-123",
+			VcsInstallationId: "12345",
+			VcsProvider:       "github",
+		},
+	}
 
 	testCases := []struct {
 		name                 string
 		authMiddlewareOption testServerOption
+		cfg                  *MockListVCSRepositoriesConfig
 		request              *http.Request
 		expectedResponse     *http.Response
 	}{
 		{
-			name:                 "Success",
+			name:                 "Success with Data",
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			cfg: &MockListVCSRepositoriesConfig{
+				expectedProvider:  "github",
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				result: &backend.VCSRepositoryPage{
+					Data:     &mockRepositories,
+					Metadata: nil,
+				},
+				err: nil,
+			},
 			request: httptest.NewRequestWithContext(t.Context(),
 				http.MethodGet, "/v1/vcs/github/repositories", nil),
 			expectedResponse: testJSONResponse(http.StatusOK, `{
-				"data": []
+				"data": [
+					{
+						"full_name": "GoogleChrome/webstatus.dev",
+						"id": "repo-123",
+						"name": "webstatus.dev",
+						"owner": "GoogleChrome",
+						"private": false,
+						"repository_id": "repo-123",
+						"vcs_installation_id": "12345",
+						"vcs_provider": "github"
+					}
+				]
+			}`),
+		},
+		{
+			name:                 "Invalid Page Token",
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			cfg: &MockListVCSRepositoriesConfig{
+				expectedProvider:  "github",
+				expectedPageSize:  100,
+				expectedPageToken: &invalidPageToken,
+				result:            nil,
+				err:               backendtypes.ErrInvalidPageToken,
+			},
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories?page_token=invalid-token", nil),
+			expectedResponse: testJSONResponse(http.StatusBadRequest, `{
+				"code": 400,
+				"message": "invalid page token"
+			}`),
+		},
+		{
+			name:                 "Unsupported Provider",
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			cfg: &MockListVCSRepositoriesConfig{
+				expectedProvider:  "unknown",
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				result:            nil,
+				err:               backendtypes.ErrUnsupportedVCSProvider,
+			},
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/unknown/repositories", nil),
+			expectedResponse: testJSONResponse(http.StatusBadRequest, `{
+				"code": 400,
+				"message": "unsupported VCS provider: unknown"
+			}`),
+		},
+		{
+			name:                 "Database Error",
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			cfg: &MockListVCSRepositoriesConfig{
+				expectedProvider:  "github",
+				expectedPageSize:  100,
+				expectedPageToken: nil,
+				result:            nil,
+				err:               errors.New("db error"),
+			},
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories", nil),
+			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
+				"code": 500,
+				"message": "failed to list VCS repositories"
 			}`),
 		},
 		{
 			name:                 "Unauthenticated",
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(nil)),
+			cfg:                  nil,
 			request: httptest.NewRequestWithContext(t.Context(),
 				http.MethodGet, "/v1/vcs/github/repositories", nil),
 			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
@@ -57,8 +149,21 @@ func TestListVCSRepositories(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			server := setupTestServer(t)
-			assertTestServerRequest(t, server, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
+			var opts []TestServerOption
+			if tc.cfg != nil {
+				//nolint:exhaustruct
+				mockStorer := &MockWPTMetricsStorer{
+					listVCSRepositoriesCfg: tc.cfg,
+					t:                      t,
+				}
+				opts = append(opts, withCustomStorer(mockStorer))
+			}
+			server := setupTestServer(t, opts...)
+			var authOpts []testServerOption
+			if tc.authMiddlewareOption != nil {
+				authOpts = append(authOpts, tc.authMiddlewareOption)
+			}
+			assertTestServerRequest(t, server, tc.request, tc.expectedResponse, authOpts...)
 		})
 	}
 }

--- a/backend/pkg/httpserver/list_vcs_repositories_test.go
+++ b/backend/pkg/httpserver/list_vcs_repositories_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httpserver tests for VCS repositories handler.
+//
+//nolint:dupl // Similar structure across simple listing handlers
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+)
+
+func TestListVCSRepositories(t *testing.T) {
+	testUser := &auth.User{ID: "user-123", GitHubUserID: new("12345")}
+
+	testCases := []struct {
+		name                 string
+		authMiddlewareOption testServerOption
+		request              *http.Request
+		expectedResponse     *http.Response
+	}{
+		{
+			name:                 "Success",
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories", nil),
+			expectedResponse: testJSONResponse(http.StatusOK, `{
+				"data": []
+			}`),
+		},
+		{
+			name:                 "Unauthenticated",
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(nil)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories", nil),
+			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
+				"code": 500,
+				"message": "internal server error"
+			}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := setupTestServer(t)
+			assertTestServerRequest(t, server, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
+		})
+	}
+}

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -199,6 +199,12 @@ type WPTMetricsStorer interface {
 		pageSize int,
 		pageToken *string,
 	) (*backend.VCSInstallationPage, error)
+	ListVCSRepositories(
+		ctx context.Context,
+		provider string,
+		pageSize int,
+		pageToken *string,
+	) (*backend.VCSRepositoryPage, error)
 }
 
 type Server struct {

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -337,6 +337,14 @@ type MockListVCSInstallationsConfig struct {
 	err               error
 }
 
+type MockListVCSRepositoriesConfig struct {
+	expectedProvider  string
+	expectedPageSize  int
+	expectedPageToken *string
+	result            *backend.VCSRepositoryPage
+	err               error
+}
+
 type basicHTTPTestCase[T any] struct {
 	name             string
 	cfg              *T
@@ -379,6 +387,7 @@ type MockWPTMetricsStorer struct {
 	validateQueryReferencesCfg                        *MockValidateQueryReferencesConfig
 	listGlobalSavedSearchesCfg                        *MockListGlobalSavedSearchesConfig
 	listVCSInstallationsCfg                           *MockListVCSInstallationsConfig
+	listVCSRepositoriesCfg                            *MockListVCSRepositoriesConfig
 	t                                                 *testing.T
 	callCountListMissingOneImplCounts                 int
 	callCountListMissingOneImplFeatures               int
@@ -1024,6 +1033,28 @@ func (m *MockWPTMetricsStorer) ListVCSInstallations(
 	}
 
 	return m.listVCSInstallationsCfg.result, m.listVCSInstallationsCfg.err
+}
+
+func (m *MockWPTMetricsStorer) ListVCSRepositories(
+	_ context.Context,
+	provider string,
+	pageSize int,
+	pageToken *string,
+) (*backend.VCSRepositoryPage, error) {
+	if provider != m.listVCSRepositoriesCfg.expectedProvider {
+		m.t.Errorf("provider mismatch: got %s, want %s",
+			provider, m.listVCSRepositoriesCfg.expectedProvider)
+	}
+	if pageSize != m.listVCSRepositoriesCfg.expectedPageSize {
+		m.t.Errorf("pageSize mismatch: got %d, want %d",
+			pageSize, m.listVCSRepositoriesCfg.expectedPageSize)
+	}
+	if !reflect.DeepEqual(pageToken, m.listVCSRepositoriesCfg.expectedPageToken) {
+		m.t.Errorf("pageToken mismatch: got %v, want %v",
+			pageToken, m.listVCSRepositoriesCfg.expectedPageToken)
+	}
+
+	return m.listVCSRepositoriesCfg.result, m.listVCSRepositoriesCfg.err
 }
 
 func (m *MockWPTMetricsStorer) DeleteNotificationChannel(

--- a/backend/pkg/httpserver/test_utils_test.go
+++ b/backend/pkg/httpserver/test_utils_test.go
@@ -62,6 +62,7 @@ func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
 		validateQueryReferencesCfg:                        nil,
 		listGlobalSavedSearchesCfg:                        nil,
 		listVCSInstallationsCfg:                           nil,
+		listVCSRepositoriesCfg:                            nil,
 		callCountListMetricsForFeatureIDBrowserAndChannel: 0,
 		callCountListMetricsOverTimeWithAggregatedTotals:  0,
 		callCountListChromeDailyUsageStats:                0,


### PR DESCRIPTION
Part of Epic #2712.
Refs #2722

### Context & Purpose
Implements the backend HTTP handler for `GET /v1/vcs/{provider}/repositories`, returning accessible repositories for the authenticated user.

### Implementation Details
- `backend/pkg/httpserver/list_vcs_repositories.go`: Returns repository list for the authenticated user.
- `backend/pkg/httpserver/list_vcs_repositories_test.go`: Framework-agnostic HTTP test suite testing success, unauthenticated, and error payloads via `assertTestServerRequest`.