### PR TITLE
fix(infra): configure Classic ALB scheme and upgrade Google provider to v8

### DIFF
--- a/infra/backend/service.tf
+++ b/infra/backend/service.tf
@@ -340,8 +340,9 @@ resource "google_compute_region_network_endpoint_group" "neg" {
 }
 
 resource "google_compute_backend_service" "lb_backend" {
-  provider = google.public_project
-  name     = "${var.env_id}-backend-service"
+  provider              = google.public_project
+  name                  = "${var.env_id}-backend-service"
+  load_balancing_scheme = "EXTERNAL"
   dynamic "backend" {
     for_each = google_compute_region_network_endpoint_group.neg
     content {
@@ -375,12 +376,13 @@ resource "google_compute_url_map" "url_map" {
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
-  provider    = google.public_project
-  name        = "${var.env_id}-backend-https-rule"
-  ip_protocol = "TCP"
-  port_range  = "443"
-  ip_address  = google_compute_global_address.ub_ip_address.id
-  target      = google_compute_target_https_proxy.lb_https_proxy.id
+  provider              = google.public_project
+  name                  = "${var.env_id}-backend-https-rule"
+  load_balancing_scheme = "EXTERNAL"
+  ip_protocol           = "TCP"
+  port_range            = "443"
+  ip_address            = google_compute_global_address.ub_ip_address.id
+  target                = google_compute_target_https_proxy.lb_https_proxy.id
 }
 
 resource "google_compute_global_address" "ub_ip_address" {
@@ -389,12 +391,13 @@ resource "google_compute_global_address" "ub_ip_address" {
 }
 
 resource "google_compute_global_forwarding_rule" "main" {
-  provider    = google.public_project
-  name        = "${var.env_id}-backend-main-https-rule"
-  ip_protocol = "TCP"
-  port_range  = "443"
-  ip_address  = google_compute_global_address.main_ip_address.id
-  target      = google_compute_target_https_proxy.lb_https_proxy.id
+  provider              = google.public_project
+  name                  = "${var.env_id}-backend-main-https-rule"
+  load_balancing_scheme = "EXTERNAL"
+  ip_protocol           = "TCP"
+  port_range            = "443"
+  ip_address            = google_compute_global_address.main_ip_address.id
+  target                = google_compute_target_https_proxy.lb_https_proxy.id
 }
 
 resource "google_compute_global_address" "main_ip_address" {

--- a/infra/frontend/service.tf
+++ b/infra/frontend/service.tf
@@ -146,8 +146,9 @@ resource "google_compute_region_network_endpoint_group" "neg" {
 }
 
 resource "google_compute_backend_service" "lb_backend" {
-  provider = google.public_project
-  name     = "${var.env_id}-frontend-service"
+  provider              = google.public_project
+  name                  = "${var.env_id}-frontend-service"
+  load_balancing_scheme = "EXTERNAL"
   dynamic "backend" {
     for_each = google_compute_region_network_endpoint_group.neg
     content {
@@ -181,12 +182,13 @@ resource "google_compute_url_map" "url_map" {
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
-  provider    = google.public_project
-  name        = "${var.env_id}-frontend-https-rule"
-  ip_protocol = "TCP"
-  port_range  = "443"
-  ip_address  = google_compute_global_address.ub_ip_address.id
-  target      = google_compute_target_https_proxy.lb_https_proxy.id
+  provider              = google.public_project
+  name                  = "${var.env_id}-frontend-https-rule"
+  load_balancing_scheme = "EXTERNAL"
+  ip_protocol           = "TCP"
+  port_range            = "443"
+  ip_address            = google_compute_global_address.ub_ip_address.id
+  target                = google_compute_target_https_proxy.lb_https_proxy.id
 }
 
 resource "google_compute_global_address" "ub_ip_address" {
@@ -195,12 +197,13 @@ resource "google_compute_global_address" "ub_ip_address" {
 }
 
 resource "google_compute_global_forwarding_rule" "main" {
-  provider    = google.public_project
-  name        = "${var.env_id}-frontend-main-https-rule"
-  ip_protocol = "TCP"
-  port_range  = "443"
-  ip_address  = google_compute_global_address.main_ip_address.id
-  target      = google_compute_target_https_proxy.lb_https_proxy.id
+  provider              = google.public_project
+  name                  = "${var.env_id}-frontend-main-https-rule"
+  load_balancing_scheme = "EXTERNAL"
+  ip_protocol           = "TCP"
+  port_range            = "443"
+  ip_address            = google_compute_global_address.main_ip_address.id
+  target                = google_compute_target_https_proxy.lb_https_proxy.id
 }
 
 resource "google_compute_global_address" "main_ip_address" {

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -16,9 +16,11 @@ terraform {
   required_version = ">= 1.14.6"
   backend "gcs" {}
   required_providers {
+    # Provider 8.0.0 defaults load_balancing_scheme to EXTERNAL_MANAGED.
+    # We explicitly declare EXTERNAL on Classic ALBs; see #2808 for migration to EXTERNAL_MANAGED.
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.4.0"
+      version = ">= 8.0.0"
     }
     docker = {
       source  = "kreuzwerker/docker"

--- a/infra/storage/repo_storage_bucket.tf
+++ b/infra/storage/repo_storage_bucket.tf
@@ -21,7 +21,7 @@ resource "google_storage_bucket" "repo_storage_bucket" {
   public_access_prevention    = "enforced"
   uniform_bucket_level_access = true
   retention_policy {
-    retention_period = 2630000 # 1 month
+    retention_period = "2630000" # 1 month
   }
 }
 


### PR DESCRIPTION
## Summary
Explicitly set `load_balancing_scheme = "EXTERNAL"` on backend services and global forwarding rules to unblock Cloud Build deployments under Google provider 8.0.0.

Supersedes #2809.

## Context & Root Cause
PR #2804 merged Google provider 8.0.0 into `infra/.terraform.lock.hcl`. In provider 8.0.0, the default `load_balancing_scheme` changed from `EXTERNAL` to `EXTERNAL_MANAGED`. Because existing frontend and backend load balancers did not specify `load_balancing_scheme`, Cloud Build deployment failed with GCP API error 400 (`Cannot change load balancing scheme until migration state is TEST_ALL_TRAFFIC`).

## Corrected Assumptions & Learnings from #2809
In #2809, an initial attempt was made to downgrade the provider back to 7.x (`7.46.0`). However, when PR #2804 merged, Cloud Build had already executed `terraform apply` on staging with provider 8.0.0, successfully upgrading several state schemas (such as `google_secret_manager_secret_version.otel_config_version`, where `secret_data_wo_version` was migrated from an Integer to a String).

When provider 7.x reads the upgraded state, it fails with:
```
Error decoding "google_secret_manager_secret_version.otel_config_version" from prior state: a number is required
Error: Resource instance managed by newer provider version
The current state of google_secret_manager_secret_version.otel_config_version was created by a newer provider version than is currently selected. Upgrade the google provider to work with this state.
```

Downgrading would require manually restoring older soft-deleted state files from GCS, which risks state drift for all resources deployed since then.

## How It Was Implemented
Following HashiCorp's Provider 8.0.0 Upgrade Guide, we embrace provider 8.0.0 and explicitly declare `load_balancing_scheme = "EXTERNAL"` to preserve Classic ALB behavior with zero unwanted mutations:
- `infra/frontend/service.tf`: Set `load_balancing_scheme = "EXTERNAL"` on `lb_backend` and both forwarding rules (`https` and `main`).
- `infra/backend/service.tf`: Set `load_balancing_scheme = "EXTERNAL"` on `lb_backend` and both forwarding rules (`https` and `main`).
- `infra/storage/repo_storage_bucket.tf`: Quote `retention_period = "2630000"` to align with provider v8 string schema.
- `infra/providers.tf`: Update constraint to `>= 8.0.0` with documentation referencing #2808 for the future staged migration to `EXTERNAL_MANAGED`.

## Verification
- `make tf-lint` passed cleanly inside the DevContainer for both staging and production.
- `terraform plan` executed against the live remote staging state in GCS (`staging.tfstate`) passed with exit code 0 and zero decode or scheme errors.

Fixes #2807
Refs #2808
