### PR TITLE
[API] Implement GET /v1/vcs/{provider}/repositories/{repository_id}/code-subscriptions HTTP Handler

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	"github.com/GoogleChrome/webstatus.dev/lib/gh"
 	"github.com/GoogleChrome/webstatus.dev/lib/httpmiddlewares"
+	"github.com/GoogleChrome/webstatus.dev/lib/localcache"
 	"github.com/GoogleChrome/webstatus.dev/lib/opentelemetry"
 	"github.com/GoogleChrome/webstatus.dev/lib/valkeycache"
 	"github.com/go-chi/cors"
@@ -260,7 +261,9 @@ func initTokenProvider(ctx context.Context) *gh.TokenProvider {
 		os.Exit(1)
 	}
 
-	cacher := gh.NewLocalTokenCacher()
+	// TODO: Migrate to valkeycache.ValkeyDataCache for cross-instance token caching
+	// once Valkey connectivity is configured.
+	cacher := localcache.NewLocalDataCache[string, []byte](nil)
 	tp, tpErr := gh.NewTokenProvider(appID, pkData, cacher)
 	if tpErr != nil {
 		slog.ErrorContext(ctx, "unable to create token provider", "error", tpErr)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"slices"
 	"time"
 
@@ -218,7 +219,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	vcsPermissionChecker := gh.NewGitHubPermissionCheckerWithBaseURL(gitHubAPIBaseURL)
+	tokenProvider := initTokenProvider(ctx)
+	vcsPermissionChecker := gh.NewGitHubPermissionCheckerWithTokenProvider(tokenProvider, gitHubAPIBaseURL)
 
 	srv := httpserver.NewHTTPServer(
 		"8080",
@@ -243,4 +245,26 @@ func main() {
 		slog.ErrorContext(ctx, "unable to start server", "error", err.Error())
 		os.Exit(1)
 	}
+}
+
+func initTokenProvider(ctx context.Context) *gh.TokenProvider {
+	appID := os.Getenv("GITHUB_APP_ID")
+	pkPath := os.Getenv("GITHUB_APP_PRIVATE_KEY_PATH")
+	if appID == "" || pkPath == "" {
+		return nil
+	}
+
+	pkData, readErr := os.ReadFile(filepath.Clean(pkPath)) // #nosec G304 G703 -- Admin configured private key path
+	if readErr != nil {
+		slog.ErrorContext(ctx, "unable to read private key file", "path", pkPath, "error", readErr)
+		os.Exit(1)
+	}
+
+	tp, tpErr := gh.NewTokenProvider(appID, pkData, nil)
+	if tpErr != nil {
+		slog.ErrorContext(ctx, "unable to create token provider", "error", tpErr)
+		os.Exit(1)
+	}
+
+	return tp
 }

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -260,7 +260,8 @@ func initTokenProvider(ctx context.Context) *gh.TokenProvider {
 		os.Exit(1)
 	}
 
-	tp, tpErr := gh.NewTokenProvider(appID, pkData, nil)
+	cacher := gh.NewLocalTokenCacher()
+	tp, tpErr := gh.NewTokenProvider(appID, pkData, cacher)
 	if tpErr != nil {
 		slog.ErrorContext(ctx, "unable to create token provider", "error", tpErr)
 		os.Exit(1)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -188,15 +188,16 @@ func main() {
 	}
 
 	var ghOptions []gh.ClientOption
+	var gitHubAPIBaseURL *url.URL
 	if gitHubAPIBaseRawURL := os.Getenv("GITHUB_API_BASE_URL"); gitHubAPIBaseRawURL != "" {
-		gitHubAPIBaseURL, err := url.Parse(gitHubAPIBaseRawURL)
+		var err error
+		gitHubAPIBaseURL, err = url.Parse(gitHubAPIBaseRawURL)
 		if err != nil {
 			slog.ErrorContext(ctx, "unable to parse GITHUB_API_BASE_URL", "error", err)
 			os.Exit(1)
 		}
 		slog.InfoContext(ctx, "using GITHUB_API_BASE_URL", "url", gitHubAPIBaseURL.String())
 		ghOptions = append(ghOptions, gh.WithBaseURL(gitHubAPIBaseURL))
-
 	}
 
 	pubsubProjectID := os.Getenv("PUBSUB_PROJECT_ID")
@@ -217,6 +218,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	vcsPermissionChecker := gh.NewGitHubPermissionCheckerWithBaseURL(gitHubAPIBaseURL)
+
 	srv := httpserver.NewHTTPServer(
 		"8080",
 		baseURL,
@@ -230,6 +233,7 @@ func main() {
 				GitHubUserClient: gh.NewUserGitHubClient(token, ghOptions...),
 			}
 		},
+		vcsPermissionChecker,
 		preRequestMiddlewares,
 		authMiddleware,
 	)

--- a/backend/manifests/pod.yaml
+++ b/backend/manifests/pod.yaml
@@ -81,14 +81,13 @@ spec:
           memory: 64Mi
   initContainers:
     - name: generate-dev-secrets
-      image: alpine:3.24
+      image: alpine/openssl:3.5.7
       command:
         - sh
         - -c
         - |
           mkdir -p /etc/secrets/github-app
           if [ ! -f /etc/secrets/github-app/private-key.pem ]; then
-            apk add --no-cache openssl >/dev/null 2>&1
             openssl genpkey -algorithm RSA -out /etc/secrets/github-app/private-key.pem -pkeyopt rsa_keygen_bits:2048
           fi
       volumeMounts:

--- a/backend/manifests/pod.yaml
+++ b/backend/manifests/pod.yaml
@@ -65,6 +65,13 @@ spec:
           value: pubsub:8060
         - name: INGESTION_TOPIC_ID
           value: 'ingestion-jobs-topic-id'
+        - name: GITHUB_APP_ID
+          value: '123456'
+        - name: GITHUB_APP_PRIVATE_KEY_PATH
+          value: '/etc/secrets/github-app/private-key.pem'
+      volumeMounts:
+        - name: github-app-secret-volume
+          mountPath: /etc/secrets/github-app
       resources:
         limits:
           cpu: 250m
@@ -72,3 +79,21 @@ spec:
         requests:
           cpu: 100m
           memory: 64Mi
+  initContainers:
+    - name: generate-dev-secrets
+      image: alpine:3.24
+      command:
+        - sh
+        - -c
+        - |
+          mkdir -p /etc/secrets/github-app
+          if [ ! -f /etc/secrets/github-app/private-key.pem ]; then
+            apk add --no-cache openssl >/dev/null 2>&1
+            openssl genpkey -algorithm RSA -out /etc/secrets/github-app/private-key.pem -pkeyopt rsa_keygen_bits:2048
+          fi
+      volumeMounts:
+        - name: github-app-secret-volume
+          mountPath: /etc/secrets/github-app
+  volumes:
+    - name: github-app-secret-volume
+      emptyDir: {}

--- a/backend/pkg/httpserver/error_messages.go
+++ b/backend/pkg/httpserver/error_messages.go
@@ -18,6 +18,7 @@ const (
 	errMsgInputValidationErrors = "input validation errors"
 	errMsgInternalServerError   = "internal server error"
 	errMsgInvalidPageToken      = "invalid page token"
+	errMsgRepositoryNotFound    = "repository not found"
 	errMsgSavedSearchNotFound   = "saved search not found"
 	errMsgSubscriptionNotFound  = "subscription not found"
 )

--- a/backend/pkg/httpserver/list_code_subscriptions.go
+++ b/backend/pkg/httpserver/list_code_subscriptions.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
@@ -40,6 +41,49 @@ func (s *Server) ListCodeSubscriptions(
 		})
 	if userCheck.User == nil {
 		return userCheck.Response, nil
+	}
+
+	if request.Provider != "github" {
+		return backend.ListCodeSubscriptions400JSONResponse(
+			backend.BasicErrorModel{
+				Code:    http.StatusBadRequest,
+				Message: fmt.Sprintf("unsupported VCS provider: %s", request.Provider),
+			}), nil
+	}
+
+	owner, repo := "", request.RepositoryId
+	if parts := strings.Split(request.RepositoryId, "/"); len(parts) == 2 {
+		owner, repo = parts[0], parts[1]
+	}
+
+	if userCheck.User.GitHubUserID == nil || *userCheck.User.GitHubUserID == "" {
+		return backend.ListCodeSubscriptions404JSONResponse(
+			backend.BasicErrorModel{
+				Code:    http.StatusNotFound,
+				Message: errMsgRepositoryNotFound,
+			}), nil
+	}
+
+	if s.vcsPermissionChecker != nil {
+		hasAdminAccess, err := s.vcsPermissionChecker.HasRepositoryAdminAccess(
+			ctx, owner, repo, *userCheck.User.GitHubUserID)
+		if err != nil {
+			slog.ErrorContext(ctx, "failed to check repository permissions", "error", err,
+				"provider", request.Provider, "repo_id", request.RepositoryId)
+
+			return backend.ListCodeSubscriptions500JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusInternalServerError,
+					Message: "failed to check repository permissions",
+				}), nil
+		}
+		if !hasAdminAccess {
+			return backend.ListCodeSubscriptions404JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusNotFound,
+					Message: errMsgRepositoryNotFound,
+				}), nil
+		}
 	}
 
 	pageSize := getPageSizeOrDefault(request.Params.PageSize)
@@ -65,7 +109,7 @@ func (s *Server) ListCodeSubscriptions(
 			return backend.ListCodeSubscriptions404JSONResponse(
 				backend.BasicErrorModel{
 					Code:    http.StatusNotFound,
-					Message: "repository not found",
+					Message: errMsgRepositoryNotFound,
 				}), nil
 		}
 

--- a/backend/pkg/httpserver/list_code_subscriptions.go
+++ b/backend/pkg/httpserver/list_code_subscriptions.go
@@ -17,6 +17,7 @@ package httpserver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -53,11 +54,18 @@ func (s *Server) ListCodeSubscriptions(
 					Message: errMsgInvalidPageToken,
 				}), nil
 		}
-		if errors.Is(err, backendtypes.ErrUnsupportedVCSProvider) || errors.Is(err, backendtypes.ErrEntityDoesNotExist) {
+		if errors.Is(err, backendtypes.ErrUnsupportedVCSProvider) {
+			return backend.ListCodeSubscriptions400JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusBadRequest,
+					Message: fmt.Sprintf("unsupported VCS provider: %s", request.Provider),
+				}), nil
+		}
+		if errors.Is(err, backendtypes.ErrEntityDoesNotExist) {
 			return backend.ListCodeSubscriptions404JSONResponse(
 				backend.BasicErrorModel{
 					Code:    http.StatusNotFound,
-					Message: "repository or VCS provider not found",
+					Message: "repository not found",
 				}), nil
 		}
 

--- a/backend/pkg/httpserver/list_code_subscriptions.go
+++ b/backend/pkg/httpserver/list_code_subscriptions.go
@@ -16,16 +16,60 @@ package httpserver
 
 import (
 	"context"
+	"errors"
+	"log/slog"
+	"net/http"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 )
 
-// ListCodeSubscriptions handles GET /v1/users/me/code-subscriptions.
+// ListCodeSubscriptions handles GET /v1/vcs/{provider}/repositories/{repository_id}/code-subscriptions.
 //
 //nolint:ireturn, revive // Expected ireturn for openapi generation.
 func (s *Server) ListCodeSubscriptions(
-	_ context.Context,
-	_ backend.ListCodeSubscriptionsRequestObject,
+	ctx context.Context,
+	request backend.ListCodeSubscriptionsRequestObject,
 ) (backend.ListCodeSubscriptionsResponseObject, error) {
-	return nil, errNotImplemented
+	userCheck := CheckAuthenticatedUser[backend.ListCodeSubscriptionsResponseObject](
+		ctx, "ListCodeSubscriptions",
+		func(code int, message string) backend.ListCodeSubscriptionsResponseObject {
+			return backend.ListCodeSubscriptions500JSONResponse(
+				backend.BasicErrorModel{Code: code, Message: message})
+		})
+	if userCheck.User == nil {
+		return userCheck.Response, nil
+	}
+
+	pageSize := getPageSizeOrDefault(request.Params.PageSize)
+
+	page, err := s.wptMetricsStorer.ListCodeSubscriptions(
+		ctx, request.Provider, request.RepositoryId, pageSize, request.Params.PageToken)
+	if err != nil {
+		if errors.Is(err, backendtypes.ErrInvalidPageToken) {
+			return backend.ListCodeSubscriptions400JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusBadRequest,
+					Message: errMsgInvalidPageToken,
+				}), nil
+		}
+		if errors.Is(err, backendtypes.ErrUnsupportedVCSProvider) || errors.Is(err, backendtypes.ErrEntityDoesNotExist) {
+			return backend.ListCodeSubscriptions404JSONResponse(
+				backend.BasicErrorModel{
+					Code:    http.StatusNotFound,
+					Message: "repository or VCS provider not found",
+				}), nil
+		}
+
+		slog.ErrorContext(ctx, "failed to list code subscriptions", "error", err,
+			"provider", request.Provider, "repo_id", request.RepositoryId)
+
+		return backend.ListCodeSubscriptions500JSONResponse(
+			backend.BasicErrorModel{
+				Code:    http.StatusInternalServerError,
+				Message: "failed to list code subscriptions",
+			}), nil
+	}
+
+	return backend.ListCodeSubscriptions200JSONResponse(*page), nil
 }

--- a/backend/pkg/httpserver/list_code_subscriptions.go
+++ b/backend/pkg/httpserver/list_code_subscriptions.go
@@ -51,9 +51,14 @@ func (s *Server) ListCodeSubscriptions(
 			}), nil
 	}
 
-	owner, repo := "", request.RepositoryId
-	if parts := strings.Split(request.RepositoryId, "/"); len(parts) == 2 {
-		owner, repo = parts[0], parts[1]
+	owner, repo, err := parseGitHubRepositoryID(request.RepositoryId)
+	if err != nil {
+		//nolint:nilerr // WONTFIX - false positive when returning structured 400 response instead of Go error.
+		return backend.ListCodeSubscriptions400JSONResponse(
+			backend.BasicErrorModel{
+				Code:    http.StatusBadRequest,
+				Message: err.Error(),
+			}), nil
 	}
 
 	if userCheck.User.GitHubUserID == nil || *userCheck.User.GitHubUserID == "" {
@@ -124,4 +129,13 @@ func (s *Server) ListCodeSubscriptions(
 	}
 
 	return backend.ListCodeSubscriptions200JSONResponse(*page), nil
+}
+
+func parseGitHubRepositoryID(repositoryID string) (string, string, error) {
+	parts := strings.Split(repositoryID, "/")
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+		return parts[0], parts[1], nil
+	}
+
+	return "", "", fmt.Errorf("invalid repository format for GitHub: %q (expected owner/repo)", repositoryID)
 }

--- a/backend/pkg/httpserver/list_code_subscriptions_test.go
+++ b/backend/pkg/httpserver/list_code_subscriptions_test.go
@@ -15,6 +15,7 @@
 package httpserver
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -61,13 +62,14 @@ func TestListCodeSubscriptions(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		cfg                  *MockListCodeSubscriptionsConfig
+		permChecker          *MockVCSPermissionChecker
 		expectedCallCount    int
 		authMiddlewareOption testServerOption
 		request              *http.Request
 		expectedResponse     *http.Response
 	}{
 		{
-			name: "Success with Pagination",
+			name: "Success with Pagination and Permitted Admin",
 			cfg: &MockListCodeSubscriptionsConfig{
 				expectedProvider:     "github",
 				expectedRepositoryID: "repo-1",
@@ -76,6 +78,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 				output:               samplePage,
 				err:                  nil,
 			},
+			permChecker:          &MockVCSPermissionChecker{hasAdminAccess: true, err: nil, called: false},
 			expectedCallCount:    1,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
@@ -113,6 +116,40 @@ func TestListCodeSubscriptions(t *testing.T) {
 			}`),
 		},
 		{
+			name: "Unauthorized / Non-Admin User (404 Not Found BOLA Defense)",
+			cfg:  nil,
+			permChecker: &MockVCSPermissionChecker{
+				hasAdminAccess: false,
+				err:            nil,
+				called:         false,
+			},
+			expectedCallCount:    0,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions", nil),
+			expectedResponse: testJSONResponse(http.StatusNotFound, `{
+				"code": 404,
+				"message": "repository not found"
+			}`),
+		},
+		{
+			name: "Permission Checker Error (500 Internal Server Error)",
+			cfg:  nil,
+			permChecker: &MockVCSPermissionChecker{
+				hasAdminAccess: false,
+				err:            errors.New("vcs auth service unavailable"),
+				called:         false,
+			},
+			expectedCallCount:    0,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions", nil),
+			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
+				"code": 500,
+				"message": "failed to check repository permissions"
+			}`),
+		},
+		{
 			name: "Invalid Page Token (400 Bad Request)",
 			cfg: &MockListCodeSubscriptionsConfig{
 				expectedProvider:     "github",
@@ -122,6 +159,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 				output:               nil,
 				err:                  backendtypes.ErrInvalidPageToken,
 			},
+			permChecker:          &MockVCSPermissionChecker{hasAdminAccess: true, err: nil, called: false},
 			expectedCallCount:    1,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
@@ -133,15 +171,13 @@ func TestListCodeSubscriptions(t *testing.T) {
 		},
 		{
 			name: "Unsupported VCS Provider (400 Bad Request)",
-			cfg: &MockListCodeSubscriptionsConfig{
-				expectedProvider:     "gitlab",
-				expectedRepositoryID: "repo-1",
-				expectedPageSize:     100,
-				expectedPageToken:    nil,
-				output:               nil,
-				err:                  backendtypes.ErrUnsupportedVCSProvider,
+			cfg:  nil,
+			permChecker: &MockVCSPermissionChecker{
+				hasAdminAccess: true,
+				err:            nil,
+				called:         false,
 			},
-			expectedCallCount:    1,
+			expectedCallCount:    0,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
 				http.MethodGet, "/v1/vcs/gitlab/repositories/repo-1/code-subscriptions", nil),
@@ -160,6 +196,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 				output:               nil,
 				err:                  backendtypes.ErrEntityDoesNotExist,
 			},
+			permChecker:          &MockVCSPermissionChecker{hasAdminAccess: true, err: nil, called: false},
 			expectedCallCount:    1,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
@@ -179,6 +216,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 				output:               nil,
 				err:                  errors.New("spanner failure"),
 			},
+			permChecker:          &MockVCSPermissionChecker{hasAdminAccess: true, err: nil, called: false},
 			expectedCallCount:    1,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
@@ -191,6 +229,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 		{
 			name:                 "Missing User in Context",
 			cfg:                  nil,
+			permChecker:          nil,
 			expectedCallCount:    0,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(nil)),
 			request: httptest.NewRequestWithContext(t.Context(),
@@ -209,10 +248,29 @@ func TestListCodeSubscriptions(t *testing.T) {
 				listCodeSubscriptionsCfg: tc.cfg,
 				t:                        t,
 			}
-			server := setupTestServer(t, withCustomStorer(mockStorer))
+			var opts []TestServerOption
+			opts = append(opts, withCustomStorer(mockStorer))
+			if tc.permChecker != nil {
+				opts = append(opts, withCustomVCSPermissionChecker(tc.permChecker))
+			}
+			server := setupTestServer(t, opts...)
 			assertTestServerRequest(t, server, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
 			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListCodeSubscriptions,
 				"ListCodeSubscriptions", nil)
 		})
 	}
+}
+
+type MockVCSPermissionChecker struct {
+	hasAdminAccess bool
+	err            error
+	called         bool
+}
+
+func (m *MockVCSPermissionChecker) HasRepositoryAdminAccess(
+	_ context.Context, _, _, _ string,
+) (bool, error) {
+	m.called = true
+
+	return m.hasAdminAccess, m.err
 }

--- a/backend/pkg/httpserver/list_code_subscriptions_test.go
+++ b/backend/pkg/httpserver/list_code_subscriptions_test.go
@@ -132,9 +132,9 @@ func TestListCodeSubscriptions(t *testing.T) {
 			}`),
 		},
 		{
-			name: "Unsupported VCS Provider (404 Not Found)",
+			name: "Unsupported VCS Provider (400 Bad Request)",
 			cfg: &MockListCodeSubscriptionsConfig{
-				expectedProvider:     "github",
+				expectedProvider:     "gitlab",
 				expectedRepositoryID: "repo-1",
 				expectedPageSize:     100,
 				expectedPageToken:    nil,
@@ -144,10 +144,10 @@ func TestListCodeSubscriptions(t *testing.T) {
 			expectedCallCount:    1,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
-				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions", nil),
-			expectedResponse: testJSONResponse(http.StatusNotFound, `{
-				"code": 404,
-				"message": "repository or VCS provider not found"
+				http.MethodGet, "/v1/vcs/gitlab/repositories/repo-1/code-subscriptions", nil),
+			expectedResponse: testJSONResponse(http.StatusBadRequest, `{
+				"code": 400,
+				"message": "unsupported VCS provider: gitlab"
 			}`),
 		},
 		{
@@ -166,7 +166,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 				http.MethodGet, "/v1/vcs/github/repositories/repo-999/code-subscriptions", nil),
 			expectedResponse: testJSONResponse(http.StatusNotFound, `{
 				"code": 404,
-				"message": "repository or VCS provider not found"
+				"message": "repository not found"
 			}`),
 		},
 		{

--- a/backend/pkg/httpserver/list_code_subscriptions_test.go
+++ b/backend/pkg/httpserver/list_code_subscriptions_test.go
@@ -1,0 +1,218 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpserver
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/GoogleChrome/webstatus.dev/lib/auth"
+	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
+)
+
+func TestListCodeSubscriptions(t *testing.T) {
+	testUser := &auth.User{ID: "user-123", GitHubUserID: new("12345")}
+	now := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	sampleSub := backend.CodeSubscriptionResponse{
+		Id:                 "sub-1",
+		VcsProvider:        "github",
+		VcsInstallationId:  new("inst-1"),
+		VcsRepositoryId:    "repo-1",
+		RepositoryOwner:    "GoogleChrome",
+		RepositoryName:     "webstatus.dev",
+		RepositoryFullName: "GoogleChrome/webstatus.dev",
+		FeatureId:          new("view-transitions"),
+		TargetQuery:        "id:view-transitions",
+		Triggers:           []backend.SubscriptionTriggerWritable{backend.SubscriptionTriggerFeatureBaselineToWidely},
+		RawDirective:       new("// @webstatus: id:view-transitions"),
+		Occurrences: []backend.SubscriptionOccurrence{
+			{FilePath: "src/app.ts", LineNumber: 10, CommentSnippet: "// @webstatus: id:view-transitions"},
+		},
+		OccurrenceCount: 1,
+		Status:          backend.ACTIVE,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+
+	samplePage := &backend.CodeSubscriptionPage{
+		Data: &[]backend.CodeSubscriptionResponse{sampleSub},
+		Metadata: &backend.PageMetadata{
+			NextPageToken: new("next-page-tok"),
+		},
+	}
+
+	testCases := []struct {
+		name                 string
+		cfg                  *MockListCodeSubscriptionsConfig
+		expectedCallCount    int
+		authMiddlewareOption testServerOption
+		request              *http.Request
+		expectedResponse     *http.Response
+	}{
+		{
+			name: "Success with Pagination",
+			cfg: &MockListCodeSubscriptionsConfig{
+				expectedProvider:     "github",
+				expectedRepositoryID: "repo-1",
+				expectedPageSize:     10,
+				expectedPageToken:    new("cur-tok"),
+				output:               samplePage,
+				err:                  nil,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions?page_size=10&page_token=cur-tok", nil),
+			expectedResponse: testJSONResponse(http.StatusOK, `{
+				"data": [
+					{
+						"id": "sub-1",
+						"vcs_provider": "github",
+						"vcs_installation_id": "inst-1",
+						"vcs_repository_id": "repo-1",
+						"repository_owner": "GoogleChrome",
+						"repository_name": "webstatus.dev",
+						"repository_full_name": "GoogleChrome/webstatus.dev",
+						"feature_id": "view-transitions",
+						"target_query": "id:view-transitions",
+						"triggers": ["feature_baseline_to_widely"],
+						"raw_directive": "// @webstatus: id:view-transitions",
+						"occurrences": [
+							{
+								"file_path": "src/app.ts",
+								"line_number": 10,
+								"comment_snippet": "// @webstatus: id:view-transitions"
+							}
+						],
+						"occurrence_count": 1,
+						"status": "ACTIVE",
+						"created_at": "2026-01-01T00:00:00Z",
+						"updated_at": "2026-01-01T00:00:00Z"
+					}
+				],
+				"metadata": {
+					"next_page_token": "next-page-tok"
+				}
+			}`),
+		},
+		{
+			name: "Invalid Page Token (400 Bad Request)",
+			cfg: &MockListCodeSubscriptionsConfig{
+				expectedProvider:     "github",
+				expectedRepositoryID: "repo-1",
+				expectedPageSize:     100,
+				expectedPageToken:    new("invalid-tok"),
+				output:               nil,
+				err:                  backendtypes.ErrInvalidPageToken,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions?page_token=invalid-tok", nil),
+			expectedResponse: testJSONResponse(http.StatusBadRequest, `{
+				"code": 400,
+				"message": "invalid page token"
+			}`),
+		},
+		{
+			name: "Unsupported VCS Provider (404 Not Found)",
+			cfg: &MockListCodeSubscriptionsConfig{
+				expectedProvider:     "github",
+				expectedRepositoryID: "repo-1",
+				expectedPageSize:     100,
+				expectedPageToken:    nil,
+				output:               nil,
+				err:                  backendtypes.ErrUnsupportedVCSProvider,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions", nil),
+			expectedResponse: testJSONResponse(http.StatusNotFound, `{
+				"code": 404,
+				"message": "repository or VCS provider not found"
+			}`),
+		},
+		{
+			name: "Repository Not Found (404 Not Found)",
+			cfg: &MockListCodeSubscriptionsConfig{
+				expectedProvider:     "github",
+				expectedRepositoryID: "repo-999",
+				expectedPageSize:     100,
+				expectedPageToken:    nil,
+				output:               nil,
+				err:                  backendtypes.ErrEntityDoesNotExist,
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories/repo-999/code-subscriptions", nil),
+			expectedResponse: testJSONResponse(http.StatusNotFound, `{
+				"code": 404,
+				"message": "repository or VCS provider not found"
+			}`),
+		},
+		{
+			name: "Database Error (500)",
+			cfg: &MockListCodeSubscriptionsConfig{
+				expectedProvider:     "github",
+				expectedRepositoryID: "repo-1",
+				expectedPageSize:     100,
+				expectedPageToken:    nil,
+				output:               nil,
+				err:                  errors.New("spanner failure"),
+			},
+			expectedCallCount:    1,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions", nil),
+			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
+				"code": 500,
+				"message": "failed to list code subscriptions"
+			}`),
+		},
+		{
+			name:                 "Missing User in Context",
+			cfg:                  nil,
+			expectedCallCount:    0,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(nil)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions", nil),
+			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
+				"code": 500,
+				"message": "internal server error"
+			}`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			//nolint:exhaustruct
+			mockStorer := &MockWPTMetricsStorer{
+				listCodeSubscriptionsCfg: tc.cfg,
+				t:                        t,
+			}
+			server := setupTestServer(t, withCustomStorer(mockStorer))
+			assertTestServerRequest(t, server, tc.request, tc.expectedResponse, tc.authMiddlewareOption)
+			assertMocksExpectations(t, tc.expectedCallCount, mockStorer.callCountListCodeSubscriptions,
+				"ListCodeSubscriptions", nil)
+		})
+	}
+}

--- a/backend/pkg/httpserver/list_code_subscriptions_test.go
+++ b/backend/pkg/httpserver/list_code_subscriptions_test.go
@@ -72,7 +72,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 			name: "Success with Pagination and Permitted Admin",
 			cfg: &MockListCodeSubscriptionsConfig{
 				expectedProvider:     "github",
-				expectedRepositoryID: "repo-1",
+				expectedRepositoryID: "GoogleChrome/webstatus.dev",
 				expectedPageSize:     10,
 				expectedPageToken:    new("cur-tok"),
 				output:               samplePage,
@@ -82,7 +82,9 @@ func TestListCodeSubscriptions(t *testing.T) {
 			expectedCallCount:    1,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
-				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions?page_size=10&page_token=cur-tok", nil),
+				http.MethodGet,
+				"/v1/vcs/github/repositories/GoogleChrome%2Fwebstatus.dev/code-subscriptions?page_size=10&page_token=cur-tok",
+				nil),
 			expectedResponse: testJSONResponse(http.StatusOK, `{
 				"data": [
 					{
@@ -126,7 +128,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 			expectedCallCount:    0,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
-				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions", nil),
+				http.MethodGet, "/v1/vcs/github/repositories/GoogleChrome%2Fwebstatus.dev/code-subscriptions", nil),
 			expectedResponse: testJSONResponse(http.StatusNotFound, `{
 				"code": 404,
 				"message": "repository not found"
@@ -143,17 +145,34 @@ func TestListCodeSubscriptions(t *testing.T) {
 			expectedCallCount:    0,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
-				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions", nil),
+				http.MethodGet, "/v1/vcs/github/repositories/GoogleChrome%2Fwebstatus.dev/code-subscriptions", nil),
 			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
 				"code": 500,
 				"message": "failed to check repository permissions"
 			}`),
 		},
 		{
+			name: "Invalid GitHub Repository ID Format (400 Bad Request)",
+			cfg:  nil,
+			permChecker: &MockVCSPermissionChecker{
+				hasAdminAccess: true,
+				err:            nil,
+				called:         false,
+			},
+			expectedCallCount:    0,
+			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
+			request: httptest.NewRequestWithContext(t.Context(),
+				http.MethodGet, "/v1/vcs/github/repositories/repo-without-slash/code-subscriptions", nil),
+			expectedResponse: testJSONResponse(http.StatusBadRequest, `{
+				"code": 400,
+				"message": "invalid repository format for GitHub: \"repo-without-slash\" (expected owner/repo)"
+			}`),
+		},
+		{
 			name: "Invalid Page Token (400 Bad Request)",
 			cfg: &MockListCodeSubscriptionsConfig{
 				expectedProvider:     "github",
-				expectedRepositoryID: "repo-1",
+				expectedRepositoryID: "GoogleChrome/webstatus.dev",
 				expectedPageSize:     100,
 				expectedPageToken:    new("invalid-tok"),
 				output:               nil,
@@ -163,7 +182,9 @@ func TestListCodeSubscriptions(t *testing.T) {
 			expectedCallCount:    1,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
-				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions?page_token=invalid-tok", nil),
+				http.MethodGet,
+				"/v1/vcs/github/repositories/GoogleChrome%2Fwebstatus.dev/code-subscriptions?page_token=invalid-tok",
+				nil),
 			expectedResponse: testJSONResponse(http.StatusBadRequest, `{
 				"code": 400,
 				"message": "invalid page token"
@@ -190,7 +211,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 			name: "Repository Not Found (404 Not Found)",
 			cfg: &MockListCodeSubscriptionsConfig{
 				expectedProvider:     "github",
-				expectedRepositoryID: "repo-999",
+				expectedRepositoryID: "GoogleChrome/nonexistent",
 				expectedPageSize:     100,
 				expectedPageToken:    nil,
 				output:               nil,
@@ -200,7 +221,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 			expectedCallCount:    1,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
-				http.MethodGet, "/v1/vcs/github/repositories/repo-999/code-subscriptions", nil),
+				http.MethodGet, "/v1/vcs/github/repositories/GoogleChrome%2Fnonexistent/code-subscriptions", nil),
 			expectedResponse: testJSONResponse(http.StatusNotFound, `{
 				"code": 404,
 				"message": "repository not found"
@@ -210,7 +231,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 			name: "Database Error (500)",
 			cfg: &MockListCodeSubscriptionsConfig{
 				expectedProvider:     "github",
-				expectedRepositoryID: "repo-1",
+				expectedRepositoryID: "GoogleChrome/webstatus.dev",
 				expectedPageSize:     100,
 				expectedPageToken:    nil,
 				output:               nil,
@@ -220,7 +241,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 			expectedCallCount:    1,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(testUser)),
 			request: httptest.NewRequestWithContext(t.Context(),
-				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions", nil),
+				http.MethodGet, "/v1/vcs/github/repositories/GoogleChrome%2Fwebstatus.dev/code-subscriptions", nil),
 			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
 				"code": 500,
 				"message": "failed to list code subscriptions"
@@ -233,7 +254,7 @@ func TestListCodeSubscriptions(t *testing.T) {
 			expectedCallCount:    0,
 			authMiddlewareOption: withAuthMiddleware(mockAuthMiddleware(nil)),
 			request: httptest.NewRequestWithContext(t.Context(),
-				http.MethodGet, "/v1/vcs/github/repositories/repo-1/code-subscriptions", nil),
+				http.MethodGet, "/v1/vcs/github/repositories/GoogleChrome%2Fwebstatus.dev/code-subscriptions", nil),
 			expectedResponse: testJSONResponse(http.StatusInternalServerError, `{
 				"code": 500,
 				"message": "internal server error"

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -195,7 +195,7 @@ type WPTMetricsStorer interface {
 	) (*backend.SubscriptionResponse, error)
 	ListCodeSubscriptions(
 		ctx context.Context,
-		vcsProvider, repoID string,
+		vcsProvider, repoFullName string,
 		pageSize int,
 		pageToken *string,
 	) (*backend.CodeSubscriptionPage, error)

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -193,6 +193,12 @@ type WPTMetricsStorer interface {
 		userID, subscriptionID string,
 		req backend.UpdateSubscriptionRequest,
 	) (*backend.SubscriptionResponse, error)
+	ListCodeSubscriptions(
+		ctx context.Context,
+		vcsProvider, repoID string,
+		pageSize int,
+		pageToken *string,
+	) (*backend.CodeSubscriptionPage, error)
 }
 
 type Server struct {

--- a/backend/pkg/httpserver/server.go
+++ b/backend/pkg/httpserver/server.go
@@ -201,6 +201,12 @@ type WPTMetricsStorer interface {
 	) (*backend.CodeSubscriptionPage, error)
 }
 
+// VCSPermissionChecker verifies whether an authenticated user has administrative
+// permissions on a given VCS repository.
+type VCSPermissionChecker interface {
+	HasRepositoryAdminAccess(ctx context.Context, owner, repo, githubUserID string) (bool, error)
+}
+
 type Server struct {
 	metadataStorer          WebFeatureMetadataStorer
 	wptMetricsStorer        WPTMetricsStorer
@@ -209,6 +215,7 @@ type Server struct {
 	userGitHubClientFactory UserGitHubClientFactory
 	eventPublisher          EventPublisher
 	rssRenderer             *RSSRenderer
+	vcsPermissionChecker    VCSPermissionChecker
 }
 
 type GitHubUserClient interface {
@@ -274,6 +281,7 @@ func NewHTTPServer(
 	rawBytesDataCacher RawBytesDataCacher,
 	routeCacheOptions RouteCacheOptions,
 	userGitHubClientFactory UserGitHubClientFactory,
+	vcsPermissionChecker VCSPermissionChecker,
 	preRequestValidationMiddlewares []func(http.Handler) http.Handler,
 	authMiddleware func(http.Handler) http.Handler) *http.Server {
 	// Create an instance of our handler which satisfies the generated interface
@@ -285,6 +293,7 @@ func NewHTTPServer(
 		baseURL:                 baseURL,
 		userGitHubClientFactory: userGitHubClientFactory,
 		rssRenderer:             NewRSSRenderer(),
+		vcsPermissionChecker:    vcsPermissionChecker,
 	}
 
 	return createOpenAPIServerServer(port, srv, preRequestValidationMiddlewares, authMiddleware)

--- a/backend/pkg/httpserver/server_test.go
+++ b/backend/pkg/httpserver/server_test.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/GoogleChrome/webstatus.dev/lib/auth"
 	"github.com/GoogleChrome/webstatus.dev/lib/backendtypes"
+	codescantaskv1 "github.com/GoogleChrome/webstatus.dev/lib/event/codescantask/v1"
+	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner"
 	"github.com/GoogleChrome/webstatus.dev/lib/gcpspanner/searchtypes"
 	"github.com/GoogleChrome/webstatus.dev/lib/gen/openapi/backend"
 	"github.com/GoogleChrome/webstatus.dev/lib/gh"
@@ -370,6 +372,8 @@ type MockWPTMetricsStorer struct {
 	updateSavedSearchSubscriptionCfg                  *MockUpdateSavedSearchSubscriptionConfig
 	validateQueryReferencesCfg                        *MockValidateQueryReferencesConfig
 	listGlobalSavedSearchesCfg                        *MockListGlobalSavedSearchesConfig
+	listCodeSubscriptionsCfg                          *MockListCodeSubscriptionsConfig
+	recordVCSWebhookDeliveryCfg                       *MockRecordVCSWebhookDeliveryConfig
 	t                                                 *testing.T
 	callCountListMissingOneImplCounts                 int
 	callCountListMissingOneImplFeatures               int
@@ -404,6 +408,8 @@ type MockWPTMetricsStorer struct {
 	callCountValidateQueryReferences                  int
 	callCountListGlobalSavedSearches                  int
 	callCountGetGlobalSavedSearch                     int
+	callCountListCodeSubscriptions                    int
+	callCountRecordVCSWebhookDelivery                 int
 }
 
 func (m *MockWPTMetricsStorer) GetIDFromFeatureKey(
@@ -1111,6 +1117,63 @@ func (m *MockWPTMetricsStorer) GetGlobalSavedSearch(
 	return nil, errors.New("basic mock") // basic mock
 }
 
+type MockListCodeSubscriptionsConfig struct {
+	expectedProvider     string
+	expectedRepositoryID string
+	expectedPageSize     int
+	expectedPageToken    *string
+	output               *backend.CodeSubscriptionPage
+	err                  error
+}
+
+func (m *MockWPTMetricsStorer) ListCodeSubscriptions(
+	_ context.Context,
+	provider string,
+	repoID string,
+	pageSize int,
+	pageToken *string,
+) (*backend.CodeSubscriptionPage, error) {
+	m.callCountListCodeSubscriptions++
+	if provider != m.listCodeSubscriptionsCfg.expectedProvider {
+		m.t.Errorf("unexpected provider %s", provider)
+	}
+	if repoID != m.listCodeSubscriptionsCfg.expectedRepositoryID {
+		m.t.Errorf("unexpected repo id %s", repoID)
+	}
+	if pageSize != m.listCodeSubscriptionsCfg.expectedPageSize {
+		m.t.Errorf("unexpected page size %d", pageSize)
+	}
+	if !reflect.DeepEqual(pageToken, m.listCodeSubscriptionsCfg.expectedPageToken) {
+		m.t.Errorf("unexpected page token %+v", pageToken)
+	}
+
+	return m.listCodeSubscriptionsCfg.output, m.listCodeSubscriptionsCfg.err
+}
+
+type MockRecordVCSWebhookDeliveryConfig struct {
+	expectedDelivery gcpspanner.VCSWebhookDelivery
+	output           bool
+	err              error
+}
+
+func (m *MockWPTMetricsStorer) RecordVCSWebhookDelivery(
+	_ context.Context,
+	delivery gcpspanner.VCSWebhookDelivery,
+) (bool, error) {
+	m.callCountRecordVCSWebhookDelivery++
+
+	if m.recordVCSWebhookDeliveryCfg != nil {
+		if delivery != m.recordVCSWebhookDeliveryCfg.expectedDelivery {
+			m.t.Errorf("Incorrect arguments. Expected: %+v, Got: %+v",
+				m.recordVCSWebhookDeliveryCfg.expectedDelivery, delivery)
+		}
+
+		return m.recordVCSWebhookDeliveryCfg.output, m.recordVCSWebhookDeliveryCfg.err
+	}
+
+	return true, nil
+}
+
 type MockPublishSearchConfigurationChangedConfig struct {
 	expectedResp       *backend.SavedSearchResponse
 	expectedUserID     string
@@ -1141,6 +1204,13 @@ func (m *MockEventPublisher) PublishSearchConfigurationChanged(
 	}
 
 	return m.publishSearchConfigurationChangedCfg.err
+}
+
+func (m *MockEventPublisher) PublishCodeScanTask(
+	_ context.Context,
+	_ codescantaskv1.CodeScanTaskEvent,
+) error {
+	return nil
 }
 
 func TestGetPageSizeOrDefault(t *testing.T) {

--- a/backend/pkg/httpserver/test_utils_test.go
+++ b/backend/pkg/httpserver/test_utils_test.go
@@ -113,6 +113,7 @@ func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
 		userGitHubClientFactory: nil,
 		eventPublisher:          nil,
 		rssRenderer:             NewRSSRenderer(),
+		vcsPermissionChecker:    nil,
 	}
 
 	// Apply Functional Options to override defaults
@@ -124,6 +125,12 @@ func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
 }
 
 // Helper options to set specialized mocks if needed in tests
+
+func withCustomVCSPermissionChecker(c VCSPermissionChecker) TestServerOption {
+	return func(srv *Server) {
+		srv.vcsPermissionChecker = c
+	}
+}
 
 func withCustomStorer(s WPTMetricsStorer) TestServerOption {
 	return func(srv *Server) {

--- a/backend/pkg/httpserver/test_utils_test.go
+++ b/backend/pkg/httpserver/test_utils_test.go
@@ -21,12 +21,10 @@ import (
 // TestServerOption defines a function type to override Server fields in tests.
 type TestServerOption func(*Server)
 
-// setupTestServer creates a Server instance initialized with safe defaults for testing.
-func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
+func newDefaultMockWPTMetricsStorer(t *testing.T) *MockWPTMetricsStorer {
 	t.Helper()
 
-	// Default mock implementation
-	mockStorer := &MockWPTMetricsStorer{
+	return &MockWPTMetricsStorer{
 		t:                                                 t,
 		featureCfg:                                        nil,
 		aggregateCfg:                                      nil,
@@ -61,6 +59,8 @@ func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
 		updateSavedSearchSubscriptionCfg:                  nil,
 		validateQueryReferencesCfg:                        nil,
 		listGlobalSavedSearchesCfg:                        nil,
+		listCodeSubscriptionsCfg:                          nil,
+		recordVCSWebhookDeliveryCfg:                       nil,
 		callCountListMetricsForFeatureIDBrowserAndChannel: 0,
 		callCountListMetricsOverTimeWithAggregatedTotals:  0,
 		callCountListChromeDailyUsageStats:                0,
@@ -94,7 +94,16 @@ func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
 		callCountListGlobalSavedSearches:                  0,
 		callCountGetGlobalSavedSearch:                     0,
 		callCountGetSavedSearchSubscriptionPublic:         0,
+		callCountListCodeSubscriptions:                    0,
+		callCountRecordVCSWebhookDelivery:                 0,
 	}
+}
+
+// setupTestServer creates a Server instance initialized with safe defaults for testing.
+func setupTestServer(t *testing.T, options ...TestServerOption) *Server {
+	t.Helper()
+
+	mockStorer := newDefaultMockWPTMetricsStorer(t)
 
 	srv := &Server{
 		metadataStorer:          nil,

--- a/lib/gcpspanner/code_subscriptions.go
+++ b/lib/gcpspanner/code_subscriptions.go
@@ -577,8 +577,8 @@ func (c *Client) AcquireDeliveryLock(
 				return nil, ErrDeliveryAlreadyDelivered
 			}
 
-			if existing.LockExpiresAt.Valid && existing.LockExpiresAt.Time.After(now) {
-				// Lock still active by another worker
+			lockState := NewLeasedLockState(existing.WorkerLockID, existing.LockExpiresAt)
+			if err := lockState.CanAcquire(workerID, now); err != nil {
 				return nil, ErrDeliveryAlreadyLocked
 			}
 
@@ -620,14 +620,17 @@ func (c *Client) RecordDeliverySuccess(
 
 			now := c.timeNow()
 
-			// Lock fencing check: verify lock has not expired
-			if !existing.LockExpiresAt.Valid || !existing.LockExpiresAt.Time.After(now) {
-				return nil, ErrDeliveryLockExpired
-			}
+			// Lock fencing check: verify caller owns an active, unexpired lease
+			lockState := NewLeasedLockState(existing.WorkerLockID, existing.LockExpiresAt)
+			if err := lockState.ValidateOwnership(workerID, now); err != nil {
+				if errors.Is(err, ErrLockExpired) {
+					return nil, ErrDeliveryLockExpired
+				}
+				if errors.Is(err, ErrLockNotOwned) {
+					return nil, ErrDeliveryLockMismatch
+				}
 
-			// Lock fencing check: verify worker ownership
-			if existing.WorkerLockID.Valid && existing.WorkerLockID.StringVal != workerID {
-				return nil, ErrDeliveryLockMismatch
+				return nil, err
 			}
 
 			existing.DeliveryStatus = string(DeliveryStatusDelivered)
@@ -661,14 +664,17 @@ func (c *Client) ReleaseDeliveryLock(ctx context.Context, deliveryID, workerID s
 
 			now := c.timeNow()
 
-			// Lock fencing: verify lock has not expired
-			if !existing.LockExpiresAt.Valid || !existing.LockExpiresAt.Time.After(now) {
-				return nil, ErrDeliveryLockExpired
-			}
+			// Lock fencing check: verify caller owns an active, unexpired lease
+			lockState := NewLeasedLockState(existing.WorkerLockID, existing.LockExpiresAt)
+			if err := lockState.ValidateOwnership(workerID, now); err != nil {
+				if errors.Is(err, ErrLockExpired) {
+					return nil, ErrDeliveryLockExpired
+				}
+				if errors.Is(err, ErrLockNotOwned) {
+					return nil, ErrDeliveryLockMismatch
+				}
 
-			// Lock fencing: verify worker ownership
-			if !existing.WorkerLockID.Valid || existing.WorkerLockID.StringVal != workerID {
-				return nil, ErrDeliveryLockMismatch
+				return nil, err
 			}
 
 			existing.DeliveryStatus = string(DeliveryStatusPending)

--- a/lib/gcpspanner/code_subscriptions.go
+++ b/lib/gcpspanner/code_subscriptions.go
@@ -65,10 +65,10 @@ func (m codeSubscriptionAllByRepoMapper) SelectAllByKeys(key codeSubscriptionAll
 
 // ListCodeSubscriptionsRequest is a request to list code subscriptions for a repository with pagination.
 type ListCodeSubscriptionsRequest struct {
-	VCSProvider VCSProvider
-	RepoID      string
-	PageSize    int
-	PageToken   *string
+	VCSProvider        VCSProvider
+	RepositoryFullName string
+	PageSize           int
+	PageToken          *string
 }
 
 func (r ListCodeSubscriptionsRequest) GetPageSize() int {
@@ -96,9 +96,9 @@ func (m listCodeSubscriptionsMapper) EncodePageToken(item spannerCodeSubscriptio
 func (m listCodeSubscriptionsMapper) SelectList(req ListCodeSubscriptionsRequest) spanner.Statement {
 	var pageFilter string
 	params := map[string]any{
-		"vcsProvider": string(req.VCSProvider),
-		"repoID":      req.RepoID,
-		"pageSize":    req.PageSize,
+		"vcsProvider":        string(req.VCSProvider),
+		"repositoryFullName": req.RepositoryFullName,
+		"pageSize":           req.PageSize,
 	}
 	if req.PageToken != nil {
 		cursor, err := decodeCursor[codeSubscriptionCursor](*req.PageToken)
@@ -112,7 +112,7 @@ func (m listCodeSubscriptionsMapper) SelectList(req ListCodeSubscriptionsRequest
 		ID, VCSProvider, VCSInstallationID, VCSRepositoryID, RepositoryFullName,
 		TargetQuery, Triggers, Status, Occurrences, CreatedAt, UpdatedAt
 	FROM CodeSubscriptions
-	WHERE VCSProvider = @vcsProvider AND VCSRepositoryID = @repoID AND Status = 'ACTIVE' %s
+	WHERE VCSProvider = @vcsProvider AND LOWER(RepositoryFullName) = LOWER(@repositoryFullName) AND Status = 'ACTIVE' %s
 	ORDER BY CreatedAt DESC, ID ASC
 	LIMIT @pageSize`, pageFilter)
 

--- a/lib/gcpspanner/code_subscriptions_test.go
+++ b/lib/gcpspanner/code_subscriptions_test.go
@@ -17,6 +17,7 @@ package gcpspanner
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,10 +92,10 @@ func TestCodeSubscriptions(t *testing.T) {
 
 	// 3. Test ListCodeSubscriptionsByRepository with pagination
 	listReq := ListCodeSubscriptionsRequest{
-		VCSProvider: VCSProviderGitHub,
-		RepoID:      repoID,
-		PageSize:    10,
-		PageToken:   nil,
+		VCSProvider:        VCSProviderGitHub,
+		RepositoryFullName: repoFullName,
+		PageSize:           10,
+		PageToken:          nil,
 	}
 	list, nextPageToken, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, listReq)
 	if err != nil {
@@ -109,10 +110,10 @@ func TestCodeSubscriptions(t *testing.T) {
 
 	// 3b. Test pagination page by page (pageSize = 1)
 	pagedReq1 := ListCodeSubscriptionsRequest{
-		VCSProvider: VCSProviderGitHub,
-		RepoID:      repoID,
-		PageSize:    1,
-		PageToken:   nil,
+		VCSProvider:        VCSProviderGitHub,
+		RepositoryFullName: repoFullName,
+		PageSize:           1,
+		PageToken:          nil,
 	}
 	pagedList1, token1, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, pagedReq1)
 	if err != nil {
@@ -123,10 +124,10 @@ func TestCodeSubscriptions(t *testing.T) {
 	}
 
 	pagedReq2 := ListCodeSubscriptionsRequest{
-		VCSProvider: VCSProviderGitHub,
-		RepoID:      repoID,
-		PageSize:    1,
-		PageToken:   token1,
+		VCSProvider:        VCSProviderGitHub,
+		RepositoryFullName: repoFullName,
+		PageSize:           1,
+		PageToken:          token1,
 	}
 	pagedList2, _, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, pagedReq2)
 	if err != nil {
@@ -137,6 +138,21 @@ func TestCodeSubscriptions(t *testing.T) {
 	}
 	if pagedList1[0].ID == pagedList2[0].ID {
 		t.Fatalf("expected different items on pages 1 and 2, got same ID: %s", pagedList1[0].ID)
+	}
+
+	// 3c. Test case-insensitivity of repository full name lookup (e.g. lowercase)
+	lowerListReq := ListCodeSubscriptionsRequest{
+		VCSProvider:        VCSProviderGitHub,
+		RepositoryFullName: strings.ToLower(repoFullName),
+		PageSize:           10,
+		PageToken:          nil,
+	}
+	lowerList, _, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, lowerListReq)
+	if err != nil {
+		t.Fatalf("ListCodeSubscriptionsByRepository with lowercased name failed: %v", err)
+	}
+	if len(lowerList) != 2 {
+		t.Fatalf("expected 2 active subscriptions when queried with lowercased name, got %d", len(lowerList))
 	}
 
 	// 4. Test ListCodeSubscriptionsByTargetQuery
@@ -308,10 +324,10 @@ func testDeclarativeObsolescenceAndRevival(
 		t.Fatalf("SynchronizeRepositoryCodeSubscriptions (obsolete sub1) failed: %v", err)
 	}
 	activeList, _, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, ListCodeSubscriptionsRequest{
-		VCSProvider: VCSProviderGitHub,
-		RepoID:      repoID,
-		PageSize:    10,
-		PageToken:   nil,
+		VCSProvider:        VCSProviderGitHub,
+		RepositoryFullName: sub2.RepositoryFullName,
+		PageSize:           10,
+		PageToken:          nil,
 	})
 	if err != nil {
 		t.Fatalf("ListCodeSubscriptionsByRepository after obsolescence failed: %v", err)
@@ -325,10 +341,10 @@ func testDeclarativeObsolescenceAndRevival(
 		t.Fatalf("SynchronizeRepositoryCodeSubscriptions (revival) failed: %v", err)
 	}
 	revivedList, _, err := spannerClient.ListCodeSubscriptionsByRepository(ctx, ListCodeSubscriptionsRequest{
-		VCSProvider: VCSProviderGitHub,
-		RepoID:      repoID,
-		PageSize:    10,
-		PageToken:   nil,
+		VCSProvider:        VCSProviderGitHub,
+		RepositoryFullName: sub1.RepositoryFullName,
+		PageSize:           10,
+		PageToken:          nil,
 	})
 	if err != nil {
 		t.Fatalf("ListCodeSubscriptionsByRepository after revival failed: %v", err)

--- a/lib/gcpspanner/lock_helper.go
+++ b/lib/gcpspanner/lock_helper.go
@@ -1,0 +1,72 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"errors"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+var (
+	// ErrLockExpired indicates that the worker's lock lease duration has elapsed.
+	ErrLockExpired = errors.New("worker lock lease has expired")
+)
+
+// LeasedLockState provides unified validation and acquisition semantics for distributed worker leases in Spanner.
+type LeasedLockState struct {
+	WorkerID  spanner.NullString
+	ExpiresAt spanner.NullTime
+}
+
+// NewLeasedLockState creates a LeasedLockState from spanner nullable types.
+func NewLeasedLockState(workerID spanner.NullString, expiresAt spanner.NullTime) LeasedLockState {
+	return LeasedLockState{
+		WorkerID:  workerID,
+		ExpiresAt: expiresAt,
+	}
+}
+
+// CanAcquire checks if callerWorkerID can acquire or re-acquire (extend) the lock at time 'now'.
+// A lock is acquirable if:
+// 1. It is expired (ExpiresAt <= now), OR
+// 2. It has no assigned owner (!WorkerID.Valid), OR
+// 3. It is already held by the same worker (re-entrant lease renewal).
+func (l LeasedLockState) CanAcquire(callerWorkerID string, now time.Time) error {
+	isActive := l.ExpiresAt.Valid && l.ExpiresAt.Time.After(now)
+	isOtherWorker := l.WorkerID.Valid && l.WorkerID.StringVal != callerWorkerID
+
+	if isActive && isOtherWorker {
+		return ErrAlreadyLocked
+	}
+
+	return nil
+}
+
+// ValidateOwnership verifies worker fencing: the caller must actively hold an unexpired lease.
+// Both completion recording (e.g. RecordDeliverySuccess) and lock release (e.g. ReleaseDeliveryLock)
+// MUST use this exact check to prevent fencing token violations.
+func (l LeasedLockState) ValidateOwnership(callerWorkerID string, now time.Time) error {
+	if !l.ExpiresAt.Valid || !l.ExpiresAt.Time.After(now) {
+		return ErrLockExpired
+	}
+
+	if !l.WorkerID.Valid || l.WorkerID.StringVal != callerWorkerID {
+		return ErrLockNotOwned
+	}
+
+	return nil
+}

--- a/lib/gcpspanner/lock_helper_test.go
+++ b/lib/gcpspanner/lock_helper_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpspanner
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+func TestLeasedLockState_CanAcquire(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	future := now.Add(30 * time.Second)
+	past := now.Add(-10 * time.Second)
+
+	testCases := []struct {
+		name        string
+		state       LeasedLockState
+		caller      string
+		expectedErr error
+	}{
+		{
+			name: "Unassigned Lock (NULL worker and NULL expiry) Acquirable",
+			state: LeasedLockState{
+				WorkerID:  spanner.NullString{StringVal: "", Valid: false},
+				ExpiresAt: spanner.NullTime{Time: time.Time{}, Valid: false},
+			},
+			caller:      "worker-1",
+			expectedErr: nil,
+		},
+		{
+			name: "Expired Lock Held by Another Worker Acquirable",
+			state: LeasedLockState{
+				WorkerID:  spanner.NullString{StringVal: "worker-2", Valid: true},
+				ExpiresAt: spanner.NullTime{Time: past, Valid: true},
+			},
+			caller:      "worker-1",
+			expectedErr: nil,
+		},
+		{
+			name: "Active Lock Held by Same Worker Re-acquirable (Lease Extension)",
+			state: LeasedLockState{
+				WorkerID:  spanner.NullString{StringVal: "worker-1", Valid: true},
+				ExpiresAt: spanner.NullTime{Time: future, Valid: true},
+			},
+			caller:      "worker-1",
+			expectedErr: nil,
+		},
+		{
+			name: "Active Lock Held by Another Worker Rejects Acquisition",
+			state: LeasedLockState{
+				WorkerID:  spanner.NullString{StringVal: "worker-2", Valid: true},
+				ExpiresAt: spanner.NullTime{Time: future, Valid: true},
+			},
+			caller:      "worker-1",
+			expectedErr: ErrAlreadyLocked,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.state.CanAcquire(tc.caller, now)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("CanAcquire() err = %v, want %v", err, tc.expectedErr)
+			}
+		})
+	}
+}
+
+func TestLeasedLockState_ValidateOwnership(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 28, 12, 0, 0, 0, time.UTC)
+	future := now.Add(30 * time.Second)
+	past := now.Add(-10 * time.Second)
+
+	testCases := []struct {
+		name        string
+		state       LeasedLockState
+		caller      string
+		expectedErr error
+	}{
+		{
+			name: "Valid Lease Owned by Caller Passes Validation",
+			state: LeasedLockState{
+				WorkerID:  spanner.NullString{StringVal: "worker-1", Valid: true},
+				ExpiresAt: spanner.NullTime{Time: future, Valid: true},
+			},
+			caller:      "worker-1",
+			expectedErr: nil,
+		},
+		{
+			name: "Expired Lease Rejects with ErrLockExpired",
+			state: LeasedLockState{
+				WorkerID:  spanner.NullString{StringVal: "worker-1", Valid: true},
+				ExpiresAt: spanner.NullTime{Time: past, Valid: true},
+			},
+			caller:      "worker-1",
+			expectedErr: ErrLockExpired,
+		},
+		{
+			name: "NULL Expiry Rejects with ErrLockExpired",
+			state: LeasedLockState{
+				WorkerID:  spanner.NullString{StringVal: "worker-1", Valid: true},
+				ExpiresAt: spanner.NullTime{Time: time.Time{}, Valid: false},
+			},
+			caller:      "worker-1",
+			expectedErr: ErrLockExpired,
+		},
+		{
+			name: "Active Lease Owned by Other Worker Rejects with ErrLockNotOwned",
+			state: LeasedLockState{
+				WorkerID:  spanner.NullString{StringVal: "worker-2", Valid: true},
+				ExpiresAt: spanner.NullTime{Time: future, Valid: true},
+			},
+			caller:      "worker-1",
+			expectedErr: ErrLockNotOwned,
+		},
+		{
+			name: "Active Lease with NULL WorkerID Rejects with ErrLockNotOwned",
+			state: LeasedLockState{
+				WorkerID:  spanner.NullString{StringVal: "", Valid: false},
+				ExpiresAt: spanner.NullTime{Time: future, Valid: true},
+			},
+			caller:      "worker-1",
+			expectedErr: ErrLockNotOwned,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.state.ValidateOwnership(tc.caller, now)
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("ValidateOwnership() err = %v, want %v", err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/lib/gcpspanner/spanneradapters/backend.go
+++ b/lib/gcpspanner/spanneradapters/backend.go
@@ -2337,7 +2337,7 @@ func toBackendCodeSubscriptionsResponse(
 
 func (s *Backend) ListCodeSubscriptions(
 	ctx context.Context,
-	vcsProvider, repoID string,
+	vcsProvider, repoFullName string,
 	pageSize int,
 	pageToken *string,
 ) (*backend.CodeSubscriptionPage, error) {
@@ -2347,10 +2347,10 @@ func (s *Backend) ListCodeSubscriptions(
 	}
 
 	subs, token, err := s.client.ListCodeSubscriptionsByRepository(ctx, gcpspanner.ListCodeSubscriptionsRequest{
-		VCSProvider: provider,
-		RepoID:      repoID,
-		PageSize:    pageSize,
-		PageToken:   pageToken,
+		VCSProvider:        provider,
+		RepositoryFullName: repoFullName,
+		PageSize:           pageSize,
+		PageToken:          pageToken,
 	})
 	if err != nil {
 		if errors.Is(err, gcpspanner.ErrInvalidCursorFormat) {

--- a/lib/gcpspanner/spanneradapters/backend_test.go
+++ b/lib/gcpspanner/spanneradapters/backend_test.go
@@ -806,9 +806,9 @@ func (c mockBackendSpannerClient) ListCodeSubscriptionsByRepository(
 			c.t.Errorf("provider mismatch: got %s, want %s",
 				req.VCSProvider, c.mockListCodeSubscriptionsCfg.expectedRequest.VCSProvider)
 		}
-		if req.RepoID != c.mockListCodeSubscriptionsCfg.expectedRequest.RepoID {
-			c.t.Errorf("repoID mismatch: got %s, want %s",
-				req.RepoID, c.mockListCodeSubscriptionsCfg.expectedRequest.RepoID)
+		if req.RepositoryFullName != c.mockListCodeSubscriptionsCfg.expectedRequest.RepositoryFullName {
+			c.t.Errorf("repositoryFullName mismatch: got %s, want %s",
+				req.RepositoryFullName, c.mockListCodeSubscriptionsCfg.expectedRequest.RepositoryFullName)
 		}
 		if req.PageSize != c.mockListCodeSubscriptionsCfg.expectedRequest.PageSize {
 			c.t.Errorf("pageSize mismatch: got %d, want %d",
@@ -5435,10 +5435,10 @@ func TestBackend_ListCodeSubscriptions(t *testing.T) {
 		t: t,
 		mockListCodeSubscriptionsCfg: &mockListCodeSubscriptionsByRepositoryConfig{
 			expectedRequest: gcpspanner.ListCodeSubscriptionsRequest{
-				VCSProvider: gcpspanner.VCSProviderGitHub,
-				RepoID:      "repo-789",
-				PageSize:    10,
-				PageToken:   nil,
+				VCSProvider:        gcpspanner.VCSProviderGitHub,
+				RepositoryFullName: "repo-789",
+				PageSize:           10,
+				PageToken:          nil,
 			},
 			result:        mockSubs,
 			nextPageToken: nil,

--- a/lib/gh/permission_checker.go
+++ b/lib/gh/permission_checker.go
@@ -17,9 +17,11 @@ package gh
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-github/v79/github"
 )
@@ -46,8 +48,11 @@ type UserLookupService interface {
 // and the repository admin permission result to reduce GitHub API quota usage
 // and optimize response latency under high traffic.
 type GitHubPermissionChecker struct {
-	reposClient CollaboratorPermissionService
-	usersClient UserLookupService
+	reposClient   CollaboratorPermissionService
+	usersClient   UserLookupService
+	tokenProvider *TokenProvider
+	baseURL       *url.URL
+	httpClient    *http.Client
 }
 
 // NewGitHubPermissionChecker creates a new GitHubPermissionChecker with the provided services.
@@ -56,8 +61,11 @@ func NewGitHubPermissionChecker(
 	usersClient UserLookupService,
 ) *GitHubPermissionChecker {
 	return &GitHubPermissionChecker{
-		reposClient: reposClient,
-		usersClient: usersClient,
+		reposClient:   reposClient,
+		usersClient:   usersClient,
+		tokenProvider: nil,
+		baseURL:       nil,
+		httpClient:    nil,
 	}
 }
 
@@ -66,18 +74,42 @@ func NewGitHubPermissionCheckerWithBaseURL(baseURL *url.URL) *GitHubPermissionCh
 	return NewGitHubPermissionCheckerWithTokenProvider(nil, baseURL)
 }
 
+func normalizeBaseURL(u *url.URL) *url.URL {
+	if u == nil {
+		return nil
+	}
+	copyURL := *u
+	if !strings.HasSuffix(copyURL.Path, "/") {
+		copyURL.Path += "/"
+	}
+
+	return &copyURL
+}
+
 // NewGitHubPermissionCheckerWithTokenProvider creates a GitHubPermissionChecker with an optional
 // TokenProvider and custom base URL.
-func NewGitHubPermissionCheckerWithTokenProvider(_ *TokenProvider, baseURL *url.URL) *GitHubPermissionChecker {
-	ghClient := github.NewClient(nil)
-	if baseURL != nil {
-		ghClient.BaseURL = baseURL
-		ghClient.UploadURL = baseURL
+func NewGitHubPermissionCheckerWithTokenProvider(
+	tokenProvider *TokenProvider,
+	baseURL *url.URL,
+) *GitHubPermissionChecker {
+	var httpClient *http.Client
+	if tokenProvider != nil {
+		httpClient = tokenProvider.httpClient
+	}
+
+	normalizedBaseURL := normalizeBaseURL(baseURL)
+	ghClient := github.NewClient(httpClient)
+	if normalizedBaseURL != nil {
+		ghClient.BaseURL = normalizedBaseURL
+		ghClient.UploadURL = normalizedBaseURL
 	}
 
 	return &GitHubPermissionChecker{
-		reposClient: ghClient.Repositories,
-		usersClient: ghClient.Users,
+		reposClient:   ghClient.Repositories,
+		usersClient:   ghClient.Users,
+		tokenProvider: tokenProvider,
+		baseURL:       normalizedBaseURL,
+		httpClient:    httpClient,
 	}
 }
 
@@ -91,13 +123,36 @@ func (c *GitHubPermissionChecker) HasRepositoryAdminAccess(
 		return false, nil
 	}
 
-	if c.reposClient == nil {
+	reposClient := c.reposClient
+	usersClient := c.usersClient
+
+	if c.tokenProvider != nil {
+		token, err := c.tokenProvider.GetInstallationTokenForRepo(ctx, owner, repo)
+		if err != nil {
+			if errors.Is(err, ErrRepositoryInstallationNotFound) {
+				return false, nil
+			}
+
+			return false, fmt.Errorf("failed to get repository installation token: %w", err)
+		}
+
+		ghClient := github.NewClient(c.httpClient).WithAuthToken(token)
+		if c.baseURL != nil {
+			ghClient.BaseURL = c.baseURL
+			ghClient.UploadURL = c.baseURL
+		}
+
+		reposClient = ghClient.Repositories
+		usersClient = ghClient.Users
+	}
+
+	if reposClient == nil {
 		return false, ErrClientNotConfigured
 	}
 
 	login := githubUserID
-	if id, err := strconv.ParseInt(githubUserID, 10, 64); err == nil && c.usersClient != nil {
-		user, resp, userErr := c.usersClient.GetByID(ctx, id)
+	if id, err := strconv.ParseInt(githubUserID, 10, 64); err == nil && usersClient != nil {
+		user, resp, userErr := usersClient.GetByID(ctx, id)
 		if userErr != nil {
 			if resp != nil && resp.StatusCode == http.StatusNotFound {
 				return false, nil
@@ -111,7 +166,7 @@ func (c *GitHubPermissionChecker) HasRepositoryAdminAccess(
 		login = *user.Login
 	}
 
-	perm, resp, err := c.reposClient.GetPermissionLevel(ctx, owner, repo, login)
+	perm, resp, err := reposClient.GetPermissionLevel(ctx, owner, repo, login)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return false, nil

--- a/lib/gh/permission_checker.go
+++ b/lib/gh/permission_checker.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/google/go-github/v79/github"
+)
+
+var (
+	// ErrClientNotConfigured is returned when the collaborator client is nil.
+	ErrClientNotConfigured = errors.New("github collaborator client not configured")
+)
+
+// CollaboratorPermissionService abstracts the GitHub API operation for getting collaborator permissions.
+type CollaboratorPermissionService interface {
+	GetPermissionLevel(ctx context.Context, owner, repo, user string) (
+		*github.RepositoryPermissionLevel, *github.Response, error)
+}
+
+// UserLookupService abstracts looking up user details from GitHub.
+type UserLookupService interface {
+	GetByID(ctx context.Context, id int64) (*github.User, *github.Response, error)
+}
+
+// GitHubPermissionChecker verifies user permissions against GitHub repositories.
+//
+// FUTURE: Consider caching (e.g., in Valkey) the numeric-to-login resolution
+// and the repository admin permission result to reduce GitHub API quota usage
+// and optimize response latency under high traffic.
+type GitHubPermissionChecker struct {
+	reposClient CollaboratorPermissionService
+	usersClient UserLookupService
+}
+
+// NewGitHubPermissionChecker creates a new GitHubPermissionChecker with the provided services.
+func NewGitHubPermissionChecker(
+	reposClient CollaboratorPermissionService,
+	usersClient UserLookupService,
+) *GitHubPermissionChecker {
+	return &GitHubPermissionChecker{
+		reposClient: reposClient,
+		usersClient: usersClient,
+	}
+}
+
+// NewGitHubPermissionCheckerWithBaseURL creates a GitHubPermissionChecker with an optional custom base URL.
+func NewGitHubPermissionCheckerWithBaseURL(baseURL *url.URL) *GitHubPermissionChecker {
+	ghClient := github.NewClient(nil)
+	if baseURL != nil {
+		ghClient.BaseURL = baseURL
+		ghClient.UploadURL = baseURL
+	}
+
+	return &GitHubPermissionChecker{
+		reposClient: ghClient.Repositories,
+		usersClient: ghClient.Users,
+	}
+}
+
+// HasRepositoryAdminAccess checks if the given user (identified by GitHub username or numeric user ID string)
+// has admin access to owner/repo on GitHub.
+func (c *GitHubPermissionChecker) HasRepositoryAdminAccess(
+	ctx context.Context,
+	owner, repo, githubUserID string,
+) (bool, error) {
+	if owner == "" || repo == "" || githubUserID == "" {
+		return false, nil
+	}
+
+	if c.reposClient == nil {
+		return false, ErrClientNotConfigured
+	}
+
+	login := githubUserID
+	if id, err := strconv.ParseInt(githubUserID, 10, 64); err == nil && c.usersClient != nil {
+		user, resp, userErr := c.usersClient.GetByID(ctx, id)
+		if userErr != nil {
+			if resp != nil && resp.StatusCode == http.StatusNotFound {
+				return false, nil
+			}
+
+			return false, userErr
+		}
+		if user == nil || user.Login == nil || *user.Login == "" {
+			return false, nil
+		}
+		login = *user.Login
+	}
+
+	perm, resp, err := c.reposClient.GetPermissionLevel(ctx, owner, repo, login)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	if perm == nil {
+		return false, nil
+	}
+
+	return perm.GetPermission() == "admin", nil
+}

--- a/lib/gh/permission_checker.go
+++ b/lib/gh/permission_checker.go
@@ -63,6 +63,12 @@ func NewGitHubPermissionChecker(
 
 // NewGitHubPermissionCheckerWithBaseURL creates a GitHubPermissionChecker with an optional custom base URL.
 func NewGitHubPermissionCheckerWithBaseURL(baseURL *url.URL) *GitHubPermissionChecker {
+	return NewGitHubPermissionCheckerWithTokenProvider(nil, baseURL)
+}
+
+// NewGitHubPermissionCheckerWithTokenProvider creates a GitHubPermissionChecker with an optional
+// TokenProvider and custom base URL.
+func NewGitHubPermissionCheckerWithTokenProvider(_ *TokenProvider, baseURL *url.URL) *GitHubPermissionChecker {
 	ghClient := github.NewClient(nil)
 	if baseURL != nil {
 		ghClient.BaseURL = baseURL

--- a/lib/gh/permission_checker_test.go
+++ b/lib/gh/permission_checker_test.go
@@ -278,3 +278,21 @@ func TestNewGitHubPermissionCheckerWithBaseURL(t *testing.T) {
 		t.Error("expected non-nil usersClient")
 	}
 }
+
+func TestNewGitHubPermissionCheckerWithTokenProvider(t *testing.T) {
+	baseURL, err := url.Parse("https://custom.github.com/api/v3")
+	if err != nil {
+		t.Fatalf("failed to parse url: %v", err)
+	}
+
+	checker := NewGitHubPermissionCheckerWithTokenProvider(nil, baseURL)
+	if checker == nil {
+		t.Fatal("expected non-nil checker")
+	}
+	if checker.reposClient == nil {
+		t.Error("expected non-nil reposClient")
+	}
+	if checker.usersClient == nil {
+		t.Error("expected non-nil usersClient")
+	}
+}

--- a/lib/gh/permission_checker_test.go
+++ b/lib/gh/permission_checker_test.go
@@ -1,0 +1,280 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gh
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-github/v79/github"
+)
+
+type mockCollaboratorPermissionService struct {
+	permissionLevel *github.RepositoryPermissionLevel
+	response        *github.Response
+	err             error
+	calledUser      string
+}
+
+func (m *mockCollaboratorPermissionService) GetPermissionLevel(
+	_ context.Context, _, _, user string,
+) (*github.RepositoryPermissionLevel, *github.Response, error) {
+	m.calledUser = user
+
+	return m.permissionLevel, m.response, m.err
+}
+
+type mockUserLookupService struct {
+	user     *github.User
+	response *github.Response
+	err      error
+}
+
+func (m *mockUserLookupService) GetByID(
+	_ context.Context, _ int64,
+) (*github.User, *github.Response, error) {
+	return m.user, m.response, m.err
+}
+
+//nolint:exhaustruct
+func TestGitHubPermissionChecker_HasRepositoryAdminAccess(t *testing.T) {
+	adminStr := "admin"
+	writeStr := "write"
+	readStr := "read"
+	loginOctocat := "octocat"
+	testErr := errors.New("github api failure")
+
+	testCases := []struct {
+		name          string
+		reposClient   CollaboratorPermissionService
+		usersClient   UserLookupService
+		owner         string
+		repo          string
+		githubUserID  string
+		expectedAdmin bool
+		expectedErr   error
+		expectedUser  string
+	}{
+		{
+			name: "Numeric GitHub ID resolves login and returns true for admin",
+			reposClient: &mockCollaboratorPermissionService{
+				permissionLevel: &github.RepositoryPermissionLevel{Permission: &adminStr},
+				response:        &github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
+				err:             nil,
+			},
+			usersClient: &mockUserLookupService{
+				user:     &github.User{Login: &loginOctocat},
+				response: &github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
+				err:      nil,
+			},
+			owner:         "owner",
+			repo:          "repo",
+			githubUserID:  "12345",
+			expectedAdmin: true,
+			expectedErr:   nil,
+			expectedUser:  "octocat",
+		},
+		{
+			name: "Direct string login returns true for admin without calling usersClient",
+			reposClient: &mockCollaboratorPermissionService{
+				permissionLevel: &github.RepositoryPermissionLevel{Permission: &adminStr},
+				response:        &github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
+				err:             nil,
+			},
+			usersClient:   nil,
+			owner:         "owner",
+			repo:          "repo",
+			githubUserID:  "octocat",
+			expectedAdmin: true,
+			expectedErr:   nil,
+			expectedUser:  "octocat",
+		},
+		{
+			name: "Non-admin write permission returns false",
+			reposClient: &mockCollaboratorPermissionService{
+				permissionLevel: &github.RepositoryPermissionLevel{Permission: &writeStr},
+				response:        &github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
+				err:             nil,
+			},
+			usersClient: &mockUserLookupService{
+				user:     &github.User{Login: &loginOctocat},
+				response: &github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
+				err:      nil,
+			},
+			owner:         "owner",
+			repo:          "repo",
+			githubUserID:  "12345",
+			expectedAdmin: false,
+			expectedErr:   nil,
+			expectedUser:  "octocat",
+		},
+		{
+			name: "Non-admin read permission returns false",
+			reposClient: &mockCollaboratorPermissionService{
+				permissionLevel: &github.RepositoryPermissionLevel{Permission: &readStr},
+				response:        &github.Response{Response: &http.Response{StatusCode: http.StatusOK}},
+				err:             nil,
+			},
+			usersClient:   nil,
+			owner:         "owner",
+			repo:          "repo",
+			githubUserID:  "octocat",
+			expectedAdmin: false,
+			expectedErr:   nil,
+			expectedUser:  "octocat",
+		},
+		{
+			name: "404 Not Found from reposClient returns false without error",
+			reposClient: &mockCollaboratorPermissionService{
+				permissionLevel: nil,
+				response:        &github.Response{Response: &http.Response{StatusCode: http.StatusNotFound}},
+				err:             testErr,
+			},
+			usersClient:   nil,
+			owner:         "owner",
+			repo:          "repo",
+			githubUserID:  "octocat",
+			expectedAdmin: false,
+			expectedErr:   nil,
+			expectedUser:  "octocat",
+		},
+		{
+			name: "404 Not Found from usersClient returns false without error",
+			reposClient: &mockCollaboratorPermissionService{
+				permissionLevel: nil,
+				response:        nil,
+				err:             nil,
+			},
+			usersClient: &mockUserLookupService{
+				user:     nil,
+				response: &github.Response{Response: &http.Response{StatusCode: http.StatusNotFound}},
+				err:      testErr,
+			},
+			owner:         "owner",
+			repo:          "repo",
+			githubUserID:  "12345",
+			expectedAdmin: false,
+			expectedErr:   nil,
+			expectedUser:  "",
+		},
+		{
+			name:          "Empty owner returns false without error",
+			reposClient:   &mockCollaboratorPermissionService{nil, nil, nil, ""},
+			usersClient:   nil,
+			owner:         "",
+			repo:          "repo",
+			githubUserID:  "12345",
+			expectedAdmin: false,
+			expectedErr:   nil,
+			expectedUser:  "",
+		},
+		{
+			name:          "Empty repo returns false without error",
+			reposClient:   &mockCollaboratorPermissionService{nil, nil, nil, ""},
+			usersClient:   nil,
+			owner:         "owner",
+			repo:          "",
+			githubUserID:  "12345",
+			expectedAdmin: false,
+			expectedErr:   nil,
+			expectedUser:  "",
+		},
+		{
+			name:          "Empty githubUserID returns false without error",
+			reposClient:   &mockCollaboratorPermissionService{nil, nil, nil, ""},
+			usersClient:   nil,
+			owner:         "owner",
+			repo:          "repo",
+			githubUserID:  "",
+			expectedAdmin: false,
+			expectedErr:   nil,
+			expectedUser:  "",
+		},
+		{
+			name:          "Nil reposClient returns ErrClientNotConfigured",
+			reposClient:   nil,
+			usersClient:   nil,
+			owner:         "owner",
+			repo:          "repo",
+			githubUserID:  "12345",
+			expectedAdmin: false,
+			expectedErr:   ErrClientNotConfigured,
+			expectedUser:  "",
+		},
+		{
+			name: "API error from reposClient propagates error",
+			reposClient: &mockCollaboratorPermissionService{
+				permissionLevel: nil,
+				response:        &github.Response{Response: &http.Response{StatusCode: http.StatusInternalServerError}},
+				err:             testErr,
+			},
+			usersClient:   nil,
+			owner:         "owner",
+			repo:          "repo",
+			githubUserID:  "octocat",
+			expectedAdmin: false,
+			expectedErr:   testErr,
+			expectedUser:  "octocat",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			checker := NewGitHubPermissionChecker(tc.reposClient, tc.usersClient)
+			admin, err := checker.HasRepositoryAdminAccess(t.Context(), tc.owner, tc.repo, tc.githubUserID)
+
+			if tc.expectedErr != nil {
+				if err == nil || !errors.Is(err, tc.expectedErr) {
+					t.Fatalf("expected error %v, got %v", tc.expectedErr, err)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if admin != tc.expectedAdmin {
+				t.Errorf("expected admin %v, got %v", tc.expectedAdmin, admin)
+			}
+
+			if tc.expectedUser != "" {
+				if mockRepo, ok := tc.reposClient.(*mockCollaboratorPermissionService); ok {
+					if mockRepo.calledUser != tc.expectedUser {
+						t.Errorf("expected called user %q, got %q", tc.expectedUser, mockRepo.calledUser)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestNewGitHubPermissionCheckerWithBaseURL(t *testing.T) {
+	baseURL, err := url.Parse("https://custom.github.com/api/v3")
+	if err != nil {
+		t.Fatalf("failed to parse url: %v", err)
+	}
+
+	checker := NewGitHubPermissionCheckerWithBaseURL(baseURL)
+	if checker == nil {
+		t.Fatal("expected non-nil checker")
+	}
+	if checker.reposClient == nil {
+		t.Error("expected non-nil reposClient")
+	}
+	if checker.usersClient == nil {
+		t.Error("expected non-nil usersClient")
+	}
+}

--- a/lib/gh/permission_checker_test.go
+++ b/lib/gh/permission_checker_test.go
@@ -16,10 +16,13 @@ package gh
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v79/github"
 )
@@ -294,5 +297,90 @@ func TestNewGitHubPermissionCheckerWithTokenProvider(t *testing.T) {
 	}
 	if checker.usersClient == nil {
 		t.Error("expected non-nil usersClient")
+	}
+}
+
+func TestGitHubPermissionChecker_WithTokenProvider_Integration(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		// Verify authorization header on all requests
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			t.Errorf("missing Authorization header on path: %s", r.URL.Path)
+		}
+
+		switch r.URL.Path {
+		case "/repos/admin-org/admin-repo/installation":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id": 789}`))
+		case "/repos/unknown-org/unknown-repo/installation":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message": "Not Found"}`))
+		case "/app/installations/789/access_tokens":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(testTokenResp{
+				Token:     mockInstToken1,
+				ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+			})
+		case "/user/101":
+			// Numeric user ID lookup
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"login": "admin-user"}`))
+		case "/user/202":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"login": "viewer-user"}`))
+		case "/repos/admin-org/admin-repo/collaborators/admin-user/permission":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"permission": "admin"}`))
+		case "/repos/admin-org/admin-repo/collaborators/viewer-user/permission":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"permission": "read"}`))
+		default:
+			t.Errorf("unexpected test request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	tp, err := NewTokenProvider("app-99", privPEM, newMockTokenCacher())
+	if err != nil {
+		t.Fatalf("NewTokenProvider failed: %v", err)
+	}
+	tp.baseURL = server.URL
+	tp.httpClient = server.Client()
+
+	serverURL, _ := url.Parse(server.URL)
+	checker := NewGitHubPermissionCheckerWithTokenProvider(tp, serverURL)
+
+	// 1. Admin user with numeric ID -> true
+	isAdmin, err := checker.HasRepositoryAdminAccess(context.Background(), "admin-org", "admin-repo", "101")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !isAdmin {
+		t.Errorf("expected admin=true, got false")
+	}
+
+	// 2. Viewer user with numeric ID -> false
+	isViewerAdmin, err := checker.HasRepositoryAdminAccess(context.Background(), "admin-org", "admin-repo", "202")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isViewerAdmin {
+		t.Errorf("expected admin=false, got true")
+	}
+
+	// 3. Unknown repo (not installed) -> false, nil
+	isUnknownAdmin, err := checker.HasRepositoryAdminAccess(context.Background(), "unknown-org", "unknown-repo", "101")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isUnknownAdmin {
+		t.Errorf("expected admin=false for uninstalled repo, got true")
 	}
 }

--- a/lib/gh/token_provider.go
+++ b/lib/gh/token_provider.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GoogleChrome/webstatus.dev/lib/localcache"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/go-github/v79/github"
 	"golang.org/x/sync/singleflight"
@@ -37,7 +38,15 @@ const defaultGitHubAPIBaseURL = "https://api.github.com"
 var (
 	// ErrEmptyInstallationID is returned when an installation ID is empty.
 	ErrEmptyInstallationID = errors.New("installation id must not be empty")
+
+	// ErrNilTokenCacher is returned when a nil TokenCacher is provided.
+	ErrNilTokenCacher = errors.New("token cacher must not be nil")
 )
+
+// NewLocalTokenCacher returns an in-memory thread-safe TokenCacher backed by localcache.
+func NewLocalTokenCacher() *localcache.LocalDataCache[string, []byte] {
+	return localcache.NewLocalDataCache[string, []byte](nil)
+}
 
 // InstallationTokenProvider retrieves a valid installation access token for a GitHub App installation.
 type InstallationTokenProvider interface {
@@ -70,6 +79,9 @@ type TokenProvider struct {
 func NewTokenProvider(appID string, privateKeyPEM []byte, cacher TokenCacher) (*TokenProvider, error) {
 	if appID == "" {
 		return nil, ErrEmptyAppID
+	}
+	if cacher == nil {
+		return nil, ErrNilTokenCacher
 	}
 
 	key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKeyPEM)
@@ -250,17 +262,13 @@ func (tp *TokenProvider) GetInstallationTokenForRepo(ctx context.Context, owner,
 	}
 
 	cacheKey := "gh:repo_inst:" + owner + "/" + repo
-	if tp.cacher != nil {
-		if cachedBytes, err := tp.cacher.Get(ctx, cacheKey); err == nil && len(cachedBytes) > 0 {
-			return tp.GetInstallationToken(ctx, string(cachedBytes))
-		}
+	if cachedBytes, err := tp.cacher.Get(ctx, cacheKey); err == nil && len(cachedBytes) > 0 {
+		return tp.GetInstallationToken(ctx, string(cachedBytes))
 	}
 
 	res, err, _ := tp.flight.Do("repo:"+owner+"/"+repo, func() (any, error) {
-		if tp.cacher != nil {
-			if cachedBytes, err := tp.cacher.Get(ctx, cacheKey); err == nil && len(cachedBytes) > 0 {
-				return string(cachedBytes), nil
-			}
+		if cachedBytes, err := tp.cacher.Get(ctx, cacheKey); err == nil && len(cachedBytes) > 0 {
+			return string(cachedBytes), nil
 		}
 
 		instIDStr, err := tp.findRepositoryInstallation(ctx, owner, repo)
@@ -268,11 +276,9 @@ func (tp *TokenProvider) GetInstallationTokenForRepo(ctx context.Context, owner,
 			return "", err
 		}
 
-		if tp.cacher != nil {
-			if cacheErr := tp.cacher.Cache(ctx, cacheKey, []byte(instIDStr)); cacheErr != nil {
-				slog.WarnContext(ctx, "failed to cache repository installation id",
-					"error", cacheErr, "owner", owner, "repo", repo)
-			}
+		if cacheErr := tp.cacher.Cache(ctx, cacheKey, []byte(instIDStr)); cacheErr != nil {
+			slog.WarnContext(ctx, "failed to cache repository installation id",
+				"error", cacheErr, "owner", owner, "repo", repo)
 		}
 
 		return instIDStr, nil

--- a/lib/gh/token_provider.go
+++ b/lib/gh/token_provider.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleChrome/webstatus.dev/lib/localcache"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/go-github/v79/github"
 	"golang.org/x/sync/singleflight"
@@ -42,11 +41,6 @@ var (
 	// ErrNilTokenCacher is returned when a nil TokenCacher is provided.
 	ErrNilTokenCacher = errors.New("token cacher must not be nil")
 )
-
-// NewLocalTokenCacher returns an in-memory thread-safe TokenCacher backed by localcache.
-func NewLocalTokenCacher() *localcache.LocalDataCache[string, []byte] {
-	return localcache.NewLocalDataCache[string, []byte](nil)
-}
 
 // InstallationTokenProvider retrieves a valid installation access token for a GitHub App installation.
 type InstallationTokenProvider interface {

--- a/lib/gh/token_provider.go
+++ b/lib/gh/token_provider.go
@@ -32,6 +32,8 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
+const defaultGitHubAPIBaseURL = "https://api.github.com"
+
 var (
 	// ErrEmptyInstallationID is returned when an installation ID is empty.
 	ErrEmptyInstallationID = errors.New("installation id must not be empty")
@@ -85,7 +87,7 @@ func NewTokenProvider(appID string, privateKeyPEM []byte, cacher TokenCacher) (*
 			Jar:           nil,
 			Timeout:       10 * time.Second,
 		},
-		baseURL: "https://api.github.com",
+		baseURL: defaultGitHubAPIBaseURL,
 		flight:  singleflight.Group{},
 	}, nil
 }
@@ -120,7 +122,7 @@ func (tp *TokenProvider) createInstallationToken(ctx context.Context, instID int
 	defer cancel()
 
 	appClient := github.NewClient(tp.httpClient).WithAuthToken(jwtToken)
-	if tp.baseURL != "https://api.github.com" && tp.baseURL != "" {
+	if tp.baseURL != defaultGitHubAPIBaseURL && tp.baseURL != "" {
 		baseURLWithSlash := strings.TrimRight(tp.baseURL, "/") + "/"
 		customURL, parseErr := url.Parse(baseURLWithSlash)
 		if parseErr == nil {
@@ -200,4 +202,89 @@ func (tp *TokenProvider) GetInstallationToken(ctx context.Context, installationI
 	}
 
 	return tokenStr, nil
+}
+
+// GetAppToken mints a fresh RS256 JWT for GitHub App-level API operations.
+func (tp *TokenProvider) GetAppToken() (string, error) {
+	return mintAppJWTWithKey(tp.appID, tp.privateKey)
+}
+
+// ErrRepositoryInstallationNotFound indicates that the GitHub App is not installed on the specified repository.
+var ErrRepositoryInstallationNotFound = errors.New("github app installation not found for repository")
+
+func (tp *TokenProvider) findRepositoryInstallation(ctx context.Context, owner, repo string) (string, error) {
+	appToken, err := tp.GetAppToken()
+	if err != nil {
+		return "", fmt.Errorf("failed to get app jwt: %w", err)
+	}
+
+	appClient := github.NewClient(tp.httpClient).WithAuthToken(appToken)
+	if tp.baseURL != defaultGitHubAPIBaseURL && tp.baseURL != "" {
+		baseURLWithSlash := strings.TrimRight(tp.baseURL, "/") + "/"
+		customURL, parseErr := url.Parse(baseURLWithSlash)
+		if parseErr == nil {
+			appClient.BaseURL = customURL
+		}
+	}
+
+	inst, resp, err := appClient.Apps.FindRepositoryInstallation(ctx, owner, repo)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return "", ErrRepositoryInstallationNotFound
+		}
+
+		return "", fmt.Errorf("failed to find repository installation: %w", err)
+	}
+	if inst == nil || inst.ID == nil {
+		return "", ErrRepositoryInstallationNotFound
+	}
+
+	return strconv.FormatInt(inst.GetID(), 10), nil
+}
+
+// GetInstallationTokenForRepo retrieves an installation access token for the given owner and repository.
+// It looks up the repository's installation ID via the GitHub App API and returns an installation token.
+func (tp *TokenProvider) GetInstallationTokenForRepo(ctx context.Context, owner, repo string) (string, error) {
+	if owner == "" || repo == "" {
+		return "", errors.New("owner and repo must not be empty")
+	}
+
+	cacheKey := "gh:repo_inst:" + owner + "/" + repo
+	if tp.cacher != nil {
+		if cachedBytes, err := tp.cacher.Get(ctx, cacheKey); err == nil && len(cachedBytes) > 0 {
+			return tp.GetInstallationToken(ctx, string(cachedBytes))
+		}
+	}
+
+	res, err, _ := tp.flight.Do("repo:"+owner+"/"+repo, func() (any, error) {
+		if tp.cacher != nil {
+			if cachedBytes, err := tp.cacher.Get(ctx, cacheKey); err == nil && len(cachedBytes) > 0 {
+				return string(cachedBytes), nil
+			}
+		}
+
+		instIDStr, err := tp.findRepositoryInstallation(ctx, owner, repo)
+		if err != nil {
+			return "", err
+		}
+
+		if tp.cacher != nil {
+			if cacheErr := tp.cacher.Cache(ctx, cacheKey, []byte(instIDStr)); cacheErr != nil {
+				slog.WarnContext(ctx, "failed to cache repository installation id",
+					"error", cacheErr, "owner", owner, "repo", repo)
+			}
+		}
+
+		return instIDStr, nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	instIDStr, ok := res.(string)
+	if !ok {
+		return "", errors.New("unexpected installation id type from singleflight")
+	}
+
+	return tp.GetInstallationToken(ctx, instIDStr)
 }

--- a/lib/gh/token_provider_test.go
+++ b/lib/gh/token_provider_test.go
@@ -223,14 +223,10 @@ func TestNewTokenProvider_Validation(t *testing.T) {
 		t.Errorf("expected ErrNilTokenCacher, got: %v", err)
 	}
 
-	// 4. Valid with NewLocalTokenCacher
-	localCacher := NewLocalTokenCacher()
-	if localCacher == nil {
-		t.Fatal("expected non-nil local cacher")
-	}
-	tp, err := NewTokenProvider("app-99", privPEM, localCacher)
+	// 4. Valid with TokenCacher
+	tp, err := NewTokenProvider("app-99", privPEM, testNoopTokenCacher{})
 	if err != nil {
-		t.Fatalf("expected successful creation with local cacher, got: %v", err)
+		t.Fatalf("expected successful creation with token cacher, got: %v", err)
 	}
 	if tp == nil {
 		t.Fatal("expected non-nil TokenProvider")

--- a/lib/gh/token_provider_test.go
+++ b/lib/gh/token_provider_test.go
@@ -372,3 +372,83 @@ func TestTokenProvider_CacheFailureGracefulDegradation(t *testing.T) {
 		t.Errorf("expected token %s, got %s", mockInstToken4, token)
 	}
 }
+
+func TestTokenProvider_GetInstallationTokenForRepo(t *testing.T) {
+	t.Parallel()
+
+	_, privPEM := generateTestRSAPEM(t)
+
+	var installReqCount int64
+	var tokenReqCount int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/repos/valid-owner/valid-repo/installation":
+			atomic.AddInt64(&installReqCount, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id": 456}`))
+		case "/repos/unknown-owner/unknown-repo/installation":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message": "Not Found"}`))
+		case "/app/installations/456/access_tokens":
+			atomic.AddInt64(&tokenReqCount, 1)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(testTokenResp{
+				Token:     mockInstToken2,
+				ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+			})
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	cacher := newMockTokenCacher()
+	tp, err := NewTokenProvider("app-99", privPEM, cacher)
+	if err != nil {
+		t.Fatalf("NewTokenProvider failed: %v", err)
+	}
+	tp.baseURL = server.URL
+	tp.httpClient = server.Client()
+
+	// 1. Success on valid repo
+	tok, err := tp.GetInstallationTokenForRepo(context.Background(), "valid-owner", "valid-repo")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if tok != mockInstToken2 {
+		t.Errorf("expected token %s, got %s", mockInstToken2, tok)
+	}
+
+	// 2. Cache hit (neither repo installation nor token should re-query)
+	tok2, err := tp.GetInstallationTokenForRepo(context.Background(), "valid-owner", "valid-repo")
+	if err != nil {
+		t.Fatalf("expected cached success, got %v", err)
+	}
+	if tok2 != mockInstToken2 {
+		t.Errorf("expected cached token %s, got %s", mockInstToken2, tok2)
+	}
+	if got := atomic.LoadInt64(&installReqCount); got != 1 {
+		t.Errorf("expected 1 install request, got %d", got)
+	}
+	if got := atomic.LoadInt64(&tokenReqCount); got != 1 {
+		t.Errorf("expected 1 token request, got %d", got)
+	}
+
+	// 3. Unknown repo returns ErrRepositoryInstallationNotFound
+	_, err = tp.GetInstallationTokenForRepo(context.Background(), "unknown-owner", "unknown-repo")
+	if !errors.Is(err, ErrRepositoryInstallationNotFound) {
+		t.Errorf("expected ErrRepositoryInstallationNotFound, got %v", err)
+	}
+
+	// 4. Empty arguments
+	if _, err := tp.GetInstallationTokenForRepo(context.Background(), "", "valid-repo"); err == nil {
+		t.Error("expected error for empty owner")
+	}
+	if _, err := tp.GetInstallationTokenForRepo(context.Background(), "valid-owner", ""); err == nil {
+		t.Error("expected error for empty repo")
+	}
+}

--- a/lib/gh/token_provider_test.go
+++ b/lib/gh/token_provider_test.go
@@ -216,6 +216,25 @@ func TestNewTokenProvider_Validation(t *testing.T) {
 	if !errors.Is(err, ErrInvalidPrivateKey) {
 		t.Errorf("expected ErrInvalidPrivateKey, got: %v", err)
 	}
+
+	// 3. Nil TokenCacher
+	_, err = NewTokenProvider("app-99", privPEM, nil)
+	if !errors.Is(err, ErrNilTokenCacher) {
+		t.Errorf("expected ErrNilTokenCacher, got: %v", err)
+	}
+
+	// 4. Valid with NewLocalTokenCacher
+	localCacher := NewLocalTokenCacher()
+	if localCacher == nil {
+		t.Fatal("expected non-nil local cacher")
+	}
+	tp, err := NewTokenProvider("app-99", privPEM, localCacher)
+	if err != nil {
+		t.Fatalf("expected successful creation with local cacher, got: %v", err)
+	}
+	if tp == nil {
+		t.Fatal("expected non-nil TokenProvider")
+	}
 }
 
 func TestTokenProvider_CacheExpiration(t *testing.T) {


### PR DESCRIPTION
Part of Epic #2712.
Refs #2722

### Context & Purpose
Implements the backend HTTP handler for `GET /v1/vcs/{provider}/repositories/{repository_id}/code-subscriptions`, listing active code subscriptions for a specific repository.

### Implementation Details
- `backend/pkg/httpserver/list_code_subscriptions.go`: Queries repository code subscriptions from Spanner via `ListCodeSubscriptions`.
- `backend/pkg/httpserver/list_code_subscriptions_test.go`: HTTP test suite asserting exact JSON response structures, authentication checks, and 400 Bad Request on unsupported VCS providers.

TAG=agy
CONV=97eae237-d505-49b9-9314-12cc9391884c