### PR TITLE
feat(infra): add Terraform modules for VCS scanner, GitHub issue delivery, and VCS sync

### DIFF
--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -102,8 +102,8 @@ wpt_region_schedules = {
 }
 
 vcs_sync_region_schedules = {
-  "us-central1"  = "0 5,11,17,23 * * *"
-  "europe-west1" = "30 5,11,17,23 * * *"
+  "us-central1"  = "0,10,20,30,40,50 * * * *"
+  "europe-west1" = "5,15,25,35,45,55 * * * *"
 }
 
 firebase_api_key_location = "prod-firebase-app-api-key"

--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -101,6 +101,11 @@ wpt_region_schedules = {
   "europe-west1" = "30 4,10,16,22 * * *"
 }
 
+vcs_sync_region_schedules = {
+  "us-central1"  = "0 5,11,17,23 * * *"
+  "europe-west1" = "30 5,11,17,23 * * *"
+}
+
 firebase_api_key_location = "prod-firebase-app-api-key"
 
 auth_github_config_locations = {
@@ -120,8 +125,10 @@ chime_details = {
 }
 
 worker_manual_instance_counts = {
-  event_producer = 4
-  push_delivery  = 2
-  email          = 2
-  webhook        = 2
+  event_producer        = 4
+  push_delivery         = 2
+  email                 = 2
+  webhook               = 2
+  vcs_scanner           = 2
+  github_issue_delivery = 2
 }

--- a/infra/.envs/prod.tfvars
+++ b/infra/.envs/prod.tfvars
@@ -113,6 +113,12 @@ auth_github_config_locations = {
   client_secret = "prod-github-client-secret"
 }
 
+github_app_config_locations = {
+  app_id          = "prod-github-app-id"
+  private_key_pem = "prod-github-app-private-key-pem"
+  webhook_secret  = "prod-github-app-webhook-secret"
+}
+
 backend_min_instance_count  = 1
 frontend_min_instance_count = 1
 notification_channel_ids    = ["projects/web-compass-prod/notificationChannels/4991947607216940054"]

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -115,6 +115,12 @@ auth_github_config_locations = {
   client_secret = "staging-github-client-secret"
 }
 
+github_app_config_locations = {
+  app_id          = "staging-github-app-id"
+  private_key_pem = "staging-github-app-private-key-pem"
+  webhook_secret  = "staging-github-app-webhook-secret"
+}
+
 # TODO: Once staging is public, we should change the minimum instance count to
 # match production.
 backend_min_instance_count  = 0

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -102,6 +102,11 @@ wpt_region_schedules = {
   "europe-west1" = "30 4,10,16,22 * * *"
 }
 
+vcs_sync_region_schedules = {
+  "us-central1"  = "0 5,11,17,23 * * *"
+  "europe-west1" = "30 5,11,17,23 * * *"
+}
+
 
 firebase_api_key_location = "staging-firebase-app-api-key"
 
@@ -124,8 +129,10 @@ chime_details = {
 }
 
 worker_manual_instance_counts = {
-  event_producer = 2
-  push_delivery  = 1
-  email          = 1
-  webhook        = 1
+  event_producer        = 2
+  push_delivery         = 1
+  email                 = 1
+  webhook               = 1
+  vcs_scanner           = 1
+  github_issue_delivery = 1
 }

--- a/infra/.envs/staging.tfvars
+++ b/infra/.envs/staging.tfvars
@@ -103,8 +103,8 @@ wpt_region_schedules = {
 }
 
 vcs_sync_region_schedules = {
-  "us-central1"  = "0 5,11,17,23 * * *"
-  "europe-west1" = "30 5,11,17,23 * * *"
+  "us-central1"  = "0,10,20,30,40,50 * * * *"
+  "europe-west1" = "5,15,25,35,45,55 * * * *"
 }
 
 

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -145,6 +145,21 @@ resource "google_cloud_run_v2_service" "service" {
         name  = "PUBSUB_PROJECT_ID"
         value = var.pubsub_project_id
       }
+      env {
+        name  = "GITHUB_APP_ID"
+        value = var.github_app_id
+      }
+      env {
+        name  = "GITHUB_APP_PRIVATE_KEY_PATH"
+        value = var.github_app_private_key_secret_id != "" ? "/etc/secrets/github-app/private-key.pem" : ""
+      }
+      dynamic "volume_mounts" {
+        for_each = var.github_app_private_key_secret_id != "" ? [1] : []
+        content {
+          name       = "github-app-key"
+          mount_path = "/etc/secrets/github-app"
+        }
+      }
     }
     containers {
       name  = "otel"
@@ -192,6 +207,19 @@ resource "google_cloud_run_v2_service" "service" {
         items {
           version = "latest"
           path    = "config.yaml"
+        }
+      }
+    }
+    dynamic "volumes" {
+      for_each = var.github_app_private_key_secret_id != "" ? [1] : []
+      content {
+        name = "github-app-key"
+        secret {
+          secret = var.github_app_private_key_secret_id
+          items {
+            version = "latest"
+            path    = "private-key.pem"
+          }
         }
       }
     }

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -142,6 +142,10 @@ resource "google_cloud_run_v2_service" "service" {
         value = var.ingestion_topic_id
       }
       env {
+        name  = "VCS_SCAN_TASKS_TOPIC_ID"
+        value = var.vcs_scan_tasks_topic_id
+      }
+      env {
         name  = "PUBSUB_PROJECT_ID"
         value = var.pubsub_project_id
       }
@@ -270,6 +274,13 @@ resource "google_cloud_run_service_iam_member" "public" {
 
 resource "google_pubsub_topic_iam_member" "pub" {
   topic    = var.ingestion_topic_id
+  role     = "roles/pubsub.publisher"
+  member   = "serviceAccount:${google_service_account.backend.email}"
+  provider = google.internal_project
+}
+
+resource "google_pubsub_topic_iam_member" "vcs_scan_tasks_pub" {
+  topic    = var.vcs_scan_tasks_topic_id
   role     = "roles/pubsub.publisher"
   member   = "serviceAccount:${google_service_account.backend.email}"
   provider = google.internal_project

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -53,6 +53,14 @@ resource "google_secret_manager_secret_iam_member" "backend_otel_config_secret_a
   member    = "serviceAccount:${google_service_account.backend.email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "backend_github_app_key_secret_access" {
+  count     = var.github_app_private_key_secret_id != "" ? 1 : 0
+  provider  = google.internal_project
+  secret_id = var.github_app_private_key_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.backend.email}"
+}
+
 resource "google_cloud_run_v2_service" "service" {
   for_each = var.region_to_subnet_info_map
   provider = google.public_project
@@ -238,6 +246,7 @@ resource "google_cloud_run_v2_service" "service" {
   depends_on = [
     google_project_iam_member.gcp_datastore_user,
     google_secret_manager_secret_iam_member.backend_otel_config_secret_access,
+    google_secret_manager_secret_iam_member.backend_github_app_key_secret_access,
   ]
 
   deletion_protection = var.deletion_protection

--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -61,6 +61,14 @@ resource "google_secret_manager_secret_iam_member" "backend_github_app_key_secre
   member    = "serviceAccount:${google_service_account.backend.email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "backend_github_app_webhook_secret_access" {
+  count     = var.github_app_webhook_secret_id != "" ? 1 : 0
+  provider  = google.internal_project
+  secret_id = var.github_app_webhook_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.backend.email}"
+}
+
 resource "google_cloud_run_v2_service" "service" {
   for_each = var.region_to_subnet_info_map
   provider = google.public_project
@@ -165,6 +173,25 @@ resource "google_cloud_run_v2_service" "service" {
         name  = "GITHUB_APP_PRIVATE_KEY_PATH"
         value = var.github_app_private_key_secret_id != "" ? "/etc/secrets/github-app/private-key.pem" : ""
       }
+      dynamic "env" {
+        for_each = var.github_app_webhook_secret_id != "" ? [1] : []
+        content {
+          name = "GITHUB_WEBHOOK_SECRET"
+          value_source {
+            secret_key_ref {
+              secret  = "projects/${var.projects.internal}/secrets/${var.github_app_webhook_secret_id}"
+              version = "latest"
+            }
+          }
+        }
+      }
+      dynamic "env" {
+        for_each = var.github_app_webhook_secret_id == "" ? [1] : []
+        content {
+          name  = "GITHUB_WEBHOOK_SECRET"
+          value = "dummy-webhook-secret"
+        }
+      }
       dynamic "volume_mounts" {
         for_each = var.github_app_private_key_secret_id != "" ? [1] : []
         content {
@@ -227,7 +254,7 @@ resource "google_cloud_run_v2_service" "service" {
       content {
         name = "github-app-key"
         secret {
-          secret = var.github_app_private_key_secret_id
+          secret = "projects/${var.projects.internal}/secrets/${var.github_app_private_key_secret_id}"
           items {
             version = "latest"
             path    = "private-key.pem"
@@ -247,6 +274,7 @@ resource "google_cloud_run_v2_service" "service" {
     google_project_iam_member.gcp_datastore_user,
     google_secret_manager_secret_iam_member.backend_otel_config_secret_access,
     google_secret_manager_secret_iam_member.backend_github_app_key_secret_access,
+    google_secret_manager_secret_iam_member.backend_github_app_webhook_secret_access,
   ]
 
   deletion_protection = var.deletion_protection

--- a/infra/backend/variables.tf
+++ b/infra/backend/variables.tf
@@ -110,6 +110,7 @@ variable "backend_api_url" {
 
 variable "pubsub_project_id" { type = string }
 variable "ingestion_topic_id" { type = string }
+variable "vcs_scan_tasks_topic_id" { type = string }
 
 variable "otel_config_secret_id" {
   type        = string

--- a/infra/backend/variables.tf
+++ b/infra/backend/variables.tf
@@ -143,3 +143,9 @@ variable "github_app_private_key_secret_id" {
   description = "The Secret Manager secret ID containing the GitHub App RSA private key"
   default     = ""
 }
+
+variable "github_app_webhook_secret_id" {
+  type        = string
+  description = "The Secret Manager secret ID containing the GitHub App webhook secret"
+  default     = ""
+}

--- a/infra/backend/variables.tf
+++ b/infra/backend/variables.tf
@@ -130,3 +130,15 @@ variable "otel_collector_endpoint" {
   type        = string
   description = "The endpoint for the application to export OTLP metrics/traces to the local collector"
 }
+
+variable "github_app_id" {
+  type        = string
+  description = "The GitHub App ID for authentication"
+  default     = ""
+}
+
+variable "github_app_private_key_secret_id" {
+  type        = string
+  description = "The Secret Manager secret ID containing the GitHub App RSA private key"
+  default     = ""
+}

--- a/infra/ingestion/variables.tf
+++ b/infra/ingestion/variables.tf
@@ -123,3 +123,27 @@ variable "otel_collector_endpoint" {
   type        = string
   description = "The endpoint for the application to export OTLP metrics/traces to the local collector"
 }
+
+variable "vcs_scan_tasks_topic_id" {
+  type        = string
+  description = "Topic ID for VCS scan tasks"
+  default     = ""
+}
+
+variable "vcs_scan_tasks_topic_name" {
+  type        = string
+  description = "Topic name for VCS scan tasks"
+  default     = ""
+}
+
+variable "github_app_id" {
+  type        = string
+  description = "The GitHub App ID"
+  default     = ""
+}
+
+variable "github_app_private_key_secret_id" {
+  type        = string
+  description = "The Secret Manager secret ID containing the GitHub App RSA private key"
+  default     = ""
+}

--- a/infra/ingestion/variables.tf
+++ b/infra/ingestion/variables.tf
@@ -86,6 +86,10 @@ variable "web_features_mapping_region_schedules" {
   type = map(string)
 }
 
+variable "vcs_sync_region_schedules" {
+  type = map(string)
+}
+
 variable "deletion_protection" {
   type = bool
 }

--- a/infra/ingestion/workflows.tf
+++ b/infra/ingestion/workflows.tf
@@ -324,3 +324,52 @@ module "web_features_mapping_workflow" {
   otel_collector_config_mount_path = var.otel_collector_config_mount_path
   otel_collector_endpoint          = var.otel_collector_endpoint
 }
+
+module "vcs_sync_workflow" {
+  source = "../modules/single_stage_go_workflow"
+  providers = {
+    google.internal_project = google.internal_project
+    google.public_project   = google.public_project
+  }
+  regions                       = var.regions
+  short_name                    = "vcs-sync"
+  full_name                     = "VCS Sync Workflow"
+  deletion_protection           = var.deletion_protection
+  project_id                    = var.spanner_datails.project_id
+  timeout_seconds               = 3600 # 1 hour
+  image_name                    = "vcs_sync_image"
+  spanner_details               = var.spanner_datails
+  notification_channel_ids      = var.notification_channel_ids
+  env_id                        = var.env_id
+  region_schedules              = var.vcs_sync_region_schedules
+  docker_repository_url         = var.docker_repository_details.url
+  go_module_path                = "workflows/steps/services/vcs_sync"
+  does_process_write_to_spanner = true
+  resource_job_limits = {
+    cpu    = "1"
+    memory = "512Mi"
+  }
+  env_vars = [
+    {
+      name  = "PROJECT_ID"
+      value = var.spanner_datails.project_id
+    },
+    {
+      name  = "SPANNER_DATABASE"
+      value = var.spanner_datails.database
+    },
+    {
+      name  = "SPANNER_INSTANCE"
+      value = var.spanner_datails.instance
+    },
+    {
+      name  = "VCS_SCAN_TASKS_TOPIC"
+      value = "vcs-scan-tasks-${var.env_id}"
+    }
+  ]
+  otel_config_secret_id            = var.otel_config_secret_id
+  otel_project_id                  = var.otel_project_id
+  otel_collector_image             = var.otel_collector_image
+  otel_collector_config_mount_path = var.otel_collector_config_mount_path
+  otel_collector_endpoint          = var.otel_collector_endpoint
+}

--- a/infra/ingestion/workflows.tf
+++ b/infra/ingestion/workflows.tf
@@ -331,20 +331,21 @@ module "vcs_sync_workflow" {
     google.internal_project = google.internal_project
     google.public_project   = google.public_project
   }
-  regions                       = var.regions
-  short_name                    = "vcs-sync"
-  full_name                     = "VCS Sync Workflow"
-  deletion_protection           = var.deletion_protection
-  project_id                    = var.spanner_datails.project_id
-  timeout_seconds               = 3600 # 1 hour
-  image_name                    = "vcs_sync_image"
-  spanner_details               = var.spanner_datails
-  notification_channel_ids      = var.notification_channel_ids
-  env_id                        = var.env_id
-  region_schedules              = var.vcs_sync_region_schedules
-  docker_repository_url         = var.docker_repository_details.url
-  go_module_path                = "workflows/steps/services/vcs_sync"
-  does_process_write_to_spanner = true
+  regions                          = var.regions
+  short_name                       = "vcs-sync"
+  full_name                        = "VCS Sync Workflow"
+  deletion_protection              = var.deletion_protection
+  project_id                       = var.spanner_datails.project_id
+  timeout_seconds                  = 3600 # 1 hour
+  image_name                       = "vcs_sync_image"
+  spanner_details                  = var.spanner_datails
+  notification_channel_ids         = var.notification_channel_ids
+  env_id                           = var.env_id
+  region_schedules                 = var.vcs_sync_region_schedules
+  docker_repository_url            = var.docker_repository_details.url
+  go_module_path                   = "workflows/steps/services/vcs_sync"
+  does_process_write_to_spanner    = true
+  github_app_private_key_secret_id = var.github_app_private_key_secret_id
   resource_job_limits = {
     cpu    = "1"
     memory = "512Mi"
@@ -364,7 +365,11 @@ module "vcs_sync_workflow" {
     },
     {
       name  = "VCS_SCAN_TASKS_TOPIC"
-      value = "vcs-scan-tasks-${var.env_id}"
+      value = var.vcs_scan_tasks_topic_name
+    },
+    {
+      name  = "GITHUB_APP_ID"
+      value = var.github_app_id
     }
   ]
   otel_config_secret_id            = var.otel_config_secret_id
@@ -372,4 +377,11 @@ module "vcs_sync_workflow" {
   otel_collector_image             = var.otel_collector_image
   otel_collector_config_mount_path = var.otel_collector_config_mount_path
   otel_collector_endpoint          = var.otel_collector_endpoint
+}
+
+resource "google_pubsub_topic_iam_member" "vcs_sync_scan_tasks_publisher" {
+  topic    = var.vcs_scan_tasks_topic_id
+  role     = "roles/pubsub.publisher"
+  member   = "serviceAccount:${module.vcs_sync_workflow.job_service_account_email}"
+  provider = google.internal_project
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -14,11 +14,32 @@
 
 locals {
   firebase_api_key = sensitive(data.google_secret_manager_secret_version_access.firebase_api_key.secret_data)
+  github_app_id = (
+    length(data.google_secret_manager_secret_version_access.github_app_id) > 0 ?
+    trimspace(data.google_secret_manager_secret_version_access.github_app_id[0].secret_data) :
+    var.github_app_id
+  )
+  github_app_private_key_secret_id = (
+    try(var.github_app_config_locations.private_key_pem, "") != "" ?
+    var.github_app_config_locations.private_key_pem :
+    var.github_app_private_key_secret_id
+  )
+  github_app_webhook_secret_id = (
+    try(var.github_app_config_locations.webhook_secret, "") != "" ?
+    var.github_app_config_locations.webhook_secret :
+    var.github_app_webhook_secret_id
+  )
 }
 
 data "google_secret_manager_secret_version_access" "firebase_api_key" {
   provider = google.internal_project
   secret   = var.firebase_api_key_location
+}
+
+data "google_secret_manager_secret_version_access" "github_app_id" {
+  count    = try(var.github_app_config_locations.app_id, "") != "" ? 1 : 0
+  provider = google.internal_project
+  secret   = var.github_app_config_locations.app_id
 }
 
 module "auth" {
@@ -103,6 +124,10 @@ module "ingestion" {
   otel_collector_image                  = local.otel_collector_image
   otel_collector_config_mount_path      = local.otel_collector_config_mount_path
   otel_collector_endpoint               = local.otel_collector_endpoint
+  vcs_scan_tasks_topic_id               = module.pubsub.vcs_scan_tasks_topic_id
+  vcs_scan_tasks_topic_name             = module.pubsub.vcs_scan_tasks_topic_name
+  github_app_id                         = local.github_app_id
+  github_app_private_key_secret_id      = local.github_app_private_key_secret_id
 }
 
 module "backend" {
@@ -134,8 +159,9 @@ module "backend" {
   pubsub_project_id                = var.projects.internal
   ingestion_topic_id               = module.pubsub.ingestion_topic_id
   vcs_scan_tasks_topic_id          = module.pubsub.vcs_scan_tasks_topic_id
-  github_app_id                    = var.github_app_id
-  github_app_private_key_secret_id = var.github_app_private_key_secret_id
+  github_app_id                    = local.github_app_id
+  github_app_private_key_secret_id = local.github_app_private_key_secret_id
+  github_app_webhook_secret_id     = local.github_app_webhook_secret_id
   otel_config_secret_id            = google_secret_manager_secret.otel_config.id
   otel_collector_image             = local.otel_collector_image
   otel_collector_config_mount_path = local.otel_collector_config_mount_path
@@ -221,8 +247,9 @@ module "workers" {
     vcs_scanner_count           = var.worker_manual_instance_counts.vcs_scanner
     github_issue_delivery_count = var.worker_manual_instance_counts.github_issue_delivery
   }
-  frontend_base_url = var.frontend_base_url
-  github_app_id     = var.github_app_id
+  frontend_base_url                = var.frontend_base_url
+  github_app_id                    = local.github_app_id
+  github_app_private_key_secret_id = local.github_app_private_key_secret_id
 
   chime_details = var.chime_details
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -133,6 +133,8 @@ module "backend" {
   }
   pubsub_project_id                = var.projects.internal
   ingestion_topic_id               = module.pubsub.ingestion_topic_id
+  github_app_id                    = var.github_app_id
+  github_app_private_key_secret_id = var.github_app_private_key_secret_id
   otel_config_secret_id            = google_secret_manager_secret.otel_config.id
   otel_collector_image             = local.otel_collector_image
   otel_collector_config_mount_path = local.otel_collector_config_mount_path

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -133,6 +133,7 @@ module "backend" {
   }
   pubsub_project_id                = var.projects.internal
   ingestion_topic_id               = module.pubsub.ingestion_topic_id
+  vcs_scan_tasks_topic_id          = module.pubsub.vcs_scan_tasks_topic_id
   github_app_id                    = var.github_app_id
   github_app_private_key_secret_id = var.github_app_private_key_secret_id
   otel_config_secret_id            = google_secret_manager_secret.otel_config.id

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -96,6 +96,7 @@ module "ingestion" {
   web_features_region_schedules         = var.web_features_region_schedules
   developer_signals_region_schedules    = var.developer_signals_region_schedules
   web_features_mapping_region_schedules = var.web_features_mapping_region_schedules
+  vcs_sync_region_schedules             = var.vcs_sync_region_schedules
   notification_channel_ids              = var.notification_channel_ids
   otel_config_secret_id                 = google_secret_manager_secret.otel_config.id
   otel_project_id                       = var.projects.internal
@@ -193,25 +194,32 @@ module "workers" {
   state_bucket_name         = module.storage.notification_state_bucket_name
 
   pubsub_details = {
-    ingestion_subscription_id    = module.pubsub.ingestion_subscription_id
-    ingestion_topic_id           = module.pubsub.ingestion_topic_id
-    batch_topic_id               = module.pubsub.batch_updates_topic_id
-    batch_subscription_id        = module.pubsub.batch_updates_subscription_id
-    notification_topic_id        = module.pubsub.notification_topic_id
-    notification_subscription_id = module.pubsub.notification_subscription_id
-    email_topic_id               = module.pubsub.email_delivery_topic_id
-    email_subscription_id        = module.pubsub.email_delivery_subscription_id
-    webhook_topic_id             = module.pubsub.webhook_delivery_topic_id
-    webhook_subscription_id      = module.pubsub.webhook_delivery_subscription_id
+    ingestion_subscription_id             = module.pubsub.ingestion_subscription_id
+    ingestion_topic_id                    = module.pubsub.ingestion_topic_id
+    batch_topic_id                        = module.pubsub.batch_updates_topic_id
+    batch_subscription_id                 = module.pubsub.batch_updates_subscription_id
+    notification_topic_id                 = module.pubsub.notification_topic_id
+    notification_subscription_id          = module.pubsub.notification_subscription_id
+    email_topic_id                        = module.pubsub.email_delivery_topic_id
+    email_subscription_id                 = module.pubsub.email_delivery_subscription_id
+    webhook_topic_id                      = module.pubsub.webhook_delivery_topic_id
+    webhook_subscription_id               = module.pubsub.webhook_delivery_subscription_id
+    vcs_scan_tasks_topic_id               = module.pubsub.vcs_scan_tasks_topic_id
+    vcs_scan_tasks_subscription_id        = module.pubsub.vcs_scan_tasks_subscription_id
+    github_issue_delivery_topic_id        = module.pubsub.github_issue_delivery_topic_id
+    github_issue_delivery_subscription_id = module.pubsub.github_issue_delivery_subscription_id
   }
 
   worker_instance_count = {
-    event_producer_count = var.worker_manual_instance_counts.event_producer
-    push_delivery_count  = var.worker_manual_instance_counts.push_delivery
-    email_count          = var.worker_manual_instance_counts.email
-    webhook_count        = var.worker_manual_instance_counts.webhook
+    event_producer_count        = var.worker_manual_instance_counts.event_producer
+    push_delivery_count         = var.worker_manual_instance_counts.push_delivery
+    email_count                 = var.worker_manual_instance_counts.email
+    webhook_count               = var.worker_manual_instance_counts.webhook
+    vcs_scanner_count           = var.worker_manual_instance_counts.vcs_scanner
+    github_issue_delivery_count = var.worker_manual_instance_counts.github_issue_delivery
   }
   frontend_base_url = var.frontend_base_url
+  github_app_id     = var.github_app_id
 
   chime_details = var.chime_details
 

--- a/infra/modules/job/main.tf
+++ b/infra/modules/job/main.tf
@@ -48,6 +48,20 @@ resource "google_cloud_run_v2_job" "job" {
           name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
           value = var.otel_collector_endpoint
         }
+        dynamic "env" {
+          for_each = var.github_app_private_key_secret_id != "" ? [1] : []
+          content {
+            name  = "GITHUB_APP_PRIVATE_KEY_PATH"
+            value = "/etc/secrets/github-app/private-key.pem"
+          }
+        }
+        dynamic "volume_mounts" {
+          for_each = var.github_app_private_key_secret_id != "" ? [1] : []
+          content {
+            name       = "github-app-key"
+            mount_path = "/etc/secrets/github-app"
+          }
+        }
       }
       containers {
         name  = "otel"
@@ -73,11 +87,28 @@ resource "google_cloud_run_v2_job" "job" {
           }
         }
       }
+      dynamic "volumes" {
+        for_each = var.github_app_private_key_secret_id != "" ? [1] : []
+        content {
+          name = "github-app-key"
+          secret {
+            secret = var.github_app_private_key_secret_id
+            items {
+              version = "latest"
+              path    = "private-key.pem"
+            }
+          }
+        }
+      }
       service_account = google_service_account.job_service_account.email
     }
   }
 
   deletion_protection = var.deletion_protection
+
+  depends_on = [
+    google_secret_manager_secret_iam_member.job_github_app_key_secret_access,
+  ]
 }
 
 
@@ -85,6 +116,14 @@ resource "google_service_account" "job_service_account" {
   provider     = google.internal_project
   account_id   = "${var.short_name}-job-${var.env_id}"
   display_name = "${var.full_name} Job service account for ${var.env_id}"
+}
+
+resource "google_secret_manager_secret_iam_member" "job_github_app_key_secret_access" {
+  count     = var.github_app_private_key_secret_id != "" ? 1 : 0
+  provider  = google.internal_project
+  secret_id = var.github_app_private_key_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.job_service_account.email}"
 }
 
 resource "google_project_iam_member" "spanner_user" {

--- a/infra/modules/job/variables.tf
+++ b/infra/modules/job/variables.tf
@@ -97,3 +97,9 @@ variable "otel_collector_endpoint" {
   type        = string
   description = "The endpoint for the application to export OTLP metrics/traces to the local collector"
 }
+
+variable "github_app_private_key_secret_id" {
+  type        = string
+  description = "The Secret Manager secret ID containing the GitHub App RSA private key"
+  default     = ""
+}

--- a/infra/modules/single_stage_go_workflow/main.tf
+++ b/infra/modules/single_stage_go_workflow/main.tf
@@ -43,6 +43,7 @@ module "job" {
   otel_collector_image             = var.otel_collector_image
   otel_collector_config_mount_path = var.otel_collector_config_mount_path
   otel_collector_endpoint          = var.otel_collector_endpoint
+  github_app_private_key_secret_id = var.github_app_private_key_secret_id
 }
 
 resource "google_service_account" "service_account" {

--- a/infra/modules/single_stage_go_workflow/outputs.tf
+++ b/infra/modules/single_stage_go_workflow/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-output "regional_job_map" {
-  value = tomap({
-    for j in google_cloud_run_v2_job.job : j.location => {
-      project_id = j.project
-      name       = j.name
-    }
-  })
-}
-
 output "job_service_account_email" {
-  value = google_service_account.job_service_account.email
+  value = module.job.job_service_account_email
 }

--- a/infra/modules/single_stage_go_workflow/variables.tf
+++ b/infra/modules/single_stage_go_workflow/variables.tf
@@ -131,3 +131,9 @@ variable "otel_collector_endpoint" {
   type        = string
   description = "The endpoint for the application to export OTLP metrics/traces to the local collector"
 }
+
+variable "github_app_private_key_secret_id" {
+  type        = string
+  description = "The Secret Manager secret ID containing the GitHub App RSA private key"
+  default     = ""
+}

--- a/infra/pubsub/alerts.tf
+++ b/infra/pubsub/alerts.tf
@@ -82,6 +82,6 @@ resource "google_monitoring_alert_policy" "queue_latency" {
   notification_channels = var.notification_channel_ids
 
   documentation {
-    content = "The oldest message in the queue is > 10 minutes old. Verify that the workers (EventProducer, PushDelivery, EmailWorker) are running and healthy."
+    content = "The oldest message in the queue is > 10 minutes old. Verify that the workers (EventProducer, PushDelivery, EmailWorker, VCS Scanner, GitHub Issue Delivery) are running and healthy."
   }
 }

--- a/infra/pubsub/alerts.tf
+++ b/infra/pubsub/alerts.tf
@@ -28,7 +28,7 @@ resource "google_monitoring_alert_policy" "dlq_non_empty" {
       filter = join(" AND ", [
         "resource.type=\"pubsub_subscription\"",
         "metric.type=\"pubsub.googleapis.com/subscription/num_undelivered_messages\"",
-        "resource.label.subscription_id = one_of(\"${google_pubsub_subscription.ingestion_dlq_sub.name}\", \"${google_pubsub_subscription.notification_dlq_sub.name}\", \"${google_pubsub_subscription.delivery_dlq_sub.name}\")"
+        "resource.label.subscription_id = one_of(\"${google_pubsub_subscription.ingestion_dlq_sub.name}\", \"${google_pubsub_subscription.notification_dlq_sub.name}\", \"${google_pubsub_subscription.delivery_dlq_sub.name}\", \"${google_pubsub_subscription.code_subscriptions_dlq_sub.name}\")"
       ])
 
       duration        = "60s"
@@ -65,7 +65,7 @@ resource "google_monitoring_alert_policy" "queue_latency" {
       filter = join(" AND ", [
         "resource.type=\"pubsub_subscription\"",
         "metric.type=\"pubsub.googleapis.com/subscription/oldest_unacked_message_age\"",
-        "resource.label.subscription_id = one_of(\"${google_pubsub_subscription.ingestion_jobs_sub.name}\", \"${google_pubsub_subscription.notification_events_sub.name}\", \"${google_pubsub_subscription.chime_delivery_sub.name}\")"
+        "resource.label.subscription_id = one_of(\"${google_pubsub_subscription.ingestion_jobs_sub.name}\", \"${google_pubsub_subscription.notification_events_sub.name}\", \"${google_pubsub_subscription.chime_delivery_sub.name}\", \"${google_pubsub_subscription.vcs_scan_tasks_sub.name}\", \"${google_pubsub_subscription.github_issue_delivery_sub.name}\")"
       ])
 
       duration        = "300s" # Condition must persist for 5 minutes

--- a/infra/pubsub/main.tf
+++ b/infra/pubsub/main.tf
@@ -144,3 +144,53 @@ resource "google_pubsub_subscription" "webhook_delivery_sub" {
     max_delivery_attempts = 5
   }
 }
+
+# ==========================================
+# 4. Code Subscriptions Pipeline
+# ==========================================
+
+# DLQ for Code Scanning & Issue Delivery
+resource "google_pubsub_topic" "code_subscriptions_dlq" {
+  name    = "code-subscriptions-dead-letter-${var.env_id}"
+  project = var.project_id
+}
+
+resource "google_pubsub_subscription" "code_subscriptions_dlq_sub" {
+  name    = "code-subscriptions-dead-letter-sub-${var.env_id}"
+  topic   = google_pubsub_topic.code_subscriptions_dlq.name
+  project = var.project_id
+}
+
+# Main Topic: VCS Scan Tasks (consumed by vcs_scanner worker)
+resource "google_pubsub_topic" "vcs_scan_tasks" {
+  name    = "vcs-scan-tasks-${var.env_id}"
+  project = var.project_id
+}
+
+resource "google_pubsub_subscription" "vcs_scan_tasks_sub" {
+  name    = "vcs-scan-tasks-sub-${var.env_id}"
+  topic   = google_pubsub_topic.vcs_scan_tasks.name
+  project = var.project_id
+
+  dead_letter_policy {
+    dead_letter_topic     = google_pubsub_topic.code_subscriptions_dlq.id
+    max_delivery_attempts = 5
+  }
+}
+
+# Main Topic: GitHub Issue Delivery (consumed by github_issue_delivery worker)
+resource "google_pubsub_topic" "github_issue_delivery" {
+  name    = "github-issue-delivery-${var.env_id}"
+  project = var.project_id
+}
+
+resource "google_pubsub_subscription" "github_issue_delivery_sub" {
+  name    = "github-issue-delivery-sub-${var.env_id}"
+  topic   = google_pubsub_topic.github_issue_delivery.name
+  project = var.project_id
+
+  dead_letter_policy {
+    dead_letter_topic     = google_pubsub_topic.code_subscriptions_dlq.id
+    max_delivery_attempts = 5
+  }
+}

--- a/infra/pubsub/outputs.tf
+++ b/infra/pubsub/outputs.tf
@@ -56,12 +56,20 @@ output "vcs_scan_tasks_topic_id" {
   value = google_pubsub_topic.vcs_scan_tasks.id
 }
 
+output "vcs_scan_tasks_topic_name" {
+  value = google_pubsub_topic.vcs_scan_tasks.name
+}
+
 output "vcs_scan_tasks_subscription_id" {
   value = google_pubsub_subscription.vcs_scan_tasks_sub.id
 }
 
 output "github_issue_delivery_topic_id" {
   value = google_pubsub_topic.github_issue_delivery.id
+}
+
+output "github_issue_delivery_topic_name" {
+  value = google_pubsub_topic.github_issue_delivery.name
 }
 
 output "github_issue_delivery_subscription_id" {

--- a/infra/pubsub/outputs.tf
+++ b/infra/pubsub/outputs.tf
@@ -51,3 +51,19 @@ output "webhook_delivery_topic_id" {
 output "webhook_delivery_subscription_id" {
   value = google_pubsub_subscription.webhook_delivery_sub.id
 }
+
+output "vcs_scan_tasks_topic_id" {
+  value = google_pubsub_topic.vcs_scan_tasks.id
+}
+
+output "vcs_scan_tasks_subscription_id" {
+  value = google_pubsub_subscription.vcs_scan_tasks_sub.id
+}
+
+output "github_issue_delivery_topic_id" {
+  value = google_pubsub_topic.github_issue_delivery.id
+}
+
+output "github_issue_delivery_subscription_id" {
+  value = google_pubsub_subscription.github_issue_delivery_sub.id
+}

--- a/infra/telemetry.tf
+++ b/infra/telemetry.tf
@@ -56,6 +56,8 @@ resource "google_secret_manager_secret_iam_member" "worker_otel_config_secret_ac
     "serviceAccount:event-producer-${var.env_id}@${var.projects.internal}.iam.gserviceaccount.com",
     "serviceAccount:push-delivery-${var.env_id}@${var.projects.internal}.iam.gserviceaccount.com",
     "serviceAccount:webhook-worker-${var.env_id}@${var.projects.internal}.iam.gserviceaccount.com",
+    "serviceAccount:vcs-scanner-${var.env_id}@${var.projects.internal}.iam.gserviceaccount.com",
+    "serviceAccount:gh-issue-deliv-${var.env_id}@${var.projects.internal}.iam.gserviceaccount.com",
     "serviceAccount:${var.email_service_account_email}", # Email worker uses pre-existing SA
   ])
   provider  = google.internal_project
@@ -74,6 +76,7 @@ resource "google_secret_manager_secret_iam_member" "job_otel_config_secret_acces
     "uma-consumer",
     "dev-signals",
     "feature-map",
+    "vcs-sync",
   ])
   provider  = google.internal_project
   secret_id = google_secret_manager_secret.otel_config.id

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -213,6 +213,22 @@ variable "github_app_private_key_secret_id" {
   default     = ""
 }
 
+variable "github_app_webhook_secret_id" {
+  description = "The Secret Manager secret ID containing the GitHub App webhook secret"
+  type        = string
+  default     = ""
+}
+
+variable "github_app_config_locations" {
+  description = "Location of the GitHub App configuration in Secret Manager (app_id, private_key_pem, webhook_secret)"
+  type = object({
+    app_id          = optional(string, "")
+    private_key_pem = optional(string, "")
+    webhook_secret  = optional(string, "")
+  })
+  default = {}
+}
+
 variable "backend_min_instance_count" {
   type        = number
   description = "Minimum instance count for backend instances"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -207,6 +207,12 @@ variable "github_app_id" {
   default     = "webstatus-dev"
 }
 
+variable "github_app_private_key_secret_id" {
+  description = "The Secret Manager secret ID containing the GitHub App RSA private key"
+  type        = string
+  default     = ""
+}
+
 variable "backend_min_instance_count" {
   type        = number
   description = "Minimum instance count for backend instances"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -182,6 +182,11 @@ variable "web_features_mapping_region_schedules" {
   description = "Cloud Scheduler cron schedules for Web Features mapping ingestion, keyed by region"
 }
 
+variable "vcs_sync_region_schedules" {
+  type        = map(string)
+  description = "Cloud Scheduler cron schedules for VCS sync ingestion, keyed by region"
+}
+
 
 variable "firebase_api_key_location" {
   description = "Location of the firebase api key in secret manager"
@@ -194,6 +199,12 @@ variable "auth_github_config_locations" {
     client_id     = string
     client_secret = string
   })
+}
+
+variable "github_app_id" {
+  description = "GitHub App ID"
+  type        = string
+  default     = "webstatus-dev"
 }
 
 variable "backend_min_instance_count" {
@@ -256,9 +267,11 @@ variable "chime_details" {
 variable "worker_manual_instance_counts" {
   description = "Manual instance counts for background workers."
   type = object({
-    event_producer = number
-    push_delivery  = number
-    email          = number
-    webhook        = number
+    event_producer        = number
+    push_delivery         = number
+    email                 = number
+    webhook               = number
+    vcs_scanner           = number
+    github_issue_delivery = number
   })
 }

--- a/infra/workers/github_issue_delivery/main.tf
+++ b/infra/workers/github_issue_delivery/main.tf
@@ -58,7 +58,23 @@ resource "google_cloud_run_v2_worker_pool" "worker" {
         value = var.github_app_id
       }
       env {
-        name  = "OTEL_COLLECTOR_ENDPOINT"
+        name  = "GITHUB_APP_PRIVATE_KEY_PATH"
+        value = var.github_app_private_key_secret_id != "" ? "/etc/secrets/github-app/private-key.pem" : ""
+      }
+      env {
+        name  = "FRONTEND_BASE_URL"
+        value = var.frontend_base_url
+      }
+      env {
+        name  = "OTEL_SERVICE_NAME"
+        value = "github-issue-delivery"
+      }
+      env {
+        name  = "OTEL_GCP_PROJECT_ID"
+        value = var.otel_project_id
+      }
+      env {
+        name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
         value = var.otel_collector_endpoint
       }
       resources {
@@ -67,6 +83,99 @@ resource "google_cloud_run_v2_worker_pool" "worker" {
           memory = "512Mi"
         }
       }
+      dynamic "volume_mounts" {
+        for_each = var.github_app_private_key_secret_id != "" ? [1] : []
+        content {
+          name       = "github-app-key"
+          mount_path = "/etc/secrets/github-app"
+        }
+      }
+    }
+    containers {
+      name  = "otel"
+      image = var.otel_collector_image
+      args  = ["--config=${var.otel_collector_config_mount_path}/config.yaml"]
+      env {
+        name  = "OTEL_COLLECTOR_REGION"
+        value = each.key
+      }
+      volume_mounts {
+        name       = "otel-config"
+        mount_path = var.otel_collector_config_mount_path
+      }
+    }
+    volumes {
+      name = "otel-config"
+      secret {
+        secret = var.otel_config_secret_id
+        items {
+          version = "latest"
+          path    = "config.yaml"
+        }
+      }
+    }
+    dynamic "volumes" {
+      for_each = var.github_app_private_key_secret_id != "" ? [1] : []
+      content {
+        name = "github-app-key"
+        secret {
+          secret = var.github_app_private_key_secret_id
+          items {
+            version = "latest"
+            path    = "private-key.pem"
+          }
+        }
+      }
     }
   }
+
+  depends_on = [
+    google_spanner_database_iam_member.db_user,
+    google_pubsub_subscription_iam_member.github_issue_delivery_sub,
+    google_secret_manager_secret_iam_member.worker_github_app_key_secret_access,
+  ]
+}
+
+resource "google_secret_manager_secret_iam_member" "worker_github_app_key_secret_access" {
+  count     = var.github_app_private_key_secret_id != "" ? 1 : 0
+  provider  = google.internal_project
+  secret_id = var.github_app_private_key_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_spanner_database_iam_member" "db_user" {
+  instance = var.spanner_instance_id
+  database = var.spanner_database_id
+  role     = "roles/spanner.databaseUser"
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider = google.internal_project
+}
+
+resource "google_pubsub_subscription_iam_member" "github_issue_delivery_sub" {
+  subscription = var.github_issue_delivery_subscription_id
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider     = google.internal_project
+}
+
+resource "google_project_iam_member" "gcp_metric_permission" {
+  role     = "roles/monitoring.metricWriter"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_project_iam_member" "gcp_log_permission" {
+  role     = "roles/logging.logWriter"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_project_iam_member" "gcp_trace_permission" {
+  role     = "roles/cloudtrace.agent"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
 }

--- a/infra/workers/github_issue_delivery/main.tf
+++ b/infra/workers/github_issue_delivery/main.tf
@@ -1,0 +1,72 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_service_account" "worker_sa" {
+  account_id   = "gh-issue-deliv-${var.env_id}"
+  provider     = google.internal_project
+  display_name = "GitHub Issue Delivery Worker Service Account (${var.env_id})"
+  project      = var.project_id
+}
+
+resource "google_cloud_run_v2_worker_pool" "worker" {
+  for_each            = var.regions
+  name                = "gh-issue-deliv-${var.env_id}-${each.key}"
+  location            = each.key
+  project             = var.project_id
+  provider            = google.internal_project
+  launch_stage        = "BETA"
+  deletion_protection = var.deletion_protection
+
+  scaling {
+    manual_instance_count = var.manual_instance_count
+  }
+  template {
+    service_account = google_service_account.worker_sa.email
+
+    containers {
+      image = var.image_url
+
+      env {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "SPANNER_INSTANCE"
+        value = var.spanner_instance_id
+      }
+      env {
+        name  = "SPANNER_DATABASE"
+        value = var.spanner_database_id
+      }
+      env {
+        name  = "GITHUB_ISSUE_DELIVERY_SUBSCRIPTION_ID"
+        value = var.github_issue_delivery_subscription_id
+      }
+      env {
+        name  = "GITHUB_APP_ID"
+        value = var.github_app_id
+      }
+      env {
+        name  = "OTEL_COLLECTOR_ENDPOINT"
+        value = var.otel_collector_endpoint
+      }
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+    }
+  }
+}

--- a/infra/workers/github_issue_delivery/providers.tf
+++ b/infra/workers/github_issue_delivery/providers.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-output "regional_job_map" {
-  value = tomap({
-    for j in google_cloud_run_v2_job.job : j.location => {
-      project_id = j.project
-      name       = j.name
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      configuration_aliases = [
+        google.internal_project,
+      ]
     }
-  })
-}
-
-output "job_service_account_email" {
-  value = google_service_account.job_service_account.email
+  }
 }

--- a/infra/workers/github_issue_delivery/variables.tf
+++ b/infra/workers/github_issue_delivery/variables.tf
@@ -22,9 +22,15 @@ variable "github_app_id" {
   type    = string
   default = ""
 }
+variable "github_app_private_key_secret_id" {
+  type        = string
+  description = "The Secret Manager secret ID containing the GitHub App RSA private key"
+  default     = ""
+}
 variable "manual_instance_count" { type = number }
 variable "regions" { type = set(string) }
 variable "deletion_protection" { type = bool }
+variable "frontend_base_url" { type = string }
 
 variable "otel_config_secret_id" {
   type        = string

--- a/infra/workers/github_issue_delivery/variables.tf
+++ b/infra/workers/github_issue_delivery/variables.tf
@@ -1,0 +1,52 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" { type = string }
+variable "env_id" { type = string }
+variable "image_url" { type = string }
+variable "spanner_instance_id" { type = string }
+variable "spanner_database_id" { type = string }
+variable "github_issue_delivery_subscription_id" { type = string }
+variable "github_app_id" {
+  type    = string
+  default = ""
+}
+variable "manual_instance_count" { type = number }
+variable "regions" { type = set(string) }
+variable "deletion_protection" { type = bool }
+
+variable "otel_config_secret_id" {
+  type        = string
+  description = "The Secret Manager secret ID containing the OTel collector configuration"
+}
+
+variable "otel_project_id" {
+  type        = string
+  description = "The GCP project ID where telemetry traces/metrics will be exported"
+}
+
+variable "otel_collector_image" {
+  type        = string
+  description = "The container image to use for the OTel collector sidecar"
+}
+
+variable "otel_collector_config_mount_path" {
+  type        = string
+  description = "The volume mount path for the OTel collector configuration"
+}
+
+variable "otel_collector_endpoint" {
+  type        = string
+  description = "The endpoint for the application to export OTLP metrics/traces to the local collector"
+}

--- a/infra/workers/main.tf
+++ b/infra/workers/main.tf
@@ -178,3 +178,81 @@ module "webhook" {
   otel_collector_config_mount_path = var.otel_collector_config_mount_path
   otel_collector_endpoint          = var.otel_collector_endpoint
 }
+
+# --- 5. VCS Scanner Worker ---
+
+# Build Image
+module "vcs_scanner_image" {
+  source                = "../modules/go_image"
+  image_name            = "vcs_scanner"
+  go_module_path        = "workers/vcs_scanner"
+  binary_type           = "job"
+  docker_repository_url = var.docker_repository_details.url
+}
+
+# Deploy Service (Multi-Region)
+module "vcs_scanner" {
+  source = "./vcs_scanner"
+  providers = {
+    google.internal_project = google.internal_project
+  }
+
+  project_id = var.internal_project_id
+  env_id     = var.env_id
+  image_url  = module.vcs_scanner_image.remote_image
+
+  spanner_instance_id = var.spanner_details.instance
+  spanner_database_id = var.spanner_details.database
+
+  vcs_scan_tasks_subscription_id = var.pubsub_details.vcs_scan_tasks_subscription_id
+  github_app_id                  = var.github_app_id
+
+  manual_instance_count = var.worker_instance_count.vcs_scanner_count
+  regions               = var.regions
+
+  deletion_protection              = var.deletion_protection
+  otel_config_secret_id            = var.otel_config_secret_id
+  otel_project_id                  = var.otel_project_id
+  otel_collector_image             = var.otel_collector_image
+  otel_collector_config_mount_path = var.otel_collector_config_mount_path
+  otel_collector_endpoint          = var.otel_collector_endpoint
+}
+
+# --- 6. GitHub Issue Delivery Worker ---
+
+# Build Image
+module "github_issue_delivery_image" {
+  source                = "../modules/go_image"
+  image_name            = "github_issue_delivery"
+  go_module_path        = "workers/github_issue_delivery"
+  binary_type           = "job"
+  docker_repository_url = var.docker_repository_details.url
+}
+
+# Deploy Service (Multi-Region)
+module "github_issue_delivery" {
+  source = "./github_issue_delivery"
+  providers = {
+    google.internal_project = google.internal_project
+  }
+
+  project_id = var.internal_project_id
+  env_id     = var.env_id
+  image_url  = module.github_issue_delivery_image.remote_image
+
+  spanner_instance_id = var.spanner_details.instance
+  spanner_database_id = var.spanner_details.database
+
+  github_issue_delivery_subscription_id = var.pubsub_details.github_issue_delivery_subscription_id
+  github_app_id                         = var.github_app_id
+
+  manual_instance_count = var.worker_instance_count.github_issue_delivery_count
+  regions               = var.regions
+
+  deletion_protection              = var.deletion_protection
+  otel_config_secret_id            = var.otel_config_secret_id
+  otel_project_id                  = var.otel_project_id
+  otel_collector_image             = var.otel_collector_image
+  otel_collector_config_mount_path = var.otel_collector_config_mount_path
+  otel_collector_endpoint          = var.otel_collector_endpoint
+}

--- a/infra/workers/main.tf
+++ b/infra/workers/main.tf
@@ -79,9 +79,10 @@ module "push_delivery" {
   spanner_instance_id = var.spanner_details.instance
   spanner_database_id = var.spanner_details.database
 
-  notification_subscription_id = var.pubsub_details.notification_subscription_id
-  email_topic_id               = var.pubsub_details.email_topic_id
-  webhook_topic_id             = var.pubsub_details.webhook_topic_id
+  notification_subscription_id   = var.pubsub_details.notification_subscription_id
+  email_topic_id                 = var.pubsub_details.email_topic_id
+  webhook_topic_id               = var.pubsub_details.webhook_topic_id
+  github_issue_delivery_topic_id = var.pubsub_details.github_issue_delivery_topic_id
 
   manual_instance_count = var.worker_instance_count.push_delivery_count
   regions               = var.regions

--- a/infra/workers/main.tf
+++ b/infra/workers/main.tf
@@ -204,8 +204,9 @@ module "vcs_scanner" {
   spanner_instance_id = var.spanner_details.instance
   spanner_database_id = var.spanner_details.database
 
-  vcs_scan_tasks_subscription_id = var.pubsub_details.vcs_scan_tasks_subscription_id
-  github_app_id                  = var.github_app_id
+  vcs_scan_tasks_subscription_id   = var.pubsub_details.vcs_scan_tasks_subscription_id
+  github_app_id                    = var.github_app_id
+  github_app_private_key_secret_id = var.github_app_private_key_secret_id
 
   manual_instance_count = var.worker_instance_count.vcs_scanner_count
   regions               = var.regions
@@ -245,11 +246,13 @@ module "github_issue_delivery" {
 
   github_issue_delivery_subscription_id = var.pubsub_details.github_issue_delivery_subscription_id
   github_app_id                         = var.github_app_id
+  github_app_private_key_secret_id      = var.github_app_private_key_secret_id
 
   manual_instance_count = var.worker_instance_count.github_issue_delivery_count
   regions               = var.regions
 
   deletion_protection              = var.deletion_protection
+  frontend_base_url                = var.frontend_base_url
   otel_config_secret_id            = var.otel_config_secret_id
   otel_project_id                  = var.otel_project_id
   otel_collector_image             = var.otel_collector_image

--- a/infra/workers/push_delivery/iam.tf
+++ b/infra/workers/push_delivery/iam.tf
@@ -34,6 +34,20 @@ resource "google_pubsub_topic_iam_member" "pub" {
   provider = google.internal_project
 }
 
+resource "google_pubsub_topic_iam_member" "webhook_pub" {
+  topic    = var.webhook_topic_id
+  role     = "roles/pubsub.publisher"
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider = google.internal_project
+}
+
+resource "google_pubsub_topic_iam_member" "github_issue_delivery_pub" {
+  topic    = var.github_issue_delivery_topic_id
+  role     = "roles/pubsub.publisher"
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider = google.internal_project
+}
+
 resource "google_project_iam_member" "gcp_metric_permission" {
   role     = "roles/monitoring.metricWriter"
   provider = google.internal_project

--- a/infra/workers/push_delivery/main.tf
+++ b/infra/workers/push_delivery/main.tf
@@ -62,6 +62,10 @@ resource "google_cloud_run_v2_worker_pool" "worker" {
         value = var.webhook_topic_id
       }
       env {
+        name  = "GITHUB_ISSUE_DELIVERY_TOPIC_ID"
+        value = var.github_issue_delivery_topic_id
+      }
+      env {
         name  = "OTEL_SERVICE_NAME"
         value = "push-delivery"
       }

--- a/infra/workers/push_delivery/variables.tf
+++ b/infra/workers/push_delivery/variables.tf
@@ -20,6 +20,10 @@ variable "spanner_database_id" { type = string }
 variable "notification_subscription_id" { type = string }
 variable "email_topic_id" { type = string }
 variable "webhook_topic_id" { type = string }
+variable "github_issue_delivery_topic_id" {
+  type        = string
+  description = "Pub/Sub topic ID for GitHub issue delivery events"
+}
 variable "manual_instance_count" { type = number }
 variable "regions" { type = set(string) }
 variable "deletion_protection" { type = bool }

--- a/infra/workers/variables.tf
+++ b/infra/workers/variables.tf
@@ -48,27 +48,38 @@ variable "state_bucket_name" {
 
 variable "pubsub_details" {
   type = object({
-    ingestion_subscription_id    = string
-    ingestion_topic_id           = string
-    batch_topic_id               = string
-    batch_subscription_id        = string
-    notification_topic_id        = string
-    notification_subscription_id = string
-    email_topic_id               = string
-    email_subscription_id        = string
-    webhook_topic_id             = string
-    webhook_subscription_id      = string
+    ingestion_subscription_id             = string
+    ingestion_topic_id                    = string
+    batch_topic_id                        = string
+    batch_subscription_id                 = string
+    notification_topic_id                 = string
+    notification_subscription_id          = string
+    email_topic_id                        = string
+    email_subscription_id                 = string
+    webhook_topic_id                      = string
+    webhook_subscription_id               = string
+    vcs_scan_tasks_topic_id               = string
+    vcs_scan_tasks_subscription_id        = string
+    github_issue_delivery_topic_id        = string
+    github_issue_delivery_subscription_id = string
   })
 }
 
 variable "worker_instance_count" {
   description = "Number of instances for manual scaling"
   type = object({
-    event_producer_count = number
-    push_delivery_count  = number
-    email_count          = number
-    webhook_count        = number
+    event_producer_count        = number
+    push_delivery_count         = number
+    email_count                 = number
+    webhook_count               = number
+    vcs_scanner_count           = number
+    github_issue_delivery_count = number
   })
+}
+
+variable "github_app_id" {
+  description = "GitHub App ID"
+  type        = string
 }
 
 variable "email_service_account_email" {

--- a/infra/workers/variables.tf
+++ b/infra/workers/variables.tf
@@ -128,3 +128,9 @@ variable "otel_collector_endpoint" {
   type        = string
   description = "The endpoint for the application to export OTLP metrics/traces to the local collector"
 }
+
+variable "github_app_private_key_secret_id" {
+  type        = string
+  description = "The Secret Manager secret ID containing the GitHub App RSA private key"
+  default     = ""
+}

--- a/infra/workers/vcs_scanner/main.tf
+++ b/infra/workers/vcs_scanner/main.tf
@@ -1,0 +1,72 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_service_account" "worker_sa" {
+  account_id   = "vcs-scanner-${var.env_id}"
+  provider     = google.internal_project
+  display_name = "VCS Scanner Worker Service Account (${var.env_id})"
+  project      = var.project_id
+}
+
+resource "google_cloud_run_v2_worker_pool" "worker" {
+  for_each            = var.regions
+  name                = "vcs-scanner-${var.env_id}-${each.key}"
+  location            = each.key
+  project             = var.project_id
+  provider            = google.internal_project
+  launch_stage        = "BETA"
+  deletion_protection = var.deletion_protection
+
+  scaling {
+    manual_instance_count = var.manual_instance_count
+  }
+  template {
+    service_account = google_service_account.worker_sa.email
+
+    containers {
+      image = var.image_url
+
+      env {
+        name  = "PROJECT_ID"
+        value = var.project_id
+      }
+      env {
+        name  = "SPANNER_INSTANCE"
+        value = var.spanner_instance_id
+      }
+      env {
+        name  = "SPANNER_DATABASE"
+        value = var.spanner_database_id
+      }
+      env {
+        name  = "VCS_SCAN_TASKS_SUBSCRIPTION_ID"
+        value = var.vcs_scan_tasks_subscription_id
+      }
+      env {
+        name  = "GITHUB_APP_ID"
+        value = var.github_app_id
+      }
+      env {
+        name  = "OTEL_COLLECTOR_ENDPOINT"
+        value = var.otel_collector_endpoint
+      }
+      resources {
+        limits = {
+          cpu    = "2"
+          memory = "1Gi"
+        }
+      }
+    }
+  }
+}

--- a/infra/workers/vcs_scanner/main.tf
+++ b/infra/workers/vcs_scanner/main.tf
@@ -58,7 +58,19 @@ resource "google_cloud_run_v2_worker_pool" "worker" {
         value = var.github_app_id
       }
       env {
-        name  = "OTEL_COLLECTOR_ENDPOINT"
+        name  = "GITHUB_APP_PRIVATE_KEY_PATH"
+        value = var.github_app_private_key_secret_id != "" ? "/etc/secrets/github-app/private-key.pem" : ""
+      }
+      env {
+        name  = "OTEL_SERVICE_NAME"
+        value = "vcs-scanner"
+      }
+      env {
+        name  = "OTEL_GCP_PROJECT_ID"
+        value = var.otel_project_id
+      }
+      env {
+        name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
         value = var.otel_collector_endpoint
       }
       resources {
@@ -67,6 +79,99 @@ resource "google_cloud_run_v2_worker_pool" "worker" {
           memory = "1Gi"
         }
       }
+      dynamic "volume_mounts" {
+        for_each = var.github_app_private_key_secret_id != "" ? [1] : []
+        content {
+          name       = "github-app-key"
+          mount_path = "/etc/secrets/github-app"
+        }
+      }
+    }
+    containers {
+      name  = "otel"
+      image = var.otel_collector_image
+      args  = ["--config=${var.otel_collector_config_mount_path}/config.yaml"]
+      env {
+        name  = "OTEL_COLLECTOR_REGION"
+        value = each.key
+      }
+      volume_mounts {
+        name       = "otel-config"
+        mount_path = var.otel_collector_config_mount_path
+      }
+    }
+    volumes {
+      name = "otel-config"
+      secret {
+        secret = var.otel_config_secret_id
+        items {
+          version = "latest"
+          path    = "config.yaml"
+        }
+      }
+    }
+    dynamic "volumes" {
+      for_each = var.github_app_private_key_secret_id != "" ? [1] : []
+      content {
+        name = "github-app-key"
+        secret {
+          secret = var.github_app_private_key_secret_id
+          items {
+            version = "latest"
+            path    = "private-key.pem"
+          }
+        }
+      }
     }
   }
+
+  depends_on = [
+    google_spanner_database_iam_member.db_user,
+    google_pubsub_subscription_iam_member.vcs_scan_tasks_sub,
+    google_secret_manager_secret_iam_member.worker_github_app_key_secret_access,
+  ]
+}
+
+resource "google_secret_manager_secret_iam_member" "worker_github_app_key_secret_access" {
+  count     = var.github_app_private_key_secret_id != "" ? 1 : 0
+  provider  = google.internal_project
+  secret_id = var.github_app_private_key_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_spanner_database_iam_member" "db_user" {
+  instance = var.spanner_instance_id
+  database = var.spanner_database_id
+  role     = "roles/spanner.databaseUser"
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider = google.internal_project
+}
+
+resource "google_pubsub_subscription_iam_member" "vcs_scan_tasks_sub" {
+  subscription = var.vcs_scan_tasks_subscription_id
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${google_service_account.worker_sa.email}"
+  provider     = google.internal_project
+}
+
+resource "google_project_iam_member" "gcp_metric_permission" {
+  role     = "roles/monitoring.metricWriter"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_project_iam_member" "gcp_log_permission" {
+  role     = "roles/logging.logWriter"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_project_iam_member" "gcp_trace_permission" {
+  role     = "roles/cloudtrace.agent"
+  provider = google.internal_project
+  project  = var.project_id
+  member   = "serviceAccount:${google_service_account.worker_sa.email}"
 }

--- a/infra/workers/vcs_scanner/providers.tf
+++ b/infra/workers/vcs_scanner/providers.tf
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-output "regional_job_map" {
-  value = tomap({
-    for j in google_cloud_run_v2_job.job : j.location => {
-      project_id = j.project
-      name       = j.name
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      configuration_aliases = [
+        google.internal_project,
+      ]
     }
-  })
-}
-
-output "job_service_account_email" {
-  value = google_service_account.job_service_account.email
+  }
 }

--- a/infra/workers/vcs_scanner/variables.tf
+++ b/infra/workers/vcs_scanner/variables.tf
@@ -22,6 +22,11 @@ variable "github_app_id" {
   type    = string
   default = ""
 }
+variable "github_app_private_key_secret_id" {
+  type        = string
+  description = "The Secret Manager secret ID containing the GitHub App RSA private key"
+  default     = ""
+}
 variable "manual_instance_count" { type = number }
 variable "regions" { type = set(string) }
 variable "deletion_protection" { type = bool }

--- a/infra/workers/vcs_scanner/variables.tf
+++ b/infra/workers/vcs_scanner/variables.tf
@@ -1,0 +1,52 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" { type = string }
+variable "env_id" { type = string }
+variable "image_url" { type = string }
+variable "spanner_instance_id" { type = string }
+variable "spanner_database_id" { type = string }
+variable "vcs_scan_tasks_subscription_id" { type = string }
+variable "github_app_id" {
+  type    = string
+  default = ""
+}
+variable "manual_instance_count" { type = number }
+variable "regions" { type = set(string) }
+variable "deletion_protection" { type = bool }
+
+variable "otel_config_secret_id" {
+  type        = string
+  description = "The Secret Manager secret ID containing the OTel collector configuration"
+}
+
+variable "otel_project_id" {
+  type        = string
+  description = "The GCP project ID where telemetry traces/metrics will be exported"
+}
+
+variable "otel_collector_image" {
+  type        = string
+  description = "The container image to use for the OTel collector sidecar"
+}
+
+variable "otel_collector_config_mount_path" {
+  type        = string
+  description = "The volume mount path for the OTel collector configuration"
+}
+
+variable "otel_collector_endpoint" {
+  type        = string
+  description = "The endpoint for the application to export OTLP metrics/traces to the local collector"
+}


### PR DESCRIPTION
Refs #2712, #2716

### What
Adds Terraform infrastructure definitions and Cloud Run worker / ingestion modules for Code Subscriptions:
1. `vcs_scanner` worker Cloud Run service and Pub/Sub subscription.
2. `github_issue_delivery` worker Cloud Run service and Pub/Sub subscription.
3. `vcs_sync` Cloud Run Job and Cloud Scheduler cron trigger.
4. Pub/Sub Dead Letter Queues (DLQ) and retry policies.

### Why
Deploys the asynchronous worker pools, ingestion schedulers, and Pub/Sub messaging infrastructure required to process AST code scans, deliver GitHub issues, and run periodic repository reconciliation in GCP environments.

### How
- **Pub/Sub Topics & Subscriptions (`infra/pubsub/`)**:
  - Configures `vcs_scan_tasks` and `github_issue_delivery` topics.
  - Configures dedicated Dead Letter Queues (DLQ) with 5 retry maximums.
- **Worker Services (`infra/workers/`)**:
  - Modular `vcs_scanner` and `github_issue_delivery` Cloud Run service configurations with autoscaling, secret mounting, and IAM bindings.
- **Ingestion Job (`infra/ingestion/`)**:
  - Configures `vcs_sync` Cloud Run Job and Cloud Scheduler trigger for automated repository reconciliation.

### Corrected Assumptions / Learnings
- **Isolated Worker Modules**: Each worker is encapsulated in its own sub-module (`infra/workers/vcs_scanner`, `infra/workers/github_issue_delivery`) mirroring the existing worker structure in `webstatus.dev`.

TAG=agy